### PR TITLE
Updating cli types to match RC1 CALM Specification (#1284)

### DIFF
--- a/calm/release/1.0-rc1/meta/flow.json
+++ b/calm/release/1.0-rc1/meta/flow.json
@@ -33,12 +33,6 @@
         ]
       }
     },
-    "metadata": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    },
     "flow": {
       "type": "object",
       "properties": {
@@ -69,7 +63,7 @@
           "$ref": "control.json#/defs/controls"
         },
         "metadata": {
-          "$ref": "#/defs/metadata"
+          "$ref": "core.json#/defs/metadata"
         }
       },
       "required": [

--- a/shared/src/model/control.ts
+++ b/shared/src/model/control.ts
@@ -3,15 +3,28 @@ import {CalmControlDetailSchema, CalmControlsSchema} from '../types/control-type
 export class CalmControlDetail {
     constructor(
         public controlRequirementUrl: string,
-        public controlConfigUrl: string
+        public controlConfigUrl?: string,
+        public controlConfig?: Record<string, unknown>
     ) {}
 
     static fromJson(data: CalmControlDetailSchema): CalmControlDetail {
-        return new CalmControlDetail(
-            data['control-requirement-url'],
-            data['control-config-url']
-        );
+        if ('control-config-url' in data) {
+            // old‐style URL config
+            return new CalmControlDetail(
+                data['control-requirement-url'],
+                data['control-config-url'],
+                undefined
+            );
+        } else {
+            // new‐style full config object
+            return new CalmControlDetail(
+                data['control-requirement-url'],
+                undefined,
+                data['control-config']
+            );
+        }
     }
+
 }
 
 export class CalmControl {

--- a/shared/src/model/core.spec.ts
+++ b/shared/src/model/core.spec.ts
@@ -1,3 +1,4 @@
+// core.spec.ts
 import { CalmCore } from './core.js';
 import { CalmCoreSchema } from '../types/core-types.js';
 
@@ -12,11 +13,23 @@ const coreData: CalmCoreSchema = {
                 'detailed-architecture': 'https://example.com/architecture',
                 'required-pattern': 'https://example.com/pattern'
             },
-            interfaces: [{ 'unique-id': 'interface-001', hostname: 'localhost'}],
-            controls: { 'control-001': { description: 'Test control', requirements: [{ 'control-requirement-url': 'https://example.com/requirement', 'control-config-url': 'https://example.com/config' }] } },
+            interfaces: [
+                { 'unique-id': 'interface-001', hostname: 'localhost' }
+            ],
+            controls: {
+                'control-001': {
+                    description: 'Test control',
+                    requirements: [
+                        {
+                            'control-requirement-url': 'https://example.com/requirement',
+                            'control-config-url': 'https://example.com/config'
+                        }
+                    ]
+                }
+            },
             metadata: [{ key: 'value' }],
             'data-classification': 'Public',
-            'run-as': 'admin',
+            'run-as': 'admin'
         }
     ],
     relationships: [
@@ -32,53 +45,91 @@ const coreData: CalmCoreSchema = {
             protocol: 'HTTP',
             authentication: 'OAuth2',
             metadata: [{ key: 'value' }],
-            controls: { 'control-001': { description: 'Test control', requirements: [{ 'control-requirement-url': 'https://example.com/requirement', 'control-config-url': 'https://example.com/config' }] } }
+            controls: {
+                'control-001': {
+                    description: 'Test control',
+                    requirements: [
+                        {
+                            'control-requirement-url': 'https://example.com/requirement',
+                            'control-config-url': 'https://example.com/config'
+                        }
+                    ]
+                }
+            }
         }
     ],
     metadata: [{ key: 'value' }],
