### PR TITLE
fixed file copying bug

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [
@@ -11,7 +11,7 @@
     "test": "jest --verbose",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
-    "copy-calm-schema": "mkdir -p dist/calm && cp -r ../calm/draft/2024-04/ dist/calm/",
+    "copy-calm-schema": "mkdir -p dist/calm && cp -r ../calm/draft/2024-04/meta dist/calm/",
     "copy-spectral-rules": "mkdir -p dist/spectral && npm run copy-spectral-instantiation-rules && npm run copy-spectral-pattern-rules",
     "copy-spectral-instantiation-rules": "cp -r ../spectral/instantiation dist/spectral",
     "copy-spectral-pattern-rules": "cp -r ../spectral/pattern dist/spectral"


### PR DESCRIPTION
I tested out this bundling on my Mac, and it worked as expected, but apparently the `cp -r` command works different on Mac vs Linux which is a new one for me! This meant that instead of the _contents_ of a folder being copied as I expected, on linux the folder itself was being copied which lead to a different file structure. Removing the trailing slash solves this problem - quite interesting though