### PR TITLE
Initial Implementation of CALM Docify Endpoint (#478)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,9 +10,10 @@
     "calm": "dist/index.js"
   },
   "scripts": {
-    "build": "tsup && npm run copy-calm-schema",
+    "build": "tsup && npm run copy-calm-schema && npm run copy-docify-templates",
     "watch": "node watch.mjs",
     "copy-calm-schema": "copyfiles \"../calm/draft/2024-10/meta/*\" dist/calm/",
+    "copy-docify-templates": "copyfiles \"../shared/src/docify/template-bundles/**/*\" dist --up 4",
     "test": "jest",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -235,6 +235,36 @@ describe('CLI Integration Tests', () => {
         }
     });
 
+    test('example docify command - generates expected output', async () => {
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
+        const outputDir = path.resolve(__dirname, 'output/documentation');
+
+        const expectedFiles = [
+            'docs/index.md',
+            'docs/flows/flow-document-upload.md',
+            'docs/nodes/document-system.md',
+            'docs/nodes/db-docs.md',
+            'docs/nodes/svc-storage.md',
+            'docs/nodes/svc-upload.md'
+        ].map(file => path.join(outputDir, file));
+
+        try {
+            const templateCommand = `calm docify --input ${testModelPath} --output ${outputDir} --url-to-local-file-mapping ${localDirectory}`;
+            await execPromise(templateCommand);
+
+            await new Promise(resolve => setTimeout(resolve, 2 * 1000));
+
+            for (const file of expectedFiles) {
+                expect(fs.existsSync(file)).toBeTruthy();
+            }
+        } finally {
+            if (fs.existsSync(outputDir)) {
+                fs.rmSync(outputDir, { recursive: true, force: true });
+            }
+        }
+    });
 
 
 });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-import {CALM_META_SCHEMA_DIRECTORY, runGenerate, TemplateProcessor} from '@finos/calm-shared';
+import {CALM_META_SCHEMA_DIRECTORY, runGenerate, TemplateProcessor, Docifier} from '@finos/calm-shared';
 import { Option, program } from 'commander';
 
 import { version } from '../package.json';
@@ -82,5 +82,24 @@ program
         const processor = new TemplateProcessor(options.input, options.bundle, options.output, localDirectory);
         await processor.processTemplate();
     });
+
+program
+    .command('docify')
+    .description('Generate files from a CALM model using a Handlebars template bundle')
+    .requiredOption('--input <path>', 'Path to the CALM model JSON file')
+    .requiredOption('--output <path>', 'Path to output directory')
+    .option('--url-to-local-file-mapping <path>', 'Path to mapping file which maps URLs to local paths')
+    .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
+    .action(async (options) => {
+        if (options.verbose) {
+            process.env.DEBUG = 'true';
+        }
+
+        const localDirectory = getUrlToLocalFileMap(options.urlToLocalFileMapping);
+
+        const docifier = new Docifier('WEBSITE', options.input,  options.output, localDirectory);
+        await docifier.docify();
+    });
+
 
 program.parse(process.argv);

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -7,12 +7,12 @@ export default defineConfig({
     format: ['cjs'],
     sourcemap: false,
     clean: true,
-    external: ['canvas', 'fsevents', '@apidevtools/json-schema-ref-parser', /node_modules/],
+    external: ['canvas', 'fsevents', '@apidevtools/json-schema-ref-parser', /node_modules/, 'ts-node'],
     noExternal: ['@finos/calm-shared', /tsup/],
     bundle: true,
     splitting: false,
     minify: false,
     shims: true,
     target: 'es2021',
-    treeshake: true
+    treeshake: true,
 });

--- a/shared/src/docify/docifier.spec.ts
+++ b/shared/src/docify/docifier.spec.ts
@@ -1,0 +1,43 @@
+import { Docifier } from './docifier';
+import { TemplateProcessor } from '../template/template-processor';
+
+jest.mock('../template/template-processor');
+
+const mockedTemplateProcessor = TemplateProcessor as jest.MockedClass<typeof TemplateProcessor>;
+
+describe('Docifier', () => {
+    const inputPath = 'some/input/path';
+    const outputPath = 'some/output/path';
+    const urlToLocalPathMapping = new Map<string, string>();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should throw an error when mode is "SAD"', () => {
+        expect(() => {
+            new Docifier('SAD', inputPath, outputPath, urlToLocalPathMapping);
+        }).toThrowError('Mode "SAD" is not supported.');
+    });
+
+    it('should instantiate TemplateProcessor for mode "WEBSITE" and call processTemplate', async () => {
+        const processTemplateMock = jest.fn().mockResolvedValue(undefined);
+
+        mockedTemplateProcessor.mockImplementationOnce(() => ({
+            processTemplate: processTemplateMock,
+        }) as never);
+
+        const docifier = new Docifier('WEBSITE', inputPath, outputPath, urlToLocalPathMapping);
+        await docifier.docify();
+
+        // Verify that TemplateProcessor was instantiated with the correct parameters.
+        expect(mockedTemplateProcessor).toHaveBeenCalledWith(
+            inputPath,
+            expect.stringContaining('template-bundles/docusaurus'),
+            outputPath,
+            urlToLocalPathMapping
+        );
+
+        expect(processTemplateMock).toHaveBeenCalled();
+    });
+});

--- a/shared/src/docify/docifier.ts
+++ b/shared/src/docify/docifier.ts
@@ -1,0 +1,30 @@
+import { TemplateProcessor } from '../template/template-processor.js';
+
+export type DocifyMode = 'SAD' | 'WEBSITE';
+
+export class Docifier {
+    private static readonly TEMPLATE_BUNDLE_PATHS: Record<DocifyMode, string> = {
+        SAD: __dirname + '/template-bundles/sad',
+        WEBSITE: __dirname + '/template-bundles/docusaurus',
+    };
+
+    private templateProcessor: TemplateProcessor;
+
+    constructor(mode: DocifyMode, inputPath: string, outputPath: string, urlToLocalPathMapping: Map<string, string>) {
+        if (mode === 'SAD') {
+            throw new Error('Mode "SAD" is not supported.');
+        }
+
+        const templateBundlePath = Docifier.TEMPLATE_BUNDLE_PATHS[mode];
+
+        if (!templateBundlePath) {
+            throw new Error(`Invalid mode: ${mode}`);
+        }
+
+        this.templateProcessor = new TemplateProcessor(inputPath, templateBundlePath, outputPath, urlToLocalPathMapping);
+    }
+
+    public async docify(): Promise<void> {
+        await this.templateProcessor.processTemplate();
+    }
+}

