### PR TITLE
Ensure SchemaDirectory works with latest CALM draft

### DIFF
--- a/calm/pattern/api-gateway.json
+++ b/calm/pattern/api-gateway.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://calm.finos.org/draft/2024-10/meta/calm.json",
+  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
   "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/pattern/api-gateway",
   "title": "API Gateway Pattern",
   "type": "object",
@@ -9,7 +9,7 @@
       "minItems": 4,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
           "properties": {
             "well-known-endpoint": {
               "type": "string"
@@ -31,7 +31,7 @@
               "minItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2024-10/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "api-gateway-ingress"
@@ -47,7 +47,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The API Consumer making an authenticated and authorized request"
@@ -64,7 +64,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The API Producer serving content"
@@ -83,7 +83,7 @@
               "minItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2024-10/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "producer-ingress"
@@ -98,7 +98,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The Identity Provider used to verify the bearer token"
@@ -121,7 +121,7 @@
       "minItems": 4,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-consumer-api-gateway"
@@ -154,7 +154,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-gateway-idp"
@@ -180,7 +180,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-gateway-api-producer"
@@ -209,7 +209,7 @@
           }
         },
         {
-            "$ref": "https://calm.finos.org/draft/2024-10/meta/core.json#/defs/relationship",
+            "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
             "properties": {
               "unique-id": {
                 "const": "api-consumer-idp"

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup && npm run copy-calm-schema && npm run copy-docify-templates",
     "watch": "node watch.mjs",
-    "copy-calm-schema": "copyfiles \"../calm/draft/2024-10/meta/*\" dist/calm/",
+    "copy-calm-schema": "copyfiles \"../calm/draft/2025-03/meta/*\" dist/calm/",
     "copy-docify-templates": "copyfiles \"../shared/dist/template-bundles/**/*\" dist --up 3",
     "test": "vitest run",
     "lint": "eslint src",


### PR DESCRIPTION
In order to use `calm generate` without specifying a schema directory, we need to copy over latest version