### PR TITLE
(fixes #1210) fixed validate crash

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/calm-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
The existing spectral rule was crashing when it failed to find a node, e.g. if it was inside a oneOf or anyOf block