### PR TITLE
Create new rate type in units.json (#1038)

### DIFF
--- a/calm/draft/2025-03/meta/units.json
+++ b/calm/draft/2025-03/meta/units.json
@@ -48,6 +48,48 @@
         }
       ]
     },
+    "rate-unit": {
+      "type": "object",
+      "description": "A unit representing a rate (e.g., operations per second).",
+      "properties": {
+        "rate": {
+          "type": "number",
+          "minimum": 0,
+          "description": "The numeric value representing the rate."
+        },
+        "per": {
+          "enum": [
+            "nanosecond",
+            "microsecond",
+            "millisecond",
+            "second",
+            "minute",
+            "hour",
+            "week",
+            "month",
+            "quarter",
+            "year"
+          ],
+          "description": "The time unit defining the rate interval."
+        }
+      },
+      "required": ["rate", "per"],
+      "additionalProperties": false,
+      "examples": [
+        {
+          "rate": 30,
+          "per": "second"
+        },
+        {
+          "rate": 1000,
+          "per": "minute"
+        },
+        {
+          "rate": 5,
+          "per": "millisecond"
+        }
+      ]
+    },
     "cron-expression": {
       "type": "string",
       "title": "Cron Expression",

--- a/calm/draft/2025-03/prototype/throughput-control-prototype.json
+++ b/calm/draft/2025-03/prototype/throughput-control-prototype.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/traderx/control-requirement/throughput",
+  "title": "Throughput Requirement",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://calm.finos.org/draft/2025-03/meta/control-requirement.json"
+    }
+  ],
+  "properties": {
+    "expected-message-rate": {
+      "$ref": "https://calm.finos.org/draft/2025-03/meta/units.json#/defs/rate-unit",
+      "description": "Define the expected message rate that the flow should handle (e.g., 1000 per second)."
+    }
+  },
+  "required": [
+    "expected-message-rate"
+  ]
+}


### PR DESCRIPTION
## Summary
This PR enhances the **units.json** schema within **CALM** to support rate-based values, such as "30 per second." 

### Key Changes:
- Introduces a **`rate-unit`** definition to represent rate-based values.
- Added example in prototype folder.
