### PR TITLE
#426 Adding a proposal json schema for documenting flows, requirements.

### DIFF
--- a/calm/draft/2024-10/meta/core.json
+++ b/calm/draft/2024-10/meta/core.json
@@ -20,6 +20,9 @@
     },
     "controls": {
       "$ref": "control.json#/defs/controls"
+    },
+    "flows": {
+      "$ref": "flow.json#/defs/flows"
     }
   },
   "defs": {

--- a/calm/draft/2024-10/meta/flow-requirement.json
+++ b/calm/draft/2024-10/meta/flow-requirement.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-09/meta/flow-requirement.json",
+  "title": "Generic Flow Specification",
+  "description": "Defines the requirements for a flow",
+  "type": "object",
+  "properties": {
+    "requirementId": {
+      "type": "string",
+      "description": "Unique identifier for the requirement"
+    },
+    "requirementDescription": {
+      "type": "string",
+      "description": "Detailed description of the requirements for the process"
+    },
+    "fields": {
+      "type": "array",
+      "description": "List of fields required for the process",
+      "items": {
+        "type": "object",
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "Name of the field"
+          },
+          "fieldType": {
+            "type": "string",
+            "enum": ["string", "integer", "boolean", "date"],
+            "description": "Data type of the field"
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Indicates if the field is required"
+          },
+          "validationRules": {
+            "type": "object",
+            "properties": {
+              "minLength": {
+                "type": "integer",
+                "description": "Minimum length for string fields"
+              },
+              "maxLength": {
+                "type": "integer",
+                "description": "Maximum length for string fields"
+              },
+              "pattern": {
+                "type": "string",
+                "description": "Regular expression pattern for field validation"
+              }
+            },
+            "required": [],
+            "additionalProperties": true
+          }
+        },
+        "required": ["fieldName", "fieldType", "isRequired"]
+      }
+    },
+    "successCriteria": {
+      "type": "string",
+      "description": "Criteria that determine the successful execution of the process"
+    },
+    "errorHandling": {
+      "type": "array",
+      "description": "List of error messages to handle failures in the process",
+      "items": {
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "Unique identifier for the error"
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Description of the error"
+          }
+        },
+        "required": ["errorCode", "errorMessage"]
+      }
+    }
+  },
+  "metadata": {
+    "type": "array",
+    "items": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "requirementId",
+    "requirementDescription",
+    "fields",
+    "successCriteria",
+    "errorHandling"
+  ]
+}

