### PR TITLE
Log warning when validating a spec against the wrong core schema versions

### DIFF
--- a/shared/src/commands/bundled-schemas.spec.ts
+++ b/shared/src/commands/bundled-schemas.spec.ts
@@ -1,0 +1,30 @@
+import { checkCoreSchemaVersion } from "./bundled-schemas";
+
+jest.mock('./helper.js', () => {
+    return {
+        initLogger: () => {
+            return {
+                info: jest.fn(),
+                debug: jest.fn(),
+                error: jest.fn()
+            };
+        }
+    };
+});
+
+describe('checkCoreSchemaVersion', () => {
+    it('Return false for non-core schema URLs', () => {
+        expect(checkCoreSchemaVersion('https://not-calm.org/spec.json', '2024-10', false))
+            .toBeFalsy();
+    })
+    
+    it('Return false for matching core schema URLs', () => {
+        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2024-10/core.json', '2024-10', false))
+            .toBeFalsy();
+    })
+    
+    it('Return true for non-matching core schema URLs', () => {
+        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2020-01/core.json', '2024-10', false))
+            .toBeTruthy();
+    })
+})

--- a/shared/src/commands/bundled-schemas.spec.ts
+++ b/shared/src/commands/bundled-schemas.spec.ts
@@ -1,4 +1,4 @@
-import { checkCoreSchemaVersion } from "./bundled-schemas";
+import { checkCoreSchemaVersion } from './bundled-schemas';
 
 jest.mock('./helper.js', () => {
     return {
@@ -17,15 +17,15 @@ describe('checkCoreSchemaVersion', () => {
     it('Return true for non-core schema URLs', () => {
         expect(checkCoreSchemaVersion('https://not-calm.org/spec.json', '2024-10', false))
             .toBeTruthy();
-    })
+    });
     
     it('Return true for core schema URLs matching loaded version', () => {
         expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2024-10/meta/core.json', '2024-10', false))
             .toBeTruthy();
-    })
+    });
     
     it('Return false for core schema URLs that dont match loaded version', () => {
         expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2020-01/meta/core.json', '2024-10', false))
             .toBeFalsy();
-    })
-})
+    });
+});