--- a/shared/src/docify/graphing/c4.spec.ts
+++ b/shared/src/docify/graphing/c4.spec.ts
@@ -1,0 +1,106 @@
+// c4model.test.ts
+
+import { buildParentChildMappings, C4Model } from './c4';
+import { CalmCore } from '../../model/core';
+import { CalmNode, CalmNodeDetails } from '../../model/node';
+import { CalmMetadata } from '../../model/metadata';
+import {
+    CalmRelationship,
+    CalmComposedOfType,
+    CalmConnectsType,
+    CalmInteractsType
+} from '../../model/relationship';
+
+describe('buildParentChildMappings', () => {
+    it('should build parent/child lookups for a composed-of relationship', () => {
+        const composedOfRel = new CalmRelationship(
+            'rel1',
+            new CalmComposedOfType('parent1', ['child1', 'child2']),
+            new CalmMetadata({}),
+            []
+        );
+        const { parentLookup, childrenLookup } = buildParentChildMappings([composedOfRel]);
+        expect(parentLookup).toEqual({ child1: 'parent1', child2: 'parent1' });
+        expect(childrenLookup).toEqual({ parent1: ['child1', 'child2'] });
+    });
+});
+
+describe('C4Model', () => {
+    it('should build elements and relationships from a CalmCore using direct constructors', () => {
+        const systemNode = buildNode('system1', 'system', 'System One', 'A system');
+        const service1Node = buildNode('service1', 'service', 'Service One', 'A service');
+        const actorNode = buildNode('actor1', 'actor', 'Actor One', 'An actor');
+        const service2Node = buildNode('service2', 'service', 'Service Two', 'Another service');
+
+        const composedRel = new CalmRelationship(
+            'rel1',
+            new CalmComposedOfType('system1', ['service1', 'service2']),
+            new CalmMetadata({}),
+            [],
+            'system1 is composed of service1 & service2'
+        );
+        const interactsRel = new CalmRelationship(
+            'rel2',
+            new CalmInteractsType('actor1', ['service1']),
+            new CalmMetadata({}),
+            [],
+            'actor1 interacts with service1'
+        );
+        const connectsRel = new CalmRelationship(
+            'rel3',
+            new CalmConnectsType({ node: 'service2', interfaces: [] }, { node: 'actor1', interfaces: []  }),
+            new CalmMetadata({}),
+            [],
+            'service2 connects to actor1'
+        );
+
+        const dummyCalmCore: CalmCore = {
+            nodes: [systemNode, service1Node, actorNode, service2Node],
+            relationships: [composedRel, interactsRel, connectsRel],
+            metadata: new CalmMetadata({}),
+            controls: [],
+            flows: []
+        };
+
+        const model = new C4Model(dummyCalmCore);
+        expect(model.elements['system1']).toBeDefined();
+        expect(model.elements['service1']).toBeDefined();
+        expect(model.elements['actor1']).toBeDefined();
+        expect(model.elements['service2']).toBeDefined();
+        expect(model.elements['system1'].elementType).toBe('System');
+        expect(model.elements['service1'].elementType).toBe('Container');
+        expect(model.elements['actor1'].elementType).toBe('Person');
+        expect(model.elements['service2'].elementType).toBe('Container');
+        expect(model.elements['service1'].parentId).toBe('system1');
+        expect(model.elements['service2'].parentId).toBe('system1');
+        expect(model.elements['system1'].children).toEqual(expect.arrayContaining(['service1', 'service2']));
+        const interaction = model.relationships.find(
+            (rel) => rel.source === 'actor1' && rel.destination === 'service1' && rel.relationshipType === 'Interacts With'
+        );
+        expect(interaction).toBeDefined();
+        const connection = model.relationships.find(
+            (rel) => rel.source === 'service2' && rel.destination === 'actor1' && rel.relationshipType === 'Connects To'
+        );
+        expect(connection).toBeDefined();
+        expect(model.graph).toBeDefined();
+    });
+
+    function buildNode(
+        uniqueId: string,
+        nodeType: 'actor' | 'system' | 'service',
+        name: string,
+        description: string
+    ) {
+        return new CalmNode(
+            uniqueId,
+            nodeType,
+            name,
+            description,
+            new CalmNodeDetails('', ''),
+            [],
+            [],
+            new CalmMetadata({})
+        );
+    }
+
+});

