### PR TITLE
HOLD: Update Flox env

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -12,8 +12,8 @@
       "gum": {
         "pkg-path": "gum"
       },
-      "jdk21": {
-        "pkg-path": "jdk21"
+      "jdk23": {
+        "pkg-path": "jdk23"
       },
       "libuuid": {
         "pkg-path": "libuuid",
@@ -408,15 +408,15 @@
       "priority": 5
     },
     {
-      "attr_path": "jdk21",
+      "attr_path": "jdk23",
       "broken": false,
-      "derivation": "/nix/store/l5a27j5b0n89h5n19pvxjpipcfasxr3z-zulu-ca-jdk-21.0.4.drv",
+      "derivation": "/nix/store/gpgp222z3lwijmdxhdlybff46sd34k8h-zulu-ca-jdk-23.0.0.drv",
       "description": "Certified builds of OpenJDK",
-      "install_id": "jdk21",
+      "install_id": "jdk23",
       "license": "GPL-2.0-only",
       "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
-      "name": "zulu-ca-jdk-21.0.4",
-      "pname": "jdk21",
+      "name": "zulu-ca-jdk-23.0.0",
+      "pname": "jdk23",
       "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "rev_count": 738172,
       "rev_date": "2025-01-14T19:41:48Z",
@@ -426,27 +426,27 @@
         "unstable"
       ],
       "unfree": false,
-      "version": "zulu-ca-jdk-21.0.4",
+      "version": "zulu-ca-jdk-23.0.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/i43yq5k7nphs1paam9xyrzypzjkn97p1-zulu-ca-jdk-21.0.4"
+        "out": "/nix/store/mmsg51qmsgp1lhylx96ix4kl0wn9b9fx-zulu-ca-jdk-23.0.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "jdk21",
+      "attr_path": "jdk23",
       "broken": false,
-      "derivation": "/nix/store/28sls8nn9nr33jy5in88wz77mf06gb7y-openjdk-21.0.5+11.drv",
+      "derivation": "/nix/store/pwbv9az3nnvky1j0kv9sdjw6c0l3z3ci-openjdk-23.0.1+11.drv",
       "description": "Open-source Java Development Kit",
-      "install_id": "jdk21",
+      "install_id": "jdk23",
       "license": "GPL-2.0-only",
       "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
-      "name": "openjdk-21.0.5+11",
-      "pname": "jdk21",
+      "name": "openjdk-23.0.1+11",
+      "pname": "jdk23",
       "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "rev_count": 738172,
       "rev_date": "2025-01-14T19:41:48Z",
@@ -456,28 +456,28 @@
         "unstable"
       ],
       "unfree": false,
-      "version": "openjdk-21.0.5+11",
+      "version": "openjdk-23.0.1+11",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/kv4krs3vzdgpfcp51xgg4cfgdwx4kvmf-openjdk-21.0.5+11-debug",
-        "out": "/nix/store/p7bxwzgpnbsafz0iz1a0yrnnzmjr0pqy-openjdk-21.0.5+11"
+        "debug": "/nix/store/v7xhjv7cx72l71wk6lljzrmj1zdhn32q-openjdk-23.0.1+11-debug",
+        "out": "/nix/store/n20dwghm2qcpkx2kw6sqb5vaay6xk6bd-openjdk-23.0.1+11"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "jdk21",
+      "attr_path": "jdk23",
       "broken": false,
-      "derivation": "/nix/store/f61wj8dkr70x8pkyr2gwn946k0v0jpid-zulu-ca-jdk-21.0.4.drv",
+      "derivation": "/nix/store/0x6z3s91i0h41l0pyps79asi5b1kgr5z-zulu-ca-jdk-23.0.0.drv",
       "description": "Certified builds of OpenJDK",
-      "install_id": "jdk21",
+      "install_id": "jdk23",
       "license": "GPL-2.0-only",
       "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
-      "name": "zulu-ca-jdk-21.0.4",
-      "pname": "jdk21",
+      "name": "zulu-ca-jdk-23.0.0",
+      "pname": "jdk23",
       "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "rev_count": 738172,
       "rev_date": "2025-01-14T19:41:48Z",
@@ -487,27 +487,27 @@
         "unstable"
       ],
       "unfree": false,
-      "version": "zulu-ca-jdk-21.0.4",
+      "version": "zulu-ca-jdk-23.0.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ij352rjrmfcw6pyfm8q4bkjvw2knzwih-zulu-ca-jdk-21.0.4"
+        "out": "/nix/store/njvhdy2ikgyhwdx7dbpchhx110l40p8i-zulu-ca-jdk-23.0.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "jdk21",
+      "attr_path": "jdk23",
       "broken": false,
