### PR TITLE
 Fix logging such that cli does not tie label (_TemplateEngine) to all usages of logger (#1389)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,6 +33,7 @@
         "@inquirer/prompts": "^7.4.1",
         "commander": "^14.0.0",
         "copyfiles": "^2.4.1",
+        "execa": "^9.6.0",
         "express-rate-limit": "^7.5.0",
         "mkdirp": "^3.0.1",
         "ts-node": "10.9.2"

--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -1,79 +1,81 @@
-import { exec, execSync } from 'child_process';
-import path, {join} from 'path';
+import { execSync } from 'child_process';
+import path, { join } from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import { execa } from 'execa';
 import { parseStringPromise } from 'xml2js';
-import util from 'util';
 import axios from 'axios';
 import { Mock } from 'vitest';
-import {expectDirectoryMatch, expectFilesMatch} from '@finos/calm-shared';
+import { expectDirectoryMatch, expectFilesMatch } from '@finos/calm-shared';
+import {spawn} from 'node:child_process';
 vi.mock('axios');
-
-const execPromise = util.promisify(exec);
 
 const millisPerSecond = 1000;
 const integrationTestPrefix = 'calm-consumer-test';
 let tempDir: string;
 const repoRoot = path.resolve(__dirname);
 
-function calm(command: string): string {
-    return `${path.join(tempDir, 'node_modules/.bin/calm')} ${command}`; //referencing local calm install in-case someone locally has installed calm globally.
+
+function run(command: string) {
+    const cp = execa(command, { cwd: tempDir, shell: true });
+    cp.stdout?.pipe(process.stdout);
+    cp.stderr?.pipe(process.stderr);
+    return cp;
+}
+
+function calm(cmd: string): string {
+    return `${path.join(tempDir, 'node_modules/.bin/calm')} ${cmd}`;
 }
 
 describe('CLI Integration Tests', () => {
-    vi.setConfig({ testTimeout: 30 * millisPerSecond });
+    vi.setConfig({testTimeout: 30 * millisPerSecond});
 
     beforeAll(() => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), integrationTestPrefix));
 
-        const tgzName = execSync('npm pack', { cwd: repoRoot }).toString().trim();
+        const tgzName = execSync('npm pack', {cwd: repoRoot}).toString().trim();
         const sourceTarball = path.join(repoRoot, tgzName);
         const targetTarball = path.join(tempDir, tgzName);
         fs.renameSync(sourceTarball, targetTarball);
 
         // Create clean test consumer
-        execSync('npm init -y', { cwd: tempDir, stdio: 'inherit' });
-        execSync(`npm install ${targetTarball}`, { cwd: tempDir, stdio: 'inherit' });
+        execSync('npm init -y', {cwd: tempDir, stdio: 'inherit'});
+        execSync(`npm install ${targetTarball}`, {cwd: tempDir, stdio: 'inherit'});
     }, millisPerSecond * 30);
 
     afterAll(() => {
         if (tempDir) {
-            fs.rmSync(tempDir, { recursive: true, force: true });
+            fs.rmSync(tempDir, {recursive: true, force: true});
         }
     });
 
     test('calm --version works', async () => {
-        const { stdout } = await execPromise(calm('--version'));
-        expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/); // basic semver check
+        const { stdout } = await run(calm('--version'));
+        expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
     });
-
 
     test('shows help if no arguments provided', async () => {
-        try {
-            await execPromise(calm(''));
-        } catch (err) {
-            expect(err.stderr).toContain('Usage:');
-        }
+        await expect(
+            run(calm(''))
+        ).rejects.toHaveProperty('stderr', expect.stringContaining('Usage:'));
     });
+
     test('calm -h shows help', async () => {
-        const { stdout } = await execPromise(calm('-h'));
+        const {stdout} = await run(calm('-h'));
         expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
         expect(stdout).toContain('Usage:');
     });
 
     test('calm --help shows help', async () => {
-        const { stdout } = await execPromise(calm('--help'));
+        const {stdout} = await run(calm('--help'));
         expect(stdout).toContain('A set of tools for interacting with the Common Architecture Language Model');
         expect(stdout).toContain('Usage:');
     });
 
