### PR TITLE
Highlight the small nodes on selection

### DIFF
--- a/calm-visualizer/src/components/cytoscape-renderer/CytoscapeRenderer.tsx
+++ b/calm-visualizer/src/components/cytoscape-renderer/CytoscapeRenderer.tsx
@@ -65,6 +65,16 @@ const CytoscapeRenderer = ({
     const [selectedNode, setSelectedNode] = useState<Node['data'] | null>(null);
     const [selectedEdge, setSelectedEdge] = useState<Edge['data'] | null>(null);
 
+    function getNodeLabelTemplateGenerator(selected=false): (data: Node["data"]) => string {
+        return (data: Node['data']) => {
+            return `<div class="node element ${selected ? 'selected-node' : ''}">
+                        <p class="title">${data.label}</p>
+                        <p class="type">${data.type}</p>
+                        <p class="description">${isNodeDescActive ? data.description : ''}</p>
+                    </div>`;
+        }
+    }
+
     useEffect(() => {
         if (cy) {
             //Ensure cytoscape zoom and context state are synchronised
@@ -75,13 +85,11 @@ const CytoscapeRenderer = ({
             (cy as Core & { nodeHtmlLabel: any }).nodeHtmlLabel([
                 {
                     query: '.node',
-                    tpl: (data: Node['data']) => {
-                        return `<div class="node element">
-                                    <p class="title">${data.label}</p>
-                                    <p class="type">${data.type}</p>
-                                    <p class="description">${isNodeDescActive ? data.description : ''}</p>
-                                </div>`;
-                    },
+                    tpl: getNodeLabelTemplateGenerator(false)
+                },
+                {
+                    query: '.node:selected',
+                    tpl: getNodeLabelTemplateGenerator(true)
                 },
             ]);
 

--- a/calm-visualizer/src/components/cytoscape-renderer/cytoscape.css
+++ b/calm-visualizer/src/components/cytoscape-renderer/cytoscape.css
@@ -8,6 +8,10 @@
     background-color: white;
 }
 
+.selected-node {
+    background-color: #CCE1F9;
+}
+
 :focus {
     border: 1px solid;
     border-color: blue;


### PR DESCRIPTION
I noticed that the small nodes, which are white in colour, don't get highlighted when you click on them, while the edges do. It would be nice to see which node corresponds to the sidebar which opens, hence I made this PR where the selected white nodes are highlighted.

The reason highlighting was not happening earlier was because these nodes were all being given a static html template for a label. I tweaked this a little to give a new node label template if the node has the `:selected` class. The result looks like this:

![image](https://github.com/user-attachments/assets/e653337a-4352-4760-98ee-8adeb9a9d8fb)

Note that:
- If we close the sidebar, the node on the graph does not get deselected.
- If we deselect on the graph (by clicking outside it), the sidebar does not get closed

This behaviour is easy enough to change, but I thought I'd keep things simple in this PR e.g. do people agree with the selection colour?