### PR TITLE
Add validation feature for patterns only

### DIFF
--- a/calm/samples/api-gateway-instantiation.json
+++ b/calm/samples/api-gateway-instantiation.json
@@ -8,7 +8,7 @@
       "interfaces": [
         {
           "unique-id": "api-gateway-ingress",
-          "host": "mygateway.com",
+          "host": "https://api-gateway-ingress.example.com",
           "port": 6000
         }
       ],
@@ -29,8 +29,8 @@
       "interfaces": [
         {
           "unique-id": "producer-ingress",
-          "host": "producer.com",
-          "port": 3000
+          "host": "https://api-producer.example.com",
+          "port": -1
         }
       ]
     },

--- a/cli/src/commands/validate/validate-pattern-only.spec.ts
+++ b/cli/src/commands/validate/validate-pattern-only.spec.ts
@@ -1,0 +1,125 @@
+import fetchMock from 'fetch-mock';
+import validate from './validate';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { ISpectralDiagnostic } from '@stoplight/spectral-core';
+
+const mockRunFunction = jest.fn();
+
+jest.mock('@stoplight/spectral-core', () => {
+    const spectralCore = jest.requireActual('@stoplight/spectral-core');
+    return {
+        ...spectralCore,
+        Spectral: jest.fn().mockImplementation(() => {
+            return {
+                run: mockRunFunction,
+                setRuleset: () => { },
+            };
+        })
+    };
+});
+
+jest.mock('../helper.js', () => {
+    return {
+        initLogger: () => {
+            return {
+                info: jest.fn(),
+                debug: jest.fn(),
+                error: jest.fn()
+            };
+        }
+    };
+});
+
+jest.mock('../../consts', () => ({
+    get CALM_SPECTRAL_RULES_DIRECTORY() { return '../spectral'; }
+}));
+
+const metaSchemaLocation = 'test_fixtures/calm';
+const debugDisabled = false;
+const jsonFormat = 'json';
+
+describe('validate - pattern only', () => {
+    let mockExit;
+
+    beforeEach(() => {
+        mockRunFunction.mockReturnValue([]);
+        mockExit = jest.spyOn(process, 'exit')
+            .mockImplementation((code) => {
+                if (code != 0) {
+                    throw new Error('Expected successful run, code was nonzero: ' + code);
+                }
+                return undefined as never;
+            });
+    });
+
+    afterEach(() => {
+        fetchMock.restore();
+        mockExit.mockRestore();
+    });
+
+    it('exits with error when the pattern does not pass all the spectral validations ', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'example-error',
+                message: 'Example error',
+                severity: 0,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        await expect(validate(undefined, 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled, jsonFormat))
+            .rejects
+            .toThrow();
+
+        expect(mockExit)
+            .toHaveBeenCalledWith(1);
+    });
+    
+    it('exits with error when spectral returns warnings, but failOnWarnings is set', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'example-warning',
+                message: 'Example warning',
+                severity: 1,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        await expect(validate(undefined, 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled, jsonFormat, undefined, true))
+            .rejects
+            .toThrow();
+
+        expect(mockExit)
+            .toHaveBeenCalledWith(1);
+    });
+
+    it('exits with error when spectral no errors, but json schema is invalid', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/bad-schema/bad-json-schema.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        await expect(validate(undefined, 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled, jsonFormat))
+            .rejects
+            .toThrow();
+
+        expect(mockExit)
+            .toHaveBeenCalledWith(1);
+    });
+});