--- a/shared/src/docify/graphing/c4.ts
+++ b/shared/src/docify/graphing/c4.ts
@@ -1,0 +1,127 @@
+import {
+    CalmComposedOfType,
+    CalmConnectsType,
+    CalmInteractsType,
+    CalmRelationship
+} from '../../model/relationship';
+import {CalmCore} from '../../model/core.js';
+import {CalmRelationshipGraph} from './relationship-graph.js';
+
+export type C4ElementType = 'System' | 'Container' | 'Component' | 'Person';
+
+export class C4Element {
+    constructor(
+        public elementType: C4ElementType,
+        public uniqueId: string,
+        public name: string,
+        public description: string,
+        public parentId?: string,
+        public children: string[] = []
+    ) {}
+}
+
+export class C4Relationship {
+    constructor(
+        public source: string,
+        public destination: string,
+        public relationshipType: string
+    ) {}
+}
+
+export function buildParentChildMappings(relationships: CalmRelationship[]): {
+    parentLookup: Record<string, string>,
+    childrenLookup: Record<string, string[]>
+} {
+    const parentLookup: Record<string, string> = {};
+    const childrenLookup: Record<string, string[]> = {};
+
+    relationships.forEach(rel => {
+        if (rel.relationshipType instanceof CalmComposedOfType) {
+            const composedRel = rel.relationshipType as CalmComposedOfType;
+            const { container, nodes } = composedRel;
+
+            if (!childrenLookup[container]) {
+                childrenLookup[container] = [];
+            }
+            childrenLookup[container].push(...nodes);
+
+            nodes.forEach(nodeId => {
+                parentLookup[nodeId] = container;
+            });
+        }
+    });
+
+    return { parentLookup, childrenLookup };
+}
+
+
+export class C4Model {
+    public elements: Record<string, C4Element> = {};
+    public relationships: C4Relationship[] = [];
+    public graph: CalmRelationshipGraph;
+
+    constructor(calmCore: CalmCore) {
+        this.buildFromCalm(calmCore);
+        this.graph = new CalmRelationshipGraph(calmCore.relationships);
+    }
+
+    private buildFromCalm(calmCore: CalmCore) {
+        const nodeTypeMapping: Record<string, C4ElementType> = {
+            'system': 'System',
+            'service': 'Container',
+            'actor': 'Person'
+        };
+        const { parentLookup, childrenLookup } = buildParentChildMappings(calmCore.relationships);
+        calmCore.nodes.forEach(node => {
+            const elementType = nodeTypeMapping[node.nodeType] || 'Container';
+            const parentId = parentLookup[node.uniqueId];
+            const children = childrenLookup[node.uniqueId] || [];
+
+            this.elements[node.uniqueId] = new C4Element(
+                elementType,
+                node.uniqueId,
+                node.name,
+                node.description,
+                parentId,
+                children
+            );
+        });
+
+
+        Object.values(this.elements).forEach(node => {
+            if (node.parentId && this.elements[node.parentId]) {
+                this.elements[node.parentId].children.push(node.uniqueId);
+            }
+        });
+
+        calmCore.relationships.forEach(rel => {
+            if (rel.relationshipType instanceof CalmComposedOfType) {
+                // Already handled via parent-child mapping, skip adding to relationships
+                return;
+            }
+            else if (rel.relationshipType instanceof CalmInteractsType) {
+                const interactsRelationship = rel.relationshipType as CalmInteractsType;
+
+                interactsRelationship.nodes.forEach(nodeId => {
+                    this.relationships.push(new C4Relationship(
+                        interactsRelationship.actor,
+                        nodeId,
+                        'Interacts With'
+                    ));
+                });
+            }
+            else if (rel.relationshipType instanceof CalmConnectsType) {
+                const connectsRelationship = rel.relationshipType as CalmConnectsType;
+
+                this.relationships.push(new C4Relationship(
+                    connectsRelationship.source.node,
+                    connectsRelationship.destination.node,
+                    'Connects To'
+                ));
+            }
+        });
+    }
+}
+
+
+

--- a/shared/src/docify/graphing/relationship-graph.spec.ts
+++ b/shared/src/docify/graphing/relationship-graph.spec.ts
@@ -1,0 +1,82 @@
+import { CalmRelationshipGraph } from './relationship-graph.js';
+import { CalmRelationship, CalmInteractsType, CalmConnectsType, CalmDeployedInType, CalmComposedOfType } from '../../model/relationship';
+import { CalmMetadata } from '../../model/metadata';
+
+describe('CalmRelationshipGraph', () => {
+    const interactsRel = new CalmRelationship(
+        'rel1',
+        new CalmInteractsType('actor1', ['service1']),
+        new CalmMetadata({}),
+        [],
+        'actor1 interacts with service1'
+    );
+
+    const connectsRel = new CalmRelationship(
+        'rel2',
+        new CalmConnectsType({ node: 'service2', interfaces: [] }, { node: 'actor2', interfaces: [] }),
+        new CalmMetadata({}),
+        [],
+        'service2 connects to actor2'
+    );
+
+    const deployedInRel = new CalmRelationship(
+        'rel3',
+        new CalmDeployedInType('container1', ['node1', 'node2']),
+        new CalmMetadata({}),
+        [],
+        'container1 deployed in node1 and node2'
+    );
+
+    const composedOfRel = new CalmRelationship(
+        'rel4',
+        new CalmComposedOfType('composed1', ['nodeA', 'nodeB']),
+        new CalmMetadata({}),
+        [],
+        'composed1 is composed of nodeA and nodeB'
+    );
+
+    const relationships = [interactsRel, connectsRel, deployedInRel, composedOfRel];
+    const graph = new CalmRelationshipGraph(relationships);
+
+    test('isRelated returns true for directly connected nodes', () => {
+        expect(graph.isRelated('actor1', 'service1')).toBe(true);
+        expect(graph.isRelated('service1', 'actor1')).toBe(true);
+        expect(graph.isRelated('service2', 'actor2')).toBe(true);
+        expect(graph.isRelated('container1', 'node1')).toBe(true);
+        expect(graph.isRelated('composed1', 'nodeA')).toBe(true);
+    });
+
+    test('isRelated returns false for unconnected nodes', () => {
+        expect(graph.isRelated('actor1', 'node1')).toBe(false);
+        expect(graph.isRelated('service2', 'nodeA')).toBe(false);
+    });
+
+    test('isNodeInRelationship returns true for nodes in relationships', () => {
+        expect(graph.isNodeInRelationship('actor1')).toBe(true);
+        expect(graph.isNodeInRelationship('service1')).toBe(true);
+        expect(graph.isNodeInRelationship('nodeA')).toBe(true);
+    });
+
+    test('isNodeInRelationship returns false for nodes not in relationships', () => {
+        expect(graph.isNodeInRelationship('nonexistent')).toBe(false);
+    });
+
+    test('getRelatedNodes returns correct neighbors', () => {
+        const relatedToActor1 = graph.getRelatedNodes('actor1');
+        expect(relatedToActor1).toContain('service1');
+        const relatedToContainer1 = graph.getRelatedNodes('container1');
+        expect(relatedToContainer1).toEqual(expect.arrayContaining(['node1', 'node2']));
+    });
+
+    test('getRelatedRelationships returns relationships involving a given node', () => {
+        const relsActor1 = graph.getRelatedRelationships('actor1');
+        expect(relsActor1).toHaveLength(1);
+        expect(relsActor1[0].uniqueId).toBe('rel1');
+        const relsNode1 = graph.getRelatedRelationships('node1');
+        expect(relsNode1).toHaveLength(1);
+        expect(relsNode1[0].uniqueId).toBe('rel3');
+        const relsService2 = graph.getRelatedRelationships('service2');
+        expect(relsService2).toHaveLength(1);
+        expect(relsService2[0].uniqueId).toBe('rel2');
+    });
+});

