### PR TITLE
Only re-generate graph if uploaded CALM instance json file has changed (finos#561)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
         "clearOnRun": "none"
     },
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "editor.formatOnSave": true,
 }

--- a/calm-visualizer/src/components/fileuploader/FileUploader.tsx
+++ b/calm-visualizer/src/components/fileuploader/FileUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface Props {
     callback: (instanceFile: File, layoutFile?: File) => void
@@ -7,10 +7,16 @@ interface Props {
 function FileUploader({ callback }: Props) {
     const [instanceFile, setInstanceFile] = useState<File | null>(null);
     const [layoutFile, setLayoutFile] = useState<File | null>(null);
+    const [filesChanged, setFilesChanged] = useState(false);
+
+    useEffect(() => {
+      setFilesChanged(true);
+    }, [instanceFile, layoutFile]);
 
     const handleSubmit = () => {
-        if (instanceFile) {
+        if (instanceFile && filesChanged) {
             callback(instanceFile, layoutFile || undefined);
+            setFilesChanged(false); 
         }
     };
 
@@ -34,6 +40,7 @@ function FileUploader({ callback }: Props) {
       {instanceFile && (
         <button 
           onClick={handleSubmit}
+          disabled={!filesChanged}
           className="submit"
         >Upload a file</button>
       )}


### PR DESCRIPTION
Disable 'visualize' button when no file changes have been made, preventing graph being re-drawn. See screenshot below:
![Screenshot 2024-11-07 at 21 22 37](https://github.com/user-attachments/assets/e4dc309c-9ac8-4cbd-b3bd-42d4cf0ffaad)
