### PR TITLE
Added group and nested group functionality

### DIFF
--- a/calm-visualizer/src/components/graph/Graph.css
+++ b/calm-visualizer/src/components/graph/Graph.css
@@ -37,3 +37,6 @@
 .node-description {
     font-size: 0.9rem;
 }
+.jtk-group-expanded{
+    border: 2px gray dashed;
+}

--- a/calm-visualizer/src/components/graph/Graph.css
+++ b/calm-visualizer/src/components/graph/Graph.css
@@ -9,10 +9,6 @@
     z-index: 3;
     background-color: white;
     border: 2px black solid;
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
     text-align: center;
     max-width: 15rem;
 }
@@ -24,11 +20,6 @@
     max-width: 250px;
 }
 
-.group-node {
-    width: fit-content;
-    height: fit-content;
-}
-
 .node-type {
     color: gray;
     font-size: 0.9rem;
@@ -37,6 +28,15 @@
 .node-description {
     font-size: 0.9rem;
 }
-.jtk-group-expanded{
-    border: 2px gray dashed;
+
+.group-container{
+    border: 2px gray dashed !important;
+    background-color: aliceblue;
+    max-width: max-content;
+    padding: 5rem;
+}
+
+.group-node {
+    border: 2px rgb(180, 178, 178) solid;
+    position: relative;
 }

--- a/calm-visualizer/src/components/graph/Graph.tsx
+++ b/calm-visualizer/src/components/graph/Graph.tsx
@@ -75,15 +75,16 @@ function getUniqueCALMContainers(relationships: CALMRelationship[]) {
 
 function createGroups(instance: BrowserJsPlumbInstance, containers: string[]) {
     containers.forEach(container => {
+        const element = document.getElementById(container)!;
+        element.classList.add('group-container')
         instance.addGroup({
-            el: document.getElementById(container)!,
+            el: element,
             id: container,
             anchor: "Continuous",
             endpoint: { type: "Dot", options: { radius: 3 } },
             dropOverride: true
         })
     })
-
 }
 
 function createDeployedInRelationship(instance: BrowserJsPlumbInstance, relationship: CALMDeployedInRelationship) {
@@ -91,7 +92,9 @@ function createDeployedInRelationship(instance: BrowserJsPlumbInstance, relation
     const nodes = relationship["relationship-type"]["deployed-in"].nodes
     if (instance.getGroup(container).id === container) {
         nodes.forEach(node => {
-            instance.addToGroup(container, document.getElementById(node)!)
+            const element = document.getElementById(node)!
+            element.classList.add("group-node");
+            instance.addToGroup(container, element)
         })
     }
 }
@@ -101,7 +104,9 @@ function createComposedOfRelationship(instance: BrowserJsPlumbInstance, relation
     const nodes = relationship["relationship-type"]["composed-of"].nodes
     if (instance.getGroup(container).id === container) {
         nodes.forEach(node => {
-            instance.addToGroup(container, document.getElementById(node)!)
+            const element = document.getElementById(node)!
+            element.classList.add("group-node");
+            instance.addToGroup(container, element)
         })
     }
 }

--- a/calm-visualizer/src/components/graph/Graph.tsx
+++ b/calm-visualizer/src/components/graph/Graph.tsx
@@ -10,15 +10,11 @@ interface Props {
     relationships: RelationshipLayout[]
 }
 
-// const groups: string[] = [];
-
-function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationships: CALMConnectsRelationship[]) {
-    relationships.map(
-            relationship =>{
-                const connects  = relationship["relationship-type"]["connects"];
+function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMConnectsRelationship) {
+                const r  = relationship["relationship-type"]["connects"];
                 instance.connect({
-                    source: document.getElementById(connects.source.node)!,
-                    target: document.getElementById(connects.destination.node)!,
+                    source: document.getElementById(r.source.node)!,
+                    target: document.getElementById(r.destination.node)!,
                     anchor: "Continuous",
                     connector: {
                         type:"Straight",
@@ -34,40 +30,38 @@ function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationsh
                         { type:"Arrow", options:{location:1}}
                     ]
                 });
-            }
-        );
-    }
+}
 
-    function createInteractsRelationship(instance: BrowserJsPlumbInstance, relationships: CALMInteractsRelationship[]) {
-        relationships.map(relationship => {
-            const interacts = relationship["relationship-type"]["interacts"];
-            interacts.nodes.forEach(node => {
-                instance.connect({
-                    source: document.getElementById(interacts.actor)!,
-                    target: document.getElementById(node)!,
-                    anchor: "Continuous",
-                    connector: {
-                        type:"Straight",
-                        options: {
-                            "stub": 25
-                        }
-                    },
-                    endpoint: {
-                        type: "Blank",
-                        options: {
-                        }
-                    },
-                    overlays:[ 
-                        { type:"Arrow", options:{location:1}}
-                    ]
-                });
-            })
+function createInteractsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMInteractsRelationship) {
+        const r = relationship["relationship-type"]["interacts"];
+        r.nodes.forEach(node => {
+            instance.connect({
+                source: document.getElementById(r.actor)!,
+                target: document.getElementById(node)!,
+                anchor: "Continuous",
+                connector: {
+                    type:"Straight",
+                    options: {
+                        "stub": 25
+                    }
+                },
+                endpoint: {
+                    type: "Blank",
+                    options: {
+                    }
+                },
+                overlays:[ 
+                    { type:"Arrow", options:{location:1}}
+                ]
+            });
         })
-    }
+}
 
-function getUniqueCALMDeployedInContainers(relationships : CALMDeployedInRelationship[]){
-    const deployedInContainers : string[] =  relationships.map(relationship=> relationship["relationship-type"]["deployed-in"].container);
-    return Array.from(new Set(deployedInContainers));
+function getUniqueCALMContainers(relationships : CALMRelationship[]){
+    const deployedInContainers : string[] =  relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"]).map(r=>r as CALMDeployedInRelationship).map(r=> r["relationship-type"]["deployed-in"].container);
+    const composedOfContainers : string[] =  relationships.filter(relationship => 'composed-of' in relationship["relationship-type"]).map(r=>r as CALMComposedOfRelationship).map(r=> r ["relationship-type"]["composed-of"].container);
+    const containers = [...deployedInContainers, ...composedOfContainers]
+    return Array.from(new Set(containers));
 }
 
 function createGroups({instance, containers}:{instance: BrowserJsPlumbInstance, containers: string[]}){
@@ -83,10 +77,7 @@ function createGroups({instance, containers}:{instance: BrowserJsPlumbInstance, 
 
 }
 
-function createDeployedInRelationship( instance: BrowserJsPlumbInstance , relationships: CALMDeployedInRelationship[] ) {
-    const containers = getUniqueCALMDeployedInContainers(relationships)
-    createGroups({instance, containers}); 
-    relationships.map(relationship => {
+function createDeployedInRelationship( instance: BrowserJsPlumbInstance , relationship: CALMDeployedInRelationship ) {
         const container = relationship["relationship-type"]["deployed-in"].container
         const nodes = relationship["relationship-type"]["deployed-in"].nodes
         if ( instance.getGroup(container).id === container){
@@ -94,18 +85,9 @@ function createDeployedInRelationship( instance: BrowserJsPlumbInstance , relati
                 instance.addToGroup(container, document.getElementById(node)!)
             })
         }
-    })
 }
 
-function getUniqueCALMComposedOfContainers(relationships : CALMComposedOfRelationship[]){
-    const composedOfContainers : string[] =  relationships.map(relationship=> relationship["relationship-type"]["composed-of"].container);
-    return Array.from(new Set(composedOfContainers));
-}
-
-function createComposedOfRelationship( instance: BrowserJsPlumbInstance , relationships: CALMComposedOfRelationship[] ) {
-    const containers =  getUniqueCALMComposedOfContainers(relationships)
-    createGroups({instance, containers}); 
-    relationships.map(relationship => {
+function createComposedOfRelationship( instance: BrowserJsPlumbInstance , relationship: CALMComposedOfRelationship ) {
         const container = relationship["relationship-type"]["composed-of"].container
         const nodes = relationship["relationship-type"]["composed-of"].nodes
         if ( instance.getGroup(container).id === container){
@@ -113,22 +95,25 @@ function createComposedOfRelationship( instance: BrowserJsPlumbInstance , relati
                 instance.addToGroup(container, document.getElementById(node)!)
             })
         }
-    })
+
 }
 
 function createGraphRelationship(instance: BrowserJsPlumbInstance, relationships: CALMRelationship[]) {
-    const filterDeployedIn : CALMDeployedInRelationship[] = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"]).map(relationship => relationship as CALMDeployedInRelationship);
-    const filterComposedOf = relationships.filter(relationship => 'composed-of' in relationship["relationship-type"]).map(relationship => relationship as CALMComposedOfRelationship);
-    const filterConnect = relationships.filter(relationship => 'connects' in relationship["relationship-type"]).map(relationship => relationship as CALMConnectsRelationship)
-    const filterInteracts = relationships.filter(relationship => 'interacts' in relationship["relationship-type"]).map(relationship => relationship as CALMInteractsRelationship)
-
-    createConnectsRelationship(instance, filterConnect);
-
-    createInteractsRelationship(instance, filterInteracts);
-
-    createDeployedInRelationship(instance, filterDeployedIn);
-
-    createComposedOfRelationship(instance, filterComposedOf); 
+    const deployedInandComposedOfRelationships  = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"] || 'composed-of' in relationship["relationship-type"]);
+    const containers = getUniqueCALMContainers(deployedInandComposedOfRelationships);
+    createGroups({instance, containers})
+    
+    relationships.forEach(relationship =>{
+        if ("connects" in relationship["relationship-type"]) {
+            createConnectsRelationship(instance, relationship as CALMConnectsRelationship);
+        } else if ("interacts" in relationship["relationship-type"]) {
+            createInteractsRelationship(instance, relationship as CALMInteractsRelationship);
+        } else if ("deployed-in" in relationship["relationship-type"]) {
+            createDeployedInRelationship(instance, relationship as CALMDeployedInRelationship)
+        }else{
+            createComposedOfRelationship(instance, relationship as CALMComposedOfRelationship)
+        }
+    })
 }
 
 function Graph({ instance, nodes, relationships }: Props) {

--- a/calm-visualizer/src/components/graph/Graph.tsx
+++ b/calm-visualizer/src/components/graph/Graph.tsx
@@ -11,106 +11,113 @@ interface Props {
 }
 
 function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMConnectsRelationship) {
-                const r  = relationship["relationship-type"]["connects"];
-                instance.connect({
-                    source: document.getElementById(r.source.node)!,
-                    target: document.getElementById(r.destination.node)!,
-                    anchor: "Continuous",
-                    connector: {
-                        type:"Straight",
-                        options: {
-                            "stub": 25
-                        }
-                    },
-                    endpoint: {
-                        type: "Blank",
-                        options: {}
-                    },
-                    overlays: [
-                        { type:"Arrow", options:{location:1}}
-                    ]
-                });
+    const r = relationship["relationship-type"]["connects"];
+    instance.connect({
+        source: document.getElementById(r.source.node)!,
+        target: document.getElementById(r.destination.node)!,
+        anchor: "Continuous",
+        connector: {
+            type: "Straight",
+            options: {
+                "stub": 25
+            }
+        },
+        endpoint: {
+            type: "Blank",
+            options: {}
+        },
+        overlays: [
+            { type: "Arrow", options: { location: 1 } }
+        ]
+    });
 }
 
 function createInteractsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMInteractsRelationship) {
-        const r = relationship["relationship-type"]["interacts"];
-        r.nodes.forEach(node => {
-            instance.connect({
-                source: document.getElementById(r.actor)!,
-                target: document.getElementById(node)!,
-                anchor: "Continuous",
-                connector: {
-                    type:"Straight",
-                    options: {
-                        "stub": 25
-                    }
-                },
-                endpoint: {
-                    type: "Blank",
-                    options: {
-                    }
-                },
-                overlays:[ 
-                    { type:"Arrow", options:{location:1}}
-                ]
-            });
-        })
+    const r = relationship["relationship-type"]["interacts"];
+    r.nodes.forEach(node => {
+        instance.connect({
+            source: document.getElementById(r.actor)!,
+            target: document.getElementById(node)!,
+            anchor: "Continuous",
+            connector: {
+                type: "Straight",
+                options: {
+                    "stub": 25
+                }
+            },
+            endpoint: {
+                type: "Blank",
+                options: {
+                }
+            },
+            overlays: [
+                { type: "Arrow", options: { location: 1 } }
+            ]
+        });
+    })
 }
 
-function getUniqueCALMContainers(relationships : CALMRelationship[]){
-    const deployedInContainers : string[] =  relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"]).map(r=>r as CALMDeployedInRelationship).map(r=> r["relationship-type"]["deployed-in"].container);
-    const composedOfContainers : string[] =  relationships.filter(relationship => 'composed-of' in relationship["relationship-type"]).map(r=>r as CALMComposedOfRelationship).map(r=> r ["relationship-type"]["composed-of"].container);
+function getUniqueCALMContainers(relationships: CALMRelationship[]) {
+    const deployedInContainers: string[] = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"])
+        .map(r => r as CALMDeployedInRelationship)
+        .map(r => r["relationship-type"]["deployed-in"].container);
+
+    const composedOfContainers: string[] = relationships.filter(relationship => 'composed-of' in relationship["relationship-type"])
+        .map(r => r as CALMComposedOfRelationship)
+        .map(r => r["relationship-type"]["composed-of"].container);
+
     const containers = [...deployedInContainers, ...composedOfContainers]
     return Array.from(new Set(containers));
 }
 
-function createGroups({instance, containers}:{instance: BrowserJsPlumbInstance, containers: string[]}){
-    containers.forEach(container =>{
+function createGroups(instance: BrowserJsPlumbInstance, containers: string[]) {
+    containers.forEach(container => {
         instance.addGroup({
             el: document.getElementById(container)!,
             id: container,
-            anchor:"Continuous",
-            endpoint:{ type:"Dot", options:{ radius:3 } },
-            dropOverride:true
-        })   
+            anchor: "Continuous",
+            endpoint: { type: "Dot", options: { radius: 3 } },
+            dropOverride: true
+        })
     })
 
 }
 
-function createDeployedInRelationship( instance: BrowserJsPlumbInstance , relationship: CALMDeployedInRelationship ) {
-        const container = relationship["relationship-type"]["deployed-in"].container
-        const nodes = relationship["relationship-type"]["deployed-in"].nodes
-        if ( instance.getGroup(container).id === container){
-            nodes.forEach(node => {
-                instance.addToGroup(container, document.getElementById(node)!)
-            })
-        }
+function createDeployedInRelationship(instance: BrowserJsPlumbInstance, relationship: CALMDeployedInRelationship) {
+    const container = relationship["relationship-type"]["deployed-in"].container
+    const nodes = relationship["relationship-type"]["deployed-in"].nodes
+    if (instance.getGroup(container).id === container) {
+        nodes.forEach(node => {
+            instance.addToGroup(container, document.getElementById(node)!)
+        })
+    }
 }
 
-function createComposedOfRelationship( instance: BrowserJsPlumbInstance , relationship: CALMComposedOfRelationship ) {
-        const container = relationship["relationship-type"]["composed-of"].container
-        const nodes = relationship["relationship-type"]["composed-of"].nodes
-        if ( instance.getGroup(container).id === container){
-            nodes.forEach(node => {
-                instance.addToGroup(container, document.getElementById(node)!)
-            })
-        }
-
+function createComposedOfRelationship(instance: BrowserJsPlumbInstance, relationship: CALMComposedOfRelationship) {
+    const container = relationship["relationship-type"]["composed-of"].container
+    const nodes = relationship["relationship-type"]["composed-of"].nodes
+    if (instance.getGroup(container).id === container) {
+        nodes.forEach(node => {
+            instance.addToGroup(container, document.getElementById(node)!)
+        })
+    }
 }
 
 function createGraphRelationship(instance: BrowserJsPlumbInstance, relationships: CALMRelationship[]) {
-    const deployedInandComposedOfRelationships  = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"] || 'composed-of' in relationship["relationship-type"]);
+    const deployedInandComposedOfRelationships = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"]
+        || 'composed-of' in relationship["relationship-type"]);
+
     const containers = getUniqueCALMContainers(deployedInandComposedOfRelationships);
-    createGroups({instance, containers})
-    
-    relationships.forEach(relationship =>{
+    createGroups(instance, containers)
+
+    relationships.forEach(relationship => {
         if ("connects" in relationship["relationship-type"]) {
             createConnectsRelationship(instance, relationship as CALMConnectsRelationship);
         } else if ("interacts" in relationship["relationship-type"]) {
             createInteractsRelationship(instance, relationship as CALMInteractsRelationship);
         } else if ("deployed-in" in relationship["relationship-type"]) {
             createDeployedInRelationship(instance, relationship as CALMDeployedInRelationship)
-        }else{
+        } else {
             createComposedOfRelationship(instance, relationship as CALMComposedOfRelationship)
         }
     })
@@ -118,7 +125,7 @@ function createGraphRelationship(instance: BrowserJsPlumbInstance, relationships
 
 function Graph({ instance, nodes, relationships }: Props) {
     useEffect(() => {
-            createGraphRelationship(instance, relationships);
+        createGraphRelationship(instance, relationships);
 
         nodes.forEach(node => {
             instance.manage(document.getElementById(node["unique-id"])!);
@@ -129,14 +136,14 @@ function Graph({ instance, nodes, relationships }: Props) {
         <>
             {
                 nodes.map(node => {
-                    return <div 
+                    return <div
                         key={node["unique-id"]}
                         id={node["unique-id"]}
                         className="node"
                         style={{
                             left: node.x,
                             top: node.y
-                        }} 
+                        }}
                     >
                         <div><b>{node.name}</b></div>
                         <div className="node-type">[{node["node-type"]}]</div>

--- a/calm-visualizer/src/components/graph/Graph.tsx
+++ b/calm-visualizer/src/components/graph/Graph.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import './Graph.css'
 import { BrowserJsPlumbInstance } from "@jsplumb/browser-ui"
 import { NodeLayout, RelationshipLayout } from "../../layout";
-import { CALMConnectsRelationship, CALMInteractsRelationship, CALMRelationship } from "../../types";
+import { CALMComposedOfRelationship, CALMConnectsRelationship, CALMDeployedInRelationship, CALMInteractsRelationship, CALMRelationship } from "../../types";
 
 interface Props {
     instance: BrowserJsPlumbInstance,
@@ -12,84 +12,128 @@ interface Props {
 
 // const groups: string[] = [];
 
-function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMConnectsRelationship) {
-    const r = relationship["relationship-type"]["connects"];
-    instance.connect({
-        source: document.getElementById(r.source.node)!,
-        target: document.getElementById(r.destination.node)!,
-        anchor: "Continuous",
-        connector: {
-            type:"Straight",
-            options: {
-                "stub": 25
+function createConnectsRelationship(instance: BrowserJsPlumbInstance, relationships: CALMConnectsRelationship[]) {
+    relationships.map(
+            relationship =>{
+                const connects  = relationship["relationship-type"]["connects"];
+                instance.connect({
+                    source: document.getElementById(connects.source.node)!,
+                    target: document.getElementById(connects.destination.node)!,
+                    anchor: "Continuous",
+                    connector: {
+                        type:"Straight",
+                        options: {
+                            "stub": 25
+                        }
+                    },
+                    endpoint: {
+                        type: "Blank",
+                        options: {}
+                    },
+                    overlays: [
+                        { type:"Arrow", options:{location:1}}
+                    ]
+                });
             }
-        },
-        endpoint: {
-            type: "Blank",
-            options: {}
-        },
-        overlays: [
-            { type:"Arrow", options:{location:1}}
-        ]
-    });
+        );
+    }
+
+    function createInteractsRelationship(instance: BrowserJsPlumbInstance, relationships: CALMInteractsRelationship[]) {
+        relationships.map(relationship => {
+            const interacts = relationship["relationship-type"]["interacts"];
+            interacts.nodes.forEach(node => {
+                instance.connect({
+                    source: document.getElementById(interacts.actor)!,
+                    target: document.getElementById(node)!,
+                    anchor: "Continuous",
+                    connector: {
+                        type:"Straight",
+                        options: {
+                            "stub": 25
+                        }
+                    },
+                    endpoint: {
+                        type: "Blank",
+                        options: {
+                        }
+                    },
+                    overlays:[ 
+                        { type:"Arrow", options:{location:1}}
+                    ]
+                });
+            })
+        })
+    }
+
+function getUniqueCALMDeployedInContainers(relationships : CALMDeployedInRelationship[]){
+    const deployedInContainers : string[] =  relationships.map(relationship=> relationship["relationship-type"]["deployed-in"].container);
+    return Array.from(new Set(deployedInContainers));
 }
 
-function createInteractsRelationship(instance: BrowserJsPlumbInstance, relationship: CALMInteractsRelationship) {
-    const r = relationship["relationship-type"]["interacts"];
-    r.nodes.forEach(node => {
-        instance.connect({
-            source: document.getElementById(r.actor)!,
-            target: document.getElementById(node)!,
-            anchor: "Continuous",
-            connector: {
-                type:"Straight",
-                options: {
-                    "stub": 25
-                }
-            },
-            endpoint: {
-                type: "Blank",
-                options: {
-                }
-            },
-            overlays: [
-                { type:"Arrow", options:{location:1}}
-            ]
-        });
+function createGroups({instance, containers}:{instance: BrowserJsPlumbInstance, containers: string[]}){
+    containers.forEach(container =>{
+        instance.addGroup({
+            el: document.getElementById(container)!,
+            id: container,
+            anchor:"Continuous",
+            endpoint:{ type:"Dot", options:{ radius:3 } },
+            dropOverride:true
+        })   
+    })
+
+}
+
+function createDeployedInRelationship( instance: BrowserJsPlumbInstance , relationships: CALMDeployedInRelationship[] ) {
+    const containers = getUniqueCALMDeployedInContainers(relationships)
+    createGroups({instance, containers}); 
+    relationships.map(relationship => {
+        const container = relationship["relationship-type"]["deployed-in"].container
+        const nodes = relationship["relationship-type"]["deployed-in"].nodes
+        if ( instance.getGroup(container).id === container){
+            nodes.forEach(node => {
+                instance.addToGroup(container, document.getElementById(node)!)
+            })
+        }
     })
 }
 
-// function createDeployedInRelationship(instance: BrowserJsPlumbInstance, relationship: CALMDeployedInRelationship) {
-//     const r = relationship["relationship-type"]["deployed-in"];
-//     if (!groups.find(group => group === r.container)) {
-//         groups.push(r.container);
-//         instance.addGroup({
-//             el: document.getElementById(r.container)!,
-//             id: r.container,
-//         });
-//     }
+function getUniqueCALMComposedOfContainers(relationships : CALMComposedOfRelationship[]){
+    const composedOfContainers : string[] =  relationships.map(relationship=> relationship["relationship-type"]["composed-of"].container);
+    return Array.from(new Set(composedOfContainers));
+}
 
-//     r.nodes.forEach(node => {
-//         instance.addToGroup(r.container, document.getElementById(node)!)
-//     });
-// }
+function createComposedOfRelationship( instance: BrowserJsPlumbInstance , relationships: CALMComposedOfRelationship[] ) {
+    const containers =  getUniqueCALMComposedOfContainers(relationships)
+    createGroups({instance, containers}); 
+    relationships.map(relationship => {
+        const container = relationship["relationship-type"]["composed-of"].container
+        const nodes = relationship["relationship-type"]["composed-of"].nodes
+        if ( instance.getGroup(container).id === container){
+            nodes.forEach(node => {
+                instance.addToGroup(container, document.getElementById(node)!)
+            })
+        }
+    })
+}
 
-function createGraphRelationship(instance: BrowserJsPlumbInstance, relationship: CALMRelationship) {
-    if ("connects" in relationship["relationship-type"]) {
-        createConnectsRelationship(instance, relationship as CALMConnectsRelationship);
-    } else if ("interacts" in relationship["relationship-type"]) {
-        createInteractsRelationship(instance, relationship as CALMInteractsRelationship);
-    } else if ("deployed-in" in relationship["relationship-type"]) {
-        // createDeployedInRelationship(instance, relationship as CALMDeployedInRelationship);
-        // TODO: Fix the "deployed-in" relationship and add "contains" relationship
-    }
+function createGraphRelationship(instance: BrowserJsPlumbInstance, relationships: CALMRelationship[]) {
+    const filterDeployedIn : CALMDeployedInRelationship[] = relationships.filter(relationship => 'deployed-in' in relationship["relationship-type"]).map(relationship => relationship as CALMDeployedInRelationship);
+    const filterComposedOf = relationships.filter(relationship => 'composed-of' in relationship["relationship-type"]).map(relationship => relationship as CALMComposedOfRelationship);
+    const filterConnect = relationships.filter(relationship => 'connects' in relationship["relationship-type"]).map(relationship => relationship as CALMConnectsRelationship)
+    const filterInteracts = relationships.filter(relationship => 'interacts' in relationship["relationship-type"]).map(relationship => relationship as CALMInteractsRelationship)
+
+    createConnectsRelationship(instance, filterConnect);
+
+    createInteractsRelationship(instance, filterInteracts);
+
+    createDeployedInRelationship(instance, filterDeployedIn);
+
+    createComposedOfRelationship(instance, filterComposedOf); 
 }
 
 function Graph({ instance, nodes, relationships }: Props) {
     useEffect(() => {
-        relationships.map(relationship => {
-            createGraphRelationship(instance, relationship);
-        });
+            createGraphRelationship(instance, relationships);
 
         nodes.forEach(node => {
             instance.manage(document.getElementById(node["unique-id"])!);


### PR DESCRIPTION
Implement functionality to create groups based on “deployed in” and “composed of” relationships.

**Note:** Additional logic is required to dynamically adjust the size of group containers to fit the nodes they encompass.


![image](https://github.com/user-attachments/assets/9a6e8c80-7d54-433f-afa9-f362e7a0742a)
