### PR TITLE
Expand nodes to fit description labels

### DIFF
--- a/calm-hub-ui/src/visualizer/components/cytoscape-renderer/CytoscapeRenderer.tsx
+++ b/calm-hub-ui/src/visualizer/components/cytoscape-renderer/CytoscapeRenderer.tsx
@@ -30,6 +30,8 @@ export type Node = {
         type: string;
         label: string;
         id: string;
+        _displayPlaceholderWithDesc: string;
+        _displayPlaceholderWithoutDesc: string;
         [idx: string]: string;
     };
 };
@@ -106,8 +108,14 @@ export const CytoscapeRenderer = ({
                 {
                     selector: 'node',
                     style: {
+                        label: isNodeDescActive ? 'data(_displayPlaceholderWithDesc)' : 'data(_displayPlaceholderWithoutDesc)',
+                        'text-valign': 'center',
+                        'text-halign': 'center',
+                        'text-wrap': 'wrap',
+                        'text-max-width': '180px',
+                        "font-family": 'Arial',
                         width: '200px',
-                        height: '100px',
+                        height: 'label',
                         shape: 'rectangle',
                     },
                 },
@@ -148,10 +156,14 @@ export const CytoscapeRenderer = ({
         (updatedCy as Core & { nodeHtmlLabel: any }).nodeHtmlLabel([
             {
                 query: '.node',
+                valign: 'top',
+                valignBox: 'top',
                 tpl: getNodeLabelTemplateGenerator(false),
             },
             {
                 query: '.node:selected',
+                valign: 'top',
+                valignBox: 'top',
                 tpl: getNodeLabelTemplateGenerator(true),
             },
         ]);

--- a/calm-hub-ui/src/visualizer/components/cytoscape-renderer/cytoscape.css
+++ b/calm-hub-ui/src/visualizer/components/cytoscape-renderer/cytoscape.css
@@ -2,9 +2,8 @@
     border: 1px solid;
     text-align: center;
     width: 200px;
-    min-height: 100px;
     font-family: Arial;
-    padding: 10px 30px 10px 30px;
+    padding: 5px 10px 5px 10px;
     background-color: white;
 }
 
@@ -26,7 +25,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: -50px;
     margin-left: -100px;
 }
 

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -99,6 +99,9 @@ export function Drawer({ calmInstance, title, isConDescActive, isNodeDescActive 
                     description: node.description,
                     type: node['node-type'],
                     id: node['unique-id'],
+                    //Used to make the size of the node scale dynamically
+                    _displayPlaceholderWithDesc: `${node.name}\n\n\n${node['node-type']}\n\n\n${node.description}\n`,
+                    _displayPlaceholderWithoutDesc: `${node.name}\n\n\n${node['node-type']}`,
                 },
             };
 


### PR DESCRIPTION
Refer to conversation for latest updates.

UI at present:

How it looks on api-gateway

<img src="https://github.com/user-attachments/assets/7ae812b7-dc59-4dcc-a0fc-252d037dd1e2" width="300" height="300">

<img src="https://github.com/user-attachments/assets/9424a656-8fa3-443a-ab42-d4b5056f31f3" width="300" height="300">

How it looks on traderX

<img src="https://github.com/user-attachments/assets/dca1b966-ddfd-4616-b84b-7ce3ea5bd0f7" width="600" height="300">

<img src="https://github.com/user-attachments/assets/5162c17a-b57a-4605-888c-8fdf08c7c692" width="600" height="300">