### PR TITLE
#1113  fixed cyctoscape render bug on upload

### DIFF
--- a/calm-hub-ui/src/visualizer/Visualizer.tsx
+++ b/calm-hub-ui/src/visualizer/Visualizer.tsx
@@ -13,23 +13,23 @@ function Visualizer() {
     const [instance, setCALMInstance] = useState<CALMArchitecture | undefined>(undefined);
     const [isConDescActive, setConDescActive] = React.useState(false);
     const [isNodeDescActive, setNodeDescActive] = React.useState(false);
-
+    const [isFileUpload, setIsFileUpload] = React.useState(false);
     const location = useLocation();
     const data = location.state || {};
-    
-    async function handleFile(instanceFile: File) {
-        const title = instanceFile.name;
-        const file = await instanceFile.text();
-        const instance = JSON.parse(file);
+    const [fileInstance, setFileInstance] = useState<any>(undefined); 
+    const [fileTitle, setFileTitle] = useState<String>("");
 
-        setTitle(title);
-        setCALMInstance(instance);
+    async function handleFile(instanceFile: File) {
+        setFileTitle(instanceFile.name);
+        const file = await instanceFile.text();
+        setFileInstance(JSON.parse(file));
     }
     
     useEffect(() => {
-        setTitle(data?.name)
-        setCALMInstance(data?.data);
-      }, [data]);
+        console.log(isFileUpload)
+        setTitle(fileTitle ? fileTitle: data?.name)
+        setCALMInstance(fileInstance? fileInstance : data?.data);
+      }, [data, fileInstance, fileTitle]);
 
     return (
         <ZoomProvider>

--- a/calm-hub-ui/src/visualizer/Visualizer.tsx
+++ b/calm-hub-ui/src/visualizer/Visualizer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import './Visualizer.css';
 import Drawer from './components/drawer/Drawer.js';
 import Navbar from '../components/navbar/Navbar.js';
@@ -14,9 +14,9 @@ function Visualizer() {
     const [isConDescActive, setConDescActive] = React.useState(false);
     const [isNodeDescActive, setNodeDescActive] = React.useState(false);
     const location = useLocation();
-    const data = location.state || {};
-    const [fileInstance, setFileInstance] = useState<any>(undefined); 
-    const [fileTitle, setFileTitle] = useState<String>("");
+    const data = useMemo(()=> location.state || {}, [location.state]);
+    const [fileInstance, setFileInstance] = useState<string | undefined>(undefined); 
+    const [fileTitle, setFileTitle] = useState<string | undefined>(undefined);
 
     async function handleFile(instanceFile: File) {
         setFileTitle(instanceFile.name);
@@ -25,9 +25,9 @@ function Visualizer() {
     }
     
     useEffect(() => {
-        setTitle(fileTitle ? fileTitle: data?.name)
-        setCALMInstance(fileInstance? fileInstance : data?.data);
-      }, [data, fileInstance, fileTitle]);
+        setTitle(fileTitle ?? data?.name)
+        setCALMInstance(fileInstance ?? data?.data);
+      }, [fileInstance, fileTitle, data]);
 
     return (
         <ZoomProvider>

--- a/calm-hub-ui/src/visualizer/Visualizer.tsx
+++ b/calm-hub-ui/src/visualizer/Visualizer.tsx
@@ -13,7 +13,6 @@ function Visualizer() {
     const [instance, setCALMInstance] = useState<CALMArchitecture | undefined>(undefined);
     const [isConDescActive, setConDescActive] = React.useState(false);
     const [isNodeDescActive, setNodeDescActive] = React.useState(false);
-    const [isFileUpload, setIsFileUpload] = React.useState(false);
     const location = useLocation();
     const data = location.state || {};
     const [fileInstance, setFileInstance] = useState<any>(undefined); 
@@ -26,7 +25,6 @@ function Visualizer() {
     }
     
     useEffect(() => {
-        console.log(isFileUpload)
         setTitle(fileTitle ? fileTitle: data?.name)
         setCALMInstance(fileInstance? fileInstance : data?.data);
       }, [data, fileInstance, fileTitle]);

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
In reference to issue #1113, the bug has been fixed, and architectures can now be rendered from Calm Hub or by manual upload.

![Screenshot 2025-04-02 at 17 13 15](https://github.com/user-attachments/assets/593b6354-06da-4237-b7d9-e40874db86f5)
![Screenshot 2025-04-02 at 17 13 59](https://github.com/user-attachments/assets/35fb3207-9586-4ed2-9781-8bd674463572)

@oliviajanejohns @DorothyEwuah @aidanm3341 @aamanrebello 
