### PR TITLE
Update endpoints and test files related to validate/generate endpoints inline with RC-1 (finos#1284)

### DIFF
--- a/calm/pattern/api-gateway.json
+++ b/calm/pattern/api-gateway.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
   "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/pattern/api-gateway",
   "title": "API Gateway Pattern",
   "type": "object",
@@ -9,7 +9,7 @@
       "minItems": 4,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "properties": {
             "well-known-endpoint": {
               "type": "string"
@@ -31,7 +31,7 @@
               "minItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "api-gateway-ingress"
@@ -47,7 +47,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The API Consumer making an authenticated and authorized request"
@@ -64,7 +64,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The API Producer serving content"
@@ -83,7 +83,7 @@
               "minItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "producer-ingress"
@@ -98,7 +98,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "properties": {
             "description": {
               "const": "The Identity Provider used to verify the bearer token"
@@ -121,7 +121,7 @@
       "minItems": 4,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-consumer-api-gateway"
@@ -154,7 +154,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-gateway-idp"
@@ -180,7 +180,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "api-gateway-api-producer"
@@ -209,7 +209,7 @@
           }
         },
         {
-            "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+            "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
             "properties": {
               "unique-id": {
                 "const": "api-consumer-idp"

--- a/calm/release/1.0-rc1/meta/core.json
+++ b/calm/release/1.0-rc1/meta/core.json
@@ -191,7 +191,7 @@
       ]
     },
     "node-type-definition": {
-      "oneOf": [
+      "anyOf": [
         {
           "enum": [
             "actor",

--- a/calm/release/1.0-rc1/meta/interface.json
+++ b/calm/release/1.0-rc1/meta/interface.json
@@ -13,7 +13,6 @@
         },
         "interface-definition-url": {
           "type": "string",
-          "format": "uri",
           "description": "URI of the external schema this interface configuration conforms to"
         },
         "configuration": {

--- a/calm/release/1.0-rc1/prototype/anyof/both-options.architecture.json
+++ b/calm/release/1.0-rc1/prototype/anyof/both-options.architecture.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/prototype/anyof/both-options-prototype.pattern.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/anyof/both-options.architecture.json",
+  "title": "Application + Database A and B Pattern Example",
+  "nodes": [
+    {
+      "unique-id": "application",
+      "name": "Application",
+      "description": "An application that optionally connects to one or more DBs",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "database-a",
+      "name": "Database A",
+      "description": "Database A, optionally used in this architecture",
+      "node-type": "database"
+    },
+    {
+      "unique-id": "database-b",
+      "name": "Database B",
+      "description": "Database B, optionally used in this architecture",
+      "node-type": "database"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "application-database-a",
+      "description": "Application connects to Database A",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application"
+          },
+          "destination": {
+            "node": "database-a"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "application-database-b",
+      "description": "Application connects to Database B",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application"
+          },
+          "destination": {
+            "node": "database-b"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "connection-options",
+      "description": "Which databases does your application connect to?",
+      "relationship-type": {
+        "options": [
+          {
+            "description": "Application connects to Database A",
+            "nodes": [
+              "application"
+            ],
+            "relationships": [
+              "application-database-a"
+            ]
+          },
+          {
+            "description": "Application connects to Database B",
+            "nodes": [
+              "application"
+            ],
+            "relationships": [
+              "application-database-b"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/anyof/neither-option.architecture.json
+++ b/calm/release/1.0-rc1/prototype/anyof/neither-option.architecture.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/prototype/anyof/both-options-prototype.pattern.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/anyof/neither-option.architecture.json",
+  "title": "Application without Database Pattern Example",
+  "nodes": [
+    {
+      "unique-id": "application",
+      "name": "Application",
+      "description": "An application that optionally connects to one or more DBs",
+      "node-type": "service"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "connection-options",
+      "description": "Which databases does your application connect to?",
+      "relationship-type": {
+        "options": []
+      }
+    }
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/anyof/options-prototype.pattern.json
+++ b/calm/release/1.0-rc1/prototype/anyof/options-prototype.pattern.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/anyof/options-prototype.pattern.json",
+  "title": "Application + Database A and/or B Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application"
+            },
+            "name": {
+              "const": "Application"
+            },
+            "description": {
+              "const": "An application that optionally connects to one or more DBs"
+            },
+            "node-type": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "database-a"
+                },
+                "name": {
+                  "const": "Database A"
+                },
+                "description": {
+                  "const": "Database A, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "database"
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "database-b"
+                },
+                "name": {
+                  "const": "Database B"
+                },
+                "description": {
+                  "const": "Database B, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "database"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "relationships": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "anyOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-database-a"
+                },
+                "description": {
+                  "const": "Application connects to Database A"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application" },
+                      "destination": { "node": "database-a" }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-database-b"
+                },
+                "description": {
+                  "const": "Application connects to Database B"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application" },
+                      "destination": { "node": "database-b" }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application-c-to-database"
+            },
+            "description": {
+              "const": "Application C connects to the Database"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": { "node": "application-c" },
+                  "destination": { "node": "database" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+                "const": "connection-options"
+            },
+            "description": {
+                "const": "Which databases does your application connect to?"
+            },
+            "relationship-type": {
+              "type": "object",
+              "properties": {
+                "options": {
+                  "type": "array",
+                  "minItems": 0,
+                  "maxItems": 2,
+                  "prefixItems": [
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Application connects to Database A"
+                            },
+                            "nodes": {
+                              "const": [
+                                "database-a"
+                              ]
+                            },
+                            "relationships": {
+                              "const": [
+                                "application-database-a"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Application connects to Database B"
+                            },
+                            "nodes": {
+                              "const": [
+                                "database-b"
+                              ]
+                            },
+                            "relationships": {
+                              "const": [
+                                "application-database-b"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "options"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/multiple-choices/architecture.json
+++ b/calm/release/1.0-rc1/prototype/multiple-choices/architecture.json
@@ -1,0 +1,104 @@
+{
+  "nodes": [
+    {
+      "unique-id": "application-a",
+      "name": "Application A",
+      "description": "Application A, optionally used in this architecture",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "node-1",
+      "name": "Node 1",
+      "description": "Node 1 description",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "node-2",
+      "name": "Node 2",
+      "description": "Node 2 description",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "application-c",
+      "name": "Application C",
+      "description": "Internal application that may receive calls from A and B",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "database",
+      "name": "Database",
+      "description": "Database used by Application C",
+      "node-type": "database"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "application-a-to-c",
+      "description": "Application A connects to Application C",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-a"
+          },
+          "destination": {
+            "node": "application-c"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "application-c-to-database",
+      "description": "Application C connects to the Database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-c"
+          },
+          "destination": {
+            "node": "database"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "connection-options",
+      "description": "The choice of nodes and relationships in the pattern",
+      "relationship-type": {
+        "options": [
+          {
+            "description": "Application A connects to Application C",
+            "nodes": [
+              "application-a"
+            ],
+            "relationships": [
+              "application-a-to-c"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "unique-id": "connection-options-2",
+      "description": "Which nodes do you want to use?",
+      "relationship-type": {
+        "options": [
+          {
+            "description": "Use Node 1",
+            "nodes": [
+              "node-1"
+            ],
+            "relationships": []
+          },
+          {
+            "description": "Use Node 2",
+            "nodes": [
+              "node-2"
+            ],
+            "relationships": []
+          }
+        ]
+      }
+    }
+  ],
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json"
+}

--- a/calm/release/1.0-rc1/prototype/multiple-choices/options-prototype.pattern.json
+++ b/calm/release/1.0-rc1/prototype/multiple-choices/options-prototype.pattern.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json",
+  "title": "Application A/B/C + Database Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-a"
+                },
+                "name": {
+                  "const": "Application A"
+                },
+                "description": {
+                  "const": "Application A, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-b"
+                },
+                "name": {
+                  "const": "Application B"
+                },
+                "description": {
+                  "const": "Application B, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "node-1"
+                },
+                "name": {
+                  "const": "Node 1"
+                },
+                "description": {
+                  "const": "Node 1 description"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "node-2"
+                },
+                "name": {
+                  "const": "Node 2"
+                },
+                "description": {
+                  "const": "Node 2 description"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application-c"
+            },
+            "name": {
+              "const": "Application C"
+            },
+            "description": {
+              "const": "Internal application that may receive calls from A and B"
+            },
+            "node-type": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "database"
+            },
+            "name": {
+              "const": "Database"
+            },
+            "description": {
+              "const": "Database used by Application C"
+            },
+            "node-type": {
+              "const": "database"
+            }
+          }
+        }
+      ]
+    },
+    "relationships": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-a-to-c"
+                },
+                "description": {
+                  "const": "Application A connects to Application C"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application-a" },
+                      "destination": { "node": "application-c" }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-b-to-c"
+                },
+                "description": {
+                  "const": "Application B connects to Application C"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application-b" },
+                      "destination": { "node": "application-c" }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application-c-to-database"
+            },
+            "description": {
+              "const": "Application C connects to the Database"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": { "node": "application-c" },
+                  "destination": { "node": "database" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+                "const": "connection-options"
+            },
+            "description": {
+                "const": "The choice of nodes and relationships in the pattern"
+            },
+            "relationship-type": {
+              "type": "object",
+              "properties": {
+                "options": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "prefixItems": [
+                    {
+                      "oneOf": [
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Application A connects to Application C"
+                            },
+                            "nodes": {
+                              "const": [
+                                "application-a"
+                              ]
+                            },
+                            "relationships": {
+                              "const": [
+                                "application-a-to-c"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Application B connects to Application C"
+                            },
+                            "nodes": {
+                              "const": [
+                                "application-b"
+                              ]
+                            },
+                            "relationships": {
+                              "const": [
+                                "application-b-to-c"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              
+            },
+            "required": [
+              "options"
+            ]
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+                "const": "connection-options-2"
+            },
+            "description": {
+                "const": "Which nodes do you want to use?"
+            },
+            "relationship-type": {
+              "type": "object",
+              "properties": {
+                "options": {
+                  "type": "array",
+                  "minItems": 0,
+                  "maxItems": 2,
+                  "prefixItems": [
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Use Node 1"
+                            },
+                            "nodes": {
+                              "const": [
+                                "node-1"
+                              ]
+                            },
+                            "relationships": {
+                              "const": []
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "const": "Use Node 2"
+                            },
+                            "nodes": {
+                              "const": [
+                                "node-2"
+                              ]
+                            },
+                            "relationships": {
+                              "const": []
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "options"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/oneof/application-a.architecture.json
+++ b/calm/release/1.0-rc1/prototype/oneof/application-a.architecture.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/application-a.architecture.json",
+  "title": "Application A/B/C + Database Pattern Example",
+  "nodes": [
+    {
+      "unique-id": "application-a",
+      "name": "Application A",
+      "description": "Application A, optionally used in this architecture",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "application-c",
+      "name": "Application C",
+      "description": "Internal application that may receive calls from A and B",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "database",
+      "name": "Database",
+      "description": "Database used by Application C",
+      "node-type": "database"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "application-a-to-c",
+      "description": "Application A connects to Application C",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-a"
+          },
+          "destination": {
+            "node": "application-c"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "application-c-to-database",
+      "description": "Application C connects to the Database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-c"
+          },
+          "destination": {
+            "node": "database"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "connection-options",
+      "description": "The choice of nodes and relationships in the pattern",
+      "relationship-type": {
+        "options": [
+          {
+            "description": "Application A connects to Application C",
+            "nodes": [
+              "application-a"
+            ],
+            "relationships": [
+              "application-a-to-c"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/oneof/application-b.architecture.json
+++ b/calm/release/1.0-rc1/prototype/oneof/application-b.architecture.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/application-b.architecture.json",
+  "title": "Application B/C + Database Pattern Example",
+  "nodes": [
+    {
+      "unique-id": "application-b",
+      "name": "Application B",
+      "description": "Application B, optionally used in this architecture",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "application-c",
+      "name": "Application C",
+      "description": "Internal application that may receive calls from A and B",
+      "node-type": "service"
+    },
+    {
+      "unique-id": "database",
+      "name": "Database",
+      "description": "Database used by Application C",
+      "node-type": "database"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "application-b-to-c",
+      "description": "Application B connects to Application C",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-b"
+          },
+          "destination": {
+            "node": "application-c"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "application-c-to-database",
+      "description": "Application C connects to the Database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "application-c"
+          },
+          "destination": {
+            "node": "database"
+          }
+        }
+      }
+    },
+    {
+      "unique-id": "connection-options",
+      "description": "The choice of nodes and relationships in the pattern",
+      "relationship-type": {
+        "options": [
+          {
+            "description": "Application B connects to Application C",
+            "nodes": [
+              "application-b"
+            ],
+            "relationships": [
+              "application-b-to-c"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json
+++ b/calm/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
+  "$id": "https://calm.finos.org/release/1.0-rc1/prototype/oneof/options-prototype.pattern.json",
+  "title": "Application A/B/C + Database Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-a"
+                },
+                "name": {
+                  "const": "Application A"
+                },
+                "description": {
+                  "const": "Application A, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-b"
+                },
+                "name": {
+                  "const": "Application B"
+                },
+                "description": {
+                  "const": "Application B, optionally used in this architecture"
+                },
+                "node-type": {
+                  "const": "service"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application-c"
+            },
+            "name": {
+              "const": "Application C"
+            },
+            "description": {
+              "const": "Internal application that may receive calls from A and B"
+            },
+            "node-type": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "database"
+            },
+            "name": {
+              "const": "Database"
+            },
+            "description": {
+              "const": "Database used by Application C"
+            },
+            "node-type": {
+              "const": "database"
+            }
+          }
+        }
+      ]
+    },
+    "relationships": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-a-to-c"
+                },
+                "description": {
+                  "const": "Application A connects to Application C"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application-a" },
+                      "destination": { "node": "application-c" }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+              "type": "object",
+              "properties": {
+                "unique-id": {
+                  "const": "application-b-to-c"
+                },
+                "description": {
+                  "const": "Application B connects to Application C"
+                },
+                "relationship-type": {
+                  "const": {
+                    "connects": {
+                      "source": { "node": "application-b" },
+                      "destination": { "node": "application-c" }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+              "const": "application-c-to-database"
+            },
+            "description": {
+              "const": "Application C connects to the Database"
+            },
+            "relationship-type": {
+              "const": {
+                "connects": {
+                  "source": { "node": "application-c" },
+                  "destination": { "node": "database" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
+          "type": "object",
+          "properties": {
+            "unique-id": {
+                "const": "connection-options"
+            },
+            "description": {
+                "const": "The choice of nodes and relationships in the pattern"
+            },
+            "relationship-type": {
+              "type": "object",
+              "properties": {
+                "options": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "prefixItems": [
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                            "type": "object",
+                            "properties": {
+                              "description": {
+                                "const": "Application A connects to Application C"
+                              },
+                              "nodes": {
+                                "const": [
+                                  "application-a"
+                                ]
+                              },
+                              "relationships": {
+                                "const": [
+                                  "application-a-to-c"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/decision",
+                            "type": "object",
+                            "properties": {
+                              "description": {
+                                "const": "Application B connects to Application C"
+                              },
+                              "nodes": {
+                                "const": [
+                                  "application-b"
+                                ]
+                              },
+                              "relationships": {
+                                "const": [
+                                  "application-b-to-c"
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ]
+}

--- a/calm/release/1.0-rc1/prototype/throughput-control-prototype.json
+++ b/calm/release/1.0-rc1/prototype/throughput-control-prototype.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/traderx/control-requirement/throughput",
+  "title": "Throughput Requirement",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json"
+    }
+  ],
+  "properties": {
+    "expected-message-rate": {
+      "$ref": "https://calm.finos.org/release/1.0-rc1/meta/units.json#/defs/rate-unit",
+      "description": "Define the expected message rate that the flow should handle (e.g., 1000 per second)."
+    }
+  },
+  "required": [
+    "expected-message-rate"
+  ]
+}

--- a/calm/workshop/architecture/conference-secure-signup-amended.arch.json
+++ b/calm/workshop/architecture/conference-secure-signup-amended.arch.json
@@ -176,5 +176,5 @@
       }
     }
   ],
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json"
 }

--- a/calm/workshop/conference-secure-signup.pattern.json
+++ b/calm/workshop/conference-secure-signup.pattern.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
   "$id": "https://calm.finos.org/workshop/conference-secure-signup.pattern.json",
   "type": "object",
   "title": "Conference Secure Signup Pattern",
@@ -11,7 +11,7 @@
       "maxItems": 5,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -32,7 +32,7 @@
               "maxItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/url-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/url-interface",
                   "properties": {
                     "unique-id": {
                       "const": "conference-website-url"
@@ -44,7 +44,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -65,7 +65,7 @@
               "maxItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "load-balancer-host-port"
@@ -77,7 +77,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -98,7 +98,7 @@
               "maxItems": 2,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/container-image-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/container-image-interface",
                   "properties": {
                     "unique-id": {
                       "const": "attendees-image"
@@ -106,7 +106,7 @@
                   }
                 },
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "attendees-port"
@@ -118,7 +118,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -139,7 +139,7 @@
               "maxItems": 2,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/container-image-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/container-image-interface",
                   "properties": {
                     "unique-id": {
                       "const": "database-image"
@@ -147,7 +147,7 @@
                   }
                 },
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "database-port"
@@ -159,7 +159,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -175,7 +175,7 @@
               "const": "system"
             },
             "controls": {
-              "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/controls",
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/controls",
               "properties": {
                 "security": {
                   "type": "object",
@@ -189,7 +189,7 @@
                       "maxItems": 1,
                       "prefixItems": [
                         {
-                          "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/control-detail",
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/control-detail",
                           "properties": {
                             "control-requirement-url": {
                               "const": "https://calm.finos.org/workshop/controls/micro-segmentation.requirement.json"
@@ -214,7 +214,7 @@
       "minItems": 1,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -239,7 +239,7 @@
               }
             },
             "controls": {
-              "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/controls",
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/controls",
               "properties": {
                 "security": {
                   "type": "object",
@@ -253,7 +253,7 @@
                       "maxItems": 1,
                       "prefixItems": [
                         {
-                          "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/control-detail",
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/control-detail",
                           "properties": {
                             "control-requirement-url": {
                               "const": "https://calm.finos.org/workshop/controls/permitted-connection.requirement.json"
@@ -275,7 +275,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -300,7 +300,7 @@
               }
             },
             "controls": {
-              "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/controls",
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/controls",
               "properties": {
                 "security": {
                   "type": "object",
@@ -314,7 +314,7 @@
                       "maxItems": 1,
                       "prefixItems": [
                         {
-                          "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/control-detail",
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/control-detail",
                           "properties": {
                             "control-requirement-url": {
                               "const": "https://calm.finos.org/workshop/controls/permitted-connection.requirement.json"
@@ -339,7 +339,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -364,7 +364,7 @@
               }
             },
             "controls": {
-              "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/controls",
+              "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/controls",
               "properties": {
                 "security": {
                   "type": "object",
@@ -378,7 +378,7 @@
                       "maxItems": 1,
                       "prefixItems": [
                         {
-                          "$ref": "https://calm.finos.org/draft/2025-03/meta/control.json#/defs/control-detail",
+                          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control.json#/defs/control-detail",
                           "properties": {
                             "control-requirement-url": {
                               "const": "https://calm.finos.org/workshop/controls/permitted-connection.requirement.json"
@@ -401,7 +401,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "deployed-in-k8s-cluster"

--- a/calm/workshop/conference-signup.pattern.json
+++ b/calm/workshop/conference-signup.pattern.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json",
   "$id": "https://calm.finos.org/workshop/conference-signup.pattern.json",
   "type": "object",
   "title": "Conference Signup Pattern",
@@ -11,7 +11,7 @@
       "maxItems": 5,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -32,7 +32,7 @@
               "maxItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/url-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/url-interface",
                   "properties": {
                     "unique-id": {
                       "const": "conference-website-url"
@@ -44,7 +44,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -65,7 +65,7 @@
               "maxItems": 1,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/host-port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/host-port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "load-balancer-host-port"
@@ -77,7 +77,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -98,7 +98,7 @@
               "maxItems": 2,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/container-image-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/container-image-interface",
                   "properties": {
                     "unique-id": {
                       "const": "attendees-image"
@@ -106,7 +106,7 @@
                   }
                 },
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "attendees-port"
@@ -118,7 +118,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -139,7 +139,7 @@
               "maxItems": 2,
               "prefixItems": [
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/container-image-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/container-image-interface",
                   "properties": {
                     "unique-id": {
                       "const": "database-image"
@@ -147,7 +147,7 @@
                   }
                 },
                 {
-                  "$ref": "https://calm.finos.org/draft/2025-03/meta/interface.json#/defs/port-interface",
+                  "$ref": "https://calm.finos.org/release/1.0-rc1/meta/interface.json#/defs/port-interface",
                   "properties": {
                     "unique-id": {
                       "const": "database-port"
@@ -159,7 +159,7 @@
           }
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -184,7 +184,7 @@
       "maxItems": 4,
       "prefixItems": [
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -214,7 +214,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -244,7 +244,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "type": "object",
           "properties": {
             "unique-id": {
@@ -274,7 +274,7 @@
           ]
         },
         {
-          "$ref": "https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship",
+          "$ref": "https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship",
           "properties": {
             "unique-id": {
               "const": "deployed-in-k8s-cluster"

--- a/calm/workshop/controls/micro-segmentation.requirement.json
+++ b/calm/workshop/controls/micro-segmentation.requirement.json
@@ -5,7 +5,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "https://calm.finos.org/draft/2025-03/meta/control-requirement.json"
+      "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json"
     }
   ],
   "properties": {

--- a/calm/workshop/controls/permitted-connection.requirement.json
+++ b/calm/workshop/controls/permitted-connection.requirement.json
@@ -5,7 +5,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "https://calm.finos.org/draft/2025-03/meta/control-requirement.json"
+      "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json"
     }
   ],
   "properties": {

--- a/calm/workshop/directory.json
+++ b/calm/workshop/directory.json
@@ -1,5 +1,5 @@
 {
-  "https://calm.finos.org/draft/2025-03/meta/control-requirement.json": "../draft/2025-03/meta/control-requirement.json",
+  "https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json": "../release/1.0-rc1/meta/control-requirement.json",
   "https://calm.finos.org/workshop/controls/micro-segmentation.config.json": "controls/micro-segmentation.config.json",
   "https://calm.finos.org/workshop/controls/micro-segmentation.requirement.json": "controls/micro-segmentation.requirement.json",
   "https://calm.finos.org/workshop/controls/permitted-connection.requirement.json": "controls/permitted-connection.requirement.json",

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,7 +48,7 @@ Generate an architecture from a CALM pattern file.
 Options:
   -p, --pattern <file>          Path to the pattern file to use. May be a file path or a URL.
   -o, --output <file>           Path location at which to output the generated file. (default: "architecture.json")
-  -s, --schemaDirectory <path>  Path to the directory containing the meta schemas to use. (default: "../calm/draft")
+  -s, --schemaDirectory <path>  Path to the directory containing the meta schemas to use. (default: "../calm/release")
   -v, --verbose                 Enable verbose logging. (default: false)
   -h, --help                    display help for command
 ```
@@ -73,7 +73,7 @@ Validate that an architecture conforms to a given CALM pattern.
 Options:
   -p, --pattern <file>          Path to the pattern file to use. May be a file path or a URL.
   -a, --architecture <file>     Path to the pattern architecture file to use. May be a file path or a URL.
-  -s, --schemaDirectory <path>  Path to the directory containing the meta schemas to use. (default: "../calm/draft")
+  -s, --schemaDirectory <path>  Path to the directory containing the meta schemas to use. (default: "../calm/release")
   --strict                      When run in strict mode, the CLI will fail if any warnings are reported. (default: false)
   -f, --format <format>         The format of the output (choices: "json", "junit", default: "json")
   -o, --output <file>           Path location at which to output the generated file.

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "build": "tsup && npm run copy-calm-schema && npm run copy-docify-templates",
         "watch": "node watch.mjs",
-        "copy-calm-schema": "copyfiles \"../calm/draft/2025-03/meta/*\" dist/calm/",
+        "copy-calm-schema": "copyfiles \"../calm/release/1.0-rc1/meta/*\" dist/calm/",
         "copy-docify-templates": "copyfiles \"../shared/dist/template-bundles/**/*\" dist --up 3",
         "test": "vitest run",
         "lint": "eslint src",

--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -173,7 +173,7 @@ describe('CLI Integration Tests', () => {
 
     test('generate command produces the expected output', async () => {
         const apiGatewayPatternPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
-        const schemaDirectoryPath = path.join(__dirname, '../../calm/draft');
+        const schemaDirectoryPath = path.join(__dirname, '../../calm/release');
         const targetOutputFile = path.join(tempDir, 'generate-output.json');
 
         const cmd = calm(`generate -p ${apiGatewayPatternPath} -o ${targetOutputFile} -s ${schemaDirectoryPath}`);

--- a/cli/src/server/routes/validation-route.spec.ts
+++ b/cli/src/server/routes/validation-route.spec.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { SchemaDirectory } from '@finos/calm-shared';
 import { FileSystemDocumentLoader } from '@finos/calm-shared/dist/document-loader/file-system-document-loader';
 
-const schemaDirectoryPath : string = __dirname + '/../../../../calm/draft';
+const schemaDirectoryPath : string = __dirname + '/../../../../calm/release';
 const apiGatewayPatternPath: string = __dirname + '/../../../../calm/pattern';
 
 describe('ValidationRouter', () => {

--- a/shared/src/commands/generate/components/options.spec.ts
+++ b/shared/src/commands/generate/components/options.spec.ts
@@ -50,7 +50,7 @@ function buildPatternOption(optionType: 'oneOf' | 'anyOf', ...choices: object[])
 
 function buildNode(uniqueId: string): object {
     return {
-        '$ref': 'https://calm.finos.org/draft/2025-03/meta/core.json#/defs/node',
+        '$ref': 'https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/node',
         'type': 'object',
         'properties': {
             'unique-id': {
@@ -71,7 +71,7 @@ function buildNode(uniqueId: string): object {
 
 function buildConnectsRelationship(id: string, prompt: string, source: string, destination: string): object {
     return {
-        '$ref': 'https://calm.finos.org/draft/2025-03/meta/core.json#/defs/relationship',
+        '$ref': 'https://calm.finos.org/release/1.0-rc1/meta/core.json#/defs/relationship',
         'type': 'object',
         'properties': {
             'unique-id': {

--- a/shared/src/commands/generate/generate.e2e.spec.ts
+++ b/shared/src/commands/generate/generate.e2e.spec.ts
@@ -16,7 +16,7 @@ const inputSecurePatternPath = join(
 
 const expectedDir = join(__dirname, '../../../test_fixtures/command/generate/expected-output');
 const outputDir = join(__dirname, '../../../test_fixtures/command/generate/actual-output');
-const schemaDir = join(__dirname, '../../../../calm/draft/2025-03/meta');
+const schemaDir = join(__dirname, '../../../../calm/release/1.0-rc1/meta');
 
 const outputPath = join(outputDir, 'conference-signup.arch.json');
 const outputSecurePath = join(outputDir, 'conference-secure-signup.arch.json');

--- a/shared/src/consts.ts
+++ b/shared/src/consts.ts
@@ -1,1 +1,1 @@
-export const CALM_META_SCHEMA_DIRECTORY = __dirname + '/calm/draft';
+export const CALM_META_SCHEMA_DIRECTORY = __dirname + '/calm/release';

--- a/shared/src/template/template-processor.e2e.spec.ts
+++ b/shared/src/template/template-processor.e2e.spec.ts
@@ -241,6 +241,7 @@ describe('TemplateProcessor E2E', () => {
         const EXPECTED_OUTPUT_WORKSHOP_DIR = path.join(FIXTURES_DIR, 'expected-output/workshop/infrastructure');
 
         const mapping = new Map<string, string>([
+            ['https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json', join(WORKSHOP_DIR, '../release/1.0-rc1/meta/control-requirement.json')],
             ['https://calm.finos.org/workshop/controls/micro-segmentation.config.json', join(WORKSHOP_DIR, 'controls/micro-segmentation.config.json')],
             ['https://calm.finos.org/workshop/controls/micro-segmentation.requirement.json', join(WORKSHOP_DIR, 'controls/micro-segmentation.requirement.json')],
             ['https://calm.finos.org/workshop/controls/permitted-connection.requirement.json', join(WORKSHOP_DIR, 'controls/permitted-connection.requirement.json')],

--- a/shared/test_fixtures/template/data/controls/owner-responsibility.requirement.json
+++ b/shared/test_fixtures/template/data/controls/owner-responsibility.requirement.json
@@ -5,7 +5,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "https://calm.finos.org/draft/2025-03/meta/control-requirement.json"
+      "$ref": "https://calm.finos.org/release/1.0-rc1/meta/control-requirement.json"
     }
   ],
   "properties": {


### PR DESCRIPTION
# Commit Summary

Update all test files to work with new `rc1` candidate of the CALM schema.  This update ensures compatibility across the test suite and confirms that the `rc1` schema is included in the distributed package.

## Out of Scope

- Development of code to make it less dependent on specific calm versions by hydrating schema registry with different schema versions.  See [architecture-as-code#836 (comment)](https://github.com/finos/architecture-as-code/issues/836#issuecomment-2884423305)

---