### PR TITLE
maint: bump recommended Node version to 21 and auto-install Java dependencies

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -6,6 +6,9 @@
       "gum": {
         "pkg-path": "gum"
       },
+      "jdk21": {
+        "pkg-path": "jdk21"
+      },
       "libuuid": {
         "pkg-path": "libuuid",
         "systems": [
@@ -13,12 +16,15 @@
           "x86_64-linux"
         ]
       },
+      "maven3": {
+        "pkg-path": "maven3"
+      },
       "nodejs_21": {
         "pkg-path": "nodejs_21"
       }
     },
     "hook": {
-      "on-activate": "  if [ ! -d \"$FLOX_ENV_PROJECT\"/node_modules ]; then\n    # Install nodejs dependencies\n    echo \"First activation of environment.  Setting some things up.\"\n    gum spin --spinner minidot --title \"Installing node packages...\" --show-output -- npm install\n\n    gum confirm \"Perform initial build (recommended)?\" && npm run build && npx link cli\n  fi\n"
+      "on-activate": "  export MAVEN_USER_HOME=\"$(realpath $FLOX_ENV_CACHE)/m2\"\n  export MAVEN_OPTS=\"-Dmaven.repo.local=$MAVEN_USER_HOME/repository\"\n\n  if [ ! -d \"$FLOX_ENV_PROJECT\"/node_modules ]; then\n    echo \"First activation of environment.  Setting some things up - you may want to get a cup of tea...\"\n\n    # Install Java dependencies\n    mvnw-deps() {\n      cd translator\n      ./mvnw dependency:resolve dependency:resolve-plugins\n      cd ..\n    }\n    export -f mvnw-deps\n    gum spin --spinner minidot --title \"Installing Java dependencies...\" --show-output -- bash -c mvnw-deps\n\n    # Install nodejs dependencies\n    gum spin --spinner minidot --title \"Installing node packages...\" --show-output -- npm install\n\n    gum confirm \"Perform initial CLI build (recommended)?\" && npm run build && npx link cli\n  fi\n"
     },
     "profile": {},
     "options": {
@@ -160,6 +166,132 @@
       "priority": 5
     },
     {
+      "attr_path": "jdk21",
+      "broken": false,
+      "derivation": "/nix/store/8ygvrc25k31zw77fxhgv9vlxm0wj52dx-zulu-ca-jdk-21.0.2.drv",
+      "description": "Certified builds of OpenJDK",
+      "install_id": "jdk21",
+      "license": "GPL-2.0-only",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "zulu-ca-jdk-21.0.2",
+      "pname": "jdk21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "zulu-ca-jdk-21.0.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ybdzj6kqlarahnqdwn4dpxwvwy2c6nlk-zulu-ca-jdk-21.0.2"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jdk21",
+      "broken": false,
+      "derivation": "/nix/store/ylh95r9y8gy2iijzp7ydzqld29hsrpyl-openjdk-21+35.drv",
+      "description": "The open-source Java Development Kit",
+      "install_id": "jdk21",
+      "license": "GPL-2.0-only",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "openjdk-21+35",
+      "pname": "jdk21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "openjdk-21+35",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/w155nhrpqqxqcz3lpnqqf922k4ywbhjr-openjdk-21+35-debug",
+        "out": "/nix/store/idsyp6qg4qlf2symkynw493wi8b9f6zr-openjdk-21+35"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jdk21",
+      "broken": false,
+      "derivation": "/nix/store/c5bn64sslxgmni9kamv4c8lwycd0j7gk-zulu-ca-jdk-21.0.2.drv",
+      "description": "Certified builds of OpenJDK",
+      "install_id": "jdk21",
+      "license": "GPL-2.0-only",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "zulu-ca-jdk-21.0.2",
+      "pname": "jdk21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "zulu-ca-jdk-21.0.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/rl72g2cy65l5f5kpqhnaw0a9lh08qfhs-zulu-ca-jdk-21.0.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jdk21",
+      "broken": false,
+      "derivation": "/nix/store/zwd1jz69b8z45imy43acfn19b2ny4k0r-openjdk-21+35.drv",
+      "description": "The open-source Java Development Kit",
+      "install_id": "jdk21",
+      "license": "GPL-2.0-only",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "openjdk-21+35",
+      "pname": "jdk21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "openjdk-21+35",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/0rzx48hsi985dc6iwr350vpd2asvsz4b-openjdk-21+35-debug",
+        "out": "/nix/store/w0jdfkacnzn1ijckp8h822nxi93vcp61-openjdk-21+35"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
       "attr_path": "libuuid",
       "broken": false,
       "derivation": "/nix/store/y2d5zfmi22gmj6sidv8s5p0d9xj8kw5a-util-linux-minimal-2.39.3.drv",
@@ -234,6 +366,130 @@
         "mount": "/nix/store/8ir2w5fk182dqrjld4qrxqin1lfi52d9-util-linux-minimal-2.39.3-mount",
         "out": "/nix/store/dyn88flqp8jd3rnpd6i4gqvw0gwxam97-util-linux-minimal-2.39.3",
         "swap": "/nix/store/3gc1a1mp4j8s58mq1jnwq2r1frrgjdlg-util-linux-minimal-2.39.3-swap"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "maven3",
+      "broken": false,
+      "derivation": "/nix/store/9h78xlmc2gip6vs73psvypk4x835hl0d-apache-maven-3.9.6.drv",
+      "description": "Build automation tool (used primarily for Java projects)",
+      "install_id": "maven3",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "apache-maven-3.9.6",
+      "pname": "maven3",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "apache-maven-3.9.6",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/1nrwl58bjv5ayy1vh8n0dhrgl0yg60hs-apache-maven-3.9.6"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "maven3",
+      "broken": false,
+      "derivation": "/nix/store/l19way296cgiclhawsh3sasw75rysign-apache-maven-3.9.6.drv",
+      "description": "Build automation tool (used primarily for Java projects)",
+      "install_id": "maven3",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "apache-maven-3.9.6",
+      "pname": "maven3",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "apache-maven-3.9.6",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/23yq68ischhbqd05lb8dlfg9n0q75k7p-apache-maven-3.9.6"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "maven3",
+      "broken": false,
+      "derivation": "/nix/store/19gjmn4kqxr2601clb5083w3v5gcimf8-apache-maven-3.9.6.drv",
+      "description": "Build automation tool (used primarily for Java projects)",
+      "install_id": "maven3",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "apache-maven-3.9.6",
+      "pname": "maven3",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "apache-maven-3.9.6",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n8avzq432b8fb9z29jg0vbsrwdvxw6hs-apache-maven-3.9.6"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "maven3",
+      "broken": false,
+      "derivation": "/nix/store/3mr5nrj85j9hmrzwidzxk4aki7khyxgm-apache-maven-3.9.6.drv",
+      "description": "Build automation tool (used primarily for Java projects)",
+      "install_id": "maven3",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "apache-maven-3.9.6",
+      "pname": "maven3",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "apache-maven-3.9.6",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kqmr4lsagk230jhhq5l66b4clffvgybq-apache-maven-3.9.6"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -13,8 +13,8 @@
           "x86_64-linux"
         ]
       },
