### PR TITLE
Fixes docify support for metadata being an object finos#1438

### DIFF
--- a/shared/src/model/metadata.spec.ts
+++ b/shared/src/model/metadata.spec.ts
@@ -46,4 +46,15 @@ describe('CalmMetadata', () => {
             key1: 'value1'
         });
     });
+
+    it('should handle single metadata object', () => {
+        const singleMetadata: CalmMetadataSchema = { key1: 'value1', key2: 'value2' };
+        const metadata = CalmMetadata.fromJson(singleMetadata);
+
+        expect(metadata).toBeInstanceOf(CalmMetadata);
+        expect(metadata.data).toEqual({
+            key1: 'value1',
+            key2: 'value2'
+        });
+    });
 });

--- a/shared/src/model/metadata.ts
+++ b/shared/src/model/metadata.ts
@@ -1,12 +1,12 @@
 import { CalmMetadataSchema } from '../types/metadata-types.js';
 
 export class CalmMetadata {
-    constructor(public data: Record<string, unknown>) {}
+    constructor(public data: Record<string, unknown>) { }
 
     static fromJson(data: CalmMetadataSchema): CalmMetadata {
-        if(!data) return new CalmMetadata({});
+        if (!data) return new CalmMetadata({});
 
-        var flattenedData: Record<string, unknown> = {};
+        let flattenedData: Record<string, unknown> = {};
         if (Array.isArray(data)) {
             flattenedData = data.reduce((acc, curr) => {
                 return { ...acc, ...curr };

--- a/shared/src/model/metadata.ts
+++ b/shared/src/model/metadata.ts
@@ -6,9 +6,15 @@ export class CalmMetadata {
     static fromJson(data: CalmMetadataSchema): CalmMetadata {
         if(!data) return new CalmMetadata({});
 
-        const flattenedData = data.reduce((acc, curr) => {
-            return { ...acc, ...curr };
-        }, {} as Record<string, unknown>);
+        var flattenedData: Record<string, unknown> = {};
+        if (Array.isArray(data)) {
+            flattenedData = data.reduce((acc, curr) => {
+                return { ...acc, ...curr };
+            }, {} as Record<string, unknown>);
+        } else {
+            // If data is not an array, we assume it's a single object
+            flattenedData = data;
+        }
 
         return new CalmMetadata(flattenedData);
     }

--- a/shared/src/types/metadata-types.ts
+++ b/shared/src/types/metadata-types.ts
@@ -1,1 +1,3 @@
-export type CalmMetadataSchema = Record<string, unknown>[];
+export type CalmMetadataSchema =
+    Record<string, unknown>[]
+    | Record<string, unknown>;


### PR DESCRIPTION
This document would fail to docify, because the metadata type in cli accepted only array-of-object. Schema allows array-of-object or object.

```
{
    "metadata" : {
        "name": "test case"
    }
}
```