### PR TITLE
Add support for flows inside pattern using const to a url reference + confirm generated arch document renders flow in docify

### DIFF
--- a/conferences/osff-ln-2025/workshop/architecture/conference-secure-signup-amended.arch.json
+++ b/conferences/osff-ln-2025/workshop/architecture/conference-secure-signup-amended.arch.json
@@ -176,5 +176,8 @@
       }
     }
   ],
+  "flows": [
+    "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
+  ],
   "$schema": "https://calm.finos.org/release/1.0-rc1/meta/calm.json"
 }

--- a/conferences/osff-ln-2025/workshop/conference-secure-signup.pattern.json
+++ b/conferences/osff-ln-2025/workshop/conference-secure-signup.pattern.json
@@ -452,11 +452,22 @@
         ]
       }]
 
+    },
+    "flows": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "prefixItems": [
+        {
+          "const": "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
+        }
+      ]
     }
   },
   "required": [
     "nodes",
     "relationships",
-    "metadata"
+    "metadata",
+    "flows"
   ]
 }

--- a/conferences/osff-ln-2025/workshop/directory.json
+++ b/conferences/osff-ln-2025/workshop/directory.json
@@ -4,5 +4,6 @@
   "https://calm.finos.org/workshop/controls/micro-segmentation.requirement.json": "controls/micro-segmentation.requirement.json",
   "https://calm.finos.org/workshop/controls/permitted-connection.requirement.json": "controls/permitted-connection.requirement.json",
   "https://calm.finos.org/workshop/controls/permitted-connection-http.config.json": "controls/permitted-connection-http.config.json",
-  "https://calm.finos.org/workshop/controls/permitted-connection-jdbc.config.json": "controls/permitted-connection-jdbc.config.json"
+  "https://calm.finos.org/workshop/controls/permitted-connection-jdbc.config.json": "controls/permitted-connection-jdbc.config.json",
+  "https://calm.finos.org/workshop/flows/conference-signup.flow.json": "flows/conference-signup.flow.json"
 }

--- a/conferences/osff-ln-2025/workshop/flows/conference-signup.flow.json
+++ b/conferences/osff-ln-2025/workshop/flows/conference-signup.flow.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0-rc1/meta/flow.json",
+  "$id": "https://calm.finos.org/workshop/flow/conference-signup.flow.json",
+  "unique-id": "flow-conference-signup",
+  "name": "Conference Signup Flow",
+  "description": "Flow for registering a user through the conference website and storing their details in the attendee database.",
+  "transitions": [
+    {
+      "relationship-unique-id": "conference-website-load-balancer",
+      "sequence-number": 1,
+      "description": "User submits sign-up form via Conference Website to Load Balancer"
+    },
+    {
+      "relationship-unique-id": "load-balancer-attendees",
+      "sequence-number": 2,
+      "description": "Load Balancer forwards request to Attendees Service"
+    },
+    {
+      "relationship-unique-id": "attendees-attendees-store",
+      "sequence-number": 3,
+      "description": "Attendees Service stores attendee info in the Attendees Store"
+    }
+  ]
+}

--- a/shared/src/commands/generate/components/instantiate.spec.ts
+++ b/shared/src/commands/generate/components/instantiate.spec.ts
@@ -231,7 +231,8 @@ describe('instantiate', () => {
                                 key: { type: 'string' }
                             },
                             required: ['key']
-                        }
+                        },
+                        { const: [ 'nested-array' ]},
                     ]
                 }
             }
@@ -248,7 +249,8 @@ describe('instantiate', () => {
             true,
             null,
             { nestedKey: 'nested-value' },
-            { key: '[[ KEY ]]' } // Non-const item should be instantiated with placeholder
+            { key: '[[ KEY ]]' }, // Non-const item should be instantiated with placeholder
+            ['nested-array' ]
         ]);
     });
 });

--- a/shared/src/commands/generate/components/instantiate.spec.ts
+++ b/shared/src/commands/generate/components/instantiate.spec.ts
@@ -210,4 +210,45 @@ describe('instantiate', () => {
         expect(result.nodes[0]['node-type']).toBe('[[ NODE_TYPE ]]');
         expect(result.nodes[0]['details']['arch']).toBe('[[ ARCH ]]');
     });