--- a/cli/src/commands/validate/validate.spec.ts
+++ b/cli/src/commands/validate/validate.spec.ts
@@ -220,7 +220,7 @@ describe('validate', () => {
             .mockImplementation((code) => {
                 console.log(code);
                 if (code != 0) {
-                    throw new Error();
+                    throw new Error("Expected successful code 0");
                 }
                 return undefined as never;
             });

--- a/cli/src/commands/validate/validate.spec.ts
+++ b/cli/src/commands/validate/validate.spec.ts
@@ -220,7 +220,7 @@ describe('validate', () => {
             .mockImplementation((code) => {
                 console.log(code);
                 if (code != 0) {
-                    throw new Error("Expected successful code 0");
+                    throw new Error('Expected successful code 0');
                 }
                 return undefined as never;
             });

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -42,7 +42,7 @@ export default async function validate(
         const spectralResultForPattern: SpectralResult = await runSpectralValidations(stripRefs(jsonSchema), spectralRulesetForPattern);
         
         if (jsonSchemaInstantiationLocation === undefined) {
-            validatePatternOnly(spectralResultForPattern, jsonSchema, ajv, failOnWarnings);
+            return validatePatternOnly(spectralResultForPattern, jsonSchema, ajv, failOnWarnings);
         }
 
         // compile the schema, producing a function that will then validate instances
@@ -90,17 +90,17 @@ export default async function validate(
  * @param ajv The AJV instance to compile with.
  * @param failOnWarnings Whether or not to treat a warning as a failure in the validation process.
  */
-function validatePatternOnly(spectralValidationResults: SpectralResult, patternSchema: any, ajv: Ajv2020, failOnWarnings: boolean) {
+function validatePatternOnly(spectralValidationResults: SpectralResult, patternSchema: object, ajv: Ajv2020, failOnWarnings: boolean) {
     logger.debug('Pattern Instantiation was not provided, only the JSON Schema will be validated');
     let errors = spectralValidationResults.errors;
-    let warnings = spectralValidationResults.warnings;
+    const warnings = spectralValidationResults.warnings;
     const jsonSchemaErrors = [];
 
     try{
         ajv.compile(patternSchema);
     } catch (error){
         errors = true;
-        jsonSchemaErrors.push(new ValidationOutput("json-schema", "error", error.message, "/"));
+        jsonSchemaErrors.push(new ValidationOutput('json-schema', 'error', error.message, '/'));
     }
 
     handleSpectralLogs(errors, warnings, failOnWarnings, prettifyJson(jsonSchemaErrors.concat(spectralValidationResults.spectralIssues)), 'JSON Schema');

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -37,19 +37,29 @@ export default async function validate(
         logger.info(`Loading pattern from : ${jsonSchemaLocation}`);
         const jsonSchema = await getFileFromUrlOrPath(jsonSchemaLocation);
 
+        const spectralRulesetForPattern = CALM_SPECTRAL_RULES_DIRECTORY + '/pattern/validation-rules.yaml';
+
+        const spectralResultForPattern: SpectralResult = await runSpectralValidations(stripRefs(jsonSchema), spectralRulesetForPattern);
+        
+        if (jsonSchemaInstantiationLocation === undefined) {
+            validatePatternOnly(spectralResultForPattern, jsonSchema, ajv, failOnWarnings);
+        }
+
+        // compile the schema, producing a function that will then validate instances
+        const validateSchema = ajv.compile(jsonSchema);
+
         logger.info(`Loading pattern instantiation from : ${jsonSchemaInstantiationLocation}`);
         const jsonSchemaInstantiation = await getFileFromUrlOrPath(jsonSchemaInstantiationLocation);
 
-        const validateSchema = ajv.compile(jsonSchema);
-
         const spectralRulesetForInstantiation = CALM_SPECTRAL_RULES_DIRECTORY + '/instantiation/validation-rules.yaml';
-        const spectralRulesetForPattern = CALM_SPECTRAL_RULES_DIRECTORY + '/pattern/validation-rules.yaml';
-        const spectralResult: SpectralResult = await runSpectralValidations(jsonSchemaInstantiation, stripRefs(jsonSchema), spectralRulesetForInstantiation, spectralRulesetForPattern);
+        const spectralResultForInstantiation: SpectralResult = await runSpectralValidations(jsonSchemaInstantiation, spectralRulesetForInstantiation);
+
+        const spectralResult = mergeSpectralResults(spectralResultForPattern, spectralResultForInstantiation);
 
         errors = spectralResult.errors;
         warnings = spectralResult.warnings;
         validations = validations.concat(spectralResult.spectralIssues);
-
+        
         let jsonSchemaValidations = [];
         if (!validateSchema(jsonSchemaInstantiation)) {
             logger.debug(`JSON Schema validation raw output: ${prettifyJson(validateSchema.errors)}`);
@@ -62,27 +72,79 @@ export default async function validate(
 
         createOutputFile(output, validationsOutput);
 
-        if(errors){
-            logger.error(`The following issues have been found on the JSON Schema instantiation ${validationsOutput}`);
-            process.exit(1);
-        }
-
-        if (warnings && failOnWarnings) {
-            logger.error(`No errors were reported. However, there were warnings, and --strict was provided. The following warnings were encountered: ${validationsOutput}`);
-            process.exit(1);
-        }
-        
-        logger.info('The JSON Schema instantiation is valid');
-        if(validationsOutput != '[]'){
-            logger.info(validationsOutput);   
-        }
-
-        process.exit(0);
+        handleSpectralLogs(errors, warnings, failOnWarnings, validationsOutput, 'JSON Schema instantiation');
+        handleProcessExit(errors, warnings, failOnWarnings);
 
     } catch (error) {
         logger.error(`An error occured: ${error}`);
         process.exit(1);
     }
+}
+
+/**
+ * Run validations for the case where only the pattern is provided. 
+ * This essentially tries to compile the pattern, and returns the errors thrown if it fails.
+ * 
+ * @param spectralValidationResults The results from running Spectral on the pattern.
+ * @param patternSchema The pattern as a JS object, parsed from the file.
+ * @param ajv The AJV instance to compile with.
+ * @param failOnWarnings Whether or not to treat a warning as a failure in the validation process.
+ */
+function validatePatternOnly(spectralValidationResults: SpectralResult, patternSchema: any, ajv: Ajv2020, failOnWarnings: boolean) {
+    logger.debug('Pattern Instantiation was not provided, only the JSON Schema will be validated');
+    let errors = spectralValidationResults.errors;
+    let warnings = spectralValidationResults.warnings;
+    const jsonSchemaErrors = [];
+
+    try{
+        ajv.compile(patternSchema);
+    } catch (error){
+        errors = true;
+        jsonSchemaErrors.push(new ValidationOutput("json-schema", "error", error.message, "/"));
+    }
+
+    handleSpectralLogs(errors, warnings, failOnWarnings, prettifyJson(jsonSchemaErrors.concat(spectralValidationResults.spectralIssues)), 'JSON Schema');
+    handleProcessExit(errors, warnings, failOnWarnings);
+}
+
+/**
+ * Merge the results from two Spectral validations together, combining any errors/warnings.
+ * @param spectralResultPattern Spectral results from the pattern validation
+ * @param spectralResultInstantiation Spectral results from the instantiation validation
+ * @returns A new SpectralResult with the error/warning status propagated and the results concatenated.
+ */
+function mergeSpectralResults(spectralResultPattern: SpectralResult, spectralResultInstantiation: SpectralResult): SpectralResult{
+    const errors: boolean = spectralResultPattern.errors || spectralResultInstantiation.errors;
+    const warnings: boolean = spectralResultPattern.warnings || spectralResultInstantiation.warnings;
+    const spectralValidations = spectralResultPattern.spectralIssues.concat(spectralResultInstantiation.spectralIssues);
+    return new SpectralResult(warnings, errors, spectralValidations);
+}
+
+function handleSpectralLogs(errors: boolean, warnings: boolean, failOnWarnings: boolean, validationsOutput: string, schemaType: string){
+    if(errors) {
+        logger.error(`The following issues have been found on the ${schemaType} ${validationsOutput}`);
+        return;
+    }
+
+    if (warnings && failOnWarnings) {
+        logger.error(`No errors were reported. However, there were warnings, and --strict was provided. The following warnings were encountered: ${validationsOutput}`);
+        return;
+    }
+    
+    logger.info(`The ${schemaType} is valid`);
+    if(validationsOutput != '[]'){
+        logger.info(validationsOutput);   
+    }
+}
+
+function handleProcessExit(errors: boolean, warnings: boolean, failOnWarnings: boolean){
+    if(errors){
+        process.exit(1);
+    }
+    if(warnings && failOnWarnings) {
+        process.exit(1);
+    }
+    process.exit(0);
 }
 
 function getFormattedOutput(
@@ -140,10 +202,8 @@ function loadMetaSchemas(ajv: Ajv2020, metaSchemaLocation: string) {
 }
 
 async function runSpectralValidations(
-    jsonSchemaInstantiation: string,
-    jsonSchema: string, 
-    spectralRulesetForInstantiation: string, 
-    spectralRulesetForPattern: string
+    schema: string, 
+    spectralRulesetLocation: string
 ): Promise<SpectralResult> {
     
     let errors = false;
@@ -151,10 +211,8 @@ async function runSpectralValidations(
     let spectralIssues: ValidationOutput[] = [];
     const spectral = new Spectral();
 
-    spectral.setRuleset(await getRuleset(spectralRulesetForInstantiation));
-    let issues = await spectral.run(jsonSchemaInstantiation);
-    spectral.setRuleset(await getRuleset(spectralRulesetForPattern));
-    issues = issues.concat(await spectral.run(jsonSchema));
+    spectral.setRuleset(await getRuleset(spectralRulesetLocation));
+    const issues = await spectral.run(schema);
 
     if (issues && issues.length > 0) {
         logger.debug(`Spectral raw output: ${prettifyJson(issues)}`);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -44,7 +44,7 @@ program
     .command('validate')
     .description('Validate that an instantiation conforms to a given CALM pattern.')
     .requiredOption('-p, --pattern <pattern>', 'Path to the pattern file to use. May be a file path or a URL.')
-    .requiredOption('-i, --instantiation <instantiation>', 'Path to the pattern instantiation file to use. May be a file path or a URL.')
+    .option('-i, --instantiation <instantiation>', 'Path to the pattern instantiation file to use. May be a file path or a URL.')
     .option('-m, --metaSchemasLocation <metaSchemaLocation>', 'The location of the directory of the meta schemas to be loaded', CALM_META_SCHEMA_DIRECTORY)
     .option('--strict', 'When run in strict mode, the CLI will fail if any warnings are reported.', false)
     .addOption(

--- a/cli/test_fixtures/bad-schema/bad-json-schema.json
+++ b/cli/test_fixtures/bad-schema/bad-json-schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
+  "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/pattern/api-gateway",
+  "title": "API Gateway Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "INVALID VALUE HERE!",
+      "minItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/node",
+          "properties": {
+            "ingress-host": {
+              "type": "string"
+            },
+            "ingress-port": {
+              "type": "integer"
+            },
+            "well-known-endpoint": {
+              "type": "string"
+            },
+            "description": {
+              "const": "The API Gateway used to verify authorization and access to downstream system"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "API Gateway"
+            },
+            "unique-id": {
+              "const": "api-gateway"
+            }
+          },
+          "required": [
+            "ingress-host",
+            "ingress-port",
+            "well-known-endpoint"
+          ]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/node",
+          "properties": {
+            "description": {
+              "const": "The API Consumer making an authenticated and authorized request"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Python Based API Consumer"
+            },
+            "unique-id": {
+              "const": "api-consumer"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/node",
+          "properties": {
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "description": {
+              "const": "The API Producer serving content"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Java Based API Producer"
+            },
+            "unique-id": {
+              "const": "api-producer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/node",
+          "properties": {
+            "description": {
+              "const": "The Identity Provider used to verify the bearer token"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Identity Provider"
+            },
+            "unique-id": {
+              "const": "idp"
+            }
+          }
+        }
+      ]
+    },
+    "relationships": {
+      "type": "array",
+      "minItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/relationship",
+          "properties": {
+            "unique-id": {
+              "const": "api-consumer-api-gateway"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": "api-consumer",
+                  "destination": "api-gateway"
+                }
+              }
+            },
+            "parties": {
+            },
+            "protocol": {
+              "const": "HTTPS"
+            },
+            "authentication": {
+              "const": "OAuth2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/relationship",
+          "properties": {
+            "unique-id": {
+              "const": "api-gateway-idp"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": "api-gateway",
+                  "destination": "idp"
+                }
+              }
+            },
+            "protocol": {
+              "const": "HTTPS"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/relationship",
+          "properties": {
+            "unique-id": {
+              "const": "api-gateway-api-producer"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": "api-gateway",
+                  "destination": "api-producer"
+                }
+              }
+            },
+            "protocol": {
+              "const": "HTTPS"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ]
+}


### PR DESCRIPTION
This adds a simple validation mode that checks the provided pattern is valid JSON Schema; this isn't perfect but it gives us some guarantees.

Addresses issue #73 and #317 