### PR TITLE
docs: update developer guide for docs

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,5 +1,24 @@
 # Developing the CALM DOCS
 
+The [CALM documentation](https://calm.finos.org/) is presented using [Docusaurus](https://docusaurus.io/).  Content is generated from Markdown files within the `docs` directory, starting with `index.md`.
+
+## Running locally
+
+From within the project folder (which contains this developer guide), run these commands to give you a locally-running Docusaurus server:
+```bash
+npm install
+npm run serve -- --build
+```
+For options such as changing the ports, see the [Docusaurus docs](https://docusaurus.io/docs/cli).
+
+Whilst the server is running, if you run `npm run build` then it'll pick up any changes you've made to the source Markdown files.  You can then simply refresh the browser to view.
+
+
+## Committing changes
+
+See the main [contributing guide](../README.md#contributing) for details on commit standards, etc.
+
+
 ## OWASP DEPENDENCY-CHECK
 The [OWASP dependency check tool](https://jeremylong.github.io/DependencyCheck/) will run on PRs and periodically on the committed code, but it can be helpful to be able to run this locally to investigate CVEs.
 


### PR DESCRIPTION
Developer guide didn't actually contain any instructions on how to build or locally test the docs.  It does now.