### PR TITLE
 update dependency vite to v6.3.4 [security] + associated test fix

### DIFF
--- a/calm-hub-ui/package.json
+++ b/calm-hub-ui/package.json
@@ -61,7 +61,7 @@
         "tailwindcss": "^4.1.4",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.14.0",
-        "vite": "^6.2.5",
+        "vite": "^6.3.4",
         "vitest": "^3.0.6"
     },
     "resolutions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
                 "tailwindcss": "^4.1.4",
                 "typescript": "^5.5.3",
                 "typescript-eslint": "^8.14.0",
-                "vite": "^6.2.5",
+                "vite": "^6.3.4",
                 "vitest": "^3.0.6"
             }
         },
@@ -27421,17 +27421,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-            "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.3",
+                "fdir": "^6.4.4",
                 "picomatch": "^4.0.2",
                 "postcss": "^8.5.3",
                 "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.12"
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -29372,7 +29372,7 @@
                 "eslint": "^9.24.0",
                 "fetch-mock": "^12.5.2",
                 "globals": "^16.0.0",
-                "msw": "^2.8.2",
+                "msw": "^2.7.3",
                 "typescript": "^5.8.3"
             }
         }

--- a/shared/src/docify/template-bundles/docusaurus/docusaurus-transformer.ts
+++ b/shared/src/docify/template-bundles/docusaurus/docusaurus-transformer.ts
@@ -219,4 +219,3 @@ export default class DocusaurusTransformer implements CalmTemplateTransformer {
         return relationshipId.split('-uses-').slice(-1)[0];
     }
 }
-module.exports = DocusaurusTransformer;

--- a/shared/src/template/template-processor.ts
+++ b/shared/src/template/template-processor.ts
@@ -116,7 +116,7 @@ export class TemplateProcessor {
                 transpileOnly: true,
                 compilerOptions: {
                     target: 'es2021',
-                    module: 'commonjs',
+                    module: 'esnext',
                     moduleResolution: 'node',
                     esModuleInterop: true,
                     sourceMap: true,
@@ -135,7 +135,7 @@ export class TemplateProcessor {
 
         try {
             const url = pathToFileURL(transformerFilePath).href;
-            const mod = await import(url);
+            const mod = await import(/* @vite-ignore */ url);
             const TransformerClass = mod.default;
             if (typeof TransformerClass !== 'function') {
                 throw new Error('❌ TransformerClass is not a constructor. Did you forget to export default?');

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     entry: [
         'src/docify/template-bundles/docusaurus/docusaurus-transformer.ts'
     ],
-    format: ['cjs'],
+    format: ['esm'],
     clean: true,
     outDir: 'dist/template-bundles/docusaurus',
     target: 'node18',


### PR DESCRIPTION
Puts in an additional fix for https://github.com/finos/architecture-as-code/pull/1263 so that vite can be upgraded.  