### PR TITLE
Add homepage and repository details to package.json finos#787

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,11 @@
     "name": "@finos/calm-cli",
     "version": "0.7.9",
     "description": "A set of tools for interacting with the Common Architecture Language Model (CALM)",
+    "homepage": "https://calm.finos.org",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/finos/architecture-as-code.git"
+    },
     "main": "dist/index.js",
     "files": [
         "dist/"


### PR DESCRIPTION
Issue #787 makes comments that the https://www.npmjs.com/package/@finos/calm-cli page was lacking polish.

## Remove docs relating to coding for the CLI and how to publish to npm.
I did not see these present on the npmjs page.

## Consider stripping down the remainder to be more concise.
I have not made changes in this regard, and welcome feedback on whether others consider the current content too verbose.

## Include links to the repo and homepage on the RHS in npm.
This PR adds these links.