### PR TITLE
#353 correctly instantiate boolean properties and improve spectral rules

### DIFF
--- a/cli/src/commands/generate/components/metadata.spec.ts
+++ b/cli/src/commands/generate/components/metadata.spec.ts
@@ -32,6 +32,9 @@ describe('instantiateMetadataObject', () => {
                 'integer-prop': {
                     'type': 'integer'
                 },
+                'boolean-prop': {
+                    'type': 'boolean'
+                },
                 'const-prop': {
                     'const': 'constant'
                 }
@@ -42,6 +45,7 @@ describe('instantiateMetadataObject', () => {
                 {
                     'string-prop': '{{ STRING_PROP }}',
                     'integer-prop': -1,
+                    'boolean-prop': '{{ BOOLEAN_BOOLEAN_PROP }}',
                     'const-prop': 'constant'
                 },
             );

--- a/cli/src/commands/generate/components/node.spec.ts
+++ b/cli/src/commands/generate/components/node.spec.ts
@@ -86,6 +86,21 @@ describe('instantiateNodes', () => {
             ]);
     });
     
+    it('return instantiated node with boolean property', () => {
+        const pattern = getSamplePatternNode({
+            'property-name': {
+                'type': 'boolean'
+            }
+        });
+
+        expect(instantiateNodes(pattern, mockSchemaDir, false, true))
+            .toEqual([
+                {
+                    'property-name': '{{ BOOLEAN_PROPERTY_NAME }}'
+                }
+            ]);
+    });
+    
     it('only instantiate required properties when instantiateAll set to false', () => {
         const pattern = getSamplePatternNode({
             'property-name': {

--- a/cli/src/commands/generate/components/property.spec.ts
+++ b/cli/src/commands/generate/components/property.spec.ts
@@ -67,4 +67,11 @@ describe('getPropertyValue', () => {
         }))
             .toBe('{{ REF_KEY_NAME }}');
     });
+    
+    it('generates boolean placeholder from variable', () => {
+        expect(getPropertyValue('key-name', {
+            'type': 'boolean'
+        }))
+            .toBe('{{ BOOLEAN_KEY_NAME }}');
+    });
 });

--- a/cli/src/commands/generate/components/property.ts
+++ b/cli/src/commands/generate/components/property.ts
@@ -6,9 +6,13 @@ export function getRefPlaceholder(name: string): string {
     return '{{ REF_' + name.toUpperCase().replaceAll('-', '_') + ' }}';
 }
 
+export function getBooleanPlaceholder(name: string): string {
+    return '{{ BOOLEAN_' + name.toUpperCase().replaceAll('-', '_') + ' }}';
+}
+
 interface Detail {
     const?: string | object,
-    type?: 'string' | 'integer' | 'number' | 'array',
+    type?: 'string' | 'integer' | 'number' | 'array' | 'boolean',
     $ref?: string
 }
 
@@ -25,6 +29,9 @@ export function getPropertyValue(keyName: string, detail: Detail): string | stri
 
         if (propertyType === 'string') {
             return getStringPlaceholder(keyName);
+        }
+        if (propertyType === 'boolean') {
+            return getBooleanPlaceholder(keyName);
         }
         if (propertyType === 'integer' || propertyType === 'number') {
             return -1;

--- a/cli/src/commands/generate/components/relationship.spec.ts
+++ b/cli/src/commands/generate/components/relationship.spec.ts
@@ -71,6 +71,21 @@ describe('instantiateRelationships', () => {
                 }
             ]);
     });
+    
+    it('return instantiated relationship with boolean property', () => {
+        const pattern = getSamplePatternRelationship({
+            'property-name': {
+                type: 'boolean'
+            }
+        });
+
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, true))
+            .toEqual([
+                {
+                    'property-name': '{{ BOOLEAN_PROPERTY_NAME }}'
+                }
+            ]);
+    });
 
     it('return instantiated relationship with const property', () => {
         const pattern = getSamplePatternRelationship({

--- a/spectral/instantiation/validation-rules.yaml
+++ b/spectral/instantiation/validation-rules.yaml
@@ -44,6 +44,16 @@ rules:
       function: pattern
       functionOptions:
         notMatch: "^{{\\s*[A-Z_]+\\s*}}$"
+  
+  instantiation-has-no-placeholder-properties-boolean:
+    description: Should not contain placeholder values with pattern {{ BOOLEAN_[property name] }}
+    message: Boolean placeholder detected in instantiated pattern.
+    severity: warn
+    given: "$..*"
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: "^{{\\s*BOOLEAN_[A-Z_]+\\s*}}$"
 
   relationship-references-existing-nodes-in-instantiation:
     description: Relationships must reference existing nodes

--- a/spectral/pattern/validation-rules.yaml
+++ b/spectral/pattern/validation-rules.yaml
@@ -64,6 +64,16 @@ rules:
       # only container and actor are in scope, since source/destination use interfaces now
       function: node-id-exists
 
+  avoid-boolean-properties:
+    description: Boolean property detected. Booleans should ideally be avoided as they are closed for extension; have you considered using an enum instead?
+    severity: warn 
+    message: Boolean property detected. Booleans should ideally be avoided as they are closed for extension; have you considered using an enum instead?
+    given: "$..type"
+    then: 
+      function: pattern 
+      functionOptions:
+        notMatch: /boolean/
+
   relationship-references-existing-nodes-in-pattern:
     description: Relationships with const properties must reference existing nodes
     severity: error 


### PR DESCRIPTION
Fixes #353. Boolean properties will be output as strings with the value `{{ BOOLEAN_[property name] }}`
We can't output `false` by default because this is a valid option and thus we can't detect it.
I wanted to keep the output valid JSON, so decided to spit out a string.

Also adds
- spectral rule to report boolean placeholders
- spectral rule to warn users that booleans are not recommended if detected in a pattern