### PR TITLE
Add code coverage and break build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Build workspace
         run: npm run build:cli
 
-      - name: Run tests for CLI
+      - name: Run tests with coverage for CLI
         run: npm run test --workspace=cli

--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Build workspace
         run: npm run build --workspace=shared
 
-      - name: Run tests for Shared
+      - name: Run tests with coverage for Shared
         run: npm run test --workspace=shared

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules/
 **/tsconfig.tsbuildinfo
 
 !/.mvn/wrapper/maven-wrapper.jar
+
+coverage/

--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -10,5 +10,14 @@ module.exports = {
         '^.+\\.ts?$': 'ts-jest', 
     },
     rootDir: '.',
-    watchPathIgnorePatterns: ['<rootDir>/../shared/']
+    watchPathIgnorePatterns: ['<rootDir>/../shared/'],
+    collectCoverage: true,
+    coverageThreshold: {
+        global: {
+            branches: 95,
+            functions: 90,
+            lines: 90,
+            statements: 90,
+        }
+    }
 };

--- a/shared/jest.config.js
+++ b/shared/jest.config.js
@@ -13,4 +13,13 @@ module.exports = {
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1'
     },
+    collectCoverage: true,
+    coverageThreshold: {
+        global: {
+            branches: 50,
+            functions: 80,
+            lines: 75,
+            statements: 75,
+        }
+    }
 };


### PR DESCRIPTION
## Summary

This PR introduces basic coverage generation for the project. The build will now **fail** if the coverage thresholds are not met, providing an early indication of insufficient test coverage. This is a foundational change to ensure we have consistent coverage metrics going forward.

## Changes

- **Basic Coverage Generation**: 
  - Jest is configured to collect and report test coverage.
  - A summary of coverage statistics will be generated after each test run.

- **Coverage Failure Thresholds**:
  - The current coverage thresholds are set to pass the build, but these are placeholders for future configuration.
  - The limits are currently configured in a way that will not break the build but will ensure that coverage is collected and monitored.

## Out of Scope
- The coverage thresholds are temporarily set to pass the build. These will be updated to reflect the required coverage levels in future PRs.  The `Shared` module still requires further work to bring it in line with the coverage statistics that we need. Some modules like the calm-hub and visualiser don't have any tests. 

## Next Steps

1. **Set the correct coverage thresholds**: Once the shared module and other parts are in alignment with the coverage requirements, we will update the coverage thresholds to ensure that the build fails if they are not met.
2. **Publish the HTML coverage report**: We plan to add an additional step to upload the coverage reports, including the HTML report, to GitHub Actions as an artifact.

    ```yaml
    - name: Upload coverage reports from CLI
      uses: actions/upload-artifact@v4
      with:
        name: coverage-report-cli
        path: ./cli/coverage/lcov-report
    ```
I've tested this works but not sure we need it.

## Conclusion

This PR is a first step toward ensuring we meet our coverage requirements. We can iteratively adjust the thresholds and further integrate coverage reports into our CI/CD process. The work done here lays the groundwork for enforcing better test coverage in the future.
