### PR TITLE
finos#1081 set quarkus.oidc.enabled build-time configuration to false

### DIFF
--- a/calm-hub/src/main/resources/application-secure.properties
+++ b/calm-hub/src/main/resources/application-secure.properties
@@ -12,3 +12,4 @@ quarkus.oidc.tls.verification=none
 quarkus.oidc.auth-server-url=https://localhost:9443/realms/calm-hub-realm
 quarkus.oidc.client-id=calm-hub-producer-app
 quarkus.oidc.token.audience=calm-hub-producer-app
+quarkus.oidc.enabled=true

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -6,4 +6,5 @@ quarkus.mongodb.connection-string = mongodb://localhost:27017
 quarkus.mongodb.database = calmSchemas
 
 #Disable creating the keycloak container for default profile.
+quarkus.oidc.enabled=false
 quarkus.keycloak.devservices.enabled=false


### PR DESCRIPTION
- Set `quarkus.oidc.enabled` build-time configuration to `false` 

TODO: As this is OIDC, enablement is a build-time configuration; either we have to build a dedicated Docker image for the secure profile, or I'll find a way to set enable as a runtime configuration.  