### PR TITLE
Output correct $schema when generating (#1201)

### DIFF
--- a/cli/test_fixtures/generate_output.json
+++ b/cli/test_fixtures/generate_output.json
@@ -109,5 +109,5 @@
       }
     }
   ],
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
+  "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/pattern/api-gateway"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/node": "^22.9.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
-        "@vitejs/plugin-react-swc": "^3.9.0",
+        "@vitejs/plugin-react-swc": "^3.7.2",
         "copyfiles": "^2.4.1",
         "cytoscape": "^3.30.3",
         "cytoscape-cola": "^2.5.1",
@@ -58,7 +58,7 @@
         "@types/file-saver": "^2.0.7",
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",
-        "@vitejs/plugin-react": "^4.4.0",
+        "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "daisyui": "^5.0.0",
         "eslint": "^9.14.0",
@@ -73,7 +73,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.14.0",
-        "vite": "^6.3.2",
+        "vite": "^6.2.5",
         "vitest": "^3.0.6"
       }
     },

--- a/shared/src/commands/generate/components/instantiate.spec.ts
+++ b/shared/src/commands/generate/components/instantiate.spec.ts
@@ -80,6 +80,7 @@ describe('instantiate', () => {
 
     const patternDocument = {
         $schema: 'schema#',
+        $id: 'test-pattern',
         properties: {
             nodes: {
                 type: 'array',
@@ -141,6 +142,13 @@ describe('instantiate', () => {
     beforeEach(() => {
         vi.resetModules();
         (fs.readFileSync as Mock).mockImplementation(() => JSON.stringify(patternDocument));
+    });
+
+    it('instantiates architecture with correct schema', async () => {
+        const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
+        const result: TestInstantiatedPattern = await instantiate(pattern, true,  'schemas');
+
+        expect(result.$schema).toEqual('test-pattern');
     });
 
     it('instantiates nodes with schema-required and const fields', async () => {

--- a/shared/src/commands/generate/components/instantiate.ts
+++ b/shared/src/commands/generate/components/instantiate.ts
@@ -11,6 +11,7 @@ interface PatternDefinition {
 }
 
 interface PatternDocument {
+    $id?: string;
     $schema?: string;
     properties: Record<string, PatternDefinition>;
 }
@@ -152,8 +153,9 @@ export async function instantiate(
 
     const output = instantiateFromProperties(pattern, schemaDir);
 
-    if (pattern.$schema) {
-        output.$schema = pattern.$schema;
+    if (pattern.$id) {
+        // $schema on an architecture identifies the pattern ID in use.
+        output.$schema = pattern.$id;
     }
 
     return output;

--- a/shared/test_fixtures/command/generate/expected-output/conference-secure-signup.arch.json
+++ b/shared/test_fixtures/command/generate/expected-output/conference-secure-signup.arch.json
@@ -176,5 +176,5 @@
       }
     }
   ],
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
+  "$schema": "https://calm.finos.org/workshop/conference-secure-signup.pattern.json"
 }

--- a/shared/test_fixtures/command/generate/expected-output/conference-signup.arch.json
+++ b/shared/test_fixtures/command/generate/expected-output/conference-signup.arch.json
@@ -132,5 +132,5 @@
       }
     }
   ],
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
+  "$schema": "https://calm.finos.org/workshop/conference-signup.pattern.json"
 }

--- a/shared/test_fixtures/template/data/conference-secure-signup.amended.arch.json
+++ b/shared/test_fixtures/template/data/conference-secure-signup.amended.arch.json
@@ -176,5 +176,5 @@
       }
     }
   ],
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
+  "$schema": "https://calm.finos.org/workshop/conference-secure-signup.pattern.json"
 }


### PR DESCRIPTION
Addresses #1201

Since the refactor `calm generate` selects the `$schema` property of the pattern when generating. It should be `$id` instead.