### PR TITLE
Make CLI errors consistent

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [

--- a/cli/src/commands/generate/generate.ts
+++ b/cli/src/commands/generate/generate.ts
@@ -1,27 +1,36 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { mkdirp } from 'mkdirp';
+import {mkdirp} from 'mkdirp';
 
 import * as winston from 'winston';
-import { initLogger } from '../helper.js';
-import { CALMInstantiation } from '../../types.js';
-import { SchemaDirectory } from './schema-directory.js';
-import { instantiateNodes } from './components/node.js';
-import { instantiateRelationships } from './components/relationship.js';
-import { CALM_META_SCHEMA_DIRECTORY } from '../../consts.js';
-import { instantiateAllMetadata } from './components/metadata.js';
+import {initLogger} from '../helper.js';
+import {CALMInstantiation} from '../../types.js';
+import {SchemaDirectory} from './schema-directory.js';
+import {instantiateNodes} from './components/node.js';
+import {instantiateRelationships} from './components/relationship.js';
+import {CALM_META_SCHEMA_DIRECTORY} from '../../consts.js';
+import {instantiateAllMetadata} from './components/metadata.js';
 
 let logger: winston.Logger; // defined later at startup
 
 function loadFile(path: string): object {
-    logger.info('Loading pattern from file: ' + path);
-    const raw = fs.readFileSync(path, 'utf-8');
+    try {
+        logger.info('Loading pattern from file: ' + path);
+        const raw = fs.readFileSync(path, 'utf-8');
 
-    logger.debug('Attempting to load pattern file: ' + raw);
-    const pattern = JSON.parse(raw);
+        logger.debug('Attempting to load pattern file: ' + raw);
+        const pattern = JSON.parse(raw);
 
-    logger.debug('Loaded pattern file.');
-    return pattern;
+        logger.debug('Loaded pattern file.');
+        return pattern;
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            logger.error('Pattern not found!');
+        } else {
+            logger.error(err);
+        }
+        process.exit(1);
+    }
 }
 
 

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -76,7 +76,7 @@ export default async function validate(
         handleProcessExit(errors, warnings, failOnWarnings);
 
     } catch (error) {
-        logger.error(`An error occured: ${error}`);
+        logger.error(error);
         process.exit(1);
     }
 }

