### PR TITLE
Rework validate command to use SchemaDirectory, and clean up process.exit() use

### DIFF
--- a/calm-visualizer/package.json
+++ b/calm-visualizer/package.json
@@ -9,7 +9,7 @@
         "lint": "eslint .",
         "format": "prettier --write .",
         "preview": "vite preview",
-        "test": "vitest"
+        "test": "vitest run"
     },
     "dependencies": {
         "cytoscape": "^3.30.3",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -57,7 +57,7 @@ program
  * Run the validate command and exit with the right status code based on the result.
  * @param options Options passed through from the argument parser.
  */
-async function runValidate(options: any) {
+async function runValidate(options) {
     if (!options.pattern && !options.architecture) {
         program.error(`error: one of the required options '${PATTERN_OPTION}' or '${ARCHITECTURE_OPTION}' was not specified`);
     }
@@ -69,7 +69,7 @@ async function runValidate(options: any) {
     }
     catch (err) {
         const logger = initLogger(options.verbose);
-        logger.error("An error occurred while validating: " + err.message);
+        logger.error('An error occurred while validating: ' + err.message);
         logger.debug(err.stack);
         process.exit(1);
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -49,22 +49,31 @@ program
     .option(OUTPUT_OPTION, 'Path location at which to output the generated file.')
     .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
     .action(async (options) => {
-        if(!options.pattern && !options.architecture) {
-            program.error(`error: one of the required options '${PATTERN_OPTION}' or '${ARCHITECTURE_OPTION}' was not specified`);
-        }
-        try {
-            const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
-            const content = getFormattedOutput(outcome, options.format);
-            writeOutputFile(options.output, content);
-            exitBasedOffOfValidationOutcome(outcome, options.strict);
-        }
-        catch (err) {
-            const logger = initLogger(options.verbose);
-            logger.error("An error occurred while validating: " + err.message);
-            logger.debug(err.stack);
-            process.exit(1);
-        }
+        await runValidate(options);
     });
+
+
+/**
+ * Run the validate command and exit with the right status code based on the result.
+ * @param options Options passed through from the argument parser.
+ */
+async function runValidate(options: any) {
+    if (!options.pattern && !options.architecture) {
+        program.error(`error: one of the required options '${PATTERN_OPTION}' or '${ARCHITECTURE_OPTION}' was not specified`);
+    }
+    try {
+        const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
+        const content = getFormattedOutput(outcome, options.format);
+        writeOutputFile(options.output, content);
+        exitBasedOffOfValidationOutcome(outcome, options.strict);
+    }
+    catch (err) {
+        const logger = initLogger(options.verbose);
+        logger.error("An error occurred while validating: " + err.message);
+        logger.debug(err.stack);
+        process.exit(1);
+    }
+}
 
 function writeOutputFile(output: string, validationsOutput: string) {
     if (output) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { mkdirp } from 'mkdirp';
 import { writeFileSync } from 'fs';
 import { version } from '../package.json';
+import { initLogger } from '@finos/calm-shared/commands/helper';
 
 const FORMAT_OPTION = '-f, --format <format>';
 const ARCHITECTURE_OPTION = '-a, --architecture <file>';
@@ -51,10 +52,18 @@ program
         if(!options.pattern && !options.architecture) {
             program.error(`error: one of the required options '${PATTERN_OPTION}' or '${ARCHITECTURE_OPTION}' was not specified`);
         }
-        const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
-        const content = getFormattedOutput(outcome, options.format);
-        writeOutputFile(options.output, content);
-        exitBasedOffOfValidationOutcome(outcome, options.strict);
+        try {
+            const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
+            const content = getFormattedOutput(outcome, options.format);
+            writeOutputFile(options.output, content);
+            exitBasedOffOfValidationOutcome(outcome, options.strict);
+        }
+        catch (err) {
+            const logger = initLogger(options.verbose);
+            logger.error("An error occurred while validating: " + err.message);
+            logger.debug(err.stack);
+            process.exit(1);
+        }
     });
 
 function writeOutputFile(output: string, validationsOutput: string) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:cli": "npm run build --workspace shared --workspace cli",
     "build:docs": "npm run build --workspace docs",
     "test": "npm run test --workspaces --if-present",
+    "test:cli": "npm run build:cli && npm run test --workspace cli",
     "lint": "npm run lint --workspaces --if-present",
     "lint-fix": "npm run lint-fix --workspaces --if-present",
     "watch": "run-p watch:cli watch:shared",

--- a/shared/src/commands/generate/generate.e2e.spec.ts
+++ b/shared/src/commands/generate/generate.e2e.spec.ts
@@ -7,6 +7,18 @@ jest.mock('../../consts', () => ({
     get CALM_META_SCHEMA_DIRECTORY() { return 'test_fixtures/calm'; }
 }));
 
+jest.mock('../helper', () => {
+    return {
+        initLogger: () => {
+            return {
+                info: () => {},
+                warn: () => {},
+                debug: () => {}
+            };
+        }
+    };
+});
+
 describe('generate spec e2e', () => {
     let tempDirectoryPath;
 

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -27,6 +27,7 @@ jest.mock('../helper.js', () => {
             return {
                 info: jest.fn(),
                 debug: jest.fn(),
+                warn: jest.fn(),
                 error: jest.fn()
             };
         }
@@ -74,7 +75,7 @@ describe('validation support functions', () => {
             exitBasedOffOfValidationOutcome(expectedValidationOutcome, true);
             expect(mockExit).toHaveBeenCalledWith(1);
         });
-    })
+    });
 
     describe('sortSpectralIssueBySeverity', () => {
 
@@ -239,7 +240,7 @@ describe('validation support functions', () => {
         });
 
     });
-})
+});
 
 describe('validate pattern and architecture', () => {
     beforeEach(() => {
@@ -516,7 +517,6 @@ describe('validate - architecture only', () => {
         fetchMock.mock('http://exist/api-gateway-implementation.json', apiGateway);
 
         const response = await validate('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled);
-        console.log(response);
         
         expect(response).not.toBeNull();
         expect(response).not.toBeUndefined();

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -507,7 +507,7 @@ describe('validate - architecture only', () => {
         expect(response.allValidationOutputs().length).toBeGreaterThan(0);
     });
 
-    it.only('returns no errors when the architecture passes all the spectral validations ', async () => {
+    it('returns no errors when the architecture passes all the spectral validations with no errors', async () => {
         const expectedSpectralOutput: ISpectralDiagnostic[] = [];
 
         mockRunFunction.mockReturnValue(expectedSpectralOutput);
@@ -521,9 +521,9 @@ describe('validate - architecture only', () => {
         expect(response).not.toBeNull();
         expect(response).not.toBeUndefined();
         expect(response.hasErrors).not.toBeTruthy();
-        expect(response.hasWarnings).toBeTruthy();
+        expect(response.hasWarnings).not.toBeTruthy();
         expect(response.allValidationOutputs()).not.toBeNull();
-        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+        expect(response.allValidationOutputs().length).toBe(0);
     });
 });
 

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { validate, validateAndExitConditionally, sortSpectralIssueBySeverity, convertSpectralDiagnosticToValidationOutputs, convertJsonSchemaIssuesToValidationOutputs, stripRefs, exitBasedOffOfValidationOutcome } from './validate';
+import { validate, sortSpectralIssueBySeverity, convertSpectralDiagnosticToValidationOutputs, convertJsonSchemaIssuesToValidationOutputs, stripRefs, exitBasedOffOfValidationOutcome } from './validate';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { ISpectralDiagnostic } from '@stoplight/spectral-core';
@@ -36,14 +36,11 @@ jest.mock('../helper.js', () => {
 const metaSchemaLocation = 'test_fixtures/calm';
 const debugDisabled = false;
 
-describe('validate-all', () => {
-    describe('validate', () => {
-
+describe('validation support functions', () => {
+    describe('exitBasedOffOfValidationOutcome', () => {
         let mockExit;
 
         beforeEach(() => {
-            mockRunFunction.mockReturnValue([]);
-            jest.useFakeTimers();
             mockExit = jest.spyOn(process, 'exit')
                 .mockImplementation((code?) => {
                     if (code != 0) {
@@ -56,182 +53,6 @@ describe('validate-all', () => {
         afterEach(() => {
             fetchMock.restore();
         });
-
-        it('returns error when the the Pattern and the Architecture are undefined or an empty string', async () => {
-            await expect(validate('', undefined, metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('returns validation error when the JSON Schema pattern cannot be found in the input path', async () => {
-            await expect(validate('../test_fixtures/api-gateway-implementation.json', 'thisFolderDoesNotExist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('returns validation error when the architecture file cannot be found in the input path', async () => {
-            await expect(validate('../doesNotExists/api-gateway-implementation.json', 'test_fixtures/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('returns validation error when the architecture file does not contain JSON', async () => {
-            await expect(validate('test_fixtures/api-gateway-implementation.json', 'test_fixtures/markdown.md', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('exits with error when the JSON Schema pattern URL returns a 404', async () => {
-            fetchMock.mock('http://does-not-exist/api-gateway.json', 404);
-
-            await expect(validate('https://does-not-exist/api-gateway-implementation.json', 'http://does-not-exist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('exits with error when the architecture URL returns a 404', async () => {
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-            fetchMock.mock('https://does-not-exist/api-gateway-implementation.json', 404);
-
-            await expect(validate('https://does-not-exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('exits with error when the architecture file at given URL returns non JSON response', async () => {
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-
-            const markdown = ' #This is markdown';
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-            fetchMock.mock('https://url/with/non/json/response', markdown);
-
-            await expect(validate('https://url/with/non/json/response', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-        it('exits with error when the meta schema location is not a directory', async () => {
-            await expect(validate('https://url/with/non/json/response', 'http://exist/api-gateway.json', 'test_fixtures/api-gateway.json', debugDisabled))
-                .rejects
-                .toThrow();
-
-            expect(mockExit).toHaveBeenCalledWith(1);
-        });
-
-
-        it('has error when the architecture does not match the json schema', async () => {
-
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-
-            const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation-that-does-not-match-schema.json'), 'utf8');
-            fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
-
-            const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
-
-            expect(response).not.toBeNull();
-            expect(response).not.toBeUndefined();
-            expect(response.hasErrors).toBeTruthy();
-            expect(response.allValidationOutputs()).not.toBeNull();
-            expect(response.allValidationOutputs().length).toBeGreaterThan(0);
-        });
-
-        it('has error when the architecture does not pass all the spectral validations', async () => {
-
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'no-empty-properties',
-                    message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
-                    severity: 0,
-                    path: ['/nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-
-            const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation-that-does-not-pass-the-spectral-validation.json'), 'utf8');
-            fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
-
-            const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
-            expect(response).not.toBeNull();
-            expect(response).not.toBeUndefined();
-            expect(response.hasErrors).toBeTruthy();
-            expect(response.allValidationOutputs()).not.toBeNull();
-            expect(response.allValidationOutputs().length).toBeGreaterThan(0);
-        });
-
-        it('has error when the pattern does not pass all the spectral validations ', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'no-empty-properties',
-                    message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
-                    severity: 0,
-                    path: ['/nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-with-no-relationships.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-
-            const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
-            fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
-
-            const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
-            expect(response).not.toBeNull();
-            expect(response).not.toBeUndefined();
-            expect(response.hasErrors).toBeTruthy();
-            expect(response.allValidationOutputs()).not.toBeNull();
-            expect(response.allValidationOutputs().length).toBeGreaterThan(0);
-        });
-
-        it('completes successfully when the spectral validation returns warnings and errors', async () => {
-
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'warning-test',
-                    message: 'Test warning',
-                    severity: 1,
-                    path: ['nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-
-            const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
-            fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
-
-            const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
-            expect(response).not.toBeNull();
-            expect(response).not.toBeUndefined();
-            expect(response.hasErrors).not.toBeTruthy();
-            expect(response.hasWarnings).toBeTruthy();
-            expect(response.allValidationOutputs()).not.toBeNull();
-            expect(response.allValidationOutputs().length).toBeGreaterThan(0);
-        });
-
         it('exit based off of validation outcomes - non-zero outcome if error', () => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mockExit = jest.spyOn(process, 'exit').mockImplementation((code?) => undefined as never);
@@ -253,8 +74,7 @@ describe('validate-all', () => {
             exitBasedOffOfValidationOutcome(expectedValidationOutcome, true);
             expect(mockExit).toHaveBeenCalledWith(1);
         });
-
-    });
+    })
 
     describe('sortSpectralIssueBySeverity', () => {
 
@@ -419,155 +239,291 @@ describe('validate-all', () => {
         });
 
     });
+})
 
-    describe('validate - pattern only', () => {
-    
-        let mockExit;
-    
-        beforeEach(() => {
-            mockRunFunction.mockReturnValue([]);
-            mockExit = jest.spyOn(process, 'exit')
-                .mockImplementation((code) => {
-                    if (code != 0) {
-                        throw new Error('Expected successful run, code was nonzero: ' + code);
-                    }
-                    return undefined as never;
-                });
-        });
-    
-        afterEach(() => {
-            fetchMock.restore();
-        });
-    
-        it('exits with non zero exit code when the pattern does not pass all the spectral validations ', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'example-error',
-                    message: 'Example error',
-                    severity: 0,
-                    path: ['/nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-    
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-    
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-    
-            await expect(validateAndExitConditionally('', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-        });
-    
-        it('exits with error when spectral returns warnings, but failOnWarnings is set', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'example-warning',
-                    message: 'Example warning',
-                    severity: 1,
-                    path: ['/nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-    
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-    
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-            await expect(validateAndExitConditionally('', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled, true))
-                .rejects
-                .toThrow();
-    
-            expect(mockExit)
-                .toHaveBeenCalledWith(1);
-        });
-    
-        it('when spectral no errors, but json schema is invalid - raise non-zero exit code', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-            ];
-    
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-    
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/bad-schema/bad-json-schema.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway.json', apiGateway);
-    
-            await expect(validateAndExitConditionally('', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-    
-            expect(mockExit)
-                .toHaveBeenCalledWith(1);
-        });
+describe('validate pattern and architecture', () => {
+    beforeEach(() => {
+        mockRunFunction.mockReturnValue([]);
+        jest.useFakeTimers();
     });
 
-    describe('validate - architecture only', () => {
-    
-        let mockExit;
-    
-        beforeEach(() => {
-            mockRunFunction.mockReturnValue([]);
-            mockExit = jest.spyOn(process, 'exit')
-                .mockImplementation((code) => {
-                    if (code != 0) {
-                        throw new Error('Expected successful run, code was nonzero: ' + code);
-                    }
-                    return undefined as never;
-                });
-        });
-    
-        afterEach(() => {
-            fetchMock.restore();
-        });
+    afterEach(() => {
+        fetchMock.restore();
+    });
 
-        it('exits with non zero exit code when the architecture cannot be found', async () => {
-            fetchMock.mock('http://exist/api-gateway-implementation.json', 404);
-    
-            await expect(validateAndExitConditionally('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            
-            expect(mockExit)
-                .toHaveBeenCalledWith(1);
-        });
-    
-        it('exits with non zero exit code when the architecture does not pass all the spectral validations ', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [
-                {
-                    code: 'example-error',
-                    message: 'Example error',
-                    severity: 0,
-                    path: ['/nodes'],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
-                }
-            ];
-    
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-    
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway-implementation.json', apiGateway);
-    
-            await expect(validateAndExitConditionally('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled))
-                .rejects
-                .toThrow();
-            
-            expect(mockExit)
-                .toHaveBeenCalledWith(1);
-        });
+    it('throws error when the the Pattern and the Architecture are undefined or an empty string', async () => {
+        await expect(validate('', undefined, metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
 
-        it('exits with zero exit code when the architecture passes all the spectral validations ', async () => {
-            const expectedSpectralOutput: ISpectralDiagnostic[] = [];
-    
-            mockRunFunction.mockReturnValue(expectedSpectralOutput);
-    
-            const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
-            fetchMock.mock('http://exist/api-gateway-implementation.json', apiGateway);
-    
-            await expect(validateAndExitConditionally('http://exist/api-gateway-implementation.json', undefined, metaSchemaLocation, debugDisabled));
-            
-            expect(mockExit)
-                .toHaveBeenCalledWith(0);
-        });
+    it('throws validation error when the JSON Schema pattern cannot be found in the input path', async () => {
+        await expect(validate('../test_fixtures/api-gateway-implementation.json', 'thisFolderDoesNotExist/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws validation error when the architecture file cannot be found in the input path', async () => {
+        await expect(validate('../doesNotExists/api-gateway-implementation.json', 'test_fixtures/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws validation error when the architecture file does not contain JSON', async () => {
+        await expect(validate('test_fixtures/api-gateway-implementation.json', 'test_fixtures/markdown.md', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws error when the JSON Schema pattern URL returns a 404', async () => {
+        fetchMock.mock('http://does-not-exist/api-gateway.json', 404);
+
+        await expect(validate('https://does-not-exist/api-gateway-implementation.json', 'http://does-not-exist/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws error when the architecture URL returns a 404', async () => {
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+        fetchMock.mock('https://does-not-exist/api-gateway-implementation.json', 404);
+
+        await expect(validate('https://does-not-exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws error when the architecture file at given URL returns non JSON response', async () => {
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+
+        const markdown = ' #This is markdown';
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+        fetchMock.mock('https://url/with/non/json/response', markdown);
+
+        await expect(validate('https://url/with/non/json/response', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('throws error when the meta schema location is not a directory', async () => {
+        await expect(validate('https://url/with/non/json/response', 'http://exist/api-gateway.json', 'test_fixtures/api-gateway.json', debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+
+    it('has error when the architecture does not match the json schema', async () => {
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation-that-does-not-match-schema.json'), 'utf8');
+        fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
+
+        const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+    it('has error when the architecture does not pass all the spectral validations', async () => {
+
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'no-empty-properties',
+                message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
+                severity: 0,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation-that-does-not-pass-the-spectral-validation.json'), 'utf8');
+        fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
+
+        const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+    it('has error when the pattern does not pass all the spectral validations ', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'no-empty-properties',
+                message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
+                severity: 0,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-with-no-relationships.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
+        fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
+
+        const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+    it('completes successfully when the spectral validation returns warnings and errors', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'warning-test',
+                message: 'Test warning',
+                severity: 1,
+                path: ['nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const apiGatewayArchitecture = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
+        fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayArchitecture);
+
+        const response = await validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).not.toBeTruthy();
+        expect(response.hasWarnings).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+});
+
+describe('validate pattern only', () => {
+    beforeEach(() => {
+        mockRunFunction.mockReturnValue([]);
+    });
+
+    afterEach(() => {
+        fetchMock.restore();
+    });
+
+    it('has errors when the pattern does not pass all the spectral validations ', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'example-error',
+                message: 'Example error',
+                severity: 0,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const response = await validate('', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+    it('has errors when spectral returns no errors, but json schema is invalid', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/bad-schema/bad-json-schema.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const response = await validate('', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+});
+
+describe('validate - architecture only', () => {
+    beforeEach(() => {
+        mockRunFunction.mockReturnValue([]);
+    });
+
+    afterEach(() => {
+        fetchMock.restore();
+    });
+
+    it('throw error when the architecture cannot be found', async () => {
+        fetchMock.mock('http://exist/api-gateway-implementation.json', 404);
+
+        await expect(validate('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+    });
+
+    it('return errors when the architecture does not pass all the spectral validations ', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [
+            {
+                code: 'example-error',
+                message: 'Example error',
+                severity: 0,
+                path: ['/nodes'],
+                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+            }
+        ];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway-implementation.json', apiGateway);
+
+        const response = await validate('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled);
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
+    });
+
+    it.only('returns no errors when the architecture passes all the spectral validations ', async () => {
+        const expectedSpectralOutput: ISpectralDiagnostic[] = [];
+
+        mockRunFunction.mockReturnValue(expectedSpectralOutput);
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway-implementation.json', apiGateway);
+
+        const response = await validate('http://exist/api-gateway-implementation.json', '', metaSchemaLocation, debugDisabled);
+        console.log(response);
+        
+        expect(response).not.toBeNull();
+        expect(response).not.toBeUndefined();
+        expect(response.hasErrors).not.toBeTruthy();
+        expect(response.hasWarnings).toBeTruthy();
+        expect(response.allValidationOutputs()).not.toBeNull();
+        expect(response.allValidationOutputs().length).toBeGreaterThan(0);
     });
 });
 

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -11,7 +11,7 @@ import { ValidationOutput, ValidationOutcome } from './validation.output.js';
 import { SpectralResult } from './spectral.result.js';
 import createJUnitReport from './output-formats/junit-output.js';
 import prettyFormat from './output-formats/pretty-output';
-import { SchemaDirectory } from '@finos/calm-shared/schema-directory';
+import { SchemaDirectory } from '../../schema-directory.js';
 
 let logger: winston.Logger; // defined later at startup
 

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -1,5 +1,5 @@
 import Ajv2020, { ErrorObject } from 'ajv/dist/2020.js';
-import { existsSync, promises as fs, readdirSync, readFileSync, statSync } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import { Spectral, ISpectralDiagnostic, RulesetDefinition } from '@stoplight/spectral-core';
 
 import validationRulesForPattern from '../../spectral/rules-pattern';

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -11,21 +11,10 @@ import { ValidationOutput, ValidationOutcome } from './validation.output.js';
 import { SpectralResult } from './spectral.result.js';
 import createJUnitReport from './output-formats/junit-output.js';
 import prettyFormat from './output-formats/pretty-output';
+import { SchemaDirectory } from '@finos/calm-shared/schema-directory';
 
 let logger: winston.Logger; // defined later at startup
 
-/**
- * Merge the results from two Spectral validations together, combining any errors/warnings.
- * @param spectralResultPattern Spectral results from the pattern validation
- * @param spectralResultArchitecture Spectral results from the architecture validation
- * @returns A new SpectralResult with the error/warning status propagated and the results concatenated.
- */
-function mergeSpectralResults(spectralResultPattern: SpectralResult, spectralResultArchitecture: SpectralResult): SpectralResult {
-    const errors: boolean = spectralResultPattern.errors || spectralResultArchitecture.errors;
-    const warnings: boolean = spectralResultPattern.warnings || spectralResultArchitecture.warnings;
-    const spectralValidations = spectralResultPattern.spectralIssues.concat(spectralResultArchitecture.spectralIssues);
-    return new SpectralResult(warnings, errors, spectralValidations);
-}
 
 /**
  * TODO - move this out of shared and into the CLI - this is process-management code.
@@ -62,16 +51,19 @@ export function formatOutput(
     }
 }
 
-function buildAjv2020(debug: boolean): Ajv2020 {
+/**
+ * Builds an AJV instance, configured to defer to the SchemaDirectory in the event of any missing schemas.
+ * 
+ * @param schemaDirectory An initialised SchemaDirectory with schemas already loaded.
+ * @param debug Whether to log at debug level.
+ * @returns An initialised Ajv instance.
+ */
+function buildAjv2020(schemaDirectory: SchemaDirectory, debug: boolean): Ajv2020 {
     const strictType = debug ? 'log' : false;
     return new Ajv2020({
-        strict: strictType, allErrors: true, loadSchema: async (uri) => {
+        strict: strictType, allErrors: true, loadSchema: async (schemaId) => {
             try {
-                const response = await fetch(uri);
-                if (!response.ok) {
-                    throw new Error(`Unable to fetch schema from ${uri}`);
-                }
-                return response.json();
+                return schemaDirectory.getSchema(schemaId);
             } catch (error) {
                 console.error(`Error fetching schema: ${error.message}`);
             }
@@ -79,40 +71,19 @@ function buildAjv2020(debug: boolean): Ajv2020 {
     });
 }
 
-function isValidURL(str: string): boolean {
-    try {
-        const url = new URL(str);
-        return ['http:', 'https:'].includes(url.protocol);
-    } catch {
-        return false;
-    }
-}
-
-async function loadMetaSchemas(ajv: Ajv2020, metaSchemaLocation: string) {
+/**
+ * Initialises a SchemaDirectory and loads schemas into it.
+ * 
+ * @param metaSchemaLocation File location from which to load schemas.
+ * @returns an initialised SchemaDirectory.
+ */
+async function loadMetaSchemas(metaSchemaLocation: string): Promise<SchemaDirectory> {
     logger.info(`Loading meta schema(s) from ${metaSchemaLocation}`);
-    if (isValidURL(metaSchemaLocation)) {
-        logger.info(`Loading meta schema from URL: ${metaSchemaLocation}`);
-        const metaSchema = await getFileFromUrlOrPath(metaSchemaLocation);
-        ajv.addSchema(metaSchema);
-    } else {
-        if (!statSync(metaSchemaLocation).isDirectory()) {
-            throw new Error(`The metaSchemaLocation: ${metaSchemaLocation} is not a directory`);
-        }
 
-        const filenames = readdirSync(metaSchemaLocation);
+    const schemaDirectory = new SchemaDirectory();
+    await schemaDirectory.loadSchemas(metaSchemaLocation);
 
-        if (filenames.length === 0) {
-            throw new Error(`The metaSchemaLocation: ${metaSchemaLocation} is an empty directory`);
-        }
-
-        filenames.forEach(filename => {
-            if (filename.endsWith('.json')) {
-                logger.debug('Adding meta schema : ' + filename);
-                const meta = JSON.parse(readFileSync(metaSchemaLocation + '/' + filename, 'utf8'));
-                ajv.addMetaSchema(meta);
-            }
-        });
-    }
+    return schemaDirectory;
 }
 
 async function runSpectralValidations(
@@ -141,6 +112,160 @@ async function runSpectralValidations(
         }
     }
     return new SpectralResult(warnings, errors, spectralIssues);
+}
+
+
+/**
+ * This is essentially the old function, just wrapped into the nicer functions.
+ * @param jsonSchemaArchitectureLocation 
+ * @param jsonSchemaLocation 
+ * @param metaSchemaPath 
+ * @param debug 
+ * @param failOnWarnings 
+ */
+export async function validateAndExitConditionally(
+    jsonSchemaArchitectureLocation: string,
+    jsonSchemaLocation: string,
+    metaSchemaPath: string,
+    debug: boolean = false,
+    failOnWarnings: boolean = false
+): Promise<void> {
+    const outcome = await validate(jsonSchemaArchitectureLocation, jsonSchemaLocation, metaSchemaPath, debug);
+    exitBasedOffOfValidationOutcome(outcome, failOnWarnings);
+}
+
+/**
+ * Validation - with simple input parameters and output validation outcomes.
+ * @param jsonSchemaArchitectureLocation 
+ * @param jsonSchemaLocation 
+ * @param metaSchemaPath 
+ * @param debug 
+ * @returns 
+ */
+export async function validate(
+    jsonSchemaArchitectureLocation: string,
+    jsonSchemaLocation: string,
+    metaSchemaPath: string,
+    debug: boolean = false): Promise<ValidationOutcome> {
+
+    logger = initLogger(debug);
+    try {
+        if (jsonSchemaArchitectureLocation && jsonSchemaLocation) {
+            return await validateArchitectureAgainstPattern(jsonSchemaArchitectureLocation, jsonSchemaLocation, metaSchemaPath, debug);
+        } else if (jsonSchemaLocation) {
+            return await validatePatternOnly(jsonSchemaLocation, metaSchemaPath, debug);
+        } else if (jsonSchemaArchitectureLocation) {
+            return await validateArchitectureOnly(jsonSchemaArchitectureLocation);
+        } else {
+            logger.debug('You must provide at least an architecture or a pattern');
+            throw new Error('You must provide at least an architecture or a pattern');
+        }
+    } catch (error) {
+        logger.error('An error occured:', error);
+        process.exit(1);
+    }
+}
+
+/**
+ * Run the spectral rules for the pattern and the architecture, and then compile the pattern and validate the architecture against it.
+ * 
+ * @param jsonSchemaArchitectureLocation - the location of the architecture to validate.
+ * @param jsonSchemaLocation - the location of the pattern to validate against.
+ * @param metaSchemaPath - the path of the meta schemas to use for ajv.
+ * @param debug - the flag to enable debug logging.
+ * @returns the validation outcome with the results of the spectral and json schema validations.
+ */
+async function validateArchitectureAgainstPattern(jsonSchemaArchitectureLocation:string, jsonSchemaLocation:string, metaSchemaPath:string, debug: boolean): Promise<ValidationOutcome>{
+    const schemaDirectory = await loadMetaSchemas(metaSchemaPath);
+    const ajv = buildAjv2020(schemaDirectory, debug);
+
+    logger.info(`Loading pattern from : ${jsonSchemaLocation}`);
+    const jsonSchema = await getFileFromUrlOrPath(jsonSchemaLocation);
+    const spectralResultForPattern: SpectralResult = await runSpectralValidations(stripRefs(jsonSchema), validationRulesForPattern);
+    const validateSchema = await ajv.compileAsync(jsonSchema);
+
+    logger.info(`Loading architecture from : ${jsonSchemaArchitectureLocation}`);
+    const jsonSchemaArchitecture = await getFileFromUrlOrPath(jsonSchemaArchitectureLocation);
+
+    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(jsonSchemaArchitecture, validationRulesForArchitecture);
+
+    const spectralResult = mergeSpectralResults(spectralResultForPattern, spectralResultForArchitecture);
+
+    let errors = spectralResult.errors;
+    const warnings = spectralResult.warnings;
+
+    let jsonSchemaValidations = [];
+
+    if (!validateSchema(jsonSchemaArchitecture)) {
+        logger.debug(`JSON Schema validation raw output: ${prettifyJson(validateSchema.errors)}`);
+        errors = true;
+        jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(validateSchema.errors);
+    }
+
+    return new ValidationOutcome(jsonSchemaValidations, spectralResult.spectralIssues, errors, warnings);
+}
+
+/**
+ * Run validations for the case where only the pattern is provided. 
+ * This essentially runs the spectral validations and tries to compile the pattern.
+ * 
+ * @param jsonSchemaLocation - the location of the patterns JSON Schema to validate.
+ * @param metaSchemaPath - the path of the meta schemas to use for ajv.
+ * @param debug - the flag to enable debug logging.
+ * @returns the validation outcome with the results of the spectral validation and the pattern compilation.
+ */
+async function validatePatternOnly(jsonSchemaLocation: string, metaSchemaPath: string, debug: boolean): Promise<ValidationOutcome> {
+    logger.debug('Architecture was not provided, only the Pattern Schema will be validated');
+    const schemaDirectory = await loadMetaSchemas(metaSchemaPath);
+    const ajv = buildAjv2020(schemaDirectory, debug);
+
+    const patternSchema = await getFileFromUrlOrPath(jsonSchemaLocation);
+    const spectralValidationResults: SpectralResult = await runSpectralValidations(stripRefs(patternSchema), validationRulesForPattern);
+    
+    let errors = spectralValidationResults.errors;
+    const warnings = spectralValidationResults.warnings;
+    const jsonSchemaErrors = [];
+
+    try {
+        await ajv.compileAsync(patternSchema); 
+    } catch (error) {
+        errors = true;
+        jsonSchemaErrors.push(new ValidationOutput('json-schema', 'error', error.message, '/'));
+    }
+
+    return new ValidationOutcome(jsonSchemaErrors, spectralValidationResults.spectralIssues, errors, warnings);// added spectral to return object
+}
+
+/**
+ * Run the spectral validations for the case where only the architecture is provided.
+ * 
+ * @param architectureSchemaLocation - The location of the architecture schema.
+ * @returns the validation outcome with the results of the spectral validation.
+ */
+async function validateArchitectureOnly(architectureSchemaLocation: string): Promise<ValidationOutcome> {
+    logger.debug('Pattern was not provided, only the Architecture will be validated');
+    
+    const jsonSchemaArchitecture = await getFileFromUrlOrPath(architectureSchemaLocation);
+    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(jsonSchemaArchitecture, validationRulesForArchitecture); 
+    return new ValidationOutcome([], spectralResultForArchitecture.spectralIssues, spectralResultForArchitecture.errors, spectralResultForArchitecture.warnings);
+}
+
+function extractSpectralRuleNames(): string[] {
+    const architectureRuleNames = getRuleNamesFromRuleset(validationRulesForArchitecture);
+    const patternRuleNames = getRuleNamesFromRuleset(validationRulesForPattern);
+    return architectureRuleNames.concat(patternRuleNames);
+}
+
+function getRuleNamesFromRuleset(ruleset: RulesetDefinition): string[] {
+    return Object.keys((ruleset as { rules: Record<string, unknown> }).rules);
+}
+
+function prettifyJson(json) {
+    return JSON.stringify(json, null, 4);
+}
+
+export function stripRefs(obj: object): string {
+    return JSON.stringify(obj).replaceAll('$ref', 'ref');
 }
 
 export function sortSpectralIssueBySeverity(issues: ISpectralDiagnostic[]): void {
@@ -223,158 +348,15 @@ async function loadFileFromUrl(fileUrl: string) {
     return body;
 }
 
-
-
-function prettifyJson(json) {
-    return JSON.stringify(json, null, 4);
-}
-
-export function stripRefs(obj: object): string {
-    return JSON.stringify(obj).replaceAll('$ref', 'ref');
-}
-
 /**
- * This is essentially the old function, just wrapped into the nicer functions.
- * @param jsonSchemaArchitectureLocation 
- * @param jsonSchemaLocation 
- * @param metaSchemaPath 
- * @param debug 
- * @param failOnWarnings 
+ * Merge the results from two Spectral validations together, combining any errors/warnings.
+ * @param spectralResultPattern Spectral results from the pattern validation
+ * @param spectralResultArchitecture Spectral results from the architecture validation
+ * @returns A new SpectralResult with the error/warning status propagated and the results concatenated.
  */
-export async function validateAndExitConditionally(
-    jsonSchemaArchitectureLocation: string,
-    jsonSchemaLocation: string,
-    metaSchemaPath: string,
-    debug: boolean = false,
-    failOnWarnings: boolean = false
-): Promise<void> {
-    const outcome = await validate(jsonSchemaArchitectureLocation, jsonSchemaLocation, metaSchemaPath, debug);
-    exitBasedOffOfValidationOutcome(outcome, failOnWarnings);
+function mergeSpectralResults(spectralResultPattern: SpectralResult, spectralResultArchitecture: SpectralResult): SpectralResult {
+    const errors: boolean = spectralResultPattern.errors || spectralResultArchitecture.errors;
+    const warnings: boolean = spectralResultPattern.warnings || spectralResultArchitecture.warnings;
+    const spectralValidations = spectralResultPattern.spectralIssues.concat(spectralResultArchitecture.spectralIssues);
+    return new SpectralResult(warnings, errors, spectralValidations);
 }
-
-/**
- * Validation - with simple input parameters and output validation outcomes.
- * @param jsonSchemaArchitectureLocation 
- * @param jsonSchemaLocation 
- * @param metaSchemaPath 
- * @param debug 
- * @returns 
- */
-export async function validate(
-    jsonSchemaArchitectureLocation: string,
-    jsonSchemaLocation: string,
-    metaSchemaPath: string,
-    debug: boolean = false): Promise<ValidationOutcome> {
-
-    logger = initLogger(debug);
-    try {
-        if (jsonSchemaArchitectureLocation && jsonSchemaLocation) {
-            return await validateArchitectureAgainstPattern(jsonSchemaArchitectureLocation, jsonSchemaLocation, metaSchemaPath, debug);
-        } else if (jsonSchemaLocation) {
-            return await validatePatternOnly(jsonSchemaLocation, metaSchemaPath, debug);
-        } else if (jsonSchemaArchitectureLocation) {
-            return await validateArchitectureOnly(jsonSchemaArchitectureLocation);
-        } else {
-            logger.debug('You must provide at least an architecture or a pattern');
-            throw new Error('You must provide at least an architecture or a pattern');
-        }
-    } catch (error) {
-        logger.error('An error occured:', error);
-        process.exit(1);
-    }
-}
-
-/**
- * Run the spectral rules for the pattern and the architecture, and then compile the pattern and validate the architecture against it.
- * 
- * @param jsonSchemaArchitectureLocation - the location of the architecture to validate.
- * @param jsonSchemaLocation - the location of the pattern to validate against.
- * @param metaSchemaPath - the path of the meta schemas to use for ajv.
- * @param debug - the flag to enable debug logging.
- * @returns the validation outcome with the results of the spectral and json schema validations.
- */
-async function validateArchitectureAgainstPattern(jsonSchemaArchitectureLocation:string, jsonSchemaLocation:string, metaSchemaPath:string, debug: boolean): Promise<ValidationOutcome>{
-    const ajv = buildAjv2020(debug);
-    await loadMetaSchemas(ajv, metaSchemaPath);
-
-    logger.info(`Loading pattern from : ${jsonSchemaLocation}`);
-    const jsonSchema = await getFileFromUrlOrPath(jsonSchemaLocation);
-    const spectralResultForPattern: SpectralResult = await runSpectralValidations(stripRefs(jsonSchema), validationRulesForPattern);
-    const validateSchema = await ajv.compileAsync(jsonSchema);
-
-    logger.info(`Loading architecture from : ${jsonSchemaArchitectureLocation}`);
-    const jsonSchemaArchitecture = await getFileFromUrlOrPath(jsonSchemaArchitectureLocation);
-
-    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(jsonSchemaArchitecture, validationRulesForArchitecture);
-
-    const spectralResult = mergeSpectralResults(spectralResultForPattern, spectralResultForArchitecture);
-
-    let errors = spectralResult.errors;
-    const warnings = spectralResult.warnings;
-
-    let jsonSchemaValidations = [];
-
-    if (!validateSchema(jsonSchemaArchitecture)) {
-        logger.debug(`JSON Schema validation raw output: ${prettifyJson(validateSchema.errors)}`);
-        errors = true;
-        jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(validateSchema.errors);
-    }
-
-    return new ValidationOutcome(jsonSchemaValidations, spectralResult.spectralIssues, errors, warnings);
-}
-
-/**
- * Run validations for the case where only the pattern is provided. 
- * This essentially runs the spectral validations and tries to compile the pattern.
- * 
- * @param jsonSchemaLocation - the location of the patterns JSON Schema to validate.
- * @param metaSchemaPath - the path of the meta schemas to use for ajv.
- * @param debug - the flag to enable debug logging.
- * @returns the validation outcome with the results of the spectral validation and the pattern compilation.
- */
-async function validatePatternOnly(jsonSchemaLocation: string, metaSchemaPath: string, debug: boolean): Promise<ValidationOutcome> {
-    logger.debug('Architecture was not provided, only the Pattern Schema will be validated');
-    const ajv = buildAjv2020(debug);
-    await loadMetaSchemas(ajv, metaSchemaPath);
-
-    const patternSchema = await getFileFromUrlOrPath(jsonSchemaLocation);
-    const spectralValidationResults: SpectralResult = await runSpectralValidations(stripRefs(patternSchema), validationRulesForPattern);
-    
-    let errors = spectralValidationResults.errors;
-    const warnings = spectralValidationResults.warnings;
-    const jsonSchemaErrors = [];
-
-    try {
-        await ajv.compileAsync(patternSchema); 
-    } catch (error) {
-        errors = true;
-        jsonSchemaErrors.push(new ValidationOutput('json-schema', 'error', error.message, '/'));
-    }
-
-    return new ValidationOutcome(jsonSchemaErrors, spectralValidationResults.spectralIssues, errors, warnings);// added spectral to return object
-}
-
-/**
- * Run the spectral validations for the case where only the architecture is provided.
- * 
- * @param architectureSchemaLocation - The location of the architecture schema.
- * @returns the validation outcome with the results of the spectral validation.
- */
-async function validateArchitectureOnly(architectureSchemaLocation: string): Promise<ValidationOutcome> {
-    logger.debug('Pattern was not provided, only the Architecture will be validated');
-    
-    const jsonSchemaArchitecture = await getFileFromUrlOrPath(architectureSchemaLocation);
-    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(jsonSchemaArchitecture, validationRulesForArchitecture); 
-    return new ValidationOutcome([], spectralResultForArchitecture.spectralIssues, spectralResultForArchitecture.errors, spectralResultForArchitecture.warnings);
-}
-
-function extractSpectralRuleNames(): string[] {
-    const architectureRuleNames = getRuleNamesFromRuleset(validationRulesForArchitecture);
-    const patternRuleNames = getRuleNamesFromRuleset(validationRulesForPattern);
-    return architectureRuleNames.concat(patternRuleNames);
-}
-
-function getRuleNamesFromRuleset(ruleset: RulesetDefinition): string[] {
-    return Object.keys((ruleset as { rules: Record<string, unknown> }).rules);
-}
-

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -116,25 +116,6 @@ async function runSpectralValidations(
 
 
 /**
- * This is essentially the old function, just wrapped into the nicer functions.
- * @param jsonSchemaArchitectureLocation 
- * @param jsonSchemaLocation 
- * @param metaSchemaPath 
- * @param debug 
- * @param failOnWarnings 
- */
-export async function validateAndExitConditionally(
-    jsonSchemaArchitectureLocation: string,
-    jsonSchemaLocation: string,
-    metaSchemaPath: string,
-    debug: boolean = false,
-    failOnWarnings: boolean = false
-): Promise<void> {
-    const outcome = await validate(jsonSchemaArchitectureLocation, jsonSchemaLocation, metaSchemaPath, debug);
-    exitBasedOffOfValidationOutcome(outcome, failOnWarnings);
-}
-
-/**
  * Validation - with simple input parameters and output validation outcomes.
  * @param jsonSchemaArchitectureLocation 
  * @param jsonSchemaLocation 
@@ -162,7 +143,7 @@ export async function validate(
         }
     } catch (error) {
         logger.error('An error occured:', error);
-        process.exit(1);
+        throw error;
     }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,7 +1,6 @@
 export {
     validate,
     formatOutput as getFormattedOutput,
-    validateAndExitConditionally,
     exitBasedOffOfValidationOutcome,
 } from './commands/validate/validate.js';
 export { OutputFormat } from './commands/validate/validate.js';

--- a/shared/src/schema-directory.spec.ts
+++ b/shared/src/schema-directory.spec.ts
@@ -26,7 +26,7 @@ describe('SchemaDirectory', () => {
         const schemaDir = new SchemaDirectory();
         
         expect(async () => {
-            await schemaDir.loadSchemas("bad-directory");
+            await schemaDir.loadSchemas('bad-directory');
         }).rejects.toThrow();
     });
 

--- a/shared/src/schema-directory.spec.ts
+++ b/shared/src/schema-directory.spec.ts
@@ -26,9 +26,8 @@ describe('SchemaDirectory', () => {
         const schemaDir = new SchemaDirectory();
         
         expect(async () => {
-            await schemaDir.loadSchemas('bad-directory');
-        })
-            .rejects.toThrow();
+            await schemaDir.loadSchemas("bad-directory");
+        }).rejects.toThrow();
     });
 
     it('loads all specs from given directory including subdirectories - 2024-10 schema', async () => {

--- a/shared/test_fixtures/api-gateway-implementation.json
+++ b/shared/test_fixtures/api-gateway-implementation.json
@@ -23,6 +23,12 @@
       "node-type": "system",
       "port": -1,
       "unique-id": "api-producer"
+    },
+    {
+      "unique-id": "idp",
+      "node-type": "system",
+      "name": "Identity Provider",
+      "description": "The Identity Provider used to verify the bearer token"
     }
   ],
   "relationships": [


### PR DESCRIPTION
Addresses #831 

- validate command now defers to SchemaDirectory for all spec loading
- validate command no longer calls process.exit() - that is deffered to the calling module (there is a helper method validateAndExitConditionally)
- big improvements to the validate command tests
- add a cli test script that always builds first to eliminate strange link issues