### PR TITLE
Fix strict option clash

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,7 +13,7 @@ const INSTANTIATE_ALL_OPTION = '-a, --instantiateAll';
 const OUTPUT_OPTION = '-o, --output <file>';
 const PATTERN_OPTION = '-p, --pattern <file>';
 const SCHEMAS_OPTION = '-s, --schemaDirectory <path>';
-const STRICT_OPTION = '-s, --strict';
+const STRICT_OPTION = '--strict';
 const VERBOSE_OPTION = '-v, --verbose';
 
 program


### PR DESCRIPTION
Fixes an issue that means the options for strict and schemadirectory clash on the validate command