### PR TITLE
Revert back docify-compose.yml change so that calm-hub can run without build

### DIFF
--- a/calm-hub/deploy/docker-compose.yml
+++ b/calm-hub/deploy/docker-compose.yml
@@ -9,10 +9,8 @@ services:
     networks:
       - calm-net
   calmhub:
-    build:
-      context: ..
-      dockerfile: src/main/docker/Dockerfile.jvm
-    image: calm-hub:latest
+    image: jpgough/calm-hub:latest
+    container_name: calm-hub
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
As per comment https://github.com/finos/architecture-as-code/pull/799#discussion_r1923571270, reverting back change to docify-compose file to allow people to run calm-hub without build.