--- a/cli/src/commands/visualize/visualize.ts
+++ b/cli/src/commands/visualize/visualize.ts
@@ -10,12 +10,11 @@ let logger: winston.Logger;
 export async function visualizeInstantiation(instantiationPath: string, output: string, debug: boolean) {
     logger = initLogger(debug);
 
-    logger.info(`Reading CALM file from [${instantiationPath}]`);
-    const calm = fs.readFileSync(instantiationPath, 'utf-8');
-
-    logger.info('Generating an SVG from input');
-
     try {
+        logger.info(`Reading CALM file from [${instantiationPath}]`);
+        const calm = fs.readFileSync(instantiationPath, 'utf-8');
+        logger.info('Generating an SVG from input');
+
         const dot = calmToDot(JSON.parse(calm), debug);
         logger.debug(`Generated the following dot: 
             ${dot}
@@ -26,7 +25,11 @@ export async function visualizeInstantiation(instantiationPath: string, output: 
         logger.info(`Outputting file at [${output}]`);
         fs.writeFileSync(output, svg);
     } catch (err) {
-        logger.error(err);
+        if (err.code === 'ENOENT') {
+            logger.error('File not found!');
+        } else {
+            logger.error(err);
+        }
         process.exit(1);
     }
 }
@@ -34,12 +37,12 @@ export async function visualizeInstantiation(instantiationPath: string, output: 
 export async function visualizePattern(patternPath: string, output: string, debug: boolean) {
     logger = initLogger(debug);
 
-    // TODO add a path to load schemas and generate intelligently
-    const instantiation = await generate(patternPath, debug, true);
-
-    logger.info('Generating an SVG from input');
-
     try {
+        // TODO add a path to load schemas and generate intelligently
+        const instantiation = await generate(patternPath, debug, true);
+
+        logger.info('Generating an SVG from input');
+
         const dot = calmToDot(instantiation, debug);
         logger.debug(`Generated the following dot: 
             ${dot}
@@ -50,7 +53,11 @@ export async function visualizePattern(patternPath: string, output: string, debu
         logger.info(`Outputting file at [${output}]`);
         fs.writeFileSync(output, svg);
     } catch (err) {
-        logger.error(err);
+        if (err.code === 'ENOENT') {
+            logger.error('File not found!');
+        } else {
+            logger.error(err);
+        }
         process.exit(1);
     }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,7 +17,7 @@ const STRICT_OPTION = '-s, --strict';
 const VERBOSE_OPTION = '-v, --verbose';
 
 program
-    .version('0.2.4')
+    .version('0.2.5')
     .description('A set of tools for interacting with the Common Architecture Language Model (CALM)');
 
 program

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,16 @@ import { runGenerate } from './commands/generate/generate.js';
 import validate  from './commands/validate/validate.js';
 import { CALM_META_SCHEMA_DIRECTORY } from './consts.js';
 
+const FORMAT_OPTION = '-f, --format <format>';
+const INSTANTIATION_OPTION = '-i, --instantiation <file>';
+const INSTANTIATE_ALL_OPTION = '-a, --instantiateAll';
+const META_SCHEMA_OPTION = '-m, --metaSchemasLocation <metaSchemaLocation>';
+const OUTPUT_OPTION = '-o, --output <file>';
+const PATTERN_OPTION = '-p, --pattern <file>';
+const SCHEMAS_OPTION = '-s, --schemaDirectory <path>';
+const STRICT_OPTION = '-s, --strict';
+const VERBOSE_OPTION = '-v, --verbose';
+
 program
     .version('0.2.4')
     .description('A set of tools for interacting with the Common Architecture Language Model (CALM)');
@@ -13,28 +23,28 @@ program
 program
     .command('visualize')
     .description('Produces an SVG file representing a visualization of the CALM Specification.')
-    .addOption(new Option('-i, --instantiation <file>', 'Path to an instantiation of a CALM pattern.').conflicts('pattern'))
-    .addOption(new Option('-p, --pattern <file>', 'Path to a CALM pattern.').conflicts('instantiation'))
-    .requiredOption('-o, --output <file>', 'Path location at which to output the SVG.', 'calm-visualization.svg')
-    .option('-v, --verbose', 'Enable verbose logging.', false)
+    .addOption(new Option(INSTANTIATION_OPTION, 'Path to an instantiation of a CALM pattern.').conflicts('pattern'))
+    .addOption(new Option(PATTERN_OPTION, 'Path to a CALM pattern.').conflicts('instantiation'))
+    .requiredOption(OUTPUT_OPTION, 'Path location at which to output the SVG.', 'calm-visualization.svg')
+    .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
     .action(async (options) => {
-        if (!options.instantiation && ! options.pattern) {
-            throw new Error('You must provide either a pattern or an instantiation');
-        } else if (options.instantiation) {
+        if (options.instantiation) {
             await visualizeInstantiation(options.instantiation, options.output, !!options.verbose);
         } else if (options.pattern) {
             await visualizePattern(options.pattern, options.output, !!options.verbose);
+        } else {
+            program.error(`error: one of required options '${INSTANTIATION_OPTION}' or '${PATTERN_OPTION}' not specified`);
         }
     });
 
 program
     .command('generate')
     .description('Generate an instantiation from a CALM pattern file.')
-    .requiredOption('-p, --pattern <source>', 'Path to the pattern file to use. May be a file path or a URL.')
-    .requiredOption('-o, --output <output>', 'Path location at which to output the generated file.', 'instantiation.json')
-    .option('-s, --schemaDirectory <path>', 'Path to directory containing schemas to use in instantiation')
-    .option('-v, --verbose', 'Enable verbose logging.', false)
-    .option('-a, --instantiateAll', 'Instantiate all properties, ignoring the "required" field.', false)
+    .requiredOption(PATTERN_OPTION, 'Path to the pattern file to use. May be a file path or a URL.')
+    .requiredOption(OUTPUT_OPTION, 'Path location at which to output the generated file.', 'instantiation.json')
+    .option(SCHEMAS_OPTION, 'Path to directory containing schemas to use in instantiation')
+    .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
+    .option(INSTANTIATE_ALL_OPTION, 'Instantiate all properties, ignoring the "required" field.', false)
     .action(async (options) => {
         await runGenerate(options.pattern, options.output, !!options.verbose, options.instantiateAll, options.schemaDirectory
         );
@@ -43,17 +53,17 @@ program
 program
     .command('validate')
     .description('Validate that an instantiation conforms to a given CALM pattern.')
-    .requiredOption('-p, --pattern <pattern>', 'Path to the pattern file to use. May be a file path or a URL.')
-    .option('-i, --instantiation <instantiation>', 'Path to the pattern instantiation file to use. May be a file path or a URL.')
-    .option('-m, --metaSchemasLocation <metaSchemaLocation>', 'The location of the directory of the meta schemas to be loaded', CALM_META_SCHEMA_DIRECTORY)
-    .option('--strict', 'When run in strict mode, the CLI will fail if any warnings are reported.', false)
+    .requiredOption(PATTERN_OPTION, 'Path to the pattern file to use. May be a file path or a URL.')
+    .option(INSTANTIATION_OPTION, 'Path to the pattern instantiation file to use. May be a file path or a URL.')
+    .option(META_SCHEMA_OPTION, 'The location of the directory of the meta schemas to be loaded', CALM_META_SCHEMA_DIRECTORY)
+    .option(STRICT_OPTION, 'When run in strict mode, the CLI will fail if any warnings are reported.', false)
     .addOption(
-        new Option('-f, --format <format>', 'The format of the output')
+        new Option(FORMAT_OPTION, 'The format of the output')
             .choices(['json', 'junit'])
             .default('json')
     )
-    .option('-o, --output <output>', 'Path location at which to output the generated file.')
-    .option('-v, --verbose', 'Enable verbose logging.', false)
+    .option(OUTPUT_OPTION, 'Path location at which to output the generated file.')
+    .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
     .action(async (options) =>
         await validate(options.instantiation, options.pattern, options.metaSchemasLocation, options.verbose, options.format, options.output, options.strict)
     );


### PR DESCRIPTION
Resolves #312 

```shell
% npx calm validate                                       
error: required option '-p, --pattern <file>' not specified

% npx calm generate 
error: required option '-p, --pattern <file>' not specified

% npx calm visualize
error: one of required options '-i, --instantiation <file>' or '-p, --pattern <file>' not specified
```