### PR TITLE
CALM Template to support DefaultTransformer (#1106)

### DIFF
--- a/shared/src/template/template-bundle-file-loader.ts
+++ b/shared/src/template/template-bundle-file-loader.ts
@@ -29,7 +29,7 @@ export class TemplateBundleFileLoader {
             logger.info(`📥 Loading index.json from ${indexFilePath}`);
             const rawConfig = JSON.parse(fs.readFileSync(indexFilePath, 'utf8'));
 
-            if (!rawConfig.name || !rawConfig.transformer || !Array.isArray(rawConfig.templates)) {
+            if (!rawConfig.name || !Array.isArray(rawConfig.templates)) {
                 logger.error('❌ Invalid index.json format: Missing required fields');
                 throw new Error('Invalid index.json format: Missing required fields');
             }

--- a/shared/src/template/template-default-transfomer.spec.ts
+++ b/shared/src/template/template-default-transfomer.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import TemplateDefaultTransformer from './template-default-transformer';
+
+describe('TemplateDefaultTransformer', () => {
+    const transformer = new TemplateDefaultTransformer();
+
+    const paymentGatewayJson = JSON.stringify(
+        {
+            nodes: [
+                {
+                    'unique-id': 'payment-api',
+                    'name': 'Payment API',
+                    'description': 'Handles incoming payment requests',
+                    'node-type': 'service'
+                },
+                {
+                    'unique-id': 'payment-db',
+                    'name': 'Payment Database',
+                    'description': 'Stores transaction records',
+                    'node-type': 'database'
+                }
+            ],
+            relationships: [
+                {
+                    'unique-id': 'api-to-db',
+                    'description': 'API stores transaction data in DB',
+                    'relationship-type': {
+                        connects: {
+                            source: {
+                                node: 'payment-api'
+                            },
+                            destination: {
+                                node: 'payment-db'
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    );
+
+    it('should transform a Payment Gateway CALM document with two nodes and one relationship', () => {
+        const result = transformer.getTransformedModel(paymentGatewayJson);
+
+        expect(result).toHaveProperty('document');
+        const doc = result.document;
+        expect(doc.nodes).toHaveLength(2);
+        expect(doc.nodes[0].name).toBe('Payment API');
+        expect(doc.nodes[1].name).toBe('Payment Database');
+
+        expect(doc.relationships).toHaveLength(1);
+        expect(doc.relationships[0].description).toContain('transaction');
+    });
+
+    it('should register and execute all helpers correctly', () => {
+        const helpers = transformer.registerTemplateHelpers();
+
+        expect(helpers.eq('a', 'a')).toBe(true);
+        expect(helpers.eq(1, 2)).toBe(false);
+        expect(helpers.lookup({ foo: 'bar' }, 'foo')).toBe('bar');
+        expect(helpers.json({ a: 1 })).toContain('"a": 1');
+        expect(helpers.instanceOf([], 'Array')).toBe(true);
+
+        expect(helpers.kebabToTitleCase('payment-api')).toBe('Payment Api');
+        expect(helpers.kebabCase('Payment API')).toBe('payment-api');
+        expect(helpers.isObject({})).toBe(true);
+        expect(helpers.isObject(null)).toBe(false);
+        expect(helpers.isArray(['x'])).toBe(true);
+        expect(helpers.isArray({})).toBe(false);
+        expect(helpers.join(['x', 'y'], '|')).toBe('x|y');
+    });
+
+    it('should throw for invalid JSON input', () => {
+        const invalidJson = '{ invalid json }';
+        expect(() => transformer.getTransformedModel(invalidJson)).toThrow();
+    });
+});

--- a/shared/src/template/template-default-transformer.ts
+++ b/shared/src/template/template-default-transformer.ts
@@ -1,0 +1,39 @@
+import {CalmTemplateTransformer} from './types';
+import {CalmCoreSchema} from '../types/core-types';
+import {Architecture, CalmCore} from '../model/core';
+
+export default class TemplateDefaultTransformer implements CalmTemplateTransformer {
+
+    getTransformedModel(calmJson: string) {
+        const calmSchema: CalmCoreSchema = JSON.parse(calmJson);
+        const architecture: Architecture = CalmCore.fromJson(calmSchema);
+        return {
+            'document': architecture
+        };
+
+    }
+
+    registerTemplateHelpers(): Record<string, (...args: unknown[]) => unknown> {
+        return {
+            eq: (a, b) => a === b,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            lookup: (obj, key: any) => obj?.[key],
+            json: (obj) => JSON.stringify(obj, null, 2),
+            instanceOf: (value, className: string) => value?.constructor?.name === className,
+            kebabToTitleCase: (str: string) => str
+                .split('-')
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                .join(' '),
+            kebabCase: (str: string) => str
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')  // Replace non-alphanumeric characters with hyphens
+                .replace(/^-+|-+$/g, ''), // Remove leading or trailing hyphens
+            isObject: (value: unknown) => typeof value === 'object' && value !== null && !Array.isArray(value),
+            isArray: (value: unknown) => Array.isArray(value),
+            join: (arr: unknown[], separator:string = ', ') =>
+                Array.isArray(arr) ? arr.join(separator) : '',
+        };
+    }
+
+}

--- a/shared/src/template/template-processor.spec.ts
+++ b/shared/src/template/template-processor.spec.ts
@@ -91,20 +91,6 @@ describe('TemplateProcessor', () => {
         expect(loggerErrorSpy).toHaveBeenCalledWith(expect.stringContaining('❌ CALM model file not found'));
     });
 
-    it('should throw an error if the transformer field is missing in config', async () => {
-        const configNoTransformer = {
-            name: 'Test Bundle',
-            templates: []
-        };
-
-        mockTemplateLoader.getConfig.mockReturnValue(configNoTransformer);
-        const processor = new TemplateProcessor('simple-nodes.json', 'bundle', 'output', new Map<string, string>());
-        await expect(processor.processTemplate()).rejects.toThrow(
-            'Missing "transformer" field in index.json. Define a transformer for this template bundle.'
-        );
-        expect(loggerErrorSpy).toHaveBeenCalledWith(expect.stringContaining('❌ Missing "transformer" field in index.json.'));
-    });
-
     it('should throw an error if loadTransformer fails', async () => {
         const configWithBadTransformer = {
             name: 'Test Bundle',

--- a/shared/src/template/types.ts
+++ b/shared/src/template/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export interface IndexFile {
     name: string;
-    transformer: string;
+    transformer?: string;
     templates: TemplateEntry[];
 }
 

--- a/shared/test_fixtures/template/bundles/default-transformer/index.json
+++ b/shared/test_fixtures/template/bundles/default-transformer/index.json
@@ -1,0 +1,6 @@
+{
+  "name": "Simple Test Bundle",
+  "templates": [
+    { "template": "main.hbs", "from": "document", "output": "doc-system-one-pager.md", "output-type": "single" }
+  ]
+}

--- a/shared/test_fixtures/template/bundles/default-transformer/main.hbs
+++ b/shared/test_fixtures/template/bundles/default-transformer/main.hbs
@@ -1,0 +1,46 @@
+## Nodes
+
+| ID            | Name           | Type     | Description                          |
+|---------------|----------------|----------|--------------------------------------|
+{{#each nodes}}
+| {{uniqueId}} | {{name}}       | {{nodeType}} | {{description}} |
+{{/each}}
+
+## Relationships
+
+| ID               | Type         | Source       | Destination / Parts | Description |
+|------------------|--------------|---------------|----------------------|-------------|
+{{#each relationships}}
+  {{#if (instanceOf relationshipType "CalmConnectsType")}}
+| {{uniqueId}} | connects      | {{relationshipType.source.node}} | {{relationshipType.destination.node}} | {{description}} |
+  {{/if}}
+  {{#if (instanceOf relationshipType "CalmInteractsType")}}
+| {{uniqueId}} | interacts     | {{relationshipType.actor}} | {{join relationshipType.nodes ", "}} | {{description}} |
+  {{/if}}
+  {{#if (instanceOf relationshipType "CalmComposedOfType")}}
+| {{uniqueId}} | composed-of   | {{relationshipType.container}} | {{join relationshipType.nodes ", "}} | |
+  {{/if}}
+{{/each}}
+
+
+## Ownership Controls
+
+{{#each controls}}
+  {{#if (eq controlId "ownership")}}
+    {{#if requirements}}
+| Owner Type      | Name        | Email               | Description                        |
+|-----------------|-------------|---------------------|------------------------------------|
+      {{#each requirements}}
+| {{controlConfigUrl.owner-type}} | {{controlConfigUrl.owner.name}} | {{controlConfigUrl.owner.email}} | {{controlConfigUrl.description}} |
+      {{/each}}
+    {{else}}
+_No ownership requirements defined._
+    {{/if}}
+  {{/if}}
+{{/each}}
+
+
+## Metadata
+```
+{{{ json metadata}}}
+```

--- a/shared/test_fixtures/template/data/controls/architect.configuration.json
+++ b/shared/test_fixtures/template/data/controls/architect.configuration.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://calm.finos.org/controls/owner-responsibility.requirement.json",
+  "$id": "https://calm.finos.org/controls/architect.configuration.json",
+  "control-id": "ownership-003",
+  "name": "Architect Responsibility",
+  "description": "Captures who is responsible for architecture",
+  "owner-type": "System Owner",
+  "owner": {
+    "name": "Mr Architect",
+    "email": "mr.architect@finos.org"
+  }
+}

--- a/shared/test_fixtures/template/data/controls/business-owner.configuration.json
+++ b/shared/test_fixtures/template/data/controls/business-owner.configuration.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://calm.finos.org/controls/owner-responsibility.requirement.json",
+  "$id": "https://calm.finos.org/controls/business-owner.configuration.json",
+  "control-id": "ownership-001",
+  "name": "Business Owner Responsibility",
+  "description": "Captures who is responsible from business perspective",
+  "owner-type": "Business Owner",
+  "owner": {
+    "name": "Jo Bloggs",
+    "email": "jo.bloggs@finos.org"
+  }
+}

--- a/shared/test_fixtures/template/data/controls/owner-responsibility.requirement.json
+++ b/shared/test_fixtures/template/data/controls/owner-responsibility.requirement.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/controls/owner-responsibility.requirement.json",
+  "title": "Owner Responsibility",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://calm.finos.org/draft/2025-03/meta/control-requirement.json"
+    }
+  ],
+  "properties": {
+    "description": {
+      "const": "Captures who is responsible"
+    },
+    "owner-type": {
+      "type": "string",
+      "description": "Type of responsibility held by the owner"
+    },
+    "owner": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Full name of the owner"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Email contact for the owner"
+        }
+      },
+      "required": ["name", "email"]
+    }
+  },
+  "required": ["owner-type", "owner"]
+}

--- a/shared/test_fixtures/template/data/controls/system-owner.configuration.json
+++ b/shared/test_fixtures/template/data/controls/system-owner.configuration.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://calm.finos.org/controls/owner-responsibility.requirement.json",
+  "$id": "https://calm.finos.org/controls/system-owner.configuration.json",
+  "control-id": "ownership-002",
+  "name": "System Owner Responsibility",
+  "description": "Captures who is responsible from system ownership",
+  "owner-type": "System Owner",
+  "owner": {
+    "name": "Jane Doe",
+    "email": "jane.doe@finos.org"
+  }
+}

--- a/shared/test_fixtures/template/data/document-system-with-controls.json
+++ b/shared/test_fixtures/template/data/document-system-with-controls.json
@@ -1,0 +1,118 @@
+{
+  "$id": "docuflow-architecture",
+  "title": "DocuFlow System",
+  "description": "DocuFlow is a document management system that allows users to upload, process, and store documents securely.",
+  "nodes": [
+    {
+      "unique-id": "document-system",
+      "name": "DocuFlow",
+      "description": "Main document management system",
+      "node-type": "system",
+      "metadata": [
+        {"arch-health": "BUY" }
+      ],
+      "controls": {
+        "ownership": {
+          "description": "Ownership Controls",
+          "requirements": [
+            {
+              "control-requirement-url": "https://calm.finos.org/controls/owner.requirement.json",
+              "control-config-url":  "https://calm.finos.org/controls/architect.configuration.json"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "svc-upload",
+      "name": "Upload Service",
+      "description": "Handles user document uploads",
+      "node-type": "service",
+      "metadata": [
+        {"arch-health": "BUY" }
+      ]
+    },
+    {
+      "unique-id": "svc-storage",
+      "name": "Storage Service",
+      "description": "Stores and retrieves documents securely",
+      "node-type": "service",
+      "metadata": [
+        {"arch-health": "HOLD" }
+      ]
+    },
+    {
+      "unique-id": "db-docs",
+      "name": "Document Database",
+      "description": "Stores metadata and document references",
+      "node-type": "database",
+      "metadata": [
+        {"arch-health": "SELL" }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "rel-upload-to-storage",
+      "description": "Upload Service sends documents to Storage Service for long-term storage",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "svc-upload"
+          },
+          "destination": {
+            "node": "svc-storage"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "rel-storage-to-db",
+      "description": "Storage Service stores document metadata in the Document Database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "svc-storage"
+          },
+          "destination": {
+            "node": "db-docs"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "document-system-system-is-composed-of",
+      "relationship-type": {
+        "composed-of": {
+          "container": "document-system",
+          "nodes": [
+            "svc-upload",
+            "svc-storage",
+            "db-docs"
+          ]
+        }
+      }
+    }
+  ],
+  "flows": [
+    "https://calm.finos.org/docuflow/flow/document-upload"
+  ],
+  "controls": {
+    "ownership": {
+      "description": "Ownership Controls",
+      "requirements": [
+        {
+          "control-requirement-url": "https://calm.finos.org/controls/owner.requirement.json",
+          "control-config-url":  "https://calm.finos.org/controls/business-owner.configuration.json"
+        },
+        {
+          "control-requirement-url": "https://calm.finos.org/controls/owner.requirement.json",
+          "control-config-url":  "https://calm.finos.org/controls/system-owner.configuration.json"
+        }
+      ]
+    }
+  },
+  "metadata": [
+    {"arch-health": "BUY" }
+  ]
+}

--- a/shared/test_fixtures/template/expected-output/doc-system-one-pager.md
+++ b/shared/test_fixtures/template/expected-output/doc-system-one-pager.md
@@ -1,0 +1,34 @@
+## Nodes
+
+| ID            | Name           | Type     | Description                          |
+|---------------|----------------|----------|--------------------------------------|
+| document-system | DocuFlow       | system | Main document management system |
+| svc-upload | Upload Service       | service | Handles user document uploads |
+| svc-storage | Storage Service       | service | Stores and retrieves documents securely |
+| db-docs | Document Database       | database | Stores metadata and document references |
+
+## Relationships
+
+| ID               | Type         | Source       | Destination / Parts | Description |
+|------------------|--------------|---------------|----------------------|-------------|
+| rel-upload-to-storage | connects      | svc-upload | svc-storage | Upload Service sends documents to Storage Service for long-term storage |
+| rel-storage-to-db | connects      | svc-storage | db-docs | Storage Service stores document metadata in the Document Database |
+| document-system-system-is-composed-of | composed-of   | document-system | svc-upload, svc-storage, db-docs | |
+
+
+## Ownership Controls
+
+| Owner Type      | Name        | Email               | Description                        |
+|-----------------|-------------|---------------------|------------------------------------|
+| Business Owner | Jo Bloggs | jo.bloggs@finos.org | Captures who is responsible from business perspective |
+| System Owner | Jane Doe | jane.doe@finos.org | Captures who is responsible from system ownership |
+
+
+## Metadata
+```
+{
+  "data": {
+    "arch-health": "BUY"
+  }
+}
+```


### PR DESCRIPTION
### 🚀 Enhancement: Support Default Transformer in CALM Template Bundles

This PR introduces a fallback mechanism to use a Detault Transfomer when a template bundle does not explicitly define a transformer in its `index.json`.

### 📎 Related Issue

Closes #1106 

### 💡 Notes

This change streamlines template development by removing boilerplate requirement to write a transformer for simple use cases and improves out-of-the-box usability of the `calm template` endpoint.