--- a/shared/src/docify/graphing/relationship-graph.ts
+++ b/shared/src/docify/graphing/relationship-graph.ts
@@ -1,0 +1,93 @@
+import {
+    CalmComposedOfType,
+    CalmConnectsType,
+    CalmDeployedInType,
+    CalmInteractsType,
+    CalmRelationship
+} from '../../model/relationship.js';
+
+
+export class CalmRelationshipGraph {
+    private adjacencyList: Map<string, Set<string>> = new Map();
+    private relationships: CalmRelationship[];
+
+    constructor(relationships: CalmRelationship[]) {
+        this.buildGraph(relationships);
+        this.relationships = relationships;
+    }
+
+    private buildGraph(relationships: CalmRelationship[]) {
+        relationships.forEach(rel => {
+            if (rel.relationshipType instanceof CalmInteractsType) {
+                this.addEdge(rel.relationshipType.actor, rel.relationshipType.nodes);
+            } else if (rel.relationshipType instanceof CalmConnectsType) {
+                this.addEdge(rel.relationshipType.source.node, [rel.relationshipType.destination.node]);
+            } else if (rel.relationshipType instanceof CalmDeployedInType) {
+                this.addEdge(rel.relationshipType.container, rel.relationshipType.nodes);
+            } else if (rel.relationshipType instanceof CalmComposedOfType) {
+                this.addEdge(rel.relationshipType.container, rel.relationshipType.nodes);
+            }
+        });
+    }
+
+    private addEdge(source: string, destinations: string[]) {
+        if (!this.adjacencyList.has(source)) {
+            this.adjacencyList.set(source, new Set());
+        }
+        destinations.forEach(dest => {
+            this.adjacencyList.get(source)!.add(dest);
+            if (!this.adjacencyList.has(dest)) {
+                this.adjacencyList.set(dest, new Set());
+            }
+            this.adjacencyList.get(dest)!.add(source); // Making the graph bidirectional
+        });
+    }
+
+    public isRelated(startNode: string, targetNode: string): boolean {
+        if (!this.adjacencyList.has(startNode) || !this.adjacencyList.has(targetNode)) {
+            return false;
+        }
+        return this.bfs(startNode, targetNode);
+    }
+
+    public isNodeInRelationship(node: string): boolean {
+        return this.adjacencyList.has(node) && this.adjacencyList.get(node)!.size > 0;
+    }
+
+    private bfs(startNode: string, targetNode: string): boolean {
+        const queue: string[] = [startNode];
+        const visited: Set<string> = new Set();
+
+        while (queue.length > 0) {
+            const node = queue.shift()!;
+            if (node === targetNode) return true;
+            visited.add(node);
+
+            for (const neighbor of this.adjacencyList.get(node) || []) {
+                if (!visited.has(neighbor)) {
+                    queue.push(neighbor);
+                }
+            }
+        }
+        return false;
+    }
+
+    public getRelatedNodes(node: string): string[] {
+        return this.adjacencyList.has(node) ? Array.from(this.adjacencyList.get(node)!) : [];
+    }
+
+    public getRelatedRelationships(node: string): CalmRelationship[] {
+        return this.relationships.filter(rel => {
+            if (rel.relationshipType instanceof CalmInteractsType) {
+                return rel.relationshipType.actor === node || rel.relationshipType.nodes.includes(node);
+            } else if (rel.relationshipType instanceof CalmConnectsType) {
+                return rel.relationshipType.source.node === node || rel.relationshipType.destination.node === node;
+            } else if (rel.relationshipType instanceof CalmDeployedInType) {
+                return rel.relationshipType.container === node || rel.relationshipType.nodes.includes(node);
+            } else if (rel.relationshipType instanceof CalmComposedOfType) {
+                return rel.relationshipType.container === node || rel.relationshipType.nodes.includes(node);
+            }
+            return false;
+        });
+    }
+}

--- a/shared/src/docify/template-bundles/docusaurus/c4-container.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/c4-container.hbs
@@ -1,0 +1,29 @@
+```mermaid
+C4Container
+{{#each C4model.elements}}
+    {{#if (eq this.elementType "System")}}
+        System_Boundary("{{this.name}}","{{this.description}}"){
+        {{#each this.children}}
+            {{#with (lookup ../../this.C4model.elements this)}}
+                Container({{this.uniqueId}},"{{this.name}}","","{{this.description}}")
+            {{/with}}
+        {{/each}}
+        }
+    {{/if}}
+    {{#if (eq this.elementType "Person")}}
+        Person({{this.uniqueId}},"{{this.name}}","{{this.description}}")
+    {{/if}}
+
+    {{#if (eq this.elementType "Container")}}
+        {{#unless parentId}}
+            Container({{this.uniqueId}},"{{this.name}}","","{{this.description}}")
+        {{/unless}}
+    {{/if}}
+{{/each}}
+
+{{#each C4model.relationships}}
+    Rel({{this.source}},{{this.destination}},"{{this.relationshipType}}")
+{{/each}}
+
+UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="0")
+```

