### PR TITLE
Issue 1190: Update upload button to avoid expand/collapse issue

### DIFF
--- a/calm-hub-ui/src/visualizer/components/menu/Menu.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/menu/Menu.test.tsx
@@ -25,7 +25,7 @@ describe('Menu', () => {
         renderMenu();
         expect(screen.getByText('Relationship Descriptions')).toBeInTheDocument();
         expect(screen.getByText('Node Descriptions')).toBeInTheDocument();
-        expect(screen.getByText('Upload')).toBeInTheDocument();
+        expect(screen.getByText('Upload Architecture')).toBeInTheDocument();
     });
 
     it('should call toggleConnectionDesc on checkbox click', async () => {
@@ -49,7 +49,7 @@ describe('Menu', () => {
     it('should call handleUpload on file input change', async () => {
         renderMenu();
         const file = new File(['example content'], 'example.txt', { type: 'text/plain' });
-        const input = screen.getByLabelText('Architecture');
+        const input = screen.getByTestId('file-input');
         const user = userEvent.setup();
         await user.upload(input, file);
         await waitFor(() => {

--- a/calm-hub-ui/src/visualizer/components/menu/Menu.tsx
+++ b/calm-hub-ui/src/visualizer/components/menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useRef } from 'react';
 
 interface MenuProps {
     handleUpload: (instanceFile: File) => void;
@@ -17,8 +17,20 @@ export function Menu({
     isConDescActive,
     isNodeDescActive,
 }: MenuProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
     const upload = (file: File) => {
         handleUpload(file);
+    };
+
+    const handleFileChange = (event: { target: { files: FileList | null } }) => {
+        if (event.target.files) {
+            const file = event.target.files[0];
+            upload(file);
+        }
+    };
+
+    const handleUploadBtnClick = () => {
+        inputRef?.current?.click();
     };
 
     return (
@@ -56,29 +68,19 @@ export function Menu({
                     )}
                 </div>
                 <div className="menu-end">
-                    <ul className="menu menu-horizontal px-1" aria-label="navbar-menu-items">
-                        <li>
-                            <details>
-                                <summary>Upload</summary>
-                                <ul className="p-2 z-1" aria-label="upload-dropdown-items">
-                                    <li className="text-base-content">
-                                        <label>
-                                            Architecture
-                                            <input
-                                                id="file"
-                                                type="file"
-                                                aria-label="upload-architecture"
-                                                className="hidden"
-                                                onChange={(
-                                                    e: React.ChangeEvent<HTMLInputElement>
-                                                ) => e.target.files && upload(e.target.files[0])}
-                                            />
-                                        </label>
-                                    </li>
-                                </ul>
-                            </details>
-                        </li>
-                    </ul>
+                    <button className="m-2 btn btn-outline" onClick={handleUploadBtnClick}>
+                        Upload Architecture
+                    </button>
+                    <input
+                        hidden
+                        id="file"
+                        data-testid="file-input"
+                        type="file"
+                        aria-label="upload-architecture"
+                        className="hidden"
+                        ref={inputRef}
+                        onChange={handleFileChange}
+                    />
                 </div>
             </div>
         </header>


### PR DESCRIPTION
In relation to https://github.com/finos/architecture-as-code/issues/1190
Before: After uploading file, user has to click outside to close the dropdown. It also interfered with the node/edge details section on the right.

Above change avoids that since we only have one option and hence uses a button directly.