--- a/calm/draft/2024-10/meta/flow.json
+++ b/calm/draft/2024-10/meta/flow.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-09/meta/flow.json",
+  "title": "Business Flow Model",
+  "description": "Defines business flows that relate to technical architectures, allowing mapping of flows to technical components and attaching control requirements.",
+  "defs": {
+    "flow": {
+      "type": "object",
+      "properties": {
+        "flowUniqueId": {
+          "type": "string",
+          "description": "Unique identifier for the flow"
+        },
+        "name": {
+          "type": "string",
+          "description": "Descriptive name for the business flow"
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the flow's purpose"
+        },
+        "flow-requirement-url": {
+          "type": "string",
+          "description": "The requirement schema that specifies how this flow should be defined",
+        },
+        "flow-requirement-instance": {
+          "type": "string",
+          "description": "The URL of the specific requirement instance that implements the generic requirement. This should point to an instance specific to this flow."
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "relationshipUniqueId": {
+                "type": "string",
+                "description": "Unique identifier for the relationship in the architecture"
+              },
+              "sequenceNumber": {
+                "type": "integer",
+                "description": "Indicates the sequence of the relationship in the flow"
+              }
+            },
+            "required": [
+              "relationshipUniqueId",
+              "sequenceNumber"
+            ]
+          }
+        },
+        "controlRequirements": {
+          "type": "array",
+          "items": {
+            "$ref": "https://calm.finos.org/draft/2024-09/meta/control-requirement.json#"
+          }
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "flowUniqueId",
+        "name",
+        "description",
+        "transitions",
+        "flow-requirement-url"
+      ]
+    },
+    "flows": {
+      "type": "object",
+      "properties": {
+        "flows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/defs/flow"
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/calm/flow-example/account-creation/account-creation-control-001
+++ b/calm/flow-example/account-creation/account-creation-control-001
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-09/meta/control-requirement.json#account-creation-control-001",
+  "control-id": "account-creation-control-001",
+  "name": "Input Validation Control",
+  "description": "Ensure that all user inputs during the account creation process are validated against defined criteria, including format, length, and required fields, to prevent invalid data from being stored in the system."
+}

--- a/calm/flow-example/account-creation/account-creation-flow.json
+++ b/calm/flow-example/account-creation/account-creation-flow.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-09/meta/flow.json",
+  "flows": {
+    "flows": [
+      {
+        "flowUniqueId": "account-creation-flow-001",
+        "name": "Account Creation Flow",
+        "description": "This flow outlines the steps for a bank user to create a new bank account using the web client.",
+        "flow-requirement-url": "https://calm.finos.org/draft/2024-09/meta/flow-requirement.json",
+        "flow-requirement-instance": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow-example/account-creation/account-creation-requirement.json",
+        "transitions": [
+          {
+            "relationshipUniqueId": "bank-user-uses-web-client",
+            "sequenceNumber": 1
+          },
+          {
+            "relationshipUniqueId": "web-client-uses-account-service",
+            "sequenceNumber": 2
+          },
+          {
+            "relationshipUniqueId": "account-service-uses-database",
+            "sequenceNumber": 3
+          }
+        ],
+        "controlRequirements": [
+          {
+            "$ref": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow-example/account-creation/account-creation-control-001.json"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/calm/flow-example/account-creation/account-creation-requirement.json
+++ b/calm/flow-example/account-creation/account-creation-requirement.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-09/meta/account-specific-requirement.json",
+  "requirementId": "account-creation-001",
+  "requirementDescription": "Requirements for creating a standard checking account",
+  "fields": [
+    {
+      "fieldName": "accountHolderName",
+      "fieldType": "string",
+      "isRequired": true,
+      "validationRules": {
+        "minLength": 1,
+        "maxLength": 100
+      }
+    },
+    {
+      "fieldName": "accountType",
+      "fieldType": "string",
+      "isRequired": true,
+      "validationRules": {
+        "pattern": "^(checking|savings)$"
+      }
+    },
+    {
+      "fieldName": "initialDeposit",
+      "fieldType": "integer",
+      "isRequired": true,
+      "validationRules": {
+        "minLength": 0
+      }
+    },
+    {
+      "fieldName": "dateOfBirth",
+      "fieldType": "date",
+      "isRequired": true
+    }
+  ],
+  "successCriteria": "Account is successfully created when all required fields are validated and processed.",
+  "errorHandling": [
+    {
+      "errorCode": "ERR001",
+      "errorMessage": "Account holder name is required."
+    },
+    {
+      "errorCode": "ERR002",
+      "errorMessage": "Initial deposit must be a non-negative integer."
+    },
+    {
+      "errorCode": "ERR003",
+      "errorMessage": "Invalid account type specified."
+    }
+  ]
+}

--- a/calm/flow-example/account-system.json
+++ b/calm/flow-example/account-system.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
+  "nodes": [
+    {
+      "unique-id": "simple-banking-system",
+      "node-type": "system",
+      "name": "Simple Banking System",
+      "description": "A basic system for managing bank accounts"
+    },
+    {
+      "unique-id": "bank-user",
+      "node-type": "actor",
+      "name": "Bank User",
+      "description": "A customer who interacts with the banking system"
+    },
+    {
+      "unique-id": "bank-web-client",
+      "node-type": "webclient",
+      "name": "Bank Web Client",
+      "description": "Web interface for customers to manage their bank accounts",
+      "data-classification": "Confidential",
+      "run-as": "user"
+    },
+    {
+      "unique-id": "account-service",
+      "node-type": "service",
+      "name": "Account Service",
+      "description": "Service responsible for managing user accounts",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "bank-database",
+      "node-type": "database",
+      "name": "Bank Database",
+      "description": "Stores account details and transaction history",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "bank-user-uses-web-client",
+      "description": "Bank User accesses the banking system via the web client",
+      "relationship-type": {
+        "interacts": {
+          "actor": "bank-user",
+          "nodes": [
+            "bank-web-client"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "web-client-uses-account-service",
+      "description": "Web client interacts with the account service",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "bank-web-client"
+          },
+          "destination": {
+            "node": "account-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "account-service-uses-database",
+      "description": "Account service stores and retrieves data from the database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "account-service"
+          },
+          "destination": {
+            "node": "bank-database"
+          }
+        }
+      },
+      "protocol": "JDBC"
+    }
+  ],
+  "flows": [
+    "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow-example/account-creation/account-creation-flow.json"
+  ]
+}


### PR DESCRIPTION
This PR introduces a new schema for defining business flows and their requirements within the CALM framework. It includes the following key changes:

**Defined Flow Schema:** A new JSON schema (flow.json) has been created to represent business flows. This schema outlines the structure for capturing the unique identifiers, names, descriptions, transitions, and associated business flow and control requirements for various flows. This schema captures both generic flow requirement schema and instance-specific requirement schema, ensuring flexibility in how flows are documented.

**Defined Flow Requirement Schema:** A new JSON schema (flow-requirement.json) has been implemented to specify how flow requirements could be defined.  I'm not sure if CALM should be defining guidelines or this should be completely open and part of the example? 

**Updated Core Structure:** The core architecture has been updated to establish link to all associated flows. 

**Example Implementation:** An example has been provided using an account creation system. This example illustrates how the flow and flow requirement schemas can be utilized to define a specific business flow, including its transitions and control requirements.

**Benefits**
These changes are designed to enhance our understanding and management of business flows within the architecture, enabling clearer communication among developers and improving our ability to implement control requirements effectively.

**Next Steps**
I look forward to feedback on this initial version as we refine the approach and consider its implications for our architecture documentation and management practices. It’s possible I've conflated another concept that CALM needs in relation to data and data lineage requirements. I also have yet to work out if evidence is part of the model—I was trying to look at other examples.
