### PR TITLE
Add ecosystem to node spec and tie flows into core.json

### DIFF
--- a/calm/draft/2024-12/meta/core.json
+++ b/calm/draft/2024-12/meta/core.json
@@ -20,6 +20,12 @@
     },
     "controls": {
       "$ref": "control.json#/defs/controls"
+    },
+    "flows": {
+      "type": "array",
+      "items": {
+        "$ref": "flow.json#/defs/flow"
+      }
     }
   },
   "defs": {
@@ -175,6 +181,7 @@
     "node-type-definition": {
       "enum": [
         "actor",
+        "ecosystem",
         "system",
         "service",
         "database",

--- a/calm/draft/2024-12/meta/flow.json
+++ b/calm/draft/2024-12/meta/flow.json
@@ -3,43 +3,6 @@
   "$id": "https://calm.finos.org/draft/2024-12/meta/flow.json",
   "title": "Business Flow Model",
   "description": "Defines business flows that relate to technical architectures, allowing mapping of flows to technical components and attaching control requirements.",
-  "type": "object",
-  "properties": {
-    "unique-id": {
-      "type": "string",
-      "description": "Unique identifier for the flow"
-    },
-    "name": {
-      "type": "string",
-      "description": "Descriptive name for the business flow"
-    },
-    "description": {
-      "type": "string",
-      "description": "Detailed description of the flow's purpose"
-    },
-    "requirement-url": {
-      "type": "string",
-      "description": "Link to a detailed requirement document"
-    },
-    "transitions": {
-      "type": "array",
-      "items": {
-        "$ref": "#/defs/transition"
-      }
-    },
-    "controls": {
-      "$ref": "https://calm.finos.org/draft/2024-12/meta/control.json#/defs/controls"
-    },
-    "metadata": {
-      "$ref": "#/defs/metadata"
-    }
-  },
-  "required": [
-    "unique-id",
-    "name",
-    "description",
-    "transitions"
-  ],
   "defs": {
     "transition": {
       "type": "object",
@@ -76,6 +39,45 @@
       "items": {
         "type": "object"
       }
+    },
+    "flow": {
+      "type": "object",
+      "properties": {
+        "unique-id": {
+          "type": "string",
+          "description": "Unique identifier for the flow"
+        },
+        "name": {
+          "type": "string",
+          "description": "Descriptive name for the business flow"
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the flow's purpose"
+        },
+        "requirement-url": {
+          "type": "string",
+          "description": "Link to a detailed requirement document"
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/defs/transition"
+          }
+        },
+        "controls": {
+          "$ref": "control.json#/defs/controls"
+        },
+        "metadata": {
+          "$ref": "#/defs/metadata"
+        }
+      },
+      "required": [
+        "unique-id",
+        "name",
+        "description",
+        "transitions"
+      ]
     }
   }
 }

--- a/calm/samples/2024-12/traderx/README.md
+++ b/calm/samples/2024-12/traderx/README.md
@@ -1,0 +1,7 @@
+### TraderX Example
+
+[TraderX](https://github.com/finos/traderX) is a Sample Trading Application, designed to be a distributed reference application in the financial services domain.
+
+This sample uses the [C4 model](https://github.com/finos/traderX/blob/main/docs/c4/c4-diagram.png) of the TraderX application and shows how to model it using CALM.
+
+You can see in thus sample how you can use the base CALM vocab is both JSON and YAML documents.

--- a/calm/samples/2024-12/traderx/controls/flow-sla-control-requirement.json
+++ b/calm/samples/2024-12/traderx/controls/flow-sla-control-requirement.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+  "title": "Flow SLA Control",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://calm.finos.org/draft/2024-12/meta/control-requirement.json"
+    }
+  ],
+  "properties": {
+    "control-id": {
+      "const": "flow-sla-001"
+    },
+    "name": {
+      "const": "Flow SLA Control"
+    },
+    "description": {
+      "const": "Ensure that each flow meets the defined Service Level Agreement (SLA)"
+    },
+    "latency": {
+      "type": "object",
+      "properties": {
+        "expected-latency": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "The expected latency for completion of flow"
+        },
+        "alert-threshold": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "If latency exceeds this threshold, an alert will be triggered."
+        }
+      },
+      "required": [
+        "expected-latency",
+        "alert-threshold"
+      ]
+    },
+    "throughput": {
+      "type": "object",
+      "properties": {
+        "expected-message-rate": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "Define the expected message rate that the flow should handle e.g. 1000 per second"
+        }
+      },
+      "required": [
+        "expected-message-rate"
+      ]
+    },
+    "availability": {
+      "type": "object",
+      "properties": {
+        "uptime-guarantee": {
+          "type": "number",
+          "description": "Percentage of availability required (e.g., 99.9%).",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "required": [
+        "uptime-guarantee"
+      ]
+    },
+    "data-integrity": {
+      "type": "object",
+      "properties": {
+        "message-reliability": {
+          "enum": [
+            "atLeastOnce",
+            "atMostOnce",
+            "exactlyOnce"
+          ],
+          "description": "Guarantee that messages are delivered in the correct order and without duplication."
+        },
+        "loss-tolerance": {
+          "type": "number",
+          "description": "Specify acceptable levels of message loss as a percentage (e.g., 0 to 100).",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "required": [
+        "message-reliability",
+        "loss-tolerance"
+      ]
+    },
+    "error-handling": {
+      "type": "object",
+      "properties": {
+        "retry-logic": {
+          "type": "object",
+          "properties": {
+            "max-retries": {
+              "type": "integer",
+              "description": "Specify the maximum number of retries in case of failures."
+            },
+            "retry-interval": {
+              "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+              "description": "Define the interval between retries."
+            }
+          },
+          "required": ["max-retries", "retry-interval"]
+        }
+      },
+      "required": [
+        "retry-logic"
+      ]
+    },
+    "monitoring": {
+      "type": "object",
+      "properties": {
+        "real-time-monitoring": {
+          "type": "string",
+          "description": "Define the monitoring systems for tracking performance against the SLA."
+        },
+        "consumer-reporting": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "Specify the reporting frequency for the consumer, e.g., daily, weekly, or monthly."
+        }
+      },
+      "required": [
+        "real-time-monitoring",
+        "consumer-reporting"
+      ]
+    },
+    "incident-response": {
+      "type": "object",
+      "properties": {
+        "incident-resolution-time": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "Define timeframes for responding to SLA-impacting issues."
+        },
+        "escalation-protocols": {
+          "type": "object",
+          "properties": {
+            "incident-start-time-post-alert": {
+              "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+              "description": "Timeframe for initiating incident response after an alert."
+            },
+            "escalation-path": {
+              "type": "string",
+              "description": "Specify the escalation path for SLA violations."
+            }
+          },
+          "required": [
+            "incident-start-time-post-alert",
+            "escalation-path"
+          ]
+        }
+      },
+      "required": [
+        "incident-resolution-time",
+        "escalation-protocols"
+      ]
+    },
+    "review-adjustments": {
+      "type": "object",
+      "properties": {
+        "sla-review": {
+          "$ref": "https://calm.finos.org/draft/2024-12/meta/units.json#/defs/time-unit",
+          "description": "Outline a schedule for regularly reviewing the SLA."
+        }
+      },
+      "required": [
+        "sla-review"
+      ]
+    }
+  },
+  "required": [
+    "control-id",
+    "name",
+    "description",
+    "latency",
+    "throughput",
+    "availability",
+    "data-integrity",
+    "error-handling",
+    "monitoring",
+    "incident-response",
+    "review-adjustments"
+  ]
+}