-      "nodejs": {
-        "pkg-path": "nodejs"
+      "nodejs_21": {
+        "pkg-path": "nodejs_21"
       }
     },
     "hook": {
@@ -38,27 +38,29 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/b8hmgi9iccbdpmckdh3rb70wm8a5m39w-gum-0.14.5.drv",
+      "derivation": "/nix/store/vrr3fgnzq8ixfgwiaayymiccmfmdix9s-gum-0.13.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "gum-0.14.5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "gum-0.13.0",
       "pname": "gum",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "0.13.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2kh20kzsh8p9b045janwracxwh43zzcf-gum-0.14.5"
+        "out": "/nix/store/rv7y82ylid613qkg947a1icajp41jhr1-gum-0.13.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -67,27 +69,29 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/hg08x7xzik61fmmwwp571ra5rl2hx5sg-gum-0.14.5.drv",
+      "derivation": "/nix/store/m3h1kk5hah1waqs525mz4gswqn7bm3vg-gum-0.13.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "gum-0.14.5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "gum-0.13.0",
       "pname": "gum",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "0.13.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/l82bhnw3lbrpjszs98wwgfnr5zkz3rz8-gum-0.14.5"
+        "out": "/nix/store/mcbsnqvcz9q3j6mnbpwy5brid0zgzll6-gum-0.13.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -96,27 +100,29 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/dxfhlmmf8c4rcxqyns6a0hk2ymh245nv-gum-0.14.5.drv",
+      "derivation": "/nix/store/2nk0hyx670vpzlbks3kgn96a67l47nyd-gum-0.13.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "gum-0.14.5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "gum-0.13.0",
       "pname": "gum",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "0.13.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/652lcsz1jind3y4dbg4vnfas6fvhblf9-gum-0.14.5"
+        "out": "/nix/store/vf21qsvvsmfs9diw5bk9b32iavp9pdfx-gum-0.13.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -125,27 +131,29 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/56mw00m93jqs5hnfqlgng6iwa6gza13m-gum-0.14.5.drv",
+      "derivation": "/nix/store/giv1hnpfzcwlbcwh4zbmnlakqppvk9qf-gum-0.13.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "gum-0.14.5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "gum-0.13.0",
       "pname": "gum",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "0.13.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0dl1rmdsxqn0x775zb433bf8cfar3cxv-gum-0.14.5"
+        "out": "/nix/store/lmc0z0s5zlq5vvyv5y0cxhi727dzvq02-gum-0.13.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -154,36 +162,38 @@
     {
       "attr_path": "libuuid",
       "broken": false,
-      "derivation": "/nix/store/rjzm2kfsd57js9xksi6r10wynzz56grm-util-linux-minimal-2.39.4.drv",
-      "description": "Set of system utilities for Linux",
+      "derivation": "/nix/store/y2d5zfmi22gmj6sidv8s5p0d9xj8kw5a-util-linux-minimal-2.39.3.drv",
+      "description": "A set of system utilities for Linux",
       "install_id": "libuuid",
       "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "util-linux-minimal-2.39.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "util-linux-minimal-2.39.3",
       "pname": "libuuid",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "util-linux-minimal-2.39.4",
+      "version": "util-linux-minimal-2.39.3",
       "outputs_to_install": [
         "bin",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/rhaj4f2nha5ff2qaaz39qmy70jz5gkm8-util-linux-minimal-2.39.4-bin",
-        "debug": "/nix/store/vyrysj9fbpwj47wnwmigyfcxv3blrjqf-util-linux-minimal-2.39.4-debug",
-        "dev": "/nix/store/c134hzsvs9m2xpsywvn4qi74jkx06284-util-linux-minimal-2.39.4-dev",
-        "lib": "/nix/store/1zvfmc7mqlljci6l7hla5wzs0qvmxvs5-util-linux-minimal-2.39.4-lib",
-        "login": "/nix/store/1x76irn6097a9b89py8cd83hi5p6s7if-util-linux-minimal-2.39.4-login",
-        "man": "/nix/store/9y3hd69wp0k7278rkicm2v2p8yl7vg3r-util-linux-minimal-2.39.4-man",
-        "mount": "/nix/store/8vq44d8cwb3w1mp6grn9s6mgxzmcfxf5-util-linux-minimal-2.39.4-mount",
-        "out": "/nix/store/ldv7sypn1mr25n4qxqrbwk3cndf6xcah-util-linux-minimal-2.39.4",
-        "swap": "/nix/store/16x1b34fcpcnxmxs3ji9v75wbhn2i8m7-util-linux-minimal-2.39.4-swap"
+        "bin": "/nix/store/53wh8a86vs97d2h7cnrp54gx5wipbna6-util-linux-minimal-2.39.3-bin",
+        "debug": "/nix/store/wbm05hbd2hr7nl2zsq0x3r2narj6zany-util-linux-minimal-2.39.3-debug",
+        "dev": "/nix/store/adj9r5g6cp7qdwl3i9pmglz88732x215-util-linux-minimal-2.39.3-dev",
+        "lib": "/nix/store/wxglc4h5bdd2w1d1p642axxbw2wy9igi-util-linux-minimal-2.39.3-lib",
+        "login": "/nix/store/ij04cv1x9nb5p0gsfjcmhffziv40hijg-util-linux-minimal-2.39.3-login",
+        "man": "/nix/store/amlvi45pfa8v4vn3qhijgr1dmh93jrcj-util-linux-minimal-2.39.3-man",
+        "mount": "/nix/store/8yfnmxbx0099f8qihmd86sqj2w50ajkk-util-linux-minimal-2.39.3-mount",
+        "out": "/nix/store/raq2k51pb5pszp6lz0b5knsmqrpr6mgw-util-linux-minimal-2.39.3",
+        "swap": "/nix/store/4gm6hy42b7fwsmbdma5jl6xysshjcl2n-util-linux-minimal-2.39.3-swap"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -192,156 +202,166 @@
     {
       "attr_path": "libuuid",
       "broken": false,
-      "derivation": "/nix/store/glwgs25vcs54dibpnbzfb32ndh85n07q-util-linux-minimal-2.39.4.drv",
-      "description": "Set of system utilities for Linux",
+      "derivation": "/nix/store/5a97qkamdf372nicj8png3rq1k8kmyhr-util-linux-minimal-2.39.3.drv",
+      "description": "A set of system utilities for Linux",
       "install_id": "libuuid",
       "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "util-linux-minimal-2.39.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "util-linux-minimal-2.39.3",
       "pname": "libuuid",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "util-linux-minimal-2.39.4",
+      "version": "util-linux-minimal-2.39.3",
       "outputs_to_install": [
         "bin",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/4bnic2wzy34ya0iirx7z9lz0y53plk8s-util-linux-minimal-2.39.4-bin",
-        "debug": "/nix/store/z27b828idk6zznf149nkvbmg6fvklxv2-util-linux-minimal-2.39.4-debug",
-        "dev": "/nix/store/n93hwhpy39jwybnx8vinva87xkbaslnl-util-linux-minimal-2.39.4-dev",
-        "lib": "/nix/store/gm5g3xyn8iwxkag8gs6rf3ci64bqld80-util-linux-minimal-2.39.4-lib",
-        "login": "/nix/store/xgkcl3gpy87bpnvv6z8bs74yishk792k-util-linux-minimal-2.39.4-login",
-        "man": "/nix/store/7wgflcakf6xii9sd34l7nzpv74r85gbb-util-linux-minimal-2.39.4-man",
-        "mount": "/nix/store/4kgxc0nk8j51gn03ynmgrqvq4iyn29sq-util-linux-minimal-2.39.4-mount",
-        "out": "/nix/store/qwfm200f1dnh2rc8zazbviydfhhnxg8v-util-linux-minimal-2.39.4",
-        "swap": "/nix/store/8m2393syd4amxqr7yc9x8k2i2a1ihrbr-util-linux-minimal-2.39.4-swap"
+        "bin": "/nix/store/1kl4qs161vf2yl76a3jf93vij7x37fys-util-linux-minimal-2.39.3-bin",
+        "debug": "/nix/store/79f1zqlrg94111inl2khzcfj5iafai6m-util-linux-minimal-2.39.3-debug",
+        "dev": "/nix/store/0kp0vin762ai0q9dp4c83vf28n6hray7-util-linux-minimal-2.39.3-dev",
+        "lib": "/nix/store/6gdrq234cm8xcclal3zalrgy1vbmp81r-util-linux-minimal-2.39.3-lib",
+        "login": "/nix/store/djk1dkqpyrn6khx6q6zg0kaxjpbmavax-util-linux-minimal-2.39.3-login",
+        "man": "/nix/store/1vw3bygssswbj3c6rmganpisswlxv74y-util-linux-minimal-2.39.3-man",
+        "mount": "/nix/store/8ir2w5fk182dqrjld4qrxqin1lfi52d9-util-linux-minimal-2.39.3-mount",
+        "out": "/nix/store/dyn88flqp8jd3rnpd6i4gqvw0gwxam97-util-linux-minimal-2.39.3",
+        "swap": "/nix/store/3gc1a1mp4j8s58mq1jnwq2r1frrgjdlg-util-linux-minimal-2.39.3-swap"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "nodejs",
+      "attr_path": "nodejs_21",
       "broken": false,
-      "derivation": "/nix/store/cpc9p6bxbw3sy02m28vwp1ixv4rwr51g-nodejs-20.18.1.drv",
+      "derivation": "/nix/store/ndcy9jlzxviid8yxb4k7afcacsdbppq7-nodejs-21.7.3.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
-      "install_id": "nodejs",
+      "install_id": "nodejs_21",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "nodejs-20.18.1",
-      "pname": "nodejs",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "nodejs-21.7.3",
+      "pname": "nodejs_21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "20.18.1",
+      "version": "nodejs-21.7.3",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/l17919sgiw0i3awxlpic9z9a3g2d0rgv-nodejs-20.18.1-libv8",
-        "out": "/nix/store/f0lm95g31vpknr8jj9xw53cx2rqly2nm-nodejs-20.18.1"
+        "libv8": "/nix/store/y6xj0m2n7mlzgx5mc62m0lb4h02dzklr-nodejs-21.7.3-libv8",
+        "out": "/nix/store/hxr5ziwxn72wxcrhxasdy542h6z0r9hg-nodejs-21.7.3"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "nodejs",
+      "attr_path": "nodejs_21",
       "broken": false,
-      "derivation": "/nix/store/3rjfcddi2krynxqz0nb99fc65nz827gi-nodejs-20.18.1.drv",
+      "derivation": "/nix/store/dgzpa4dzhzlwvqwz83z798w8n13m3m36-nodejs-21.7.3.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
-      "install_id": "nodejs",
+      "install_id": "nodejs_21",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "nodejs-20.18.1",
-      "pname": "nodejs",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "nodejs-21.7.3",
+      "pname": "nodejs_21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "20.18.1",
+      "version": "nodejs-21.7.3",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/1pp9h9ma5ps2w3n7abkd3ipgjnmixwpm-nodejs-20.18.1-libv8",
-        "out": "/nix/store/vqv3dblqx76k185jg4ym5i3dz196lv19-nodejs-20.18.1"
+        "libv8": "/nix/store/vjr64cmj37yglbzjz6hrwqa4z6hw2mz2-nodejs-21.7.3-libv8",
+        "out": "/nix/store/xfddvy0bfzc78yipmyx81irjqfpkm1d0-nodejs-21.7.3"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "nodejs",
+      "attr_path": "nodejs_21",
       "broken": false,
-      "derivation": "/nix/store/1zm0n4n1sgqc6cb5dzyxbj7as8wlijd4-nodejs-20.18.1.drv",
+      "derivation": "/nix/store/qk5651cbzcmx327lprc6w4vj2wkmwghn-nodejs-21.7.3.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
-      "install_id": "nodejs",
+      "install_id": "nodejs_21",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "nodejs-20.18.1",
-      "pname": "nodejs",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "nodejs-21.7.3",
+      "pname": "nodejs_21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "20.18.1",
+      "version": "nodejs-21.7.3",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/85x3jn8wf6n6ihr3ar70fhgc4p87znsq-nodejs-20.18.1-libv8",
-        "out": "/nix/store/gbrd92gjhi88lhj43bsa2y9zvcn4vsb8-nodejs-20.18.1"
+        "libv8": "/nix/store/wnzqqc8ik64a6zn4k4bbcgzvi8dp8vnb-nodejs-21.7.3-libv8",
+        "out": "/nix/store/pnrd7gl28dmy86pprrpifq7qny3sx1xp-nodejs-21.7.3"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "nodejs",
+      "attr_path": "nodejs_21",
       "broken": false,
-      "derivation": "/nix/store/2znhzcp5ran8q5mzyqgz6lxi3a56rgva-nodejs-20.18.1.drv",
+      "derivation": "/nix/store/2vza1j6chgmfa1s77ws7c0li9cnzl0jq-nodejs-21.7.3.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
-      "install_id": "nodejs",
+      "install_id": "nodejs_21",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "name": "nodejs-20.18.1",
-      "pname": "nodejs",
-      "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
-      "rev_count": 720697,
-      "rev_date": "2024-12-11T18:06:44Z",
-      "scrape_date": "2024-12-14T03:50:50Z",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=6143fc5eeb9c4f00163267708e26191d1e918932",
+      "name": "nodejs-21.7.3",
+      "pname": "nodejs_21",
+      "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+      "rev_count": 615148,
+      "rev_date": "2024-04-21T15:54:59Z",
+      "scrape_date": "2024-06-13T19:49:37Z",
       "stabilities": [
+        "stable",
+        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "20.18.1",
+      "version": "nodejs-21.7.3",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/6cpw80r57lyippnjl5knrvymcwalv1m2-nodejs-20.18.1-libv8",
-        "out": "/nix/store/wfxq6w9bkp5dcfr8yb6789b0w7128gnb-nodejs-20.18.1"
+        "libv8": "/nix/store/iq38acw88hl92vpwamfkzgk3pk3dsr0x-nodejs-21.7.3-libv8",
+        "out": "/nix/store/dfs59hwhc4mb4hdk77nc5dd39k2v2qs2-nodejs-21.7.3"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -15,10 +15,10 @@ version = 1
 ##  $ flox show gum     <- show all versions of a package
 ## -------------------------------------------------------------------
 [install]
-nodejs = { pkg-path = "nodejs" }
 libuuid.pkg-path = "libuuid"
 libuuid.systems = ["aarch64-linux", "x86_64-linux"]
 gum.pkg-path = "gum"
+nodejs_21.pkg-path = "nodejs_21"
 
 
 ## Environment Variables ---------------------------------------------

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -19,6 +19,8 @@ libuuid.pkg-path = "libuuid"
 libuuid.systems = ["aarch64-linux", "x86_64-linux"]
 gum.pkg-path = "gum"
 nodejs_21.pkg-path = "nodejs_21"
+jdk21.pkg-path = "jdk21"
+maven3.pkg-path = "maven3"
 
 
 ## Environment Variables ---------------------------------------------
@@ -34,12 +36,25 @@ nodejs_21.pkg-path = "nodejs_21"
 ## -------------------------------------------------------------------
 [hook]
 on-activate = """
+  export MAVEN_USER_HOME="$(realpath $FLOX_ENV_CACHE)/m2"
+  export MAVEN_OPTS="-Dmaven.repo.local=$MAVEN_USER_HOME/repository"
+
   if [ ! -d "$FLOX_ENV_PROJECT"/node_modules ]; then
+    echo "First activation of environment.  Setting some things up - you may want to get a cup of tea..."
+
+    # Install Java dependencies
+    mvnw-deps() {
+      cd translator
+      ./mvnw dependency:resolve dependency:resolve-plugins
+      cd ..
+    }
+    export -f mvnw-deps
+    gum spin --spinner minidot --title "Installing Java dependencies..." --show-output -- bash -c mvnw-deps
+
     # Install nodejs dependencies
-    echo "First activation of environment.  Setting some things up."
     gum spin --spinner minidot --title "Installing node packages..." --show-output -- npm install
 
-    gum confirm "Perform initial build (recommended)?" && npm run build && npx link cli
+    gum confirm "Perform initial CLI build (recommended)?" && npm run build && npx link cli
   fi
 """
 

--- a/cli/DEVELOPER_GUIDE.md
+++ b/cli/DEVELOPER_GUIDE.md
@@ -10,7 +10,7 @@
 
 ### Everyone else
 
-  1. Install Node v20.18.1 (use `nvm` to manage Node versions if needed).  The `canvas` package we use does not seem to be compatible with later versions of node.
+  1. Install Node v21.7.3 (use `nvm` to manage Node versions if needed).  The `canvas` package we use does not currently seem to be compatible with node v22+.
   1. Make sure `libuuid.so` is installed (`ldconfig -p | grep libuuid`) and install it if not (instructions will depend on your OS).
   1. Clone the git repo and `cd` into the directory
   1. Run the following:


### PR DESCRIPTION
Node v21 is also compatible with `canvas`, so bumping the recommended version and updating the Flox environment to match.