--- a/shared/src/commands/bundled-schemas.spec.ts
+++ b/shared/src/commands/bundled-schemas.spec.ts
@@ -6,25 +6,26 @@ jest.mock('./helper.js', () => {
             return {
                 info: jest.fn(),
                 debug: jest.fn(),
-                error: jest.fn()
+                error: jest.fn(),
+                warn: jest.fn()
             };
         }
     };
 });
 
 describe('checkCoreSchemaVersion', () => {
-    it('Return false for non-core schema URLs', () => {
+    it('Return true for non-core schema URLs', () => {
         expect(checkCoreSchemaVersion('https://not-calm.org/spec.json', '2024-10', false))
-            .toBeFalsy();
-    })
-    
-    it('Return false for matching core schema URLs', () => {
-        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2024-10/core.json', '2024-10', false))
-            .toBeFalsy();
-    })
-    
-    it('Return true for non-matching core schema URLs', () => {
-        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2020-01/core.json', '2024-10', false))
             .toBeTruthy();
+    })
+    
+    it('Return true for core schema URLs matching loaded version', () => {
+        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2024-10/meta/core.json', '2024-10', false))
+            .toBeTruthy();
+    })
+    
+    it('Return false for core schema URLs that dont match loaded version', () => {
+        expect(checkCoreSchemaVersion('https://calm.finos.org/calm/draft/2020-01/meta/core.json', '2024-10', false))
+            .toBeFalsy();
     })
 })

--- a/shared/src/commands/bundled-schemas.ts
+++ b/shared/src/commands/bundled-schemas.ts
@@ -20,27 +20,35 @@ export function getBundledSchemaVersion(debug: boolean): string {
     return null;
 }
 
+/**
+ * Check whether a Schema URL is a core CALM schema, and if it is, log a warning if it doesn't match the bundled version.
+ * @param uri The schema URI to check
+ * @param bundledVersion The CALM schema version that was loaded
+ * @param debug Whether to log debug info
+ * @returns true if the schema version is valid, false otherwise
+ */
 export function checkCoreSchemaVersion(uri: string, bundledVersion: string, debug: boolean) {
     const logger = initLogger(debug);
 
     if (bundledVersion === null) {
-        return false;
+        return true;
     }
 
     const matches = calmSchemaRegex.exec(uri);
 
     if (!matches || matches.length < 2) {
-        return false;
+        // not a CALM core schema
+        return true;
     }
 
     const requestedCoreSchemaVersion = matches[1];
     if (requestedCoreSchemaVersion === bundledVersion) {
-        return false;
+        return true;
     }
 
     const warningMessage = `WARNING: attempting to load a core CALM schema with a version (${requestedCoreSchemaVersion}) that was not bundled with the CALM CLI. ` + 
         `This may produce unexpected errors. ` +
         `The bundled version is ${bundledVersion}. `;
     logger.warn(warningMessage);
-    return true;
+    return false;
 }

--- a/shared/src/commands/bundled-schemas.ts
+++ b/shared/src/commands/bundled-schemas.ts
@@ -1,22 +1,22 @@
-import { readdirSync } from "fs";
-import { CALM_META_SCHEMA_DIRECTORY } from "../consts";
-import { initLogger } from "./helper";
+import { readdirSync } from 'fs';
+import { CALM_META_SCHEMA_DIRECTORY } from '../consts';
+import { initLogger } from './helper';
 
 const calmSchemaRegex = new RegExp('https://.*/draft/([0-9-]+)/meta/.*');
 
 export function getBundledSchemaVersion(debug: boolean): string {
     const logger = initLogger(debug);
     try {
-        var files = readdirSync(CALM_META_SCHEMA_DIRECTORY);
+        const files = readdirSync(CALM_META_SCHEMA_DIRECTORY);
         if (files.length > 0) {
             return files[0];
         }
     }
-    catch (e) {
-        logger.warn("Error looking up bundled CALM schemas. Disabling checks for incorrect core schema versions.")
+    catch (_) {
+        logger.warn('Error looking up bundled CALM schemas. Disabling checks for incorrect core schema versions.');
         return null;
     }
-    logger.warn("Did not find bundled CALM schemas. Disabling checks for incorrect core schema versions.")
+    logger.warn('Did not find bundled CALM schemas. Disabling checks for incorrect core schema versions.');
     return null;
 }
 
@@ -47,7 +47,7 @@ export function checkCoreSchemaVersion(uri: string, bundledVersion: string, debu
     }
 
     const warningMessage = `WARNING: attempting to load a core CALM schema with a version (${requestedCoreSchemaVersion}) that was not bundled with the CALM CLI. ` + 
-        `This may produce unexpected errors. ` +
+        'This may produce unexpected errors. ' +
         `The bundled version is ${bundledVersion}. `;
     logger.warn(warningMessage);
     return false;

--- a/shared/src/commands/bundled-schemas.ts
+++ b/shared/src/commands/bundled-schemas.ts
@@ -1,0 +1,46 @@
+import { readdirSync } from "fs";
+import { CALM_META_SCHEMA_DIRECTORY } from "../consts";
+import { initLogger } from "./helper";
+
+const calmSchemaRegex = new RegExp('https://.*/draft/([0-9-]+)/meta/.*');
+
+export function getBundledSchemaVersion(debug: boolean): string {
+    const logger = initLogger(debug);
+    try {
+        var files = readdirSync(CALM_META_SCHEMA_DIRECTORY);
+        if (files.length > 0) {
+            return files[0];
+        }
+    }
+    catch (e) {
+        logger.warn("Error looking up bundled CALM schemas. Disabling checks for incorrect core schema versions.")
+        return null;
+    }
+    logger.warn("Did not find bundled CALM schemas. Disabling checks for incorrect core schema versions.")
+    return null;
+}
+
+export function checkCoreSchemaVersion(uri: string, bundledVersion: string, debug: boolean) {
+    const logger = initLogger(debug);
+
+    if (bundledVersion === null) {
+        return false;
+    }
+
+    const matches = calmSchemaRegex.exec(uri);
+
+    if (!matches || matches.length < 2) {
+        return false;
+    }
+
+    const requestedCoreSchemaVersion = matches[1];
+    if (requestedCoreSchemaVersion === bundledVersion) {
+        return false;
+    }
+
+    const warningMessage = `WARNING: attempting to load a core CALM schema with a version (${requestedCoreSchemaVersion}) that was not bundled with the CALM CLI. ` + 
+        `This may produce unexpected errors. ` +
+        `The bundled version is ${bundledVersion}. `;
+    logger.warn(warningMessage);
+    return true;
+}

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -35,10 +35,10 @@ jest.mock('../helper.js', () => {
 
 jest.mock('../bundled-schemas.js', () => {
     return {
-        getBundledSchemaVersion: (debug: boolean) => null,
-        checkCoreSchemaVersion: (uri: string, bundledVersion: string, debug: boolean) => null
-    }
-})
+        getBundledSchemaVersion: () => null,
+        checkCoreSchemaVersion: () => null
+    };
+});
 
 const metaSchemaLocation = 'test_fixtures/calm';
 const debugDisabled = false;

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -33,6 +33,13 @@ jest.mock('../helper.js', () => {
     };
 });
 
+jest.mock('../bundled-schemas.js', () => {
+    return {
+        getBundledSchemaVersion: (debug: boolean) => null,
+        checkCoreSchemaVersion: (uri: string, bundledVersion: string, debug: boolean) => null
+    }
+})
+
 const metaSchemaLocation = 'test_fixtures/calm';
 const debugDisabled = false;
 

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -11,6 +11,7 @@ import { ValidationOutput, ValidationOutcome } from './validation.output.js';
 import { SpectralResult } from './spectral.result.js';
 import createJUnitReport from './output-formats/junit-output.js';
 import prettyFormat from './output-formats/pretty-output';
+import { checkCoreSchemaVersion, getBundledSchemaVersion } from '../bundled-schemas';
 
 let logger: winston.Logger; // defined later at startup
 
@@ -64,9 +65,12 @@ export function formatOutput(
 
 function buildAjv2020(debug: boolean): Ajv2020 {
     const strictType = debug ? 'log' : false;
+    const bundledSchemaVersion = getBundledSchemaVersion(debug);
     return new Ajv2020({
         strict: strictType, allErrors: true, loadSchema: async (uri) => {
             try {
+                // validate schema version
+                checkCoreSchemaVersion(uri, bundledSchemaVersion, debug);
                 const response = await fetch(uri);
                 if (!response.ok) {
                     throw new Error(`Unable to fetch schema from ${uri}`);


### PR DESCRIPTION
Initial stab at #314 

This looks at the bundled files and then intercepts any load to look at the URL. It's quite crude, but wanted to get an initial PR up to see people's thoughts.