--- a/shared/src/docify/template-bundles/docusaurus/control-requirement.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/control-requirement.hbs
@@ -1,0 +1,8 @@
+---
+title: {{kebabToTitleCase id}}
+---
+### Specification
+
+```json
+{{{json this}}}
+```

--- a/shared/src/docify/template-bundles/docusaurus/controls.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/controls.hbs
@@ -1,0 +1,17 @@
+## Controls
+
+{{#if controls.length}}
+    {{#each controls}}
+
+        ### {{kebabToTitleCase controlId}}
+
+        {{description}}
+
+        {{#each requirements}}
+            {{> table-template.html data=controlConfigUrl}}
+        {{/each}}
+
+    {{/each}}
+{{else}}
+    _No controls defined._
+{{/if}}

--- a/shared/src/docify/template-bundles/docusaurus/custom.css
+++ b/shared/src/docify/template-bundles/docusaurus/custom.css
@@ -1,0 +1,42 @@
+.table-container {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+    overflow-x: auto; /* Allow scrolling if necessary */
+}
+
+.table-container table {
+    flex: 1; /* Ensure all tables are equal width */
+    width: 100%;
+    min-width: 600px; /* Prevent tables from being too small */
+    table-layout: fixed; /* Force table to obey column widths */
+    border-collapse: collapse;
+}
+
+.table-container thead {
+    display: inherit; /* Ensures correct header grouping */
+    width: 100%;
+}
+
+.table-container th,
+.table-container td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+    vertical-align: top; /* Ensure alignment stays consistent */
+    word-wrap: break-word; /* Ensure text wraps properly */
+    overflow-wrap: break-word;
+}
+
+/* Fix column widths */
+.table-container th:first-child,
+.table-container td:first-child {
+    min-width: 200px; /* Fix first column width */
+    max-width: 200px; /* Fix first column width */
+    white-space: wrap; /* Prevent wrapping */
+}
+
+.table-container th:last-child,
+.table-container td:last-child {
+    width: 100%; /* Expand second column */
+}

--- a/shared/src/docify/template-bundles/docusaurus/docusaurus-transformer.ts
+++ b/shared/src/docify/template-bundles/docusaurus/docusaurus-transformer.ts
@@ -1,0 +1,204 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import {Architecture, CalmControl, CalmCore, CalmFlowTransition, CalmTemplateTransformer} from '@finos/calm-shared';
+import {CalmCoreSchema} from '@finos/calm-shared/types/core-types';
+import {CalmRelationshipGraph, C4Model} from '@finos/calm-shared';
+
+
+export default class DocusaurusTransformer implements CalmTemplateTransformer {
+    getTransformedModel(calmJson: string) {
+        const calmSchema: CalmCoreSchema = JSON.parse(calmJson);
+        const architecture: Architecture = CalmCore.fromJson(calmSchema);
+
+        const relationships = architecture.relationships;
+        const graph = new CalmRelationshipGraph(architecture.relationships);
+
+        const nodes = architecture.nodes.map(node => ({
+            id: node.uniqueId,
+            title: node.name,
+            name: node.name,
+            slug: node.uniqueId, // Generate slug
+            description: node.description || 'No description available.',
+            nodeType: node.nodeType || 'unknown',
+            controls: node.controls,
+            interfaces: node.interfaces,
+            runAs: node.runAs,
+            dataClassification: node.dataClassification,
+            relatedRelationships: graph.getRelatedRelationships(node.uniqueId),
+            relatedNodes: graph.getRelatedNodes(node.uniqueId)
+        }));
+
+        const flows = architecture.flows.map(flow => {
+            const transformedTransitions = flow.transitions.map((transition: CalmFlowTransition) => ({
+                relationshipId: transition.relationshipUniqueId,
+                sequenceNumber: transition.sequenceNumber,
+                summary: transition.summary,
+                direction: transition.direction,
+                source: this.getSourceFromRelationship(transition.relationshipUniqueId),
+                target: this.getTargetFromRelationship(transition.relationshipUniqueId)
+            }));
+
+            return {
+                title: flow.name,
+                id: flow.uniqueId,
+                slug: flow.uniqueId,
+                name: flow.name,
+                description: flow.description,
+                transitions: transformedTransitions,
+                controls: flow.controls
+            };
+        });
+
+        const controlRequirements: Record<string, { id:string, content:string, domain:string}[]> = {};
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const addControlRequirementToTable = (controls: CalmControl[], domain: string, appliedTo: string) => {
+            controls.forEach(control => {
+                control.requirements.forEach( detail => {
+                    const requirement =  detail.controlRequirementUrl;
+                    const id = requirement['$id'].split('/').filter(Boolean).pop() || '';
+                    if (!controlRequirements[id]) {
+                        controlRequirements[id] = [];
+                        controlRequirements[id].push({
+                            id: id,
+                            content: requirement,
+                            domain: control.controlId
+
+                        });
+                    }
+
+                });
+            });
+        };
+
+        const controlConfigurations: Record<string, { id:string, name:string, schema:string, description:string, domain: string, scope: string, appliedTo: string, content: string }[]> = {};
+
+        // Collect control requirements and configurations from nodes, flows, and relationships
+        const addControlConfigurationToTable = (controls: CalmControl[], scope: string, appliedTo: string) => {
+            controls.forEach(control => {
+                control.requirements.forEach( detail => {
+                    const configuration =  detail.controlConfigUrl;
+                    if (!controlConfigurations[configuration['control-id']]) {
+                        controlConfigurations[configuration['control-id']] = [];
+                    }
+                    controlConfigurations[configuration['control-id']].push({
+                        id: configuration['control-id'],
+                        name: configuration['name'],
+                        schema: configuration['$schema'],
+                        description: configuration['description'],
+                        domain: control.controlId,
+                        scope,
+                        appliedTo,
+                        content: configuration
+                    });
+                });
+            });
+        };
+
+        architecture.nodes.forEach(node => {
+            addControlConfigurationToTable(node.controls, 'Node', node.uniqueId);
+            addControlRequirementToTable(node.controls, 'Node', node.uniqueId);
+        });
+
+        architecture.relationships.forEach(relationship => {
+            addControlConfigurationToTable(relationship.controls, 'Relationship', relationship.uniqueId);
+            addControlRequirementToTable(relationship.controls, 'Relationship', relationship.uniqueId);
+        });
+
+        architecture.flows.forEach(flow => {
+            addControlConfigurationToTable(flow.controls, 'Flow', flow.uniqueId);
+            addControlRequirementToTable(flow.controls, 'Flow', flow.uniqueId);
+        });
+
+
+        const groupedByDomainRequirements: Record<string, { id: string; content: string; domain: string }[]> = {};
+
+        Object.values(controlRequirements).forEach(requirements => {
+            requirements.forEach(req => {
+                if (!groupedByDomainRequirements[req.domain]) {
+                    groupedByDomainRequirements[req.domain] = [];
+                }
+                groupedByDomainRequirements[req.domain].push(req);
+            });
+        });
+
+
+        const groupedByDomainConfigurations: Record<string, { id:string, name:string, schema:string, description:string, domain: string, scope: string, appliedTo: string, content: string }[]> = {};
+
+        Object.values(controlConfigurations).forEach(controlConfigurations => {
+            controlConfigurations.forEach(req => {
+                if (!groupedByDomainConfigurations[req.domain]) {
+                    groupedByDomainConfigurations[req.domain] = [];
+                }
+                groupedByDomainConfigurations[req.domain].push(req);
+            });
+        });
+
+
+
+        const controls = Object.entries(controlConfigurations).flatMap(([id, configurations]) =>
+            configurations.map(config => ({
+                id,
+                ...config
+            }))
+        );
+
+        const controlReqs = Object.entries(controlRequirements).flatMap(([id, requirements]) =>
+            requirements.map(requirement => ({
+                id,
+                ...requirement
+            }))
+        );
+
+        const C4model =  new C4Model(architecture);
+
+        return {
+            nodes,
+            flows,
+            controls,
+            controlReqs,
+            C4model,
+            docs: {
+                nodes,
+                flows,
+                controls,
+                relationships,
+                controlReqs,
+                groupedByDomainRequirements,
+                groupedByDomainConfigurations,
+                C4model,
+                controlConfigurations
+            }
+        };
+    }
+
+    registerTemplateHelpers(): Record<string, (...args: unknown[]) => unknown> {
+        return {
+            eq: (a, b) => a === b,
+            lookup: (obj, key: any) => obj?.[key],
+            json: (obj) => JSON.stringify(obj, null, 2),
+            instanceOf: (value, className: string) => value?.constructor?.name === className,
+            kebabToTitleCase: (str: string) => str
+                .split('-')
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                .join(' '),
+            kebabCase: (str: string) => str
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')  // Replace non-alphanumeric characters with hyphens
+                .replace(/^-+|-+$/g, ''), // Remove leading or trailing hyphens
+            isObject: (value: unknown) => typeof value === 'object' && value !== null && !Array.isArray(value),
+            isArray: (value: unknown) => Array.isArray(value)
+        };
+    }
+
+
+
+
+    private getSourceFromRelationship(relationshipId: string): string {
+        return relationshipId.split('-uses-')[0];
+    }
+
+    private getTargetFromRelationship(relationshipId: string): string {
+        return relationshipId.split('-uses-').slice(-1)[0];
+    }
+}

--- a/shared/src/docify/template-bundles/docusaurus/docusaurus.config.js
+++ b/shared/src/docify/template-bundles/docusaurus/docusaurus.config.js
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef */
+const remarkReplaceLinks = require('./src/remark/remark-replace-links');
+
+module.exports = {
+    title: 'My Docusaurus Docs',
+    tagline: 'Generated documentation from CALM',
+    url: 'http://localhost',
+    baseUrl: '/',
+    onBrokenLinks: 'throw',
+    onBrokenMarkdownLinks: 'warn',
+    favicon: 'img/favicon.ico',
+    organizationName: 'my-org',
+    projectName: 'calm-docs',
+
+    themes: [
+        '@docusaurus/theme-mermaid',
+    ],
+    markdown: {
+        mermaid: true
+    },
+    stylesheets: [
+        '/css/custom.css'
+    ],
+    presets: [
+        [
+            'classic',
+            {
+                docs: {
+                    sidebarPath: require.resolve('./sidebars.js'),
+                    routeBasePath: '/',
+                    remarkPlugins: [remarkReplaceLinks]
+                },
+            },
+        ],
+    ],
+    plugins: [
+        [
+            require.resolve('docusaurus-plugin-search-local'),
+            {
+                indexDocs: true,
+                indexPages: true,
+                highlightSearchTermsOnTargetPage: true,
+                removeDefaultStopWordFilter: true
+            },
+        ],
+    ],
+};

--- a/shared/src/docify/template-bundles/docusaurus/flow-sequence.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/flow-sequence.hbs
@@ -1,0 +1,15 @@
+```mermaid
+sequenceDiagram
+title {{name}}
+{{#each transitions}}
+    {{#if direction}}
+        {{#if (eq direction 'destination-to-source')}}
+            {{target}} -->> {{source}}: {{summary}}
+        {{else}}
+            {{source}} ->> {{target}}: {{summary}}
+        {{/if}}
+    {{else}}
+        {{source}} ->> {{target}}: {{summary}}
+    {{/if}}
+{{/each}}
+```

--- a/shared/src/docify/template-bundles/docusaurus/flow.mdx.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/flow.mdx.hbs
@@ -1,0 +1,11 @@
+---
+id: {{id}}
+title: {{title}}
+---
+
+## Flow Overview
+{{description}}
+
+{{> flow-sequence.hbs}}
+
+{{> controls.hbs}}

--- a/shared/src/docify/template-bundles/docusaurus/index.json
+++ b/shared/src/docify/template-bundles/docusaurus/index.json
@@ -1,0 +1,81 @@
+{
+  "name": "docusaurus-docs",
+  "transformer": "docusaurus-transformer",
+  "templates": [
+    {
+      "template": "node.mdx.hbs",
+      "from": "nodes",
+      "output": "docs/nodes/{{id}}.md",
+      "output-type": "repeated",
+      "partials": [
+        "controls.hbs",
+        "relationships.hbs",
+        "table-template.html",
+        "row-template.html"
+      ]
+    },
+    {
+      "template": "sidebar.js.hbs",
+      "from": "docs",
+      "output": "sidebars.js",
+      "output-type": "single"
+    },
+    {
+      "template": "docusaurus.config.js",
+      "from": "docs",
+      "output": "docusaurus.config.js",
+      "output-type": "single"
+    },
+    {
+      "template": "remark-replace-links.js",
+      "from": "docs",
+      "output": "src/remark/remark-replace-links.js",
+      "output-type": "single"
+    },
+    {
+      "template": "custom.css",
+      "from": "docs",
+      "output": "static/css/custom.css",
+      "output-type": "single"
+    },
+    {
+      "template": "index.md.hbs",
+      "from": "docs",
+      "output": "docs/index.md",
+      "output-type": "single",
+      "partials": [
+        "c4-container.hbs"
+      ]
+    },
+    {
+      "template": "package.json",
+      "from": "docs",
+      "output": "package.json",
+      "output-type": "single"
+    },
+    {
+      "template": "json-doc.mdx.hbs",
+      "from": "controls",
+      "output": "docs/controls/{{id}}.md",
+      "output-type": "repeated"
+    },
+    {
+      "template": "control-requirement.hbs",
+      "from": "controlReqs",
+      "output": "docs/control-requirements/{{id}}.md",
+      "output-type": "repeated"
+    },
+    {
+      "template": "flow.mdx.hbs",
+      "from": "flows",
+      "output": "docs/flows/{{id}}.md",
+      "output-type": "repeated",
+      "partials": [
+        "controls.hbs",
+        "flow-sequence.hbs",
+        "table-template.html",
+        "row-template.html"
+      ]
+    }
+  ]
+}

--- a/shared/src/docify/template-bundles/docusaurus/index.md.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/index.md.hbs
@@ -1,0 +1,31 @@
+---
+id: index
+title: Welcome to CALM Documentation
+sidebar_position: 1
+slug: /
+---
+
+# Welcome to CALM Documentation
+
+This documentation is generated from the **CALM Architecture-as-Code** model.
+
+## High Level Architecture
+{{> c4-container.hbs}}
+
+### Nodes
+{{#each nodes}}
+    - [{{title}}](nodes/{{slug}})
+{{/each}}
+
+### Flows
+{{#each flows}}
+    - [{{title}}](flows/{{slug}})
+{{/each}}
+
+### Controls
+
+| ID    | Name             | Description                  | Domain    | Scope        | Applied To                |
+|-------|------------------|------------------------------|-----------|--------------|---------------------------|
+{{#controls}}
+|{{id}}|{{name}}|{{description}}|{{domain}}|{{scope}}|{{appliedTo}}|
+{{/controls}}

--- a/shared/src/docify/template-bundles/docusaurus/json-doc.mdx.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/json-doc.mdx.hbs
@@ -1,0 +1,2 @@
+```json
+{{{json this}}}

--- a/shared/src/docify/template-bundles/docusaurus/node.mdx.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/node.mdx.hbs
@@ -1,0 +1,34 @@
+---
+id: {{id}}
+title: {{title}}
+---
+
+## Node Details
+<div className="table-container">
+| Field               | Value                    |
+|---------------------|--------------------------|
+| **Unique ID**       | {{id}}                   |
+| **Node Type**       | {{nodeType}}             |
+| **Name**            | {{name}}                 |
+| **Description**     | {{description}}          |
+| **Data Classification** | {{dataClassification}} |
+| **Run As**          | {{runAs}}                |
+</div>
+
+## Interfaces
+{{#if interfaces.length}}
+    | Unique ID | Host | Port | Url |
+    |-----------|------|------|-----|
+    {{#each interfaces}}
+        | {{uniqueId}} | {{host}} | {{port}} | {{url}} |
+    {{/each}}
+{{else}}
+    _No interfaces defined._
+{{/if}}
+
+
+## Related Nodes
+
+{{> relationships.hbs}}
+
+{{> controls.hbs}}

--- a/shared/src/docify/template-bundles/docusaurus/package.json
+++ b/shared/src/docify/template-bundles/docusaurus/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "arch-docs",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "serve": "docusaurus serve",
+    "clear": "rm -rf node_modules/.cache build"
+  },
+  "dependencies": {
+    "@docusaurus/core": "^3.7.0",
+    "@docusaurus/preset-classic": "^3.7.0",
+    "@docusaurus/plugin-content-docs": "^3.7.0",
+    "@docusaurus/theme-classic": "^3.7.0",
+    "@docusaurus/theme-live-codeblock": "^3.7.0",
+    "@docusaurus/theme-mermaid": "^3.7.0",
+    "docusaurus-plugin-search-local": "^2.1.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "unist-util-visit": "^5.0.0"
+  }
+}

--- a/shared/src/docify/template-bundles/docusaurus/relationships.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/relationships.hbs
@@ -1,0 +1,29 @@
+```mermaid
+graph TD;
+{{id}}[{{id}}]:::highlight;
+{{#each relatedRelationships}}
+{{#if (instanceOf relationshipType "CalmInteractsType")}}
+{{#each relationshipType.nodes}}
+{{../relationshipType.actor}} -- Interacts --> {{this}};
+{{/each}}
+{{else if (instanceOf relationshipType "CalmConnectsType")}}
+{{relationshipType.source.node }} -- Connects --> {{relationshipType.destination.node}};
+{{else if (instanceOf relationshipType "CalmComposedOfType")}}
+{{#if (eq relationshipType.container ../id)}}
+{{#each relationshipType.nodes}}
+{{../relationshipType.container}} -- Composed Of --> {{this}};
+{{/each}}
+{{/if}}
+{{#each relationshipType.nodes}}
+{{#if (eq this ../../id)}}
+{{../relationshipType.container}} -- Composed Of --> {{this}};
+{{/if}}
+
+{{/each}}
+{{/if}}
+{{/each}}
+
+classDef highlight fill:#f2bbae;
+
+```
+

--- a/shared/src/docify/template-bundles/docusaurus/remark-replace-links.js
+++ b/shared/src/docify/template-bundles/docusaurus/remark-replace-links.js
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit';
+/* eslint-disable no-undef */
+module.exports = function remarkReplaceLinks() {
+    return (tree) => {
+        visit(tree, 'link', (node) => {
+            if (node.url && node.url.startsWith('https://calm.finos.org/traderx/control-requirements/')) {
+                const lastSegment = node.url.split('/').pop();
+                node.url = `/control-requirements/${lastSegment}`;
+
+                // Ensure node.properties exists before setting attributes
+                node.data = node.data || {};
+                node.data.hProperties = node.data.hProperties || {};
+                node.data.hProperties.target = '_blank';
+                node.data.hProperties.rel = 'noopener noreferrer';
+            }
+        });
+    };
+};

--- a/shared/src/docify/template-bundles/docusaurus/row-template.html
+++ b/shared/src/docify/template-bundles/docusaurus/row-template.html
@@ -1,0 +1,18 @@
+<tr>
+    <td>
+        <b>{{kebabToTitleCase @key}}</b>
+    </td>
+    <td>
+        {{#if (isObject this)}}
+        {{> table-template.html data=this}}
+        {{else if (isArray this)}}
+        <ul>
+            {{#each this}}
+            <li>{{this}}</li>
+            {{/each}}
+        </ul>
+        {{else}}
+        {{this}}
+        {{/if}}
+    </td>
+</tr>

--- a/shared/src/docify/template-bundles/docusaurus/sidebar.js.hbs
+++ b/shared/src/docify/template-bundles/docusaurus/sidebar.js.hbs
@@ -1,0 +1,27 @@
+module.exports = {
+    docs: [
+        {
+            type: 'doc',
+            id: 'index',
+            label: 'Home',
+        },
+        {
+            type: 'category',
+            label: 'Nodes',
+            items: [
+                {{#each nodes}}
+                'nodes/{{this.id}}'{{#unless @last}},{{/unless}}
+                {{/each}}
+            ],
+        },
+        {
+            type: 'category',
+            label: 'Flows',
+            items: [
+                {{#each flows}}
+                'flows/{{this.id}}'{{#unless @last}},{{/unless}}
+                {{/each}}
+            ],
+        }
+    ]
+};

--- a/shared/src/docify/template-bundles/docusaurus/table-template.html
+++ b/shared/src/docify/template-bundles/docusaurus/table-template.html
@@ -1,0 +1,15 @@
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th>Key</th>
+            <th>Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{#each data}}
+        {{> row-template.html}}
+        {{/each}}
+        </tbody>
+    </table>
+</div>

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -12,3 +12,12 @@ export { initLogger } from './logger.js';
 export { TemplateProcessor } from './template/template-processor.js';
 export * from './template/types.js';
 export * from './types';
+export { Docifier, DocifyMode } from './docify/docifier.js';
+export * from './model/flow.js';
+export * from './model/core.js';
+export * from './model/control.js';
+export * from './model/metadata.js';
+export * from './model/interface.js';
+export {C4Model} from './docify/graphing/c4.js';
+export {CalmRelationshipGraph} from './docify/graphing/relationship-graph.js';
+

--- a/shared/src/model/metadata.ts
+++ b/shared/src/model/metadata.ts
@@ -4,6 +4,8 @@ export class CalmMetadata {
     constructor(public data: Record<string, unknown>) {}
 
     static fromJson(data: CalmMetadataSchema): CalmMetadata {
+        if(!data) return new CalmMetadata({});
+
         const flattenedData = data.reduce((acc, curr) => {
             return { ...acc, ...curr };
         }, {} as Record<string, unknown>);


### PR DESCRIPTION
## Summary
This PR introduces a new `docify` endpoint that generates an initial architecture documentation website from CALM models. This serves as the foundation for integrating structured architectural documentation directly from CALM-defined models.

## Context
This work addresses [Issue #478](https://github.com/finos/architecture-as-code/issues/478), which aims to provide a streamlined way to convert CALM models into a browsable website. The goal of this first PR is to establish the basic functionality of the `docify` endpoint and generate an initial version of the website.

## Scope of This PR
- Implements the `docify` endpoint to generate static documentation.
- Converts CALM models into structured documentation pages.
- Sets up an initial framework for rendering content.

## Acknowledged Enhancements
The following additional enhancements will improve the maintainability and flexibility of this feature but checking in this version so work can be done in parallel.
These will be  tracked as separate issues:
- [#1032](https://github.com/finos/architecture-as-code/issues/1032) - Support directory structure for template bundles.
- [#1033](https://github.com/finos/architecture-as-code/issues/1033) - Add global partials support in `index.json`.
- [#1035](https://github.com/finos/architecture-as-code/issues/1035) - Improve flow sequence diagram generation using the full CALM model.
- [#1036](https://github.com/finos/architecture-as-code/issues/1036) - Introduce Pre-Processing Step in docify for Non-CALM model dependent templates
- [#1037](https://github.com/finos/architecture-as-code/issues/1037) -  Add Support for Solution Architect One-Pager Generation in CALM

These enhancements will be addressed in follow-up PRs to refine and extend the functionality introduced here.

## Next Steps
- Review and merge this foundational implementation.
- Iterate on the enhancements mentioned above.
- Expand documentation support based on feedback.