+
+    it('uses const values directly for array items', async () => {
+        // Define a pattern document with an array that contains items with const values
+        const patternWithConstArrayItems = {
+            $schema: 'schema#',
+            $id: 'test-pattern-const-array',
+            properties: {
+                simpleArray: {
+                    type: 'array',
+                    prefixItems: [
+                        { const: 'string-value' },
+                        { const: 42 },
+                        { const: true },
+                        { const: null },
+                        { const: { nestedKey: 'nested-value' } },
+                        {
+                            type: 'object',
+                            properties: {
+                                key: { type: 'string' }
+                            },
+                            required: ['key']
+                        }
+                    ]
+                }
+            }
+        };
+
+        (fs.readFileSync as Mock).mockImplementation(() => JSON.stringify(patternWithConstArrayItems));
+
+        const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
+        const result = await instantiate(pattern, true, new SchemaDirectory(null));
+
+        expect(result['simpleArray']).toEqual([
+            'string-value',
+            42,
+            true,
+            null,
+            { nestedKey: 'nested-value' },
+            { key: '[[ KEY ]]' } // Non-const item should be instantiated with placeholder
+        ]);
+    });
 });

--- a/shared/src/commands/generate/components/instantiate.ts
+++ b/shared/src/commands/generate/components/instantiate.ts
@@ -101,12 +101,17 @@ async function instantiateFromProperties(
         const resolvedDef = await resolveSchema(def as JsonSchema, schemaDir);
 
         if (resolvedDef.type === 'array' && resolvedDef.prefixItems) {
-            output[key] = await Promise.all(resolvedDef.prefixItems.map(async (itemDef, idx) => {
-                const resolvedItem = await resolveSchema(itemDef, schemaDir);
-                return instantiateObject(resolvedItem, schemaDir, [key, `${idx}`]);
-            }));
+            output[key] = await Promise.all(
+                resolvedDef.prefixItems.map(async (itemDef, idx) => {
+                    const resolvedItem = await resolveSchema(itemDef, schemaDir);
+                    if (resolvedItem.const !== undefined) {
+                        return resolvedItem.const;
+                    }
+                    return await instantiateObject(resolvedItem, schemaDir, [key, `${idx}`]);
+                })
+            );
         } else {
-            output[key] = instantiateObject(resolvedDef, schemaDir, [key]);
+            output[key] = await instantiateObject(resolvedDef, schemaDir, [key]);
         }
     }
 

