### PR TITLE
Simple, repeatable dev env set-up with Flox

### DIFF
--- a/.flox/.gitignore
+++ b/.flox/.gitignore
@@ -1,0 +1,4 @@
+run/
+cache/
+lib/
+log/

--- a/.flox/env.json
+++ b/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "calm",
+  "version": 1
+}

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -1,0 +1,351 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "gum": {
+        "pkg-path": "gum"
+      },
+      "libuuid": {
+        "pkg-path": "libuuid",
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "nodejs": {
+        "pkg-path": "nodejs"
+      }
+    },
+    "hook": {
+      "on-activate": "  if [ ! -d \"$FLOX_ENV_PROJECT\"/node_modules ]; then\n    # Install nodejs dependencies\n    echo \"First activation of environment.  Setting some things up.\"\n    gum spin --spinner minidot --title \"Installing node packages...\" --show-output -- npm install\n\n    gum confirm \"Perform initial build (recommended)?\" && npm run build && npx link cli\n  fi\n"
+    },
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/b8hmgi9iccbdpmckdh3rb70wm8a5m39w-gum-0.14.5.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "gum-0.14.5",
+      "pname": "gum",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.14.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/2kh20kzsh8p9b045janwracxwh43zzcf-gum-0.14.5"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/hg08x7xzik61fmmwwp571ra5rl2hx5sg-gum-0.14.5.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "gum-0.14.5",
+      "pname": "gum",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.14.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/l82bhnw3lbrpjszs98wwgfnr5zkz3rz8-gum-0.14.5"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/dxfhlmmf8c4rcxqyns6a0hk2ymh245nv-gum-0.14.5.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "gum-0.14.5",
+      "pname": "gum",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.14.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/652lcsz1jind3y4dbg4vnfas6fvhblf9-gum-0.14.5"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/56mw00m93jqs5hnfqlgng6iwa6gza13m-gum-0.14.5.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "gum-0.14.5",
+      "pname": "gum",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.14.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/0dl1rmdsxqn0x775zb433bf8cfar3cxv-gum-0.14.5"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "libuuid",
+      "broken": false,
+      "derivation": "/nix/store/rjzm2kfsd57js9xksi6r10wynzz56grm-util-linux-minimal-2.39.4.drv",
+      "description": "Set of system utilities for Linux",
+      "install_id": "libuuid",
+      "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "util-linux-minimal-2.39.4",
+      "pname": "libuuid",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "util-linux-minimal-2.39.4",
+      "outputs_to_install": [
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/rhaj4f2nha5ff2qaaz39qmy70jz5gkm8-util-linux-minimal-2.39.4-bin",
+        "debug": "/nix/store/vyrysj9fbpwj47wnwmigyfcxv3blrjqf-util-linux-minimal-2.39.4-debug",
+        "dev": "/nix/store/c134hzsvs9m2xpsywvn4qi74jkx06284-util-linux-minimal-2.39.4-dev",
+        "lib": "/nix/store/1zvfmc7mqlljci6l7hla5wzs0qvmxvs5-util-linux-minimal-2.39.4-lib",
+        "login": "/nix/store/1x76irn6097a9b89py8cd83hi5p6s7if-util-linux-minimal-2.39.4-login",
+        "man": "/nix/store/9y3hd69wp0k7278rkicm2v2p8yl7vg3r-util-linux-minimal-2.39.4-man",
+        "mount": "/nix/store/8vq44d8cwb3w1mp6grn9s6mgxzmcfxf5-util-linux-minimal-2.39.4-mount",
+        "out": "/nix/store/ldv7sypn1mr25n4qxqrbwk3cndf6xcah-util-linux-minimal-2.39.4",
+        "swap": "/nix/store/16x1b34fcpcnxmxs3ji9v75wbhn2i8m7-util-linux-minimal-2.39.4-swap"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "libuuid",
+      "broken": false,
+      "derivation": "/nix/store/glwgs25vcs54dibpnbzfb32ndh85n07q-util-linux-minimal-2.39.4.drv",
+      "description": "Set of system utilities for Linux",
+      "install_id": "libuuid",
+      "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "util-linux-minimal-2.39.4",
+      "pname": "libuuid",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "util-linux-minimal-2.39.4",
+      "outputs_to_install": [
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/4bnic2wzy34ya0iirx7z9lz0y53plk8s-util-linux-minimal-2.39.4-bin",
+        "debug": "/nix/store/z27b828idk6zznf149nkvbmg6fvklxv2-util-linux-minimal-2.39.4-debug",
+        "dev": "/nix/store/n93hwhpy39jwybnx8vinva87xkbaslnl-util-linux-minimal-2.39.4-dev",
+        "lib": "/nix/store/gm5g3xyn8iwxkag8gs6rf3ci64bqld80-util-linux-minimal-2.39.4-lib",
+        "login": "/nix/store/xgkcl3gpy87bpnvv6z8bs74yishk792k-util-linux-minimal-2.39.4-login",
+        "man": "/nix/store/7wgflcakf6xii9sd34l7nzpv74r85gbb-util-linux-minimal-2.39.4-man",
+        "mount": "/nix/store/4kgxc0nk8j51gn03ynmgrqvq4iyn29sq-util-linux-minimal-2.39.4-mount",
+        "out": "/nix/store/qwfm200f1dnh2rc8zazbviydfhhnxg8v-util-linux-minimal-2.39.4",
+        "swap": "/nix/store/8m2393syd4amxqr7yc9x8k2i2a1ihrbr-util-linux-minimal-2.39.4-swap"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs",
+      "broken": false,
+      "derivation": "/nix/store/cpc9p6bxbw3sy02m28vwp1ixv4rwr51g-nodejs-20.18.1.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "nodejs-20.18.1",
+      "pname": "nodejs",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "20.18.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "libv8": "/nix/store/l17919sgiw0i3awxlpic9z9a3g2d0rgv-nodejs-20.18.1-libv8",
+        "out": "/nix/store/f0lm95g31vpknr8jj9xw53cx2rqly2nm-nodejs-20.18.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs",
+      "broken": false,
+      "derivation": "/nix/store/3rjfcddi2krynxqz0nb99fc65nz827gi-nodejs-20.18.1.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "nodejs-20.18.1",
+      "pname": "nodejs",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "20.18.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "libv8": "/nix/store/1pp9h9ma5ps2w3n7abkd3ipgjnmixwpm-nodejs-20.18.1-libv8",
+        "out": "/nix/store/vqv3dblqx76k185jg4ym5i3dz196lv19-nodejs-20.18.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs",
+      "broken": false,
+      "derivation": "/nix/store/1zm0n4n1sgqc6cb5dzyxbj7as8wlijd4-nodejs-20.18.1.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "nodejs-20.18.1",
+      "pname": "nodejs",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "20.18.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "libv8": "/nix/store/85x3jn8wf6n6ihr3ar70fhgc4p87znsq-nodejs-20.18.1-libv8",
+        "out": "/nix/store/gbrd92gjhi88lhj43bsa2y9zvcn4vsb8-nodejs-20.18.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs",
+      "broken": false,
+      "derivation": "/nix/store/2znhzcp5ran8q5mzyqgz6lxi3a56rgva-nodejs-20.18.1.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "name": "nodejs-20.18.1",
+      "pname": "nodejs",
+      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+      "rev_count": 720697,
+      "rev_date": "2024-12-11T18:06:44Z",
+      "scrape_date": "2024-12-14T03:50:50Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "20.18.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "libv8": "/nix/store/6cpw80r57lyippnjl5knrvymcwalv1m2-nodejs-20.18.1-libv8",
+        "out": "/nix/store/wfxq6w9bkp5dcfr8yb6789b0w7128gnb-nodejs-20.18.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,0 +1,82 @@
+## Flox Environment Manifest -----------------------------------------
+##
+##   _Everything_ you need to know about the _manifest_ is here:
+##
+##               https://flox.dev/docs/concepts/manifest
+##
+## -------------------------------------------------------------------
+# Flox manifest version managed by Flox CLI
+version = 1
+
+
+## Install Packages --------------------------------------------------
+##  $ flox install gum  <- puts a package in [install] section below
+##  $ flox search gum   <- search for a package
+##  $ flox show gum     <- show all versions of a package
+## -------------------------------------------------------------------
+[install]
+nodejs = { pkg-path = "nodejs" }
+libuuid.pkg-path = "libuuid"
+libuuid.systems = ["aarch64-linux", "x86_64-linux"]
+gum.pkg-path = "gum"
+
+
+## Environment Variables ---------------------------------------------
+##  ... available for use in the activated environment
+##      as well as [hook], [profile] scripts and [services] below.
+## -------------------------------------------------------------------
+[vars]
+# INTRO_MESSAGE = "It's gettin' Flox in here"
+
+
+## Activation Hook ---------------------------------------------------
+##  ... run by _bash_ shell when you run 'flox activate'.
+## -------------------------------------------------------------------
+[hook]
+on-activate = """
+  if [ ! -d "$FLOX_ENV_PROJECT"/node_modules ]; then
+    # Install nodejs dependencies
+    echo "First activation of environment.  Setting some things up."
+    gum spin --spinner minidot --title "Installing node packages..." --show-output -- npm install
+
+    gum confirm "Perform initial build (recommended)?" && npm run build && npx link cli
+  fi
+"""
+
+
+## Profile script ----------------------------------------------------
+## ... sourced by _your shell_ when you run 'flox activate'.
+## -------------------------------------------------------------------
+[profile]
+# common = '''
+#   gum style \
+#   --foreground 212 --border-foreground 212 --border double \
+#   --align center --width 50 --margin "1 2" --padding "2 4" \
+#     $INTRO_MESSAGE
+# '''
+## Shell specific profiles go here:
+# bash = ...
+# zsh  = ...
+# fish = ...
+
+
+## Services ----------------------------------------------------------
+##  $ flox services start             <- Starts all services
+##  $ flox services status            <- Status of running services
+##  $ flox activate --start-services  <- Activates & starts all
+## -------------------------------------------------------------------
+[services]
+# myservice.command = "python3 -m http.server"
+
+
+## Other Environment Options -----------------------------------------
+[options]
+# Systems that environment is compatible with
+systems = [
+  "aarch64-darwin",
+  "aarch64-linux",
+  "x86_64-darwin",
+  "x86_64-linux",
+]
+# Uncomment to disable CUDA detection.
+# cuda-detection = false

--- a/cli/DEVELOPER_GUIDE.md
+++ b/cli/DEVELOPER_GUIDE.md
@@ -1,20 +1,34 @@
 # Developing the CALM CLI
 
-## Prerequisites
+## One-time environment set-up
 
-We recommend using Node v20.18.1 (use `nvm` to manage node versions if needed).  The `canvas` package we use does not seem to be compatible with later versions of node.
+### [Flox](https://flox.dev) users
+
+  1. Clone the git repo and `cd` into the directory.
+  1. Run `flox activate`.  The first time you do this, it will locally install all the dependencies and Node packages, and configure the environment ready for you to develop and test.
+
+
+### Everyone else
+
+  1. Install Node v20.18.1 (use `nvm` to manage Node versions if needed).  The `canvas` package we use does not seem to be compatible with later versions of node.
+  1. Make sure `libuuid.so` is installed (`ldconfig -p | grep libuuid`) and install it if not (instructions will depend on your OS).
+  1. Clone the git repo and `cd` into the directory
+  1. Run the following:
+  ```shell
+     npm install
+     npm run build
+     npx link cli
+   ```
 
 ## Building & linking the CLI
 
-Clone the project and run the following commands from within this `cli` directory:
+When you've made a change to the CLI and want to test it out, you can rerun the build and link steps from within the `cli` directory:
 
 ```shell
-npm install
 npm run build
 npx link .
 ```
 
-When you've made a change to the CLI and want to test it out, you can rerun the build and link steps.
 This will make the CLI available on your local `node_modules` path.
 
 `npx link` uses the `link` package to symlink the `calm` executable in `node_modules/.bin` to your locally-built CLI.


### PR DESCRIPTION
[Flox](https://flox.dev) makes development environment set-up simple and repeatable, as it explicitly installs dependencies locally to the project rather than relying on whatever versions of things you may happen to have installed globally.

Setting up the CALM environment on a fresh Ubuntu image with Flox and git already installed:
```bash
git clone https://github.com/finos/architecture-as-code.git
cd architecture-as-code
flox activate
```
And that's it!  Flox will install the right version of Node, `libuuid.so`, do the `npm install`, and even do the initial build and link for you.  And we'll know exactly what versions of everything are being used, which makes debugging environment problems much much easier.