### PR TITLE
Fix incorrect line/character numbers in CALM validate output

### DIFF
--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -117,7 +117,7 @@ describe('validation support functions', () => {
                         'destination',
                         'interface'
                     ],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                    range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
                 }
             ];
 
@@ -145,7 +145,7 @@ describe('validation support functions', () => {
                     message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
                     severity: 0,
                     path: [],
-                    range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                    range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
                 }
             ];
 
@@ -342,7 +342,7 @@ describe('validate pattern and architecture', () => {
                 message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
                 severity: 0,
                 path: ['/nodes'],
-                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
             }
         ];
 
@@ -369,7 +369,7 @@ describe('validate pattern and architecture', () => {
                 message: 'Must not contain string properties set to the empty string or numerical properties set to zero',
                 severity: 0,
                 path: ['/nodes'],
-                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
             }
         ];
 
@@ -396,7 +396,7 @@ describe('validate pattern and architecture', () => {
                 message: 'Test warning',
                 severity: 1,
                 path: ['nodes'],
-                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
             }
         ];
 
@@ -435,7 +435,7 @@ describe('validate pattern only', () => {
                 message: 'Example error',
                 severity: 0,
                 path: ['/nodes'],
-                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
             }
         ];
 
@@ -494,7 +494,7 @@ describe('validate - architecture only', () => {
                 message: 'Example error',
                 severity: 0,
                 path: ['/nodes'],
-                range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+                range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
             }
         ];
 
@@ -581,6 +581,6 @@ function buildISpectralDiagnostic(code: string, message: string, severity: numbe
             'destination',
             'interface'
         ],
-        range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
+        range: { start: { line: 0, character: 1 }, end: { line: 1, character: 1 } }
     };
 }


### PR DESCRIPTION
## Summary
Fixes issue #1401 where line/character numbers in CALM validation output were incorrect, making it difficult for users to locate errors in their source files.

## Problem
The validation process was parsing JSON files into objects and re-serializing them, which destroyed the original formatting and line position information that Spectral needs to provide accurate line/character coordinates.

## Solution
- **Added `getFileAndStringFromUrlOrPath()`**: Returns both parsed object and original string using TypeScript tuples, eliminating duplicate file reads
- **Added `stripRefsFromString()`**: Strips `$ref` properties from JSON strings while preserving original formatting  
- **Updated validation logic**: Uses original JSON strings for Spectral validation while maintaining parsed objects for JSON Schema validation
- **Fixed line number conversion**: Properly converts Spectral's 0-based line numbers to 1-based numbers for human-readable output
- **Updated tests**: Corrected test data to match Spectral's actual 0-based line number behavior

## Test Results
**Before fix:**
- Error at line 11 incorrectly reported as line 10
- All line numbers were off by 1

**After fix:**
- All line numbers now point to correct locations in source files
- Validation errors can be directly navigated to in editors

## Testing
- ✅ All existing tests pass
- ✅ Validated fix with `calm validate --architecture ./calm/getting-started/conference-signup.arch.json`
- ✅ Line numbers now accurately match file content

Closes #1401

🤖 Generated with [Claude Code](https://claude.ai/code)