### PR TITLE
Adding units.json (#454)

### DIFF
--- a/calm/draft/2024-10/meta/units.json
+++ b/calm/draft/2024-10/meta/units.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/draft/2024-10/meta/units.json",
+  "title": "Common Architecture Language Model Units",
+  "defs": {
+    "time-unit": {
+      "type": "object",
+      "description": "A unit of time with a value and a unit type.",
+      "properties": {
+        "unit": {
+          "enum": [
+            "nanoseconds",
+            "milliseconds",
+            "seconds",
+            "minutes",
+            "hours",
+            "days",
+            "weeks",
+            "months",
+            "years"
+          ],
+          "description": "The unit of time (e.g., seconds, minutes, hours)."
+        },
+        "value": {
+          "type": "number",
+          "minimum": 0,
+          "description": "The numeric value representing the amount of time."
+        }
+      },
+      "required": ["unit", "value"],
+      "additionalProperties": false,
+      "examples": [
+        {
+          "unit": "seconds",
+          "value": 30
+        },
+        {
+          "unit": "minutes",
+          "value": 15
+        },
+        {
+          "unit": "hours",
+          "value": 1
+        },
+        {
+          "unit": "days",
+          "value": 7
+        }
+      ]
+    },
+    "cron-expression": {
+      "type": "string",
+      "title": "Cron Expression",
+      "description": "A valid Unix-style cron expression.",
+      "pattern": "^([0-5]?\\d)\\s([01]?\\d|2[0-3])\\s(3[01]|[12]\\d|0?[1-9])\\s(1[0-2]|0?[1-9])\\s([0-6])$",
+      "examples": [
+        "0 0 * * 0",
+        "30 14 1 * 5",
+        "15 10 * * *"
+      ]
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Added units.json which will define time unit and cron expression schema to be commonly used in `controls` 

**DISCLAIMER**
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.