### PR TITLE
Refactor CLI to add more test coverage and add e2e test in cli for calm template endpoint (#890)

### DIFF
--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -19,5 +19,8 @@ module.exports = {
             lines: 90,
             statements: 90,
         }
+    },
+    moduleNameMapper: {
+        '^@finos/calm-shared/(.*)$': '<rootDir>/../node_modules/@finos/calm-shared/dist/$1'
     }
 };

--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -1,0 +1,235 @@
+import { exec } from 'child_process';
+import path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { parseStringPromise } from 'xml2js';
+import util from 'util';
+import axios from 'axios';
+
+
+
+// Mock axios
+jest.mock('axios');
+
+const execPromise = util.promisify(exec);
+
+describe('CLI Integration Tests', () => {
+
+    let tempDir: string;
+    const millisPerSecond = 1000;
+    const integrationTestPrefix = 'calm-test';
+    const projectRoot = __dirname;
+    jest.setTimeout(30 * millisPerSecond);
+
+    beforeAll(async () => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), integrationTestPrefix));
+        await callNpxFunction(`${projectRoot}/../..`, 'link cli');      // Link the CLI package to the top-level node_modules
+    }, millisPerSecond * 20);
+
+    afterAll(async () => {
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true });
+        }
+    }, millisPerSecond * 20);
+
+    test('shows help if no arguments provided', (done) => {
+        const noArgCommand = 'calm';
+        exec(noArgCommand, (error, _stdout, stderr) => {
+            expect(error).not.toBeNull();
+            expect(stderr).toContain('A set of tools for interacting with the Common Architecture Language Model');
+            expect(stderr).toContain('Usage:');
+            done();
+        });
+    });
+
+    test('shows help if -h provided', (done) => {
+        const helpShortFlagCommand = 'calm -h';
+        exec(helpShortFlagCommand, (_error, stdout, _stderr) => {
+            expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
+            expect(stdout).toContain('Usage:');
+            done();
+        });
+    });
+
+    test('shows help if --help provided', (done) => {
+        const helpLongFlagCommand = 'calm --help';
+        exec(helpLongFlagCommand, (_error, stdout, _stderr) => {
+            expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
+            expect(stdout).toContain('Usage:');
+            done();
+        });
+    });
+
+    test('example validate command - outputting JSON to stdout', (done) => {
+        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json';
+        exec(exampleValidateCommand, (_error, stdout, _stderr) => {
+            const parsedOutput = JSON.parse(stdout);
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output.json');
+            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
+            expect(parsedOutput).toEqual(expectedJson);
+            done();
+        });
+    });
+
+    test('example validate command - outputting JSON to file', (done) => {
+        const targetOutputFile = path.join(tempDir, 'validate-output.json');
+        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -o ${targetOutputFile}`;
+        exec(exampleValidateCommand, (_error, _stdout, _stderr) => {
+            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
+
+            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
+            const parsedOutput = JSON.parse(outputString);
+
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output.json');
+            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
+
+            expect(parsedOutput).toEqual(expectedJson);
+
+            done();
+        });
+    });
+
+    test('example validate command - outputting JUNIT to stdout', (done) => {
+        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f junit';
+        exec(exampleValidateCommand, async (_error, stdout, _stderr) => {
+            const parsedOutput = await parseStringPromise(stdout);
+
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
+            const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
+            const expectedXml = await parseStringPromise(expectedXmlString);
+
+            expect(parsedOutput).toEqual(expectedXml);
+            done();
+        });
+    });
+
+    test('example validate command - outputting JUNIT to file', (done) => {
+        const targetOutputFile = path.join(tempDir, 'validate-output.xml');
+        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f junit -o ${targetOutputFile}`;
+        exec(exampleValidateCommand, async (_error, _stdout, _stderr) => {
+            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
+
+            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
+            const parsedOutput = await parseStringPromise(outputString);
+
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
+            const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
+            const expectedXml = await parseStringPromise(expectedXmlString);
+
+            expect(parsedOutput).toEqual(expectedXml);
+
+            done();
+        });
+    });
+
+
+    test('example generate command - does it give the output we expect', (done) => {
+        const targetOutputFile = path.join(tempDir, 'generate-output.json');
+        const exampleGenerateCommand = `calm generate -p ../calm/pattern/api-gateway.json -o ${targetOutputFile}`;
+        exec(exampleGenerateCommand, async (_error, _stdout, _stderr) => {
+
+            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
+            const parsedOutput = JSON.parse(outputString);
+
+
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/generate_output.json');
+            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
+
+            expect(parsedOutput).toEqual(expectedJson);
+
+            done();
+        });
+    });
+
+    test('example validate command - outputting PRETTY to stdout', (done) => {
+        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f pretty';
+        exec(exampleValidateCommand, (_error, stdout, _stderr) => {
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_pretty.txt');
+            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
+            //Some minor replacement logic to avoid issues with line endings
+            expect(stdout.replace(/\r\n/g, '\n')).toEqual(expectedOutput.replace(/\r\n/g, '\n'));
+            done();
+        });
+    });
+
+    test('example validate command - outputting PRETTY to file', (done) => {
+        const targetOutputFile = path.join(tempDir, 'validate-output-pretty.txt');
+        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f pretty -o ${targetOutputFile}`;
+        exec(exampleValidateCommand, (_error, _stdout, _stderr) => {
+            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
+
+            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_pretty.txt');
+            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
+
+            //Some minor replacement logic to avoid issues with line endings
+            expect(outputString.replace(/\r\n/g, '\n')).toEqual(expectedOutput.replace(/\r\n/g, '\n'));
+            done();
+        });
+    });
+
+    test('example validate command - fails when neither an architecture or a pattern is provided', (done) => {
+        const calmValidateCommand = 'calm validate';
+        exec(calmValidateCommand, (error, _stdout, stderr) => {
+            expect(error).not.toBeNull();
+            expect(stderr).toContain('error: one of the required options \'-p, --pattern <file>\' or \'-a, --architecture <file>\' was not specified');
+            done();
+        });
+    });
+
+    test('example validate command - validates an architecture only', (done) => {
+        const calmValidateArchitectureOnlyCommand = 'calm validate -a ../calm/samples/api-gateway-architecture.json';
+        exec(calmValidateArchitectureOnlyCommand, (error, stdout, _stderr) => {
+            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_architecture_only_output.json');
+            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
+            expect(error).toBeNull();
+            expect(stdout).toContain(expectedOutput);
+            done();
+        });
+    });
+
+    test('example server command - starts server and responds to requests', async () => {
+        // Mock the axios response
+        const mockResponse = { status: 200, data: { status: 'ok' } };
+        (axios.get as jest.Mock).mockResolvedValue(mockResponse);
+
+        const serverCommand = 'calm server -p 3001 --schemaDirectory ../../dist/calm/';
+        const serverProcess = exec(serverCommand);
+        // Give the server some time to start
+        await new Promise(resolve => setTimeout(resolve, 5 * millisPerSecond));
+        try {
+            const response = await axios.get('http://127.0.0.1:3001/health');
+            expect(response.status).toBe(200);
+            expect(response.data.status).toBe('ok');
+        } finally {
+            serverProcess.kill();
+        }
+    });
+
+    test('example template command - generates expected output', async () => {
+
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const templateBundlePath = path.join(fixtureDir, 'template-bundles/doc-system');
+        const outputDir = path.resolve(__dirname, 'output');
+        const outputFile = path.join(outputDir, 'cli-e2e-output.html');
+
+        const templateCommand = `calm template --input ${testModelPath} --bundle ${templateBundlePath} --output ${outputDir}`;
+        await execPromise(templateCommand);
+
+        await new Promise(resolve => setTimeout(resolve, 2 * millisPerSecond));
+
+        expect(fs.existsSync(outputFile)).toBe(true);
+
+        if (fs.existsSync(outputFile)) {
+            fs.unlinkSync(outputFile);
+        }
+    });
+
+
+
+});
+
+async function callNpxFunction(projectRoot: string, command: string) {
+    await execPromise(`npx ${command}`, { cwd: projectRoot });
+}

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -1,210 +1,122 @@
-import { exec } from 'child_process';
-import path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
-import { parseStringPromise } from 'xml2js';
-import util from 'util';
-import axios from 'axios';
+jest.mock('@finos/calm-shared', () => ({
+    ...jest.requireActual('@finos/calm-shared'),
+    runGenerate: jest.fn(),
+    TemplateProcessor: jest.fn().mockImplementation(() => ({
+        processTemplate: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
 
-// Mock axios
-jest.mock('axios');
+jest.mock('./server/cli-server', () => ({
+    startServer: jest.fn(),
+}));
 
-const execPromise = util.promisify(exec);
+jest.mock('./validate/validate', () => ({
+    runValidate: jest.fn(() => Promise.resolve()),
+    checkValidateOptions: jest.fn(() => Promise.resolve()),
+}));
 
-describe('CLI Integration Tests', () => {
+describe('CLI Commands', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
 
-    let tempDir: string;
-    const millisPerSecond = 1000;
-    const integrationTestPrefix = 'calm-test';
-    const projectRoot = __dirname;
-    jest.setTimeout(30 * millisPerSecond);
-
-    beforeAll(async () => {
-        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), integrationTestPrefix));
-        await callNpxFunction(`${projectRoot}/../..`, 'link cli');      // Link the CLI package to the top-level node_modules
-    }, millisPerSecond * 20);
-
-    afterAll(async () => {
-        if (tempDir) {
-            fs.rmSync(tempDir, { recursive: true });
-        }
-    }, millisPerSecond * 20);
-
-    test('shows help if no arguments provided', (done) => {
-        const noArgCommand = 'calm';
-        exec(noArgCommand, (error, _stdout, stderr) => {
-            expect(error).not.toBeNull();
-            expect(stderr).toContain('A set of tools for interacting with the Common Architecture Language Model');
-            expect(stderr).toContain('Usage:');
-            done();
+    describe('Generate Command', () => {
+        it('should call runGenerate with correct arguments', async () => {
+            process.argv = [
+                'node',
+                'cli.js',
+                'generate',
+                '-p',
+                'pattern.json',
+                '-o',
+                'output.json',
+                '--verbose',
+                '--generateAll',
+                '--schemaDirectory',
+                'schemas'
+            ];
+            await import('./index');
+            const { runGenerate } = jest.requireMock('@finos/calm-shared');
+            expect(runGenerate).toHaveBeenCalledTimes(1);
+            expect(runGenerate).toHaveBeenCalledWith(
+                'pattern.json',
+                'output.json',
+                true,
+                true,
+                'schemas'
+            );
         });
     });
 
-    test('shows help if -h provided', (done) => {
-        const helpShortFlagCommand = 'calm -h';
-        exec(helpShortFlagCommand, (_error, stdout, _stderr) => {
-            expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
-            expect(stdout).toContain('Usage:');
-            done();
+    describe('Validate Command', () => {
+        it('should call runValidate with correct options', async () => {
+            process.argv = [
+                'node',
+                'cli.js',
+                'validate',
+                '-p',
+                'pattern.json',
+                '-a',
+                'arch.json'
+            ];
+            const { runValidate, checkValidateOptions } = jest.requireMock('./validate/validate');
+            await import('./index');
+            expect(checkValidateOptions).toHaveBeenCalledTimes(1);
+            expect(runValidate).toHaveBeenCalledTimes(1);
+            expect(runValidate.mock.calls[0][0]).toEqual(
+                expect.objectContaining({
+                    pattern: 'pattern.json',
+                    architecture: 'arch.json'
+                })
+            );
+        });
+
+    });
+
+    describe('Server Command', () => {
+        it('should call startServer with correct options', async () => {
+            process.argv = [
+                'node',
+                'cli.js',
+                'server',
+                '--port',
+                '4000',
+                '--schemaDirectory',
+                'mySchemas',
+                '--verbose'
+            ];
+            await import('./index');
+            const { startServer } = jest.requireMock('./server/cli-server');
+            expect(startServer).toHaveBeenCalledTimes(1);
+            expect(startServer).toHaveBeenCalledWith({
+                port: '4000',
+                schemaDirectory: 'mySchemas',
+                verbose: true
+            });
         });
     });
 
-    test('shows help if --help provided', (done) => {
-        const helpLongFlagCommand = 'calm --help';
-        exec(helpLongFlagCommand, (_error, stdout, _stderr) => {
-            expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
-            expect(stdout).toContain('Usage:');
-            done();
+    describe('Template Command', () => {
+        it('should instantiate TemplateProcessor with correct arguments and call processTemplate', async () => {
+            process.argv = [
+                'node',
+                'cli.js',
+                'template',
+                '--input',
+                'model.json',
+                '--bundle',
+                'templateDir',
+                '--output',
+                'outDir',
+                '--verbose'
+            ];
+            await import('./index');//
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const TemplateProcessorMock = (require('@finos/calm-shared').TemplateProcessor as jest.Mock);
+            await import('./index');
+            expect(TemplateProcessorMock.mock.calls.length).toBe(1);
+            expect(TemplateProcessorMock.mock.calls[0]).toEqual(['model.json', 'templateDir', 'outDir']);
         });
-    });
-
-    test('example validate command - outputting JSON to stdout', (done) => {
-        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json';
-        exec(exampleValidateCommand, (_error, stdout, _stderr) => {
-            const parsedOutput = JSON.parse(stdout);
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output.json');
-            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
-            expect(parsedOutput).toEqual(expectedJson);
-            done();
-        });
-    });
-
-    test('example validate command - outputting JSON to file', (done) => {
-        const targetOutputFile = path.join(tempDir, 'validate-output.json');
-        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -o ${targetOutputFile}`;
-        exec(exampleValidateCommand, (_error, _stdout, _stderr) => {
-            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
-
-            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-            const parsedOutput = JSON.parse(outputString);
-
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output.json');
-            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
-
-            expect(parsedOutput).toEqual(expectedJson);
-
-            done();
-        });
-    });
-
-    test('example validate command - outputting JUNIT to stdout', (done) => {
-        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f junit';
-        exec(exampleValidateCommand, async (_error, stdout, _stderr) => {
-            const parsedOutput = await parseStringPromise(stdout);
-
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
-            const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
-            const expectedXml = await parseStringPromise(expectedXmlString);
-
-            expect(parsedOutput).toEqual(expectedXml);
-            done();
-        });
-    });
-
-    test('example validate command - outputting JUNIT to file', (done) => {
-        const targetOutputFile = path.join(tempDir, 'validate-output.xml');
-        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f junit -o ${targetOutputFile}`;
-        exec(exampleValidateCommand, async (_error, _stdout, _stderr) => {
-            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
-
-            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-            const parsedOutput = await parseStringPromise(outputString);
-
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
-            const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
-            const expectedXml = await parseStringPromise(expectedXmlString);
-
-            expect(parsedOutput).toEqual(expectedXml);
-
-            done();
-        });
-    });
-
-
-    test('example generate command - does it give the output we expect', (done) => {
-        const targetOutputFile = path.join(tempDir, 'generate-output.json');
-        const exampleGenerateCommand = `calm generate -p ../calm/pattern/api-gateway.json -o ${targetOutputFile}`;
-        exec(exampleGenerateCommand, async (_error, _stdout, _stderr) => {
-
-            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-            const parsedOutput = JSON.parse(outputString);
-
-
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/generate_output.json');
-            const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
-
-            expect(parsedOutput).toEqual(expectedJson);
-
-            done();
-        });
-    });
-
-    test('example validate command - outputting PRETTY to stdout', (done) => {
-        const exampleValidateCommand = 'calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f pretty';
-        exec(exampleValidateCommand, (_error, stdout, _stderr) => {
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_pretty.txt');
-            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
-            //Some minor replacement logic to avoid issues with line endings
-            expect(stdout.replace(/\r\n/g, '\n')).toEqual(expectedOutput.replace(/\r\n/g, '\n'));
-            done();
-        });
-    });
-
-    test('example validate command - outputting PRETTY to file', (done) => {
-        const targetOutputFile = path.join(tempDir, 'validate-output-pretty.txt');
-        const exampleValidateCommand = `calm validate -p ../calm/pattern/api-gateway.json -a ../calm/samples/api-gateway-architecture.json -f pretty -o ${targetOutputFile}`;
-        exec(exampleValidateCommand, (_error, _stdout, _stderr) => {
-            expect(fs.existsSync(targetOutputFile)).toBeTruthy();
-
-            const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_pretty.txt');
-            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
-
-            //Some minor replacement logic to avoid issues with line endings
-            expect(outputString.replace(/\r\n/g, '\n')).toEqual(expectedOutput.replace(/\r\n/g, '\n'));
-            done();
-        });
-    });
-
-    test('example validate command - fails when neither an architecture or a pattern is provided', (done) => {
-        const calmValidateCommand = 'calm validate';
-        exec(calmValidateCommand, (error, _stdout, stderr) => {
-            expect(error).not.toBeNull();
-            expect(stderr).toContain('error: one of the required options \'-p, --pattern <file>\' or \'-a, --architecture <file>\' was not specified');
-            done();
-        });
-    });
-
-    test('example validate command - validates an architecture only', (done) => {
-        const calmValidateArchitectureOnlyCommand = 'calm validate -a ../calm/samples/api-gateway-architecture.json';
-        exec(calmValidateArchitectureOnlyCommand, (error, stdout, _stderr) => {
-            const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_architecture_only_output.json');
-            const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
-            expect(error).toBeNull();
-            expect(stdout).toContain(expectedOutput);
-            done();
-        });
-    });
-
-    test('example server command - starts server and responds to requests', async () => {
-        // Mock the axios response
-        const mockResponse = { status: 200, data: { status: 'ok' } };
-        (axios.get as jest.Mock).mockResolvedValue(mockResponse);
-
-        const serverCommand = 'calm server -p 3001 --schemaDirectory ../../dist/calm/';
-        const serverProcess = exec(serverCommand);
-        // Give the server some time to start
-        await new Promise(resolve => setTimeout(resolve, 5 * millisPerSecond));
-        try {
-            const response = await axios.get('http://127.0.0.1:3001/health');
-            expect(response.status).toBe(200);
-            expect(response.data.status).toBe('ok');
-        } finally {
-            serverProcess.kill();
-        }
     });
 });
-
-async function callNpxFunction(projectRoot: string, command: string) {
-    await execPromise(`npx ${command}`, { cwd: projectRoot });
-}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,13 +1,11 @@
 #! /usr/bin/env node
 
-import { CALM_META_SCHEMA_DIRECTORY, getFormattedOutput, runGenerate, validate, exitBasedOffOfValidationOutcome, TemplateProcessor } from '@finos/calm-shared';
+import {CALM_META_SCHEMA_DIRECTORY, runGenerate, TemplateProcessor} from '@finos/calm-shared';
 import { Option, program } from 'commander';
-import path from 'path';
-import { mkdirp } from 'mkdirp';
-import { writeFileSync } from 'fs';
+
 import { version } from '../package.json';
-import { initLogger } from '@finos/calm-shared/logger';
 import { startServer } from './server/cli-server';
+import {checkValidateOptions, runValidate} from './validate/validate';
 
 const FORMAT_OPTION = '-f, --format <format>';
 const ARCHITECTURE_OPTION = '-a, --architecture <file>';
@@ -17,8 +15,6 @@ const PATTERN_OPTION = '-p, --pattern <file>';
 const SCHEMAS_OPTION = '-s, --schemaDirectory <path>';
 const STRICT_OPTION = '--strict';
 const VERBOSE_OPTION = '-v, --verbose';
-
-
 
 program
     .name('calm')
@@ -52,31 +48,11 @@ program
     .option(OUTPUT_OPTION, 'Path location at which to output the generated file.')
     .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
     .action(async (options) => {
+        checkValidateOptions(program, options, PATTERN_OPTION, ARCHITECTURE_OPTION);
         await runValidate(options);
     });
 
 
-/**
- * Run the validate command and exit with the right status code based on the result.
- * @param options Options passed through from the argument parser.
- */
-async function runValidate(options) {
-    if (!options.pattern && !options.architecture) {
-        program.error(`error: one of the required options '${PATTERN_OPTION}' or '${ARCHITECTURE_OPTION}' was not specified`);
-    }
-    try {
-        const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
-        const content = getFormattedOutput(outcome, options.format);
-        writeOutputFile(options.output, content);
-        exitBasedOffOfValidationOutcome(outcome, options.strict);
-    }
-    catch (err) {
-        const logger = initLogger(options.verbose);
-        logger.error('An error occurred while validating: ' + err.message);
-        logger.debug(err.stack);
-        process.exit(1);
-    }
-}
 
 program
     .command('server')
@@ -88,15 +64,7 @@ program
         startServer(options);
     });
 
-function writeOutputFile(output: string, validationsOutput: string) {
-    if (output) {
-        const dirname = path.dirname(output);
-        mkdirp.sync(dirname);
-        writeFileSync(output, validationsOutput);
-    } else {
-        process.stdout.write(validationsOutput);
-    }
-}
+
 program
     .command('template')
     .description('Generate files from a CALM model using a Handlebars template bundle')
@@ -112,7 +80,5 @@ program
         const processor = new TemplateProcessor(options.input, options.bundle, options.output);
         await processor.processTemplate();
     });
-
-
 
 program.parse(process.argv);

--- a/cli/src/validate/validate.spec.ts
+++ b/cli/src/validate/validate.spec.ts
@@ -1,0 +1,133 @@
+import { getFormattedOutput, validate, exitBasedOffOfValidationOutcome } from '@finos/calm-shared';
+import { initLogger } from '@finos/calm-shared/logger';
+import { mkdirp } from 'mkdirp';
+import { writeFileSync } from 'fs';
+import path from 'path';
+import {runValidate, writeOutputFile, checkValidateOptions} from './validate';
+import { Command } from 'commander';
+
+jest.mock('@finos/calm-shared', () => ({
+    ...jest.requireActual('@finos/calm-shared'),
+    validate: jest.fn(),
+    getFormattedOutput: jest.fn(),
+    exitBasedOffOfValidationOutcome: jest.fn(),
+}));
+
+jest.mock('@finos/calm-shared/logger', () => ({
+    initLogger: jest.fn(),
+}));
+
+jest.mock('mkdirp', () => ({
+    mkdirp: { sync: jest.fn() },
+}));
+
+jest.mock('fs', () => ({
+    ...jest.requireActual('fs'),
+    writeFileSync: jest.fn(),
+}));
+
+describe('runValidate', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should process validation successfully', async () => {
+        const options = {
+            architecture: 'arch.json',
+            pattern: 'pattern.json',
+            schemaDirectory: 'schemas',
+            verbose: true,
+            format: 'json',
+            output: 'out.json',
+            strict: false,
+        };
+
+        const fakeOutcome = { valid: true };
+        (validate as jest.Mock).mockResolvedValue(fakeOutcome);
+        (getFormattedOutput as jest.Mock).mockReturnValue('formatted output');
+
+        await runValidate(options);
+
+        expect(validate).toHaveBeenCalledWith('arch.json', 'pattern.json', 'schemas', true);
+        expect(getFormattedOutput).toHaveBeenCalledWith(fakeOutcome, 'json');
+        expect(exitBasedOffOfValidationOutcome).toHaveBeenCalledWith(fakeOutcome, false);
+
+        // When output is provided, writeOutputFile should call mkdirp.sync and writeFileSync
+        expect(mkdirp.sync).toHaveBeenCalledWith(path.dirname('out.json'));
+        expect(writeFileSync).toHaveBeenCalledWith('out.json', 'formatted output');
+    });
+
+    it('should call process.exit(1) when an error occurs', async () => {
+        const options = {
+            architecture: 'arch.json',
+            pattern: 'pattern.json',
+            schemaDirectory: 'schemas',
+            verbose: false,
+            format: 'json',
+            output: 'out.json',
+            strict: false,
+        };
+
+        const error = new Error('Validation failed');
+        (validate as jest.Mock).mockRejectedValue(error);
+        const loggerMock = { error: jest.fn(), debug: jest.fn() };
+        (initLogger as jest.Mock).mockReturnValue(loggerMock);
+        const exitSpy = jest.spyOn(process, 'exit').mockImplementation((code?: number) => {
+            throw new Error(`process.exit called with ${code}`);
+        });
+
+        await expect(runValidate(options)).rejects.toThrow('process.exit called with 1');
+        expect(loggerMock.error).toHaveBeenCalledWith('An error occurred while validating: ' + error.message);
+        expect(loggerMock.debug).toHaveBeenCalled();
+        exitSpy.mockRestore();
+    });
+});
+
+describe('writeOutputFile', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should write output to file if output is provided', () => {
+        const output = 'dir/out.txt';
+        const content = 'some content';
+        writeOutputFile(output, content);
+        expect(mkdirp.sync).toHaveBeenCalledWith(path.dirname(output));
+        expect(writeFileSync).toHaveBeenCalledWith(output, content);
+    });
+
+    it('should write output to stdout if no output is provided', () => {
+        const content = 'stdout content';
+        const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        writeOutputFile('', content);
+        expect(stdoutSpy).toHaveBeenCalledWith(content);
+        stdoutSpy.mockRestore();
+    });
+});
+
+
+describe('checkValidateOptions', () => {
+    it('should call program.error if neither pattern nor architecture is provided', () => {
+        const program = new Command();
+        const errorSpy = jest.spyOn(program, 'error').mockImplementation((msg: string) => { throw new Error(msg); });
+        const options = {};
+        expect(() => checkValidateOptions(program, options, '-p, --pattern <file>', '-a, --architecture <file>')).toThrow(/one of the required options/);
+        errorSpy.mockRestore();
+    });
+
+    it('should not call program.error if a pattern is provided', () => {
+        const program = new Command();
+        const errorSpy = jest.spyOn(program, 'error').mockImplementation((msg: string) => { throw new Error(msg); });
+        const options = { pattern: 'pattern.json' };
+        expect(() => checkValidateOptions(program, options, '-p, --pattern <file>', '-a, --architecture <file>')).not.toThrow();
+        errorSpy.mockRestore();
+    });
+
+    it('should not call program.error if an architecture is provided', () => {
+        const program = new Command();
+        const errorSpy = jest.spyOn(program, 'error').mockImplementation((msg: string) => { throw new Error(msg); });
+        const options = { architecture: 'arch.json' };
+        expect(() => checkValidateOptions(program, options, '-p, --pattern <file>', '-a, --architecture <file>')).not.toThrow();
+        errorSpy.mockRestore();
+    });
+});

--- a/cli/src/validate/validate.ts
+++ b/cli/src/validate/validate.ts
@@ -1,0 +1,41 @@
+
+import { getFormattedOutput, validate, exitBasedOffOfValidationOutcome } from '@finos/calm-shared';
+import { initLogger } from '@finos/calm-shared/logger';
+import path from 'path';
+import { mkdirp } from 'mkdirp';
+import { writeFileSync } from 'fs';
+import {Command} from 'commander';
+
+export async function runValidate(options) {
+
+    try {
+        const outcome = await validate(options.architecture, options.pattern, options.schemaDirectory, options.verbose);
+        const content = getFormattedOutput(outcome, options.format);
+        writeOutputFile(options.output, content);
+        exitBasedOffOfValidationOutcome(outcome, options.strict);
+    }
+    catch (err) {
+        const logger = initLogger(options.verbose);
+        logger.error('An error occurred while validating: ' + err.message);
+        logger.debug(err.stack);
+        process.exit(1);
+    }
+}
+
+
+export function writeOutputFile(output: string, validationsOutput: string) {
+    if (output) {
+        const dirname = path.dirname(output);
+        mkdirp.sync(dirname);
+        writeFileSync(output, validationsOutput);
+    } else {
+        process.stdout.write(validationsOutput);
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function checkValidateOptions(program: Command, options: any, patternOption: string, architectureOption: string) {
+    if (!options.pattern && !options.architecture) {
+        program.error(`error: one of the required options '${patternOption}' or '${architectureOption}' was not specified`);
+    }
+}

--- a/cli/test_fixtures/template/model/document-system.json
+++ b/cli/test_fixtures/template/model/document-system.json
@@ -1,0 +1,74 @@
+{
+  "$id": "docuflow-architecture",
+  "title": "DocuFlow System",
+  "description": "DocuFlow is a document management system that allows users to upload, process, and store documents securely.",
+  "nodes": [
+    {
+      "unique-id": "document-system",
+      "name": "DocuFlow",
+      "description": "Main document management system",
+      "node-type": "system"
+    },
+    {
+      "unique-id": "svc-upload",
+      "name": "Upload Service",
+      "description": "Handles user document uploads",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "svc-storage",
+      "name": "Storage Service",
+      "description": "Stores and retrieves documents securely",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "db-docs",
+      "name": "Document Database",
+      "description": "Stores metadata and document references",
+      "node-type": "database"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "rel-upload-to-storage",
+      "description": "Upload Service sends documents to Storage Service for long-term storage",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "svc-upload"
+          },
+          "destination": {
+            "node": "svc-storage"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "rel-storage-to-db",
+      "description": "Storage Service stores document metadata in the Document Database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "svc-storage"
+          },
+          "destination": {
+            "node": "db-docs"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "document-system-system-is-composed-of",
+      "relationship-type": {
+        "composed-of": {
+          "container": "document-system",
+          "nodes": [
+            "svc-upload",
+            "svc-storage",
+            "db-docs"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/cli/test_fixtures/template/template-bundles/doc-system/basic-transformer.js
+++ b/cli/test_fixtures/template/template-bundles/doc-system/basic-transformer.js
@@ -1,0 +1,12 @@
+module.exports = class BasicTransformer {
+    registerTemplateHelpers() {
+        return {};
+    }
+
+    getTransformedModel(rawJson) {
+        const document = JSON.parse(rawJson);
+        return {
+            document: document
+        };
+    }
+};

--- a/cli/test_fixtures/template/template-bundles/doc-system/index.json
+++ b/cli/test_fixtures/template/template-bundles/doc-system/index.json
@@ -1,0 +1,12 @@
+{
+  "name": "CLI E2E Template Endpoint Test Bundle",
+  "transformer": "basic-transformer",
+  "templates": [
+    {
+      "template": "main.hbs",
+      "from": "document",
+      "output": "cli-e2e-output.html",
+      "output-type": "single"
+    }
+  ]
+}

--- a/cli/test_fixtures/template/template-bundles/doc-system/main.hbs
+++ b/cli/test_fixtures/template/template-bundles/doc-system/main.hbs
@@ -1,0 +1,16 @@
+<h1>{{title}}</h1>
+<p>{{description}}</p>
+
+<h2>Nodes</h2>
+<ul>
+{{#each nodes}}
+    <li><strong>{{name}}</strong> ({{node-type}}): {{description}}</li>
+{{/each}}
+</ul>
+
+<h2>Relationships</h2>
+<ul>
+    {{#each relationships}}
+    <li>{{description}}</li>
+    {{/each}}
+</ul>


### PR DESCRIPTION
## **Summary**
This PR enhances the test coverage for the CLI. Coverage was not being puc

## **Changes**
✅ **Renamed `cli.spec.ts` → `cli.e2e.spec.ts`** since it was acting as an integration test rather than a unit test.  
✅ **Added a new e2e test (`cli.e2e.spec.ts`)** to properly test the `calm template` command by executing it as a subprocess. 
✅ **Created new CLI unit tests (`cli.spec.ts`)** to properly mock CLI behavior without spawning subprocesses.  
✅ **Refactored CLI validation logic** by extracting it from `index.ts` into a separate module, improving testability and separation of concerns.  

## **Why This Change?**
- **🔍 Improves Test Coverage**: The CLI subprocess was not being counted in coverage, leading to misleading results i.e. coverage report wasn't covering index.ts
- **📂 Better Test Structure**: Separates **unit tests** from **E2E tests**, ensuring both are properly validated.
- **🛠 Cleaner CLI Code**: The validation logic is now more modular and easier to maintain.

## **Testing & Validation**
- ✅ Ran `npm run test` to confirm all tests pass.
- ✅ Verified that coverage now correctly includes CLI execution.

