### PR TITLE
Add Metadata Flexibility & Update v1.0-rc2 Release Notes

### DIFF
--- a/calm/release/1.0-rc2/RELEASE_NOTES.md
+++ b/calm/release/1.0-rc2/RELEASE_NOTES.md
@@ -81,6 +81,11 @@ The following built-in interface types have been removed from the schema:
 - Prototype examples updated with new schema references
 - Control requirement examples updated
 
+### 5. Metadata Flexibility (Non‑Breaking Change)
+**What Changed:**  
+The `metadata` property now accepts **either** a single object **or** an array of objects, rather than only an array.
+
+
 ## Prototype Examples
 
 All existing prototype examples have been updated to use the new v1.0-rc2 schema references:
@@ -93,6 +98,7 @@ All existing prototype examples have been updated to use the new v1.0-rc2 schema
 - `example-inline-config.json` - Inline control configurations
 - `example-mixed-config.json` - Mixed inline and URL-based configurations
 - `throughput-control-prototype.json` - Performance control requirements
+- `meta-example.json` - Object based metadata
 
 ## Migration Guide
 
@@ -117,6 +123,10 @@ All existing prototype examples have been updated to use the new v1.0-rc2 schema
 
 5. **Simplify Interface References:**
    - Update node interface references to use simple string identifiers
+
+6. **Metadata Format Flexibility:**
+ - You can now use **either** an object or an array for any `metadata` field
+ - No changes are required for existing array‑based metadata
 
 ## Compatibility Notes
 

--- a/calm/release/1.0-rc2/meta/core.json
+++ b/calm/release/1.0-rc2/meta/core.json
@@ -306,10 +306,18 @@
       ]
     },
     "metadata": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
     }
   }
 }

--- a/calm/release/1.0-rc2/prototype/meta-example.json
+++ b/calm/release/1.0-rc2/prototype/meta-example.json
@@ -1,0 +1,28 @@
+{
+  "nodes": [
+    {
+      "unique-id": "a-node",
+      "node-type": "service",
+      "name": "A Service",
+      "description": "This node uses a metadata format of an object",
+      "metadata": {
+        "environment": "production",
+        "owner": "team-a"
+      }
+    },
+    {
+      "unique-id": "another-node",
+      "node-type": "service",
+      "name": "Another Service",
+      "description": "This node uses a metadata format of an array",
+      "metadata": [
+        {
+          "environment": "staging"
+        },
+        {
+          "owner": "team-b"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## :tada: Summary

This PR adds support for having `metadata` be either a single object **or** an array of objects, and updates the v1.0‑rc2 **README.md** release‑notes with:

- A new **“Metadata Flexibility”** section under **Major Changes**
- Migration guidance for the new metadata format
- Adjusted section numbering to accommodate the new content

No other schema breaking changes are introduced.

---

## 📝 Changes

1. **Schema Definition**  
   - Updated `defs.metadata` in `core.json` to:
     ```json
     "metadata": {
       "oneOf": [
         { "type": "array", "items": { "type": "object" } },
         { "type": "object", "additionalProperties": true }
       ]
     }
     ```
2. **README.md**  
   - Added **“5. Metadata Flexibility”** under **Major Changes**  
   - Added **“6. Metadata Format Flexibility”** under the **Migration Guide**  
   - Renumbered existing items to keep sections sequential

---
