### PR TITLE
Fix global install issues with cli (#1043)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [
@@ -32,7 +32,9 @@
     "commander": "^13.0.0",
     "copyfiles": "^2.4.1",
     "mkdirp": "^3.0.1",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
+    "@apidevtools/json-schema-ref-parser": "^11.9.3",
+    "ts-node": "10.9.2"
   },
   "devDependencies": {
     "@types/supertest": "^6.0.2",
@@ -54,10 +56,10 @@
     "supertest": "^7.0.0",
     "link": "^2.1.1",
     "ts-jest": "^29.2.5",
-    "ts-node": "10.9.2",
     "tsup": "^8.0.0",
     "typescript": "^5.4.3",
     "xml2js": "^0.6.2"
+
   },
   "overrides": {
     "esbuild": "^0.25.0"

--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -12,7 +12,7 @@ vi.mock('axios');
 const execPromise = util.promisify(exec);
 
 const millisPerSecond = 1000;
-const integrationTestPrefix = 'calm-pack-test';
+const integrationTestPrefix = 'calm-consumer-test';
 let tempDir: string;
 const repoRoot = path.resolve(__dirname);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "calm": "dist/index.js"
       },
       "devDependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.9.3",
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
         "@types/json-pointer": "^1.0.34",
@@ -2611,7 +2612,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2624,7 +2624,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -8032,28 +8031,24 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/acorn": {
@@ -11705,7 +11700,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -12814,7 +12808,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -18631,7 +18624,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -27776,7 +27768,6 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -27820,7 +27811,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfck": {
@@ -28658,7 +28648,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -30263,7 +30252,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -30323,6 +30311,7 @@
         "lodash": "^4.17.21",
         "mkdirp": "^3.0.1",
         "string-table": "^0.1.5",
+        "ts-node": "10.9.2",
         "winston": "^3.14.1"
       },
       "devDependencies": {
@@ -30341,7 +30330,6 @@
         "jest": "^29.7.0",
         "msw": "^2.7.3",
         "ts-jest": "^29.2.5",
-        "ts-node": "10.9.2",
         "typescript": "^5.4.3"
       }
     }

--- a/shared/package.json
+++ b/shared/package.json
@@ -43,7 +43,8 @@
         "lodash": "^4.17.21",
         "mkdirp": "^3.0.1",
         "string-table": "^0.1.5",
-        "winston": "^3.14.1"
+        "winston": "^3.14.1",
+        "ts-node": "10.9.2"
     },
     "devDependencies": {
         "@stoplight/types": "^14.1.1",
@@ -61,7 +62,6 @@
         "jest": "^29.7.0",
         "msw": "^2.7.3",
         "ts-jest": "^29.2.5",
-        "ts-node": "10.9.2",
         "typescript": "^5.4.3"
     },
     "overrides": {


### PR DESCRIPTION
The following issue fixes issue1 with tsnode and json-ref-parser libraries not being installed as part of the calm cli (a pre-requisite for the `calm template` endpoint

The cli.e2e.spec.ts now leverages npm pack to simulate the actual package that npm publishes and simulates a consumer installing calm from npm in an isolated node environment. Going forward this test now gives full confidence on cli endpoints.