--- a/calm/samples/2024-12/traderx/flows/add-update-account/add-update-account-control-configuration.json
+++ b/calm/samples/2024-12/traderx/flows/add-update-account/add-update-account-control-configuration.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+  "$id": "https://calm.finos.org/traderx/control/add-update-account-control-configuration",
+  "control-id": "add-update-account-control-configuration",
+  "name": "Flow SLA Control for Add or Update Account",
+  "description": "Ensure that the Add or Update Account flow meets the defined Service Level Agreement (SLA).",
+  "latency": {
+    "expected-latency": {
+      "value": 100,
+      "unit": "milliseconds"
+    },
+    "alert-threshold": {
+      "value": 150,
+      "unit": "milliseconds"
+    }
+  },
+  "throughput": {
+    "expected-message-rate": {
+      "value": 500,
+      "unit": "seconds"
+    }
+  },
+  "availability": {
+    "uptime-guarantee": 99.9
+  },
+  "data-integrity": {
+    "message-reliability": "atLeastOnce",
+    "loss-tolerance": 0
+  },
+  "error-handling": {
+    "retry-logic": {
+      "max-retries": 3,
+      "retry-interval": {
+        "value": 10,
+        "unit": "seconds"
+      }
+    }
+  },
+  "monitoring": {
+    "real-time-monitoring": "Use of monitoring tools like Prometheus or Grafana for SLA tracking.",
+    "consumer-reporting": {
+      "value": 1,
+      "unit": "days"
+    }
+  },
+  "incident-response": {
+    "incident-resolution-time": {
+      "value": 30,
+      "unit": "minutes"
+    },
+    "escalation-protocols": {
+      "incident-start-time-post-alert": {
+        "value": 5,
+        "unit": "minutes"
+      },
+      "escalation-path": "Notify the incident response team via the dedicated Slack channel."
+    }
+  },
+  "review-adjustments": {
+    "sla-review": {
+      "value": 1,
+      "unit": "months"
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/flows/add-update-account/add-update-account.json
+++ b/calm/samples/2024-12/traderx/flows/add-update-account/add-update-account.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/add-update-account",
+  "unique-id": "flow-add-update-account",
+  "name": "Add or Update Account",
+  "description": "Flow for adding or updating account information in the database.",
+  "transitions": [
+    {
+      "relationship-unique-id": "web-gui-process-uses-accounts-service",
+      "sequence-number": 1,
+      "summary": "Submit Account Create/Update"
+    },
+    {
+      "relationship-unique-id": "accounts-service-uses-traderx-db-for-accounts",
+      "sequence-number": 2,
+      "summary": "inserts or updates account"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-accounts-service",
+      "sequence-number": 3,
+      "summary": "Returns Account Create/Update Response Status",
+      "direction": "destination-to-source"
+    }
+  ],
+  "controls": {
+    "add-update-account-sla": {
+      "description": "Control requirement for flow SLA",
+      "requirements": [
+        {
+          "control-requirement-url": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+          "control-config-url": "https://calm.finos.org/traderx/control/add-update-account-control-configuration"
+        }
+      ]
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/flows/load-list-of-accounts/load-list-of-accounts.json
+++ b/calm/samples/2024-12/traderx/flows/load-list-of-accounts/load-list-of-accounts.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/load-list-of-accounts",
+  "unique-id": "flow-load-list-of-accounts",
+  "name": "Load List of Accounts",
+  "description": "Flow for loading a list of accounts from the database to populate the GUI drop-down for user account selection.",
+  "transitions": [
+    {
+      "relationship-unique-id": "web-gui-process-uses-accounts-service",
+      "sequence-number": 1,
+      "summary": "Load list of accounts"
+    },
+    {
+      "relationship-unique-id": "accounts-service-uses-traderx-db-for-accounts",
+      "sequence-number": 2,
+      "summary": "Query for all Accounts"
+    },
+    {
+      "relationship-unique-id": "accounts-service-uses-traderx-db-for-accounts",
+      "sequence-number": 3,
+      "summary": "Returns list of accounts",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-accounts-service",
+      "sequence-number": 4,
+      "summary": "Returns list of accounts",
+      "direction": "destination-to-source"
+    }
+  ]
+}

--- a/calm/samples/2024-12/traderx/flows/load-positions/load-positions.json
+++ b/calm/samples/2024-12/traderx/flows/load-positions/load-positions.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/load-positions",
+  "unique-id": "flow-load-positions",
+  "name": "Load Positions",
+  "description": "Flow for loading positions for a specific account and subscribing to updates.",
+  "transitions": [
+    {
+      "relationship-unique-id": "web-gui-uses-position-service-for-position-queries",
+      "sequence-number": 1,
+      "summary": "Load Positions (acc)"
+    },
+    {
+      "relationship-unique-id": "position-service-uses-traderx-db-for-positions",
+      "sequence-number": 2,
+      "summary": "Query Positions for Account"
+    },
+    {
+      "relationship-unique-id": "position-service-uses-traderx-db-for-positions",
+      "sequence-number": 3,
+      "summary": "Return Positions for Account",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-uses-position-service-for-position-queries",
+      "sequence-number": 4,
+      "summary": "Return Positions for Account",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-uses-trade-feed",
+      "sequence-number": 5,
+      "summary": "Subscribe to Position updates (accounts/$id/positions)"
+    },
+    {
+      "relationship-unique-id": "web-gui-uses-trade-feed",
+      "sequence-number": 6,
+      "summary": "Publish Position Updates",
+      "direction": "destination-to-source"
+    }
+  ]
+}

--- a/calm/samples/2024-12/traderx/flows/submit-trade-ticket/submit-trade-ticket-control-configuration.json
+++ b/calm/samples/2024-12/traderx/flows/submit-trade-ticket/submit-trade-ticket-control-configuration.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+  "$id": "https://calm.finos.org/traderx/control/submit-trade-ticket-control-configuration",
+  "control-id": "submit-trade-ticket-control-configuration",
+  "name": "Flow SLA Control for Trade Ticket Submission",
+  "description": "Ensure that Trade Ticket Submission flow meets the defined Service Level Agreement (SLA).",
+  "latency": {
+    "expected-latency": {
+      "value": 100,
+      "unit": "milliseconds"
+    },
+    "alert-threshold": {
+      "value": 150,
+      "unit": "milliseconds"
+    }
+  },
+  "throughput": {
+    "expected-message-rate": {
+      "value": 1000,
+      "unit": "seconds"
+    }
+  },
+  "availability": {
+    "uptime-guarantee": 99.9
+  },
+  "data-integrity": {
+    "message-reliability": "exactlyOnce",
+    "loss-tolerance": 0
+  },
+  "error-handling": {
+    "retry-logic": {
+      "max-retries": 3,
+      "retry-interval": {
+        "value": 10,
+        "unit": "seconds"
+      }
+    }
+  },
+  "monitoring": {
+    "real-time-monitoring": "Use of monitoring tools like Prometheus or Grafana for SLA tracking.",
+    "consumer-reporting": {
+      "value": 1,
+      "unit": "days"
+    }
+  },
+  "incident-response": {
+    "incident-resolution-time": {
+      "value": 30,
+      "unit": "minutes"
+    },
+    "escalation-protocols": {
+      "incident-start-time-post-alert": {
+        "value": 5,
+        "unit": "minutes"
+      },
+      "escalation-path": "Notify the incident response team via the dedicated Slack channel."
+    }
+  },
+  "review-adjustments": {
+    "sla-review": {
+      "value": 1,
+      "unit": "months"
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/flows/submit-trade-ticket/submit-trade-ticket.json
+++ b/calm/samples/2024-12/traderx/flows/submit-trade-ticket/submit-trade-ticket.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/submit-trade-ticket",
+  "unique-id": "flow-submit-trade-ticket",
+  "name": "Submitting a Trade Ticket",
+  "description": "Flow for submitting a trade ticket and validating the trade, account, and publishing a new trade event.",
+  "transitions": [
+    {
+      "relationship-unique-id": "web-gui-process-uses-reference-data-service",
+      "sequence-number": 1,
+      "summary": "Load ticker list"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-reference-data-service",
+      "sequence-number": 2,
+      "summary": "Return ticker list",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trading-services",
+      "sequence-number": 3,
+      "summary": "Submit trade (acct, ticker, side, qty)"
+    },
+    {
+      "relationship-unique-id": "trading-services-connects-to-reference-data-service",
+      "sequence-number": 4,
+      "summary": "Validate Ticker"
+    },
+    {
+      "relationship-unique-id": "trading-services-uses-account-service",
+      "sequence-number": 5,
+      "summary": "Validate Account Number"
+    },
+    {
+      "relationship-unique-id": "trading-services-uses-trade-feed",
+      "sequence-number": 6,
+      "summary": "Publish new Trade Event (trades/new)"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trading-services",
+      "sequence-number": 7,
+      "summary": "Trade Submission Complete",
+      "direction": "destination-to-source"
+    }
+  ],
+  "controls": {
+    "submit-trade-ticket-sla": {
+      "description": "Control requirement for flow SLA",
+      "requirements": [
+        {
+          "control-requirement-url": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+          "control-config-url": "https://calm.finos.org/traderx/flow/submit-trade-ticket"
+        }
+      ]
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-control-configuration.json
+++ b/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-control-configuration.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+  "$id": "https://calm.finos.org/traderx/flow/trade-processing-control-configuration",
+  "control-id": "trade-processing-control-configuration",
+  "name": "Flow SLA Control for Trade Processing",
+  "description": "Ensure that Trade Processing flows meet the defined Service Level Agreement (SLA).",
+  "latency": {
+    "expected-latency": {
+      "value": 100,
+      "unit": "milliseconds"
+    },
+    "alert-threshold": {
+      "value": 150,
+      "unit": "milliseconds"
+    }
+  },
+  "throughput": {
+    "expected-message-rate": {
+      "value": 1000,
+      "unit": "seconds"
+    }
+  },
+  "availability": {
+    "uptime-guarantee": 99.9
+  },
+  "data-integrity": {
+    "message-reliability": "atLeastOnce",
+    "loss-tolerance": 0
+  },
+  "error-handling": {
+    "retry-logic": {
+      "max-retries": 3,
+      "retry-interval": {
+        "value": 10,
+        "unit": "seconds"
+      }
+    }
+  },
+  "monitoring": {
+    "real-time-monitoring": "Use of monitoring tools like Prometheus or Grafana for SLA tracking.",
+    "consumer-reporting": {
+      "value": 1,
+      "unit": "days"
+    }
+  },
+  "incident-response": {
+    "incident-resolution-time": {
+      "value": 30,
+      "unit": "minutes"
+    },
+    "escalation-protocols": {
+      "incident-start-time-post-alert": {
+        "value": 5,
+        "unit": "minutes"
+      },
+      "escalation-path": "Notify the incident response team via the dedicated Slack channel."
+    }
+  },
+  "review-adjustments": {
+    "sla-review": {
+      "value": 1,
+      "unit": "months"
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-new-trade.json
+++ b/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-new-trade.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/new-trade",
+  "unique-id": "flow-new-trade",
+  "name": "Trade Processing - New Trade",
+  "description": "The process flow for handling new trade events",
+  "transitions": [
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 1,
+      "summary": "New Trade Request (trades/new)",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-traderx-db",
+      "sequence-number": 2,
+      "summary": "Insert New Trade"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 3,
+      "summary": "Publish New TradeEvent (accounts/$id/trades)"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 3,
+      "summary": "Publish PositionEvent (accounts/$id/positions)"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trade-feed",
+      "sequence-number": 4,
+      "summary": "New Trade Created",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trade-feed",
+      "sequence-number": 4,
+      "summary": "Position Updated",
+      "direction": "destination-to-source"
+    }
+  ],
+  "controls": {
+    "trade-processing-sla": {
+      "description": "Control requirement for flow SLA",
+      "requirements": [
+        {
+          "control-requirement-url": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+          "control-config-url": "https://calm.finos.org/traderx/control/trade-processing-control-configuration"
+        }
+      ]
+    }
+  }
+}
+

--- a/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-update-trade.json
+++ b/calm/samples/2024-12/traderx/flows/trade-processing/trade-processing-update-trade.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/flow.json",
+  "$id": "https://calm.finos.org/traderx/flow/update-trade",
+  "unique-id": "flow-update-trade",
+  "name": "Trade Processing - Update Trade",
+  "description": "The process flow for handling update trade events",
+  "transitions": [
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 1,
+      "summary": "Update Trade Request (trades/update)",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-traderx-db",
+      "sequence-number": 2,
+      "summary": "Update Trade"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 3,
+      "summary": "Publish TradeUpdatedEvent (accounts/$id/trades)"
+    },
+    {
+      "relationship-unique-id": "trade-processor-connects-to-trade-feed",
+      "sequence-number": 3,
+      "summary": "Publish PositionEvent (accounts/$id/positions)"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trade-feed",
+      "sequence-number": 4,
+      "summary": "Trade Updated",
+      "direction": "destination-to-source"
+    },
+    {
+      "relationship-unique-id": "web-gui-process-uses-trade-feed",
+      "sequence-number": 4,
+      "summary": "Position Updated",
+      "direction": "destination-to-source"
+    }
+  ],
+  "controls": {
+    "trade-processing-sla": {
+      "description": "Control requirement for flow SLA",
+      "requirements": [
+        {
+          "control-requirement-url": "https://calm.finos.org/traderx/control/flow-sla-control-requirement",
+          "control-config-url": "https://calm.finos.org/traderx/control/trade-processing-control-configuration"
+        }
+      ]
+    }
+  }
+}

--- a/calm/samples/2024-12/traderx/traderx.json
+++ b/calm/samples/2024-12/traderx/traderx.json
@@ -1,0 +1,465 @@
+{
+  "$schema": "https://calm.finos.org/draft/2024-12/meta/calm.json",
+  "nodes": [
+    {
+      "unique-id": "traderx-system",
+      "node-type": "system",
+      "name": "TraderX",
+      "description": "Simple Trading System"
+    },
+    {
+      "unique-id": "traderx-trader",
+      "node-type": "actor",
+      "name": "Trader",
+      "description": "Person who manages accounts and executes trades"
+    },
+    {
+      "unique-id": "web-client",
+      "node-type": "webclient",
+      "name": "Web Client",
+      "description": "Browser based web interface for TraderX",
+      "data-classification": "Confidential",
+      "run-as": "user"
+    },
+    {
+      "unique-id": "web-gui-process",
+      "node-type": "service",
+      "name": "Web GUI",
+      "description": "Allows employees to manage accounts and book trades",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "position-service",
+      "node-type": "service",
+      "name": "Position Service",
+      "description": "Server process which processes trading activity and updates positions",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "traderx-db",
+      "node-type": "database",
+      "name": "TraderX DB",
+      "description": "Database which stores account, trade and position state",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "internal-bank-network",
+      "node-type": "network",
+      "name": "Bank ABC Internal Network",
+      "description": "Internal network for Bank ABC",
+      "instance": "Internal Network"
+    },
+    {
+      "unique-id": "reference-data-service",
+      "node-type": "service",
+      "name": "Reference Data Service",
+      "description": "Service which provides reference data",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "trading-services",
+      "node-type": "service",
+      "name": "Trading Services",
+      "description": "Service which provides trading services",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "trade-feed",
+      "node-type": "service",
+      "name": "Trade Feed",
+      "description": "Message bus for streaming updates to trades and positions",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "trade-processor",
+      "node-type": "service",
+      "name": "Trade Processor",
+      "description": "Process incoming trade requests, settle and persist",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "accounts-service",
+      "node-type": "service",
+      "name": "Accounts Service",
+      "description": "Service which provides account management",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "people-service",
+      "node-type": "service",
+      "name": "People Service",
+      "description": "Service which provides user details management",
+      "data-classification": "Confidential",
+      "run-as": "systemId"
+    },
+    {
+      "unique-id": "user-directory",
+      "node-type": "ldap",
+      "name": "User Directory",
+      "description": "Golden source of user data",
+      "data-classification": "PII",
+      "run-as": "systemId"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "trader-executes-trades",
+      "description": "Executes Trades",
+      "relationship-type": {
+        "interacts": {
+          "actor": "traderx-trader",
+          "nodes": [
+            "web-client"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "trader-manages-accounts",
+      "description": "Manage Accounts",
+      "relationship-type": {
+        "interacts": {
+          "actor": "traderx-trader",
+          "nodes": [
+            "web-client"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "trader-views-trade-status",
+      "description": "View Trade Status / Positions",
+      "relationship-type": {
+        "interacts": {
+          "actor": "traderx-trader",
+          "nodes": [
+            "web-client"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "web-client-uses-web-gui",
+      "description": "Web client interacts with the Web GUI process.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-client"
+          },
+          "destination": {
+            "node": "web-gui-process"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "web-gui-uses-position-service-for-position-queries",
+      "description": "Load positions for account.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "position-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "web-gui-uses-position-service-for-trade-queries",
+      "description": "Load trades for account.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "position-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "position-service-uses-traderx-db-for-positions",
+      "description": "Looks up default positions for a given account.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "position-service"
+          },
+          "destination": {
+            "node": "traderx-db"
+          }
+        }
+      },
+      "protocol": "JDBC"
+    },
+    {
+      "unique-id": "position-service-uses-traderx-db-for-trades",
+      "description": "Looks up all trades for a given account.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "position-service"
+          },
+          "destination": {
+            "node": "traderx-db"
+          }
+        }
+      },
+      "protocol": "JDBC"
+    },
+    {
+      "unique-id": "traderx-system-is-deployed-in-internal-bank-network",
+      "relationship-type": {
+        "deployed-in": {
+          "container": "internal-bank-network",
+          "nodes": [
+            "traderx-system"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "traderx-system-is-composed-of",
+      "relationship-type": {
+        "composed-of": {
+          "container": "traderx-system",
+          "nodes": [
+            "web-client",
+            "web-gui-process",
+            "position-service",
+            "traderx-db",
+            "people-service",
+            "reference-data-service",
+            "trading-services",
+            "trade-feed",
+            "trade-processor",
+            "accounts-service"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "traderx-system-components-are-deployed-in-internal-bank-network",
+      "relationship-type": {
+        "deployed-in": {
+          "container": "internal-bank-network",
+          "nodes": [
+            "web-client",
+            "web-gui-process",
+            "position-service",
+            "traderx-db",
+            "people-service",
+            "reference-data-service",
+            "trading-services",
+            "trade-feed",
+            "trade-processor",
+            "accounts-service",
+            "user-directory"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "web-gui-process-uses-reference-data-service",
+      "description": "Looks up securities to assist with creating a trade ticket.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "reference-data-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "web-gui-process-uses-trading-services",
+      "description": "Creates new trades and cancels existing trades.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "trading-services"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "web-gui-process-uses-trade-feed",
+      "description": "Subscribes to trade/position updates feed for currently viewed account.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "trade-feed"
+          }
+        }
+      },
+      "protocol": "WebSocket"
+    },
+    {
+      "unique-id": "trade-processor-connects-to-trade-feed",
+      "description": "Processes incoming trade requests, persist and publish updates.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "trade-processor"
+          },
+          "destination": {
+            "node": "trade-feed"
+          }
+        }
+      },
+      "protocol": "SocketIO"
+    },
+    {
+      "unique-id": "trade-processor-connects-to-traderx-db",
+      "description": "Looks up current positions when bootstrapping state, persist trade state and position state.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "trade-processor"
+          },
+          "destination": {
+            "node": "traderx-db"
+          }
+        }
+      },
+      "protocol": "JDBC"
+    },
+    {
+      "unique-id": "web-gui-process-uses-accounts-service",
+      "description": "Creates/Updates accounts. Gets list of accounts.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "accounts-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "web-gui-process-uses-people-service",
+      "description": "Looks up people data based on typeahead from GUI.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "web-gui-process"
+          },
+          "destination": {
+            "node": "people-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "people-service-connects-to-user-directory",
+      "description": "Looks up people data.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "people-service"
+          },
+          "destination": {
+            "node": "user-directory"
+          }
+        }
+      },
+      "protocol": "LDAP"
+    },
+    {
+      "unique-id": "trading-services-connects-to-reference-data-service",
+      "description": "Validates securities when creating trades.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "trading-services"
+          },
+          "destination": {
+            "node": "reference-data-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "trading-services-uses-trade-feed",
+      "description": "Publishes updates to trades and positions after persisting in the DB.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "trading-services"
+          },
+          "destination": {
+            "node": "trade-feed"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "trading-services-uses-account-service",
+      "description": "Validates accounts when creating trades.",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "trading-services"
+          },
+          "destination": {
+            "node": "accounts-service"
+          }
+        }
+      },
+      "protocol": "HTTPS"
+    },
+    {
+      "unique-id": "accounts-service-uses-traderx-db-for-accounts",
+      "description": "CRUD operations on account",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "accounts-service"
+          },
+          "destination": {
+            "node": "traderx-db"
+          }
+        }
+      },
+      "protocol": "JDBC"
+    }
+  ],
+  "flows": [
+    "https://calm.finos.org/traderx/flow/add-update-account",
+    "https://calm.finos.org/traderx/flow/load-list-of-accounts",
+    "https://calm.finos.org/traderx/flow/load-positions",
+    "https://calm.finos.org/traderx/flow/submit-trade-ticket/submit-trade-ticket",
+    "https://calm.finos.org/traderx/flow/new-trade",
+    "https://calm.finos.org/traderx/flow/update-trade"
+  ]
+}


### PR DESCRIPTION
This PR addresses the feature request detailed in issue [650](https://github.com/finos/architecture-as-code/issues/650) by implementing the following enhancements to CALM

1. Adds ecosystem definition to node-type
2. Add flows to core.json. This will allow the eventual traversal of calm-hub by calm-docify
3. It additionally contains some small changes to $id and $url references with the intention that these documents will be hosted network addressable and in calm-hub