### PR TITLE
Add example interface type definitions for CALM examples to refer to

### DIFF
--- a/calm/interfaces/example/README.md
+++ b/calm/interfaces/example/README.md
@@ -1,0 +1,5 @@
+# Example interfaces
+
+This directory contains interface types that are considered examples and may only be partially well-formed.
+
+References to them should only be made from within the `finos/architecture-as-code` repository examples as they may change without warning.

--- a/calm/interfaces/example/container-image.json
+++ b/calm/interfaces/example/container-image.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/interfaces/example/container-image",
+  "title": "Container Image Interface",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "string",
+      "description": "Location of the container image, for example in the format 'registry/repository:tag'."
+    }
+  },
+  "required": ["image"],
+  "examples": [
+    {
+      "image": "docker.io/library/nginx:latest"
+    },
+    {
+      "image": "calm.finos.org/images/repository:version"
+    }
+  ]
+}

--- a/calm/interfaces/example/tcp-host-port.json
+++ b/calm/interfaces/example/tcp-host-port.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/interfaces/example/tcp-host-port",
+  "title": "TCP Host / Port Interface",
+  "type": "object",
+  "properties": {
+    "host": {
+      "type": "string",
+      "format": "hostname",
+      "description": "The hostname or IP"
+    },
+    "port": {
+      "type": "integer",
+      "description": "The port on which connections are accepted",
+      "minimum": 1,
+      "maximum": 65535
+    }
+  },
+  "required": ["host", "port"],
+  "examples": [
+    {
+      "host": "localhost",
+      "port": 8080
+    },
+    {
+      "host": "example.com",
+      "port": 443
+    }
+  ]
+}

--- a/calm/interfaces/example/tcp-port.json
+++ b/calm/interfaces/example/tcp-port.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/interfaces/example/tcp-port",
+  "title": "TCP Port Interface",
+  "description": "This interface defines a TCP port configuration for a service or application. It specifies the port number on which the service will accept connections.",
+  "type": "object",
+  "properties": {
+    "port": {
+      "type": "integer",
+      "description": "The port on which connections are accepted",
+      "minimum": 1,
+      "maximum": 65535
+    }
+  },
+  "required": ["port"],
+  "examples": [
+    {
+      "port": 8080
+    },
+    {
+      "port": 443
+    }
+  ]
+}

--- a/calm/interfaces/example/url.json
+++ b/calm/interfaces/example/url.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calm.finos.org/interfaces/example/url",
+  "title": "URL Interface",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "format": "hostname",
+      "description": "The URL"
+    }
+  },
+  "required": ["url"],
+  "examples": [
+    {
+      "url": "https://example.com"
+    },
+    {
+      "url": "http://localhost:8080/api/v1/resource"
+    }
+  ]
+}


### PR DESCRIPTION
Need to add before referring to them so that `calm generate` can reference. #1238

This is work required to remove 1.0-rc1 references from examples such as the getting-started guide, which has the `conference-signup.pattern.json` use 1.0-rc2 schema, apart from its interfaces.

Our example guides should always use the latest and greatest.

Was discussed in #1453 with @rocketstack-matt that we should add some interface types to the `calm/interfaces` folder to be used in examples.

When/If we consider these interface definitions more than fit for examples we could change the folder name.

