### PR TITLE
Update Getting Started Docs Prerequisites

### DIFF
--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -26,7 +26,7 @@ This demo showcases the **CALM** approach in action. Designed to help you get st
 
 * Java 21 or higher
 * Maven 3.8.6 or higher
-* Node.js 18 or higher
+* Node.js 18 (e.g. 18.20.8)
 * NPM
 * Have a clone of the [architecture-as-code repository](https://github.com/finos/architecture-as-code)
 


### PR DESCRIPTION
more specific node version in getting started prereqs because node 22 doesn't work