### PR TITLE
tests: fix problem with running tests when not root

### DIFF
--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -17,7 +17,7 @@ describe('CLI Integration Tests', () => {
 
     beforeAll(async () => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), integrationTestPrefix));
-        await callNpmFunction(`${projectRoot}`, 'link');
+        await callNpxFunction(`${projectRoot}/../..`, 'link cli');      // Link the CLI package to the top-level node_modules
     }, millisPerSecond * 20);
 
     afterAll(async () => {
@@ -164,7 +164,7 @@ describe('CLI Integration Tests', () => {
 });
 
 
-async function callNpmFunction(projectRoot: string, command: string) {
-    await execPromise(`npm ${command}`, { cwd: projectRoot });
+async function callNpxFunction(projectRoot: string, command: string) {
+    await execPromise(`npx ${command}`, { cwd: projectRoot });
 }
 


### PR DESCRIPTION
In `cli.spec.ts`, it was doing an `npm link` even though in the docs is says not to do that. This means the tests were failing if you weren't running as an account that could modify the global `node_modules`. I've changed this to use `npx link` instead.