-      "derivation": "/nix/store/7cg8jrm8xr34v8w92ybw181kwv7hh5i7-openjdk-21.0.5+11.drv",
+      "derivation": "/nix/store/iy7lwvzhywyx8sgf6snpfli9p3h2sasa-openjdk-23.0.1+11.drv",
       "description": "Open-source Java Development Kit",
-      "install_id": "jdk21",
+      "install_id": "jdk23",
       "license": "GPL-2.0-only",
       "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
-      "name": "openjdk-21.0.5+11",
-      "pname": "jdk21",
+      "name": "openjdk-23.0.1+11",
+      "pname": "jdk23",
       "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "rev_count": 738172,
       "rev_date": "2025-01-14T19:41:48Z",
@@ -517,13 +517,13 @@
         "unstable"
       ],
       "unfree": false,
-      "version": "openjdk-21.0.5+11",
+      "version": "openjdk-23.0.1+11",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/ihdvawhishsymc3dcdj22w400f3pwnv2-openjdk-21.0.5+11-debug",
-        "out": "/nix/store/v5p972p1lsfnb3v62jy3qcf69as7x8wp-openjdk-21.0.5+11"
+        "debug": "/nix/store/88xs0bcqym2bdmx3qp42vr8rcx5g9d8q-openjdk-23.0.1+11-debug",
+        "out": "/nix/store/zqrpvgh2d18gp07ajv0mxn2gani3qdf5-openjdk-23.0.1+11"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -3,6 +3,12 @@
   "manifest": {
     "version": 1,
     "install": {
+      "docker": {
+        "pkg-path": "docker"
+      },
+      "docker-compose": {
+        "pkg-path": "docker-compose"
+      },
       "gum": {
         "pkg-path": "gum"
       },
@@ -24,7 +30,7 @@
       }
     },
     "hook": {
-      "on-activate": "  export MAVEN_USER_HOME=\"$(realpath $FLOX_ENV_CACHE)/m2\"\n  export MAVEN_OPTS=\"-Dmaven.repo.local=$MAVEN_USER_HOME/repository\"\n\n  if [ ! -d \"$FLOX_ENV_PROJECT\"/node_modules ]; then\n    echo \"First activation of environment.  Setting some things up - you may want to get a cup of tea...\"\n\n    # Install Java dependencies\n    mvnw-deps() {\n      cd translator\n      ./mvnw dependency:resolve dependency:resolve-plugins\n      cd ..\n    }\n    export -f mvnw-deps\n    gum spin --spinner minidot --title \"Installing Java dependencies...\" --show-output -- bash -c mvnw-deps\n\n    # Install nodejs dependencies\n    gum spin --spinner minidot --title \"Installing node packages...\" --show-output -- npm install\n\n    gum confirm \"Perform initial CLI build (recommended)?\" && npm run build && npx link cli\n  fi\n"
+      "on-activate": "  export MAVEN_USER_HOME=\"$(realpath $FLOX_ENV_CACHE)/m2\"\n  export MAVEN_OPTS=\"-Dmaven.repo.local=$MAVEN_USER_HOME/repository\"\n\n  if [ ! -d \"$FLOX_ENV_PROJECT\"/node_modules ]; then\n    echo \"First activation of environment.  Setting some things up - you may want to get a cup of tea...\"\n\n    # Install Java dependencies\n    gum spin --spinner minidot --title \"Installing Java dependencies...\" --show-output -- ./mvnw dependency:resolve dependency:resolve-plugins\n\n    # Install nodejs dependencies\n    gum spin --spinner minidot --title \"Installing node packages...\" --show-output -- npm install\n\n    echo \"Build CLI with \"npm run build\" then \"npx link cli\".\"\n  fi\n"
     },
     "profile": {},
     "options": {
@@ -42,20 +48,261 @@
   },
   "packages": [
     {
+      "attr_path": "docker",
+      "broken": false,
+      "derivation": "/nix/store/1m41rlq3m5xbdx19yczzbn7clbf9r3hz-docker-27.4.1.drv",
+      "description": "Open source project to pack, ship and run any application as a lightweight container",
+      "install_id": "docker",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-27.4.1",
+      "pname": "docker",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "27.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4j3f6xqn2wi3590fw54hj9pcwz58dcbd-docker-27.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker",
+      "broken": false,
+      "derivation": "/nix/store/zdzbivzijm4ikrz8mhp57rgkqbj9l0gy-docker-27.4.1.drv",
+      "description": "Open source project to pack, ship and run any application as a lightweight container",
+      "install_id": "docker",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-27.4.1",
+      "pname": "docker",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "27.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c8wf4nvpxqmc92yx2yc01ixhklpqkswk-docker-27.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker",
+      "broken": false,
+      "derivation": "/nix/store/7gan3k1j8h4gds6w7spidvf0araivz8p-docker-27.4.1.drv",
+      "description": "Open source project to pack, ship and run any application as a lightweight container",
+      "install_id": "docker",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-27.4.1",
+      "pname": "docker",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "27.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/rflmb941mrih44am3girmnadq04vqghv-docker-27.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker",
+      "broken": false,
+      "derivation": "/nix/store/5xy7d710ifmfrzyjx49jd4c5d1k499rg-docker-27.4.1.drv",
+      "description": "Open source project to pack, ship and run any application as a lightweight container",
+      "install_id": "docker",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-27.4.1",
+      "pname": "docker",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "27.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/bfvmfq48yv5nz0wgg2c1pbc43ijlhjz7-docker-27.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker-compose",
+      "broken": false,
+      "derivation": "/nix/store/gpcb857amm9s8yx9wc7anvpbz8369hfl-docker-compose-2.32.2.drv",
+      "description": "Docker CLI plugin to define and run multi-container applications with Docker",
+      "install_id": "docker-compose",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-compose-2.32.2",
+      "pname": "docker-compose",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.32.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/z1lx4rn2n1jfbp83jjl83qzfniz56v8n-docker-compose-2.32.2"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker-compose",
+      "broken": false,
+      "derivation": "/nix/store/frp5az1nlnrj3sql3paz5qgxk6zn1kv0-docker-compose-2.32.2.drv",
+      "description": "Docker CLI plugin to define and run multi-container applications with Docker",
+      "install_id": "docker-compose",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-compose-2.32.2",
+      "pname": "docker-compose",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.32.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/cdjj4rf7gvldgv3yn9mj5wjxypf51p8g-docker-compose-2.32.2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker-compose",
+      "broken": false,
+      "derivation": "/nix/store/ps4f1bd5b6ph9xlvwgpm4fhpr6wzr3ag-docker-compose-2.32.2.drv",
+      "description": "Docker CLI plugin to define and run multi-container applications with Docker",
+      "install_id": "docker-compose",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-compose-2.32.2",
+      "pname": "docker-compose",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.32.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/72lapq24xp7kbm5likw4v86v4cy4s1s8-docker-compose-2.32.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "docker-compose",
+      "broken": false,
+      "derivation": "/nix/store/p8xc8sjcsj3bwn1fjy0969sw8zhxzm9v-docker-compose-2.32.2.drv",
+      "description": "Docker CLI plugin to define and run multi-container applications with Docker",
+      "install_id": "docker-compose",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "name": "docker-compose-2.32.2",
+      "pname": "docker-compose",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.32.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/rxx7z7sjindad4qzhkzpv7x9lxd8b3hk-docker-compose-2.32.2"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
       "attr_path": "gum",
       "broken": false,
       "derivation": "/nix/store/saqsc2cnrj5kdswscdl8f7za5pjh29f7-gum-0.14.5.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "gum-0.14.5",
       "pname": "gum",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -77,14 +324,15 @@
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "gum-0.14.5",
       "pname": "gum",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -106,14 +354,15 @@
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "gum-0.14.5",
       "pname": "gum",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -135,14 +384,15 @@
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "gum-0.14.5",
       "pname": "gum",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -164,14 +414,15 @@
       "description": "Certified builds of OpenJDK",
       "install_id": "jdk21",
       "license": "GPL-2.0-only",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "zulu-ca-jdk-21.0.4",
       "pname": "jdk21",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -193,14 +444,15 @@
       "description": "Open-source Java Development Kit",
       "install_id": "jdk21",
       "license": "GPL-2.0-only",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "openjdk-21.0.5+11",
       "pname": "jdk21",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -223,14 +475,15 @@
       "description": "Certified builds of OpenJDK",
       "install_id": "jdk21",
       "license": "GPL-2.0-only",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "zulu-ca-jdk-21.0.4",
       "pname": "jdk21",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -252,14 +505,15 @@
       "description": "Open-source Java Development Kit",
       "install_id": "jdk21",
       "license": "GPL-2.0-only",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "openjdk-21.0.5+11",
       "pname": "jdk21",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -282,14 +536,15 @@
       "description": "Set of system utilities for Linux",
       "install_id": "libuuid",
       "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "util-linux-minimal-2.39.4",
       "pname": "libuuid",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -320,14 +575,15 @@
       "description": "Set of system utilities for Linux",
       "install_id": "libuuid",
       "license": "[ GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "util-linux-minimal-2.39.4",
       "pname": "libuuid",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -358,14 +614,15 @@
       "description": "Build automation tool (used primarily for Java projects)",
       "install_id": "maven3",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "maven-3.9.9",
       "pname": "maven3",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -387,14 +644,15 @@
       "description": "Build automation tool (used primarily for Java projects)",
       "install_id": "maven3",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "maven-3.9.9",
       "pname": "maven3",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -416,14 +674,15 @@
       "description": "Build automation tool (used primarily for Java projects)",
       "install_id": "maven3",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "maven-3.9.9",
       "pname": "maven3",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -445,14 +704,15 @@
       "description": "Build automation tool (used primarily for Java projects)",
       "install_id": "maven3",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "maven-3.9.9",
       "pname": "maven3",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -474,14 +734,15 @@
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs_22",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "nodejs-22.11.0",
       "pname": "nodejs_22",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -504,14 +765,15 @@
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs_22",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "nodejs-22.11.0",
       "pname": "nodejs_22",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -534,14 +796,15 @@
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs_22",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "nodejs-22.11.0",
       "pname": "nodejs_22",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -564,14 +827,15 @@
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs_22",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=634fd46801442d760e09493a794c4f15db2d0cbb",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
       "name": "nodejs-22.11.0",
       "pname": "nodejs_22",
-      "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
-      "rev_count": 729082,
-      "rev_date": "2024-12-27T09:21:16Z",
-      "scrape_date": "2024-12-28T03:56:01Z",
+      "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+      "rev_count": 738172,
+      "rev_date": "2025-01-14T19:41:48Z",
+      "scrape_date": "2025-01-16T00:14:48Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -44,6 +44,29 @@
         "licenses": []
       },
       "semver": {}
+    },
+    "services": {
+      "calmhub-server": {
+        "command": "cd $FLOX_ENV_PROJECT/calm-hub && ../mvnw package && ../mvnw quarkus:dev",
+        "vars": null,
+        "is-daemon": null,
+        "shutdown": null,
+        "systems": null
+      },
+      "calmhub-ui": {
+        "command": "cd $FLOX_ENV_PROJECT/calm-hub/src/main/webapp && npm start",
+        "vars": null,
+        "is-daemon": null,
+        "shutdown": null,
+        "systems": null
+      },
+      "mongodb": {
+        "command": "cd $FLOX_ENV_PROJECT/calm-hub/local-dev && docker-compose up",
+        "vars": null,
+        "is-daemon": null,
+        "shutdown": null,
+        "systems": null
+      }
     }
   },
   "packages": [

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -77,7 +77,9 @@ on-activate = """
 ##  $ flox activate --start-services  <- Activates & starts all
 ## -------------------------------------------------------------------
 [services]
-# myservice.command = "python3 -m http.server"
+mongodb.command = "cd $FLOX_ENV_PROJECT/calm-hub/local-dev && docker-compose up"
+calmhub-server.command = "cd $FLOX_ENV_PROJECT/calm-hub && ../mvnw package && ../mvnw quarkus:dev"
+calmhub-ui.command = "cd $FLOX_ENV_PROJECT/calm-hub/src/main/webapp && npm start"
 
 
 ## Other Environment Options -----------------------------------------

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -18,11 +18,11 @@ version = 1
 libuuid.pkg-path = "libuuid"
 libuuid.systems = ["aarch64-linux", "x86_64-linux"]
 gum.pkg-path = "gum"
-jdk21.pkg-path = "jdk21"
 maven3.pkg-path = "maven3"
 nodejs_22.pkg-path = "nodejs_22"
 docker-compose.pkg-path = "docker-compose"
 docker.pkg-path = "docker"
+jdk23.pkg-path = "jdk23"
 
 
 ## Environment Variables ---------------------------------------------

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -21,6 +21,8 @@ gum.pkg-path = "gum"
 jdk21.pkg-path = "jdk21"
 maven3.pkg-path = "maven3"
 nodejs_22.pkg-path = "nodejs_22"
+docker-compose.pkg-path = "docker-compose"
+docker.pkg-path = "docker"
 
 
 ## Environment Variables ---------------------------------------------

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -43,18 +43,12 @@ on-activate = """
     echo "First activation of environment.  Setting some things up - you may want to get a cup of tea..."
 
     # Install Java dependencies
-    mvnw-deps() {
-      cd translator
-      ./mvnw dependency:resolve dependency:resolve-plugins
-      cd ..
-    }
-    export -f mvnw-deps
-    gum spin --spinner minidot --title "Installing Java dependencies..." --show-output -- bash -c mvnw-deps
+    gum spin --spinner minidot --title "Installing Java dependencies..." --show-output -- ./mvnw dependency:resolve dependency:resolve-plugins
 
     # Install nodejs dependencies
     gum spin --spinner minidot --title "Installing node packages..." --show-output -- npm install
 
-    gum confirm "Perform initial CLI build (recommended)?" && npm run build && npx link cli
+    echo "Build CLI with \"npm run build\" then \"npx link cli\"."
   fi
 """
 


### PR DESCRIPTION
- Update the Flox environment with the currently required Java version, and add docker and docker-compose for calmhub-server
- Define Flox services so the Mongodb, Calmhub server and Calmhub UI can all be started with a simple `flox services start`