### PR TITLE
Remove unused cytoscape dependencies

### DIFF
--- a/calm-hub-ui/package.json
+++ b/calm-hub-ui/package.json
@@ -23,7 +23,6 @@
         "cytoscape": "^3.30.3",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-dagre": "^2.5.0",
-        "cytoscape-expand-collapse": "^4.1.1",
         "cytoscape-node-edge-html-label": "^1.0.6",
         "oidc-client": "^1.11.5",
         "react": "^18.2.0",

--- a/calm-hub-ui/src/visualizer/components/cytoscape-renderer/CytoscapeRenderer.tsx
+++ b/calm-hub-ui/src/visualizer/components/cytoscape-renderer/CytoscapeRenderer.tsx
@@ -2,7 +2,6 @@ import './cytoscape.css';
 import { useContext, useEffect, useRef, useState } from 'react';
 import cytoscape, { Core, EdgeSingular, NodeSingular } from 'cytoscape';
 import nodeEdgeHtmlLabel from 'cytoscape-node-edge-html-label';
-import expandCollapse from 'cytoscape-expand-collapse';
 import { Sidebar } from '../sidebar/Sidebar.js';
 import { ZoomContext } from '../zoom-context.provider.js';
 import { Edge, CalmNode } from '../../contracts/contracts.js';
@@ -10,7 +9,6 @@ import { LayoutCorrectionService } from '../../services/layout-correction-servic
 
 // Initialize Cytoscape plugins
 nodeEdgeHtmlLabel(cytoscape);
-expandCollapse(cytoscape);
 
 // Layout configuration
 const breadthFirstLayout = {

--- a/calm-hub-ui/src/visualizer/components/cytoscape-renderer/cytoscape.d.ts
+++ b/calm-hub-ui/src/visualizer/components/cytoscape-renderer/cytoscape.d.ts
@@ -1,4 +1,2 @@
 declare module 'cytoscape-node-html-label';
-declare module 'cytoscape-cose-bilkent';
-declare module 'cytoscape-expand-collapse';
 declare module 'cytoscape-node-edge-html-label';


### PR DESCRIPTION
Removed these dependencies as they are unused and was seeing errors in our console previously
<img width="424" alt="Screenshot 2025-05-16 at 16 19 09" src="https://github.com/user-attachments/assets/944fa96a-2cf0-4d86-b18c-6e15dfe217bd" />

