### PR TITLE
Fix CLI

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,7 +64,7 @@ program
     .option(OUTPUT_OPTION, 'Path location at which to output the generated file.')
     .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
     .action(async (options) => {
-        const outcome = await validate(options.instantiation, options.pattern, options.metaSchemasLocation, options.verbose);
+        const outcome = await validate(options.instantiation, options.pattern, options.schemaDirectory, options.verbose);
         const content = getFormattedOutput(outcome, options.format, options.instantiation, options.pattern);
         writeOutputFile(options.output, content);
         exitBasedOffOfValidationOutcome(outcome, options.strict);

--- a/shared/package.json
+++ b/shared/package.json
@@ -15,8 +15,8 @@
         "test": "jest --verbose",
         "lint": "eslint src --config ./.eslintrc.json",
         "lint-fix": "eslint src -- --fix",
-        "copy-calm-schema": "copyfiles ../calm/draft/2024-04/meta/* dist/calm/",
-        "copy-spectral-rules": "copyfiles ../spectral/**/* dist/spectral/",
+        "copy-calm-schema": "copyfiles \"../calm/draft/2024-04/meta/*\" dist/calm/",
+        "copy-spectral-rules": "copyfiles \"../spectral/**/*\" dist/spectral/",
         "copy-calm-schema-old": "mkdir -p dist/calm && cp -r ../calm/draft/2024-04/meta dist/calm/",
         "dependency-check": "dependency-check --project 'calm-shared' --scan . --out ./dependency-check-report --format ALL --suppression ../.github/node-cve-ignore-list.xml"
     },

--- a/shared/src/commands/generate/schema-directory.ts
+++ b/shared/src/commands/generate/schema-directory.ts
@@ -50,7 +50,7 @@ export class SchemaDirectory {
             this.logger.info(`Loaded ${this.schemas.size} schemas.`);
         } catch (err) {
             if (err.code === 'ENOENT') {
-                this.logger.error('Schema Path not found!');
+                this.logger.error('Schema Path not found: ' + dir);
             } else {
                 this.logger.error(err);
             }

--- a/shared/src/commands/generate/schema-directory.ts
+++ b/shared/src/commands/generate/schema-directory.ts
@@ -50,7 +50,7 @@ export class SchemaDirectory {
             this.logger.info(`Loaded ${this.schemas.size} schemas.`);
         } catch (err) {
             if (err.code === 'ENOENT') {
-                this.logger.error('Schema Path not found: ' + dir);
+                this.logger.error('Schema Path not found: ', dir, ', error: ', err);
             } else {
                 this.logger.error(err);
             }

--- a/shared/src/commands/helper.ts
+++ b/shared/src/commands/helper.ts
@@ -7,6 +7,15 @@ export function initLogger(debug: boolean): winston.Logger {
             new winston.transports.Console()
         ],
         level: level,
-        format: winston.format.cli(),
+        format: winston.format.combine(
+            winston.format.cli(),
+            winston.format.errors({ stack: true }),
+            winston.format.printf(({ level, message, stack }) => {
+                if (stack) {
+                    return `${level}: ${message} - ${stack}`;
+                }
+                return `${level}: ${message}`;
+            }),
+        )
     });
 }

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -331,7 +331,7 @@ export async function validate(
 
         return new ValidationOutcome(jsonSchemaValidations, spectralResult.spectralIssues, errors, warnings);
     } catch (error) {
-        logger.error(`An error occured: ${error}`);
+        logger.error('An error occured:', error);
         process.exit(1);
     }
 }

--- a/shared/src/consts.ts
+++ b/shared/src/consts.ts
@@ -1,2 +1,2 @@
-export const CALM_META_SCHEMA_DIRECTORY = __dirname + '/calm/meta';
+export const CALM_META_SCHEMA_DIRECTORY = __dirname + '/calm/draft';
 export const CALM_SPECTRAL_RULES_DIRECTORY = __dirname + '/spectral';


### PR DESCRIPTION
Fixes a number of issues accidentally introduced as part of splitting up the project into modules.

- issue with path for loading meta schema
- copyfiles not copying spectral functions on unix
- schema directory name wrong
- error logging insufficient
- cli parse command using wrong name for schemaDirectory arg

This PR highlights that integration tests are urgently needed!

Outstanding issues this PR does not fix:
- build step does not seem to correctly chmod index.js
- github actions can't build the CLI with the new modules - we can't publish


Tests to check:
```
calm validate -p ../calm/pattern/api-gateway.json -i ../calm/samples/api-gateway-instantiation.json
calm generate -p ../calm/pattern/api-gateway.json -o test.json
```