-    controls: { 'control-001': { description: 'Test control', requirements: [{ 'control-requirement-url': 'https://example.com/requirement', 'control-config-url': 'https://example.com/config' }] } },
-    flows: []
+    controls: {
+        'control-001': {
+            description: 'Test control',
+            requirements: [
+                {
+                    'control-requirement-url': 'https://example.com/requirement',
+                    'control-config-url': 'https://example.com/config'
+                }
+            ]
+        }
+    },
+    flows: [],
+    adrs: ['http://adr1', 'http://adr2']
 };
 
 describe('CalmCore', () => {
-    it('should create a CalmCore instance from CoreSchema data', () => {
+    it('should create a CalmCore instance from full CoreSchema data', () => {
         const core = CalmCore.fromJson(coreData);
 
         expect(core).toBeInstanceOf(CalmCore);
         expect(core.nodes).toHaveLength(1);
         expect(core.relationships).toHaveLength(1);
-        expect(core.metadata).toEqual({ data: { key: 'value' } });
+        expect(core.metadata.data).toEqual({ key: 'value' });
         expect(core.controls).toHaveLength(1);
-        expect(core.controls[0].controlId).toBe('control-001');
         expect(core.flows).toHaveLength(0);
+
+        // New ADRs field
+        expect(core.adrs).toEqual(['http://adr1', 'http://adr2']);
     });
 
-    it('should handle optional fields in CalmCore', () => {
-        const coreDataWithoutOptionalFields: CalmCoreSchema = {
+    it('should handle missing optional fields (relationships, flows, adrs)', () => {
+        const minimalData: CalmCoreSchema = {
             nodes: [
                 {
                     'unique-id': 'node-002',
                     'node-type': 'service',
-                    name: 'Another Test Node',
-                    description: 'Another test node description',
+                    name: 'Another Node',
+                    description: 'Another test node',
                     details: {
-                        'detailed-architecture': 'https://example.com/architecture-2',
-                        'required-pattern': 'https://example.com/pattern-2'
+                        'detailed-architecture': '',
+                        'required-pattern': ''
                     },
-                    interfaces: [{ 'unique-id': 'interface-001', hostname: 'localhost'}],
-                    controls: { 'control-002': { description: 'Another test control', requirements: [{ 'control-requirement-url': 'https://example.com/requirement2', 'control-config-url': 'https://example.com/config2' }] } },
-                    metadata: [{ key: 'value' }]
+                    interfaces: [],
+                    controls: {},
+                    metadata: []
                 }
             ],
-            metadata: [{ key: 'value' }],
-            controls: { 'control-002': { description: 'Another test control', requirements: [{ 'control-requirement-url': 'https://example.com/requirement2', 'control-config-url': 'https://example.com/config2' }] } },
+            metadata: [],
+            controls: {}
+            // relationships, flows, adrs omitted
         };
+        const core = CalmCore.fromJson(minimalData);
 
-        const coreWithoutOptionalFields = CalmCore.fromJson(coreDataWithoutOptionalFields);
+        expect(core).toBeInstanceOf(CalmCore);
+        expect(core.nodes).toHaveLength(1);
+        expect(core.relationships).toHaveLength(0);
+        expect(core.flows).toHaveLength(0);
+        expect(core.adrs).toEqual([]);
+        expect(core.metadata.data).toEqual({});
+        expect(core.controls).toHaveLength(0);
+    });
 
-        expect(coreWithoutOptionalFields).toBeInstanceOf(CalmCore);
-        expect(coreWithoutOptionalFields.nodes).toHaveLength(1);
-        expect(coreWithoutOptionalFields.relationships).toHaveLength(0);
-        expect(coreWithoutOptionalFields.flows).toHaveLength(0);
+    it('should default all collections when empty schema is passed', () => {
+        const emptySchema: CalmCoreSchema = {};
+        const core = CalmCore.fromJson(emptySchema);
+
+        expect(core.nodes).toHaveLength(0);
+        expect(core.relationships).toHaveLength(0);
+        expect(core.controls).toHaveLength(0);
+        expect(core.flows).toHaveLength(0);
+        expect(core.adrs).toEqual([]);
+        expect(core.metadata.data).toEqual({});
     });
 });

--- a/shared/src/model/core.ts
+++ b/shared/src/model/core.ts
@@ -11,7 +11,8 @@ export class CalmCore {
         public relationships: CalmRelationship[],
         public metadata: CalmMetadata,
         public controls: CalmControl[],
-        public flows: CalmFlow[]
+        public flows: CalmFlow[],
+        public adrs: string[]
     ) {}
 
     static fromJson(data: CalmCoreSchema): CalmCore {
@@ -20,7 +21,8 @@ export class CalmCore {
             data.relationships?  data.relationships.map(CalmRelationship.fromJson) : [],
             data.metadata? CalmMetadata.fromJson(data.metadata) : new CalmMetadata({}),
             data.controls? CalmControl.fromJson(data.controls) : [],
-            data.flows? data.flows.map(CalmFlow.fromJson) : []
+            data.flows? data.flows.map(CalmFlow.fromJson) : [],
+            data.adrs ? data.adrs : []
         );
     }
 }

--- a/shared/src/model/interface.spec.ts
+++ b/shared/src/model/interface.spec.ts
@@ -8,7 +8,7 @@ import {
     CalmRateLimitInterface,
     CalmContainerImageInterface,
     CalmPortInterface,
-    CalmRateLimitKey
+    CalmRateLimitKey, CalmInterfaceDefinition
 } from './interface.js';
 import {
     CalmHostPortInterfaceSchema,
@@ -45,6 +45,34 @@ const rateLimitData: CalmRateLimitInterfaceSchema = {
     'time-unit': 'Seconds',
     calls: 100
 };
+
+// Add the following test cases to your existing interface.spec.ts
+
+describe('CalmInterfaceDefinition', () => {
+    it('should create a CalmInterfaceDefinition when "interface-definition-url" and "configuration" are present', () => {
+        const defData = {
+            'unique-id': 'def-123',
+            'interface-definition-url': 'https://example.com/def.json',
+            configuration: { alpha: true, threshold: 5 }
+        };
+        const iface = CalmInterface.fromJson(defData);
+        expect(iface).toBeInstanceOf(CalmInterfaceDefinition);
+        const def = iface as CalmInterfaceDefinition;
+        expect(def.uniqueId).toBe('def-123');
+        expect(def.interfaceDefinitionUrl).toBe('https://example.com/def.json');
+        expect(def.configuration).toEqual({ alpha: true, threshold: 5 });
+    });
+
+    it('should throw if "interface-definition-url" is present but configuration is missing', () => {
+        const badDef = {
+            'unique-id': 'bad-001',
+            'interface-definition-url': 'https://example.com/def.json'
+        };
+        expect(() => CalmInterface.fromJson(badDef))
+            .toThrow(/Unknown interface type|configuration/);
+    });
+
+});
 
 describe('CalmInterface', () => {
     it('should create a CalmHostPortInterface from JSON data', () => {

--- a/shared/src/model/interface.ts
+++ b/shared/src/model/interface.ts
@@ -2,19 +2,24 @@ import {
     CalmContainerImageInterfaceSchema,
     CalmHostnameInterfaceSchema,
     CalmHostPortInterfaceSchema,
-    CalmInterfaceTypeSchema,
     CalmNodeInterfaceSchema,
     CalmOAuth2AudienceInterfaceSchema,
     CalmPathInterfaceSchema, CalmPortInterfaceSchema,
     CalmRateLimitInterfaceSchema, CalmRateLimitKeySchema,
     CalmURLInterfaceSchema
 } from '../types/interface-types.js';
+import { CalmInterfaceDefinitionSchema } from '../types/interface-types.js';
+import { CalmInterfaceSchema }           from '../types/core-types.js';
+
 
 export class CalmInterface {
     constructor(public uniqueId: string) {}
 
-    static fromJson(data: CalmInterfaceTypeSchema): CalmInterface {
-        if ('host' in data && 'port' in data) {
+    static fromJson(data: CalmInterfaceSchema): CalmInterface {
+        if ('interface-definition-url' in data && 'configuration' in data) {
+            return CalmInterfaceDefinition.fromJson(data as CalmInterfaceDefinitionSchema);
+        }
+        else if ('host' in data && 'port' in data) {
             return CalmHostPortInterface.fromJson(data as CalmHostPortInterfaceSchema);
         } else if ('hostname' in data) {
             return CalmHostnameInterface.fromJson(data as CalmHostnameInterfaceSchema);
@@ -33,6 +38,24 @@ export class CalmInterface {
         } else {
             throw new Error('Unknown interface type');
         }
+    }
+}
+
+export class CalmInterfaceDefinition extends CalmInterface {
+    constructor(
+        public uniqueId: string,
+        public interfaceDefinitionUrl: string,
+        public configuration: Record<string, unknown>
+    ) {
+        super(uniqueId);
+    }
+
+    static fromJson(data: CalmInterfaceDefinitionSchema): CalmInterfaceDefinition {
+        return new CalmInterfaceDefinition(
+            data['unique-id'],
+            data['interface-definition-url'],
+            data.configuration
+        );
     }
 }
 

--- a/shared/src/model/relationship.spec.ts
+++ b/shared/src/model/relationship.spec.ts
@@ -1,4 +1,12 @@
-import { CalmRelationship, CalmInteractsType, CalmConnectsType, CalmDeployedInType, CalmComposedOfType, CalmOptionsRelationshipType } from './relationship.js';
+import {
+    CalmRelationship,
+    CalmInteractsType,
+    CalmConnectsType,
+    CalmDeployedInType,
+    CalmComposedOfType,
+    CalmOptionsRelationshipType,
+    CalmOptionType
+} from './relationship.js';
 import { CalmRelationshipSchema } from '../types/core-types.js';
 import { CalmNodeInterface } from './interface.js';
 
@@ -120,37 +128,58 @@ describe('CalmRelationship', () => {
             'unique-id': 'relationship-004',
             description: 'A choice between which nodes will be in the architecture',
             'relationship-type': {
-                'options': [
-                    {
-                        description: 'This is option 1',
-                        nodes: ['node-1'],
-                        relationships: ['relationship-1-x']
-                    },
-                    {
-                        description: 'This is option 2',
-                        nodes: ['node-2'],
-                        relationships: ['relationship-2-x']
-                    }
+                options: [
+                    [
+                        {
+                            description: 'This is option 1',
+                            nodes: ['node-1'],
+                            relationships: ['relationship-1-x']
+                        }
+                    ],
+                    [
+                        {
+                            description: 'This is option 2',
+                            nodes: ['node-2'],
+                            relationships: ['relationship-2-x']
+                        }
+                    ]
                 ]
             },
             protocol: 'TCP',
             authentication: 'OAuth2',
             metadata: [{ key: 'value4' }],
-            controls: { 'control-004': { description: 'Test control 4', requirements: [{ 'control-requirement-url': 'https://example.com/requirement4', 'control-config-url': 'https://example.com/config4' }] } }
+            controls: {
+                'control-004': {
+                    description: 'Test control 4',
+                    requirements: [
+                        {
+                            'control-requirement-url': 'https://example.com/requirement4',
+                            'control-config-url': 'https://example.com/config4'
+                        }
+                    ]
+                }
+            }
         };
 
         const relationship = CalmRelationship.fromJson(composedOfRelationshipData);
-
         expect(relationship).toBeInstanceOf(CalmRelationship);
-        expect(relationship.relationshipType).toBeInstanceOf(CalmOptionsRelationshipType);
+        expect(relationship.relationshipType).toBeInstanceOf(
+            CalmOptionsRelationshipType
+        );
 
-        const optionsRelationship = relationship.relationshipType as CalmOptionsRelationshipType;
-        expect(optionsRelationship.options).toEqual([
+        const optionsRt = relationship.relationshipType as CalmOptionsRelationshipType;
+        expect(optionsRt.options).toHaveLength(2);
+        expect(optionsRt.options[0]).toBeInstanceOf(CalmOptionType);
+        expect(optionsRt.options[1]).toBeInstanceOf(CalmOptionType);
+
+        expect(optionsRt.options[0].decisions).toEqual([
             {
                 description: 'This is option 1',
                 nodes: ['node-1'],
                 relationships: ['relationship-1-x']
-            },
+            }
+        ]);
+        expect(optionsRt.options[1].decisions).toEqual([
             {
                 description: 'This is option 2',
                 nodes: ['node-2'],
@@ -158,4 +187,5 @@ describe('CalmRelationship', () => {
             }
         ]);
     });
+
 });

--- a/shared/src/model/relationship.ts
+++ b/shared/src/model/relationship.ts
@@ -2,7 +2,7 @@ import { CalmMetadata } from './metadata.js';
 import { CalmControl } from './control.js';
 import {
     CalmComposedOfRelationshipSchema,
-    CalmConnectsRelationshipSchema, CalmDeployedInRelationshipSchema,
+    CalmConnectsRelationshipSchema, CalmDecisionSchema, CalmDeployedInRelationshipSchema,
     CalmInteractsRelationshipSchema,
     CalmOptionsRelationshipSchema,
     CalmOptionTypeSchema,
@@ -99,12 +99,21 @@ export class CalmComposedOfType extends CalmRelationshipType {
 }
 
 export class CalmOptionType {
-    constructor(public description: string, public nodes: string[], public relationships: string[]) {}
+    constructor(public decisions: CalmDecisionType[]) {}
 
     static fromJson(data: CalmOptionTypeSchema) {
-        return new CalmOptionType(data.description, data.nodes, data.relationships);
+        return new CalmOptionType(data);
     }
 }
+
+export class CalmDecisionType {
+    constructor(public description: string, public nodes: string[], public relationships: string[], public controls?: string[], public metadata?: string[]) {}
+
+    static fromJson(data: CalmDecisionSchema) {
+        return new CalmDecisionType(data.description, data.nodes, data.relationships, data.controls, data.metadata);
+    }
+}
+
 
 export class CalmOptionsRelationshipType extends CalmRelationshipType {
     constructor(public options: CalmOptionType[]) {

--- a/shared/src/types/control-types.ts
+++ b/shared/src/types/control-types.ts
@@ -1,6 +1,10 @@
 export type CalmControlDetailSchema = {
     'control-requirement-url': string;
     'control-config-url': string;
+}
+    | {
+    'control-requirement-url': string;
+    'control-config': Record<string, unknown>;
 };
 
 export type CalmControlSchema = {

--- a/shared/src/types/core-types.ts
+++ b/shared/src/types/core-types.ts
@@ -2,58 +2,40 @@ import {
     CalmContainerImageInterfaceSchema,
     CalmHostnameInterfaceSchema,
     CalmHostPortInterfaceSchema,
+    CalmInterfaceDefinitionSchema,
     CalmInterfaceTypeSchema,
     CalmNodeInterfaceSchema,
     CalmOAuth2AudienceInterfaceSchema,
-    CalmPathInterfaceSchema,
-    CalmPortInterfaceSchema,
+    CalmPathInterfaceSchema, CalmPortInterfaceSchema,
     CalmRateLimitInterfaceSchema,
-    CalmURLInterfaceSchema,
+    CalmURLInterfaceSchema
 } from './interface-types.js';
 import { CalmControlsSchema } from './control-types.js';
 import { CalmMetadataSchema } from './metadata-types.js';
 import { CalmFlowSchema } from './flow-types.js';
 
-export type CalmNodeTypeSchema =
-    | 'actor'
-    | 'ecosystem'
-    | 'system'
-    | 'service'
-    | 'database'
-    | 'network'
-    | 'ldap'
-    | 'webclient'
-    | 'data-asset';
-export type CalmDataClassificationSchema =
-    | 'Public'
-    | 'Confidential'
-    | 'Highly Restricted'
-    | 'MNPI'
-    | 'PII';
-export type CalmProtocolSchema =
-    | 'HTTP'
-    | 'HTTPS'
-    | 'FTP'
-    | 'SFTP'
-    | 'JDBC'
-    | 'WebSocket'
-    | 'SocketIO'
-    | 'LDAP'
-    | 'AMQP'
-    | 'TLS'
-    | 'mTLS'
-    | 'TCP';
-export type CalmAuthenticationSchema =
-    | 'Basic'
-    | 'OAuth2'
-    | 'Kerberos'
-    | 'SPNEGO'
-    | 'Certificate';
+export type CalmNodeTypeSchema = 'actor' | 'ecosystem' | 'system' | 'service' | 'database' | 'network' | 'ldap' | 'webclient' | 'data-asset';
+export type CalmDataClassificationSchema = 'Public' | 'Confidential' | 'Highly Restricted' | 'MNPI' | 'PII';
+export type CalmProtocolSchema = 'HTTP' | 'HTTPS' | 'FTP' | 'SFTP' | 'JDBC' | 'WebSocket' | 'SocketIO' | 'LDAP' | 'AMQP' | 'TLS' | 'mTLS' | 'TCP';
+export type CalmAuthenticationSchema = 'Basic' | 'OAuth2' | 'Kerberos' | 'SPNEGO' | 'Certificate';
 
 export type CalmNodeDetailsSchema = {
     'detailed-architecture': string;
     'required-pattern': string;
 };
+
+export type CalmInterfaceSchema =
+    | CalmInterfaceDefinitionSchema
+    | CalmInterfaceTypeSchema
+    | CalmHostPortInterfaceSchema
+    | CalmHostnameInterfaceSchema
+    | CalmPathInterfaceSchema
+    | CalmOAuth2AudienceInterfaceSchema
+    | CalmURLInterfaceSchema
+    | CalmRateLimitInterfaceSchema
+    | CalmContainerImageInterfaceSchema
+    | CalmPortInterfaceSchema
+
 
 export type CalmNodeSchema = {
     'unique-id': string;
@@ -63,17 +45,7 @@ export type CalmNodeSchema = {
     details?: CalmNodeDetailsSchema;
     'data-classification'?: CalmDataClassificationSchema;
     'run-as'?: string;
-    interfaces?: (
-        | CalmInterfaceTypeSchema
-        | CalmHostPortInterfaceSchema
-        | CalmHostnameInterfaceSchema
-        | CalmPathInterfaceSchema
-        | CalmOAuth2AudienceInterfaceSchema
-        | CalmURLInterfaceSchema
-        | CalmRateLimitInterfaceSchema
-        | CalmContainerImageInterfaceSchema
-        | CalmPortInterfaceSchema
-    )[];
+    interfaces?: CalmInterfaceSchema[];
     controls?: CalmControlsSchema;
     metadata?: CalmMetadataSchema;
 };
@@ -98,11 +70,15 @@ export type CalmComposedOfRelationshipSchema = {
     nodes: string[];
 };
 
-export type CalmOptionTypeSchema = {
-    description: string;
-    nodes: string[];
-    relationships: string[];
-};
+export type CalmOptionTypeSchema = CalmDecisionSchema[]
+
+export type CalmDecisionSchema = {
+    description: string,
+    nodes: string[],
+    relationships: string[],
+    controls?: string[],
+    metadata?: string[]
+}
 
 export type CalmOptionsRelationshipSchema = CalmOptionTypeSchema[];
 
@@ -114,9 +90,10 @@ export type CalmRelationshipTypeSchema = {
     options?: CalmOptionsRelationshipSchema;
 };
 
+
 export type CalmRelationshipSchema = {
     'unique-id': string;
-    description?: string;
+    'description'?: string;
     'relationship-type': CalmRelationshipTypeSchema;
     protocol?: CalmProtocolSchema;
     authentication?: CalmAuthenticationSchema;
@@ -124,14 +101,14 @@ export type CalmRelationshipSchema = {
     controls?: CalmControlsSchema;
 };
 
-//TODO: There is no required section.
 export type CalmCoreSchema = {
     nodes?: CalmNodeSchema[];
     relationships?: CalmRelationshipSchema[];
     metadata?: CalmMetadataSchema;
     controls?: CalmControlsSchema;
     flows?: CalmFlowSchema[];
+    adrs?: string[];
 };
 
-export type CalmArchitectureSchema = CalmCoreSchema;
-export type CalmPatternSchema = CalmCoreSchema;
+export type CalmArchitectureSchema = CalmCoreSchema
+export type CalmPatternSchema = CalmCoreSchema

--- a/shared/src/types/interface-types.ts
+++ b/shared/src/types/interface-types.ts
@@ -1,3 +1,8 @@
+export type CalmInterfaceDefinitionSchema = {
+    'unique-id': string
+    'interface-definition-url': string
+    configuration: Record<string, unknown>
+}
 
 export type CalmInterfaceTypeSchema = {
     'unique-id': string;
@@ -5,7 +10,7 @@ export type CalmInterfaceTypeSchema = {
 
 export type CalmNodeInterfaceSchema = {
     node: string;
-    interfaces: string[];
+    interfaces?: string[];
 };
 
 export type CalmHostPortInterfaceSchema = CalmInterfaceTypeSchema & {

--- a/shared/test_fixtures/template/bundles/default-transformer/main.hbs
+++ b/shared/test_fixtures/template/bundles/default-transformer/main.hbs
@@ -31,14 +31,21 @@
 | Owner Type      | Name        | Email               | Description                        |
 |-----------------|-------------|---------------------|------------------------------------|
       {{#each requirements}}
-| {{controlConfigUrl.owner-type}} | {{controlConfigUrl.owner.name}} | {{controlConfigUrl.owner.email}} | {{controlConfigUrl.description}} |
+        {{#if controlConfigUrl}}
+          {{#with controlConfigUrl}}
+| {{owner-type}} | {{owner.name}} | {{owner.email}} | {{description}} |
+          {{/with}}
+        {{else}}
+          {{#with controlConfig}}
+| {{owner-type}} | {{owner.name}} | {{owner.email}} | {{description}} |
+          {{/with}}
+        {{/if}}
       {{/each}}
     {{else}}
 _No ownership requirements defined._
     {{/if}}
   {{/if}}
 {{/each}}
-
 
 ## Metadata
 ```

--- a/shared/test_fixtures/template/data/document-system-with-controls.json
+++ b/shared/test_fixtures/template/data/document-system-with-controls.json
@@ -108,6 +108,21 @@
         {
           "control-requirement-url": "https://calm.finos.org/controls/owner.requirement.json",
           "control-config-url":  "https://calm.finos.org/controls/system-owner.configuration.json"
+        },
+        {
+          "control-requirement-url": "https://calm.finos.org/controls/owner.requirement.json",
+          "control-config": {
+            "$schema": "https://calm.finos.org/controls/owner-responsibility.requirement.json",
+            "$id": "https://calm.finos.org/controls/data-captain.configuration.json",
+            "control-id": "ownership-003",
+            "name": "Data Captain Responsibility",
+            "description": "Captures who is responsible for data captain",
+            "owner-type": "Data Owner",
+            "owner": {
+              "name": "Captain Data",
+              "email": "captain.data@finos.org"
+            }
+          }
         }
       ]
     }

--- a/shared/test_fixtures/template/expected-output/doc-system-one-pager.md
+++ b/shared/test_fixtures/template/expected-output/doc-system-one-pager.md
@@ -22,7 +22,7 @@
 |-----------------|-------------|---------------------|------------------------------------|
 | Business Owner | Jo Bloggs | jo.bloggs@finos.org | Captures who is responsible from business perspective |
 | System Owner | Jane Doe | jane.doe@finos.org | Captures who is responsible from system ownership |
-
+| Data Owner | Captain Data | captain.data@finos.org | Captures who is responsible for data captain |
 
 ## Metadata
 ```


### PR DESCRIPTION
## Summary

This PR contains a start of changes in the cli to support the new release candidate.  The PR focuses mainly on type changes. 

## Key Changes

### 1. flow.json Schema Update
- Removed `metadata` definition from `flow.json` (was previously a duplicate).
- Updated the `$ref` to metadata to point to `core.json#/defs/metadata` for consistency.

### 2. Type and model definition changes based on various CALM specification changes since draft 2025-01

Option/Decision Schema Support - https://github.com/finos/architecture-as-code/pull/931
ADRs on core.json - https://github.com/finos/architecture-as-code/pull/1268
Support for custom interfaces - https://github.com/finos/architecture-as-code/issues/1083
Support for inline controls - https://github.com/finos/architecture-as-code/issues/1233

### 3. Extend CALM docify and template endpoints to work with type and model changes.
Updated one test to show how inline controls can work within the template. 

Docify templates update to happen on subsequent PR