-
     test('validate command outputs JSON to stdout', async () => {
         const apiGatewayPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
         const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
-        const cmd = calm(`validate -p ${apiGatewayPath.toString()} -a ${apiGatewayArchPath.toString()}`);
-        const { stdout } = await execPromise(cmd);
-
+        const {stdout} = await run(calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath}`));
         const expected = JSON.parse(fs.readFileSync(path.join(__dirname, '../test_fixtures/validate_output.json'), 'utf8'));
         const parsedOutput = JSON.parse(stdout);
         removeLineNumbers(parsedOutput);
@@ -85,17 +87,10 @@ describe('CLI Integration Tests', () => {
         const apiGatewayPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
         const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
         const targetOutputFile = path.join(tempDir, 'validate-output.json');
-
-        const cmd = calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -o ${targetOutputFile}`);
-        await execPromise(cmd);
-
+        await run(calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -o ${targetOutputFile}`));
         expect(fs.existsSync(targetOutputFile)).toBe(true);
-
-        const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-        const parsedOutput = JSON.parse(outputString);
-
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output.json');
-        const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
+        const expectedJson = JSON.parse(fs.readFileSync(targetOutputFile, 'utf8'));
+        const parsedOutput = JSON.parse(fs.readFileSync(path.join(__dirname, '../test_fixtures/validate_output.json'), 'utf8'));
         removeLineNumbers(parsedOutput);
         removeLineNumbers(expectedJson);
         expect(parsedOutput).toEqual(expectedJson);
@@ -104,115 +99,56 @@ describe('CLI Integration Tests', () => {
     test('validate command outputs JUNIT to stdout', async () => {
         const apiGatewayPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
         const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
-        const cmd = calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -f junit`);
-
-        const { stdout } = await execPromise(cmd);
-        const parsedOutput = await parseStringPromise(stdout);
-
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
-        const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
-        const expectedXml = await parseStringPromise(expectedXmlString);
-
-        expect(parsedOutput).toEqual(expectedXml);
+        const {stdout} = await run(calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -f junit`));
+        const actual = await parseStringPromise(stdout);
+        const expected = await parseStringPromise(fs.readFileSync(path.join(__dirname, '../test_fixtures/validate_output_junit.xml'), 'utf8'));
+        expect(actual).toEqual(expected);
     });
 
     test('validate command outputs JUNIT to file', async () => {
         const apiGatewayPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
         const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
         const targetOutputFile = path.join(tempDir, 'validate-output.xml');
-
-        const cmd = calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -f junit -o ${targetOutputFile}`);
-        await execPromise(cmd);
-
+        await run(calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -f junit -o ${targetOutputFile}`));
         expect(fs.existsSync(targetOutputFile)).toBe(true);
-
-        const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-        const parsedOutput = await parseStringPromise(outputString);
-
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_junit.xml');
-        const expectedXmlString = fs.readFileSync(expectedFilePath, 'utf-8');
-        const expectedXml = await parseStringPromise(expectedXmlString);
-
-        expect(parsedOutput).toEqual(expectedXml);
+        const actual = await parseStringPromise(fs.readFileSync(targetOutputFile, 'utf8'));
+        const expected = await parseStringPromise(fs.readFileSync(path.join(__dirname, '../test_fixtures/validate_output_junit.xml'), 'utf8'));
+        expect(actual).toEqual(expected);
     });
-
 
     test('validate command outputs PRETTY to stdout', async () => {
-        const apiGatewayPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
-        const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
-        const cmd = calm(`validate -p ${apiGatewayPath} -a ${apiGatewayArchPath} -f pretty`);
-
-        const { stdout } = await execPromise(cmd);
-
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_output_pretty.txt');
-        const expectedOutput = fs.readFileSync(expectedFilePath, 'utf-8');
-
-        // Normalize line endings to avoid platform-specific mismatches
-        expect(stdout.replace(/\r\n/g, '\n')).toEqual(expectedOutput.replace(/\r\n/g, '\n'));
+        const p = path.join(__dirname, '../../calm/pattern/api-gateway.json');
+        const a = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
+        const {stdout} = await run(calm(`validate -p ${p} -a ${a} -f pretty`));
+        const expected = fs.readFileSync(path.join(__dirname, '../test_fixtures/validate_output_pretty.txt'), 'utf8');
+        expect(stdout.trim().replace(/\r\n/g, '\n')).toEqual(expected.trim().replace(/\r\n/g, '\n'));
     });
-
-    test('validate command fails when neither architecture nor pattern is provided', async () => {
-        const cmd = calm('validate');
-
-        await expect(execPromise(cmd)).rejects.toMatchObject({
-            stderr: expect.stringContaining(
-                'error: one of the required options \'-p, --pattern <file>\' or \'-a, --architecture <file>\' was not specified'
-            )
-        });
-    });
-
-    test('validate command validates an architecture only', async () => {
-        const apiGatewayArchPath = path.join(__dirname, '../../calm/samples/api-gateway-architecture.json');
-        const targetOutputFile = path.join(tempDir, 'validate-output.json');
-        const cmd = calm(`validate -a ${apiGatewayArchPath} -o ${targetOutputFile}`);
-
-        await execPromise(cmd);
-        const outputFile = fs.readFileSync(targetOutputFile, 'utf-8');
-
-        const parsedOutput = JSON.parse(outputFile);
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/validate_architecture_only_output.json');
-        const expectedOutput = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
-        
-        removeLineNumbers(parsedOutput);
-        removeLineNumbers(expectedOutput);
-        
-        expect(parsedOutput).toEqual(expectedOutput);
-    });
-
-
 
     test('generate command produces the expected output', async () => {
-        const apiGatewayPatternPath = path.join(__dirname, '../../calm/pattern/api-gateway.json');
-        const schemaDirectoryPath = path.join(__dirname, '../../calm/release');
-        const targetOutputFile = path.join(tempDir, 'generate-output.json');
-
-        const cmd = calm(`generate -p ${apiGatewayPatternPath} -o ${targetOutputFile} -s ${schemaDirectoryPath}`);
-        await execPromise(cmd);
-
-        const outputString = fs.readFileSync(targetOutputFile, 'utf-8');
-        const parsedOutput = JSON.parse(outputString);
-
-        const expectedFilePath = path.join(__dirname, '../test_fixtures/generate_output.json');
-        const expectedJson = JSON.parse(fs.readFileSync(expectedFilePath, 'utf-8'));
-
-        expect(parsedOutput).toEqual(expectedJson);
+        const p = path.join(__dirname, '../../calm/pattern/api-gateway.json');
+        const s = path.join(__dirname, '../../calm/release');
+        const out = path.join(tempDir, 'generate-output.json');
+        await run(calm(`generate -p ${p} -o ${out} -s ${s}`));
+        const actual = JSON.parse(fs.readFileSync(out, 'utf8'));
+        const expected = JSON.parse(fs.readFileSync(path.join(__dirname, '../test_fixtures/generate_output.json'), 'utf8'));
+        expect(actual).toEqual(expected);
     });
 
-
     test('server command starts and responds to /health', async () => {
-        // TODO does this actually test anything? 
-        // mock axios.get to return a 200 response and then call axios.get and assert it's 200?
-        (axios.get as Mock).mockResolvedValue({ status: 200, data: { status: 'ok' } });
-        const serverCmd = calm('server -p 3002 --schemaDirectory ../../dist/calm/');
-        const serverProcess = exec(serverCmd);
-
-        await new Promise(res => setTimeout(res, 5 * millisPerSecond));
+        (axios.get as Mock).mockResolvedValue({status: 200, data: {status: 'ok'}});
+        const serverProcess = spawn(calm('server -p 3002 --schemaDirectory ../../dist/calm/'), {
+            cwd: tempDir,
+            shell: true,
+            stdio: 'inherit',
+            detached: true
+        });
+        await new Promise(r => setTimeout(r, 5 * millisPerSecond));
         try {
             const res = await axios.get('http://127.0.0.1:3002/health');
             expect(res.status).toBe(200);
             expect(res.data.status).toBe('ok');
         } finally {
-            serverProcess.kill();
+            process.kill(-serverProcess.pid);
         }
     });
 
@@ -222,14 +158,12 @@ describe('CLI Integration Tests', () => {
         const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
         const templateBundlePath = path.join(fixtureDir, 'template-bundles/doc-system');
         const expectedOutput = path.join(fixtureDir, 'expected-output/cli-e2e-output.html');
-        const outputDir = path.resolve(tempDir, 'output');
+        const outputDir = path.join(tempDir, 'output');
         const outputFile = path.join(outputDir, 'cli-e2e-output.html');
 
-        const cmd = calm(`template --input ${testModelPath} --bundle ${templateBundlePath} --output ${outputDir} --url-to-local-file-mapping ${localDirectory}`);
-        await execPromise(cmd);
+        await run(calm(`template --input ${testModelPath} --bundle ${templateBundlePath} --output ${outputDir} --url-to-local-file-mapping ${localDirectory}`));
 
         expect(fs.existsSync(outputFile)).toBe(true);
-
         const actualContent = fs.readFileSync(outputFile, 'utf8').trim();
         const expectedContent = fs.readFileSync(expectedOutput, 'utf8').trim();
         expect(actualContent).toEqual(expectedContent);
@@ -239,23 +173,16 @@ describe('CLI Integration Tests', () => {
         const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
         const testModelPath = path.join(fixtureDir, 'model/document-system.json');
         const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
-        const outputDir = path.resolve(tempDir, 'output/documentation');
-
-        const expectedFiles = [
+        const outputDir = path.join(tempDir, 'output/documentation');
+        await run(calm(`docify --input ${testModelPath} --output ${outputDir} --url-to-local-file-mapping ${localDirectory}`));
+        [
             'docs/index.md',
             'docs/flows/flow-document-upload.md',
             'docs/nodes/document-system.md',
             'docs/nodes/db-docs.md',
             'docs/nodes/svc-storage.md',
             'docs/nodes/svc-upload.md'
-        ].map(file => path.join(outputDir, file));
-
-        const cmd = calm(`docify --input ${testModelPath} --output ${outputDir} --url-to-local-file-mapping ${localDirectory}`);
-        await execPromise(cmd);
-
-        for (const file of expectedFiles) {
-            expect(fs.existsSync(file)).toBeTruthy();
-        }
+        ].forEach(f => expect(fs.existsSync(path.join(outputDir, f))).toBeTruthy());
     });
 
     test('Getting Started Verification - CLI Steps', async () => {
@@ -263,13 +190,13 @@ describe('CLI Integration Tests', () => {
         const GETTING_STARTED_TEST_FIXTURES_DIR = join(__dirname,'../../cli/test_fixtures/getting-started');
 
         // This will enforce that people verify the getting-started guide works prior to any cli change
-        const { stdout } = await execPromise(calm('--version'));
+        const {stdout} = await run(calm('--version'));
         expect(stdout.trim()).toMatch('0.7.9'); // basic semver check
 
         //STEP 1: Generate Architecture From Pattern
         const inputPattern = path.resolve(GETTING_STARTED_DIR, 'conference-signup.pattern.json');
         const outputArchitecture = path.resolve(tempDir,'conference-signup.arch.json');
-        await execPromise(calm(`generate --pattern ${inputPattern} --output ${outputArchitecture}`));
+        await run(calm(`generate -p ${inputPattern} -o ${outputArchitecture}`));
 
         const expectedOutputArchitecture = path.resolve(GETTING_STARTED_TEST_FIXTURES_DIR,'STEP-1/conference-signup.arch.json');
         await expectFilesMatch(expectedOutputArchitecture, outputArchitecture);
@@ -277,7 +204,7 @@ describe('CLI Integration Tests', () => {
 
         //STEP 2: Generate Docify Website From Architecture
         const outputWebsite = path.resolve(tempDir, 'website');
-        await execPromise(calm(`docify --input ${outputArchitecture} --output ${outputWebsite}`));
+        await run(calm(`docify --input ${outputArchitecture} --output ${outputWebsite}`));
 
         const expectedOutputDocifyWebsite = path.resolve(GETTING_STARTED_TEST_FIXTURES_DIR,'STEP-2/website');
         await expectDirectoryMatch(expectedOutputDocifyWebsite, outputWebsite);
@@ -346,7 +273,7 @@ describe('CLI Integration Tests', () => {
         );
 
         const outputWebsiteWithFlow = path.resolve(tempDir, 'website-with-flow');
-        await execPromise(calm(`docify --input ${outputArchitecture} --output ${outputWebsiteWithFlow} --url-to-local-file-mapping ${directory}`));
+        await run(calm(`docify --input ${outputArchitecture} --output ${outputWebsiteWithFlow} --url-to-local-file-mapping ${directory}`));
 
         const expectedOutputDocifyWebsiteWithFLow = path.resolve(GETTING_STARTED_TEST_FIXTURES_DIR,'STEP-3/website');
         await expectDirectoryMatch(expectedOutputDocifyWebsiteWithFLow, outputWebsiteWithFlow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,13 +173,14 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "0.7.8",
+            "version": "0.7.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^12.0.0",
                 "@inquirer/prompts": "^7.4.1",
                 "commander": "^14.0.0",
                 "copyfiles": "^2.4.1",
+                "execa": "^9.6.0",
                 "express-rate-limit": "^7.5.0",
                 "mkdirp": "^3.0.1",
                 "ts-node": "10.9.2"
@@ -205,6 +206,124 @@
                 "tsup": "^8.4.0",
                 "typescript": "^5.8.3",
                 "xml2js": "^0.6.2"
+            }
+        },
+        "cli/node_modules/execa": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+            "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "cli/node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "cli/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "cli/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "cli/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "cli/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "cli/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "cli/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "docs": {
@@ -7390,6 +7509,12 @@
                 "win32"
             ]
         },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "license": "MIT"
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -7427,6 +7552,18 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@slorber/remark-comment": {
@@ -17119,6 +17256,18 @@
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
             "license": "MIT"
         },
+        "node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -21665,6 +21814,18 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "license": "MIT"
         },
+        "node_modules/parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/parse-numeric-range": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
@@ -23622,6 +23783,21 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-ms": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+            "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/pretty-time": {
@@ -27294,6 +27470,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/unified": {
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -29631,6 +29819,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+            "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"


### PR DESCRIPTION
Cli tests which uses sub-process now prints logs so you can see what the cli tests are doing and can make assertions if required

![image](https://github.com/user-attachments/assets/b7921485-d903-4835-8283-6d4a753f07a6)

This resolves  #1389