--- a/shared/src/docify/docifier.e2e.spec.ts
+++ b/shared/src/docify/docifier.e2e.spec.ts
@@ -10,7 +10,7 @@ const INPUT_DIR = join(
 );
 const WORKSHOP_DIR = join(
     __dirname,
-    '../../../conferences/osff-ln-2025/workshop/controls'
+    '../../../conferences/osff-ln-2025/workshop'
 );
 
 const OUTPUT_DIR = join(
@@ -46,10 +46,8 @@ describe('Docifier E2E - Real Model and Template', () => {
 
     it('generates documentation from the conference-secure-signup.arch.json model with explicit local mapping', async () => {
         const mapping = new Map<string, string>([
-            [
-                'https://calm.finos.org/workshop/controls/micro-segmentation.config.json',
-                join(WORKSHOP_DIR, 'micro-segmentation.config.json'),
-            ],
+            ['https://calm.finos.org/workshop/controls/micro-segmentation.config.json', join(WORKSHOP_DIR, 'controls/micro-segmentation.config.json')],
+            ['https://calm.finos.org/workshop/flows/conference-signup.flow.json', join(WORKSHOP_DIR, 'flows/conference-signup.flow.json')],
         ]);
 
         const docifier = new Docifier(
@@ -67,11 +65,16 @@ describe('Docifier E2E - Real Model and Template', () => {
     });
 
     it('generates documentation from the conference-secure-signup.arch.json model with no mapping as workshop documents are available', async () => {
+        const mapping = new Map<string, string>([
+            ['https://calm.finos.org/workshop/flows/conference-signup.flow.json', join(WORKSHOP_DIR, 'flows/conference-signup.flow.json')],
+        ]);
+
+
         const docifier = new Docifier(
             'WEBSITE',
             join(INPUT_DIR, 'conference-secure-signup-amended.arch.json'),
             SECURE_VERSION_DOC_WEBSITE,
-            new Map<string, string>()
+            mapping
         );
         await docifier.docify();
         await expectDirectoryMatch(

--- a/shared/test_fixtures/command/generate/expected-output/conference-secure-signup-amended.arch.json
+++ b/shared/test_fixtures/command/generate/expected-output/conference-secure-signup-amended.arch.json
@@ -176,5 +176,8 @@
       }
     }
   ],
+  "flows": [
+    "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
+  ],
   "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json"
 }

--- a/shared/test_fixtures/command/generate/expected-output/conference-secure-signup.arch.json
+++ b/shared/test_fixtures/command/generate/expected-output/conference-secure-signup.arch.json
@@ -176,5 +176,8 @@
       }
     }
   ],
+  "flows": [
+    "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
+  ],
   "$schema": "https://calm.finos.org/workshop/conference-secure-signup.pattern.json"
 }

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/flows/flow-conference-signup.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/flows/flow-conference-signup.md
@@ -1,0 +1,26 @@
+---
+id: flow-conference-signup
+title: Conference Signup Flow
+---
+
+## Details
+<div className="table-container">
+| Field               | Value                    |
+|---------------------|--------------------------|
+| **Unique ID**       | flow-conference-signup                   |
+| **Name**            | Conference Signup Flow                 |
+| **Description**     | Flow for registering a user through the conference website and storing their details in the attendee database.          |
+</div>
+
+## Sequence Diagram
+```mermaid
+sequenceDiagram
+            Conference Website ->> Load Balancer: User submits sign-up form via Conference Website to Load Balancer
+            Load Balancer ->> Attendees Service: Load Balancer forwards request to Attendees Service
+            Attendees Service ->> Attendees Store: Attendees Service stores attendee info in the Attendees Store
+```
+## Controls
+    _No controls defined._
+
+## Metadata
+  _No Metadata defined._

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/index.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/index.md
@@ -48,7 +48,7 @@ UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="0")
 
 
 ## Flows
-     _No flows defined._
+    - [Conference Signup Flow](flows/flow-conference-signup)
 
 ## Controls
 | ID    | Name             | Description                  | Domain    | Scope        | Applied To                |

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/sidebars.js
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/sidebars.js
@@ -26,5 +26,12 @@ module.exports = {
                 'relationships/deployed-in-k8s-cluster'
             ],
         },
+        {
+            type: 'category',
+            label: 'Flows',
+            items: [
+                'flows/flow-conference-signup'
+            ],
+        }
     ]
 };

--- a/shared/test_fixtures/template/data/conference-secure-signup.amended.arch.json
+++ b/shared/test_fixtures/template/data/conference-secure-signup.amended.arch.json
@@ -176,5 +176,8 @@
       }
     }
   ],
+  "flows": [
+    "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
+  ],
   "$schema": "https://calm.finos.org/workshop/conference-secure-signup.pattern.json"
 }


### PR DESCRIPTION
# Changes to calm generate Function

The `instantiateFromProperties` function in the `instantiate.ts` file has been modified with three key changes:

## 1. Added Support for Constant Values in Array Items
This allows support in the pattern like this

```json
    "flows": {
      "type": "array",
      "minItems": 1,
      "maxItems": 1,
      "prefixItems": [
        {
          "const": "https://calm.finos.org/workshop/flows/conference-signup.flow.json"
        }
      ]
    }
```

## 2. Updated example on workshop to show generate works as expected and that subsequent docify command will render flow diagram like below

![image](https://github.com/user-attachments/assets/b656fe2b-d54e-453b-9d89-59ce0d38e1db)


