### PR TITLE
Add support for --template and --template-dir (#1469)

### DIFF
--- a/cli/src/cli.e2e.spec.ts
+++ b/cli/src/cli.e2e.spec.ts
@@ -317,6 +317,47 @@ describe('CLI Integration Tests', () => {
         expect(actualContent).toEqual(expectedContent);
     });
 
+
+    test('template command works with --template mode', async () => {
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
+        const templatePath = path.join(fixtureDir, 'self-provided/single-template.hbs');
+        const expectedOutputPath = path.join(fixtureDir, 'expected-output/single-template-output.md');
+        const outputDir = path.join(tempDir, 'output-single-template');
+        const outputFile = path.join(outputDir, 'simple-template-output.md');
+
+        await run(
+            calm(
+                `template --input ${testModelPath} --template ${templatePath} --output ${outputFile} --url-to-local-file-mapping ${localDirectory}`
+            )
+        );
+
+        expect(fs.existsSync(outputFile)).toBe(true);
+        const actual = fs.readFileSync(outputFile, 'utf8').trim();
+        const expected = fs.readFileSync(expectedOutputPath, 'utf8').trim();
+        expect(actual).toEqual(expected);
+    });
+
+    test('template command works with --template-dir mode', async () => {
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
+        const templateDirPath = path.join(fixtureDir, 'self-provided/template-dir');
+        const expectedOutputDir = path.join(fixtureDir, 'expected-output/template-dir');
+        const actualOutputDir = path.join(tempDir, 'output-template-dir');
+
+        await run(
+            calm(
+                `template --input ${testModelPath} --template-dir ${templateDirPath} --output ${actualOutputDir} --url-to-local-file-mapping ${localDirectory}`
+            )
+        );
+
+        await expectDirectoryMatch(expectedOutputDir, actualOutputDir);
+    });
+
+
+
     test('docify command generates expected files', async () => {
         const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
         const testModelPath = path.join(
@@ -344,6 +385,46 @@ describe('CLI Integration Tests', () => {
             expect(fs.existsSync(path.join(outputDir, f))).toBeTruthy()
         );
     });
+
+
+    test('docify command works with --template mode', async () => {
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
+        const templatePath = path.join(fixtureDir, 'self-provided/single-template.hbs');
+        const expectedOutputPath = path.join(fixtureDir, 'expected-output/single-template-output.md');
+        const outputDir = path.join(tempDir, 'output-single-template');
+        const outputFile = path.join(outputDir, 'simple-template-output.md');
+
+        await run(
+            calm(
+                `docify --input ${testModelPath} --template ${templatePath} --output ${outputFile} --url-to-local-file-mapping ${localDirectory}`
+            )
+        );
+
+        expect(fs.existsSync(outputFile)).toBe(true);
+        const actual = fs.readFileSync(outputFile, 'utf8').trim();
+        const expected = fs.readFileSync(expectedOutputPath, 'utf8').trim();
+        expect(actual).toEqual(expected);
+    });
+
+    test('docify command works with --template-dir mode', async () => {
+        const fixtureDir = path.resolve(__dirname, '../test_fixtures/template');
+        const testModelPath = path.join(fixtureDir, 'model/document-system.json');
+        const localDirectory = path.join(fixtureDir, 'model/url-to-file-directory.json');
+        const templateDirPath = path.join(fixtureDir, 'self-provided/template-dir');
+        const expectedOutputDir = path.join(fixtureDir, 'expected-output/template-dir');
+        const actualOutputDir = path.join(tempDir, 'output-template-dir');
+
+        await run(
+            calm(
+                `docify --input ${testModelPath} --template-dir ${templateDirPath} --output ${actualOutputDir} --url-to-local-file-mapping ${localDirectory}`
+            )
+        );
+
+        await expectDirectoryMatch(expectedOutputDir, actualOutputDir);
+    });
+
 
     test('Getting Started Verification - CLI Steps', async () => {
         const GETTING_STARTED_DIR = join(

--- a/cli/test_fixtures/template/expected-output/single-template-output.md
+++ b/cli/test_fixtures/template/expected-output/single-template-output.md
@@ -1,0 +1,1 @@
+document-system

--- a/cli/test_fixtures/template/expected-output/template-dir/nodes.md
+++ b/cli/test_fixtures/template/expected-output/template-dir/nodes.md
@@ -1,0 +1,30 @@
+# All Nodes
+
+## Node: DocuFlow
+
+- **ID**: document-system
+- **Type**: system
+- **Description**: Main document management system
+
+---
+## Node: Upload Service
+
+- **ID**: svc-upload
+- **Type**: service
+- **Description**: Handles user document uploads
+
+---
+## Node: Storage Service
+
+- **ID**: svc-storage
+- **Type**: service
+- **Description**: Stores and retrieves documents securely
+
+---
+## Node: Document Database
+
+- **ID**: db-docs
+- **Type**: database
+- **Description**: Stores metadata and document references
+
+---

--- a/cli/test_fixtures/template/expected-output/template-dir/relationships.md
+++ b/cli/test_fixtures/template/expected-output/template-dir/relationships.md
@@ -1,0 +1,17 @@
+# All Relationships
+
+## Relationship: rel-upload-to-storage
+
+- **Description**: Upload Service sends documents to Storage Service for long-term storage
+
+---
+## Relationship: rel-storage-to-db
+
+- **Description**: Storage Service stores document metadata in the Document Database
+
+---
+## Relationship: document-system-system-is-composed-of
+
+- **Description**: Document System contains services
+
+---

--- a/cli/test_fixtures/template/self-provided/single-template.hbs
+++ b/cli/test_fixtures/template/self-provided/single-template.hbs
@@ -1,0 +1,3 @@
+{{#with nodes.[0]}}
+  {{uniqueId}}
+{{/with}}

--- a/cli/test_fixtures/template/self-provided/template-dir/nodes.md
+++ b/cli/test_fixtures/template/self-provided/template-dir/nodes.md
@@ -1,0 +1,11 @@
+# All Nodes
+
+{{#each nodes}}
+## Node: {{name}}
+
+- **ID**: {{uniqueId}}
+- **Type**: {{nodeType}}
+- **Description**: {{description}}
+
+---
+{{/each}}

--- a/cli/test_fixtures/template/self-provided/template-dir/relationships.md
+++ b/cli/test_fixtures/template/self-provided/template-dir/relationships.md
@@ -1,0 +1,9 @@
+# All Relationships
+
+{{#each relationships}}
+## Relationship: {{uniqueId}}
+
+- **Description**: {{description}}
+
+---
+{{/each}}

--- a/shared/src/docify/docifier.spec.ts
+++ b/shared/src/docify/docifier.spec.ts
@@ -1,6 +1,7 @@
 import { Docifier } from './docifier';
 import { TemplateProcessor } from '../template/template-processor';
 import { Mock } from 'vitest';
+
 vi.mock('../template/template-processor');
 
 const MockedTemplateProcessor: Mock = vi.mocked(TemplateProcessor);
@@ -22,7 +23,6 @@ describe('Docifier', () => {
 
     it('should instantiate TemplateProcessor for mode "WEBSITE" and call processTemplate', async () => {
         const processTemplateMock = vi.fn().mockResolvedValue(undefined);
-
         MockedTemplateProcessor.mockImplementationOnce(() => ({
             processTemplate: processTemplateMock,
         }));
@@ -34,9 +34,59 @@ describe('Docifier', () => {
             inputPath,
             expect.stringContaining('template-bundles/docusaurus'),
             outputPath,
-            urlToLocalPathMapping
+            urlToLocalPathMapping,
+            'bundle'
+        );
+        expect(processTemplateMock).toHaveBeenCalled();
+    });
+
+    it('should throw if USER_PROVIDED mode is used without templatePath', () => {
+        expect(() => {
+            new Docifier('USER_PROVIDED', inputPath, outputPath, urlToLocalPathMapping);
+        }).toThrowError('USER_PROVIDED mode requires an explicit templatePath.');
+    });
+
+    it('should use provided templatePath in USER_PROVIDED mode', async () => {
+        const processTemplateMock = vi.fn().mockResolvedValue(undefined);
+        MockedTemplateProcessor.mockImplementationOnce(() => ({
+            processTemplate: processTemplateMock,
+        }));
+
+        const customTemplatePath = '/custom/templates/';
+        const docifier = new Docifier(
+            'USER_PROVIDED',
+            inputPath,
+            outputPath,
+            urlToLocalPathMapping,
+            'template-directory',
+            customTemplatePath
+        );
+
+        await docifier.docify();
+
+        expect(MockedTemplateProcessor).toHaveBeenCalledWith(
+            inputPath,
+            customTemplatePath,
+            outputPath,
+            urlToLocalPathMapping,
+            'template-directory'
         );
 
         expect(processTemplateMock).toHaveBeenCalled();
+    });
+
+    it('should use fallback path from TEMPLATE_BUNDLE_PATHS if templatePath not provided', async () => {
+        const processTemplateMock = vi.fn().mockResolvedValue(undefined);
+        MockedTemplateProcessor.mockImplementationOnce(() => ({
+            processTemplate: processTemplateMock,
+        }));
+
+        const docifier = new Docifier('WEBSITE', inputPath, outputPath, urlToLocalPathMapping);
+        await docifier.docify();
+
+        const [[calledInput, calledTemplatePath]] = MockedTemplateProcessor.mock.calls;
+
+        expect(calledInput).toBe(inputPath);
+        expect(calledTemplatePath).toMatch(/template-bundles\/docusaurus/);
     });
 });

--- a/shared/src/docify/docifier.ts
+++ b/shared/src/docify/docifier.ts
@@ -1,27 +1,42 @@
-import { TemplateProcessor } from '../template/template-processor.js';
+import {TemplateProcessingMode, TemplateProcessor} from '../template/template-processor.js';
 
-export type DocifyMode = 'SAD' | 'WEBSITE';
+export type DocifyMode = 'SAD' | 'WEBSITE' | 'USER_PROVIDED';
 
 export class Docifier {
     private static readonly TEMPLATE_BUNDLE_PATHS: Record<DocifyMode, string> = {
         SAD: __dirname + '/template-bundles/sad',
         WEBSITE: __dirname + '/template-bundles/docusaurus',
+        USER_PROVIDED: __dirname + '/template-bundles/null-pattern'
     };
 
     private templateProcessor: TemplateProcessor;
 
-    constructor(mode: DocifyMode, inputPath: string, outputPath: string, urlToLocalPathMapping: Map<string, string>) {
+    constructor(
+        mode: DocifyMode,
+        inputPath: string,
+        outputPath: string,
+        urlToLocalPathMapping: Map<string, string>,
+        templateProcessingMode: TemplateProcessingMode = 'bundle',
+        templatePath?: string
+    ) {
         if (mode === 'SAD') {
             throw new Error('Mode "SAD" is not supported.');
         }
 
-        const templateBundlePath = Docifier.TEMPLATE_BUNDLE_PATHS[mode];
-
-        if (!templateBundlePath) {
-            throw new Error(`Invalid mode: ${mode}`);
+        if (mode === 'USER_PROVIDED' && !templatePath) {
+            throw new Error('USER_PROVIDED mode requires an explicit templatePath.');
         }
 
-        this.templateProcessor = new TemplateProcessor(inputPath, templateBundlePath, outputPath, urlToLocalPathMapping);
+        const finalTemplatePath =
+            templatePath ?? Docifier.TEMPLATE_BUNDLE_PATHS[mode];
+
+        this.templateProcessor = new TemplateProcessor(
+            inputPath,
+            finalTemplatePath,
+            outputPath,
+            urlToLocalPathMapping,
+            templateProcessingMode
+        );
     }
 
     public async docify(): Promise<void> {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -13,7 +13,7 @@ export { ValidationOutput } from './commands/validate/validation.output.js';
 export { CALM_META_SCHEMA_DIRECTORY } from './consts.js';
 export { SchemaDirectory } from './schema-directory.js';
 export { initLogger } from './logger.js';
-export { TemplateProcessor } from './template/template-processor.js';
+export { TemplateProcessor, TemplateProcessingMode } from './template/template-processor.js';
 export * from './template/types.js';
 export * from './types/core-types.js';
 export { Docifier, DocifyMode } from './docify/docifier.js';

--- a/shared/src/template/template-engine.ts
+++ b/shared/src/template/template-engine.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import Handlebars from 'handlebars';
 import { IndexFile, TemplateEntry, CalmTemplateTransformer } from './types.js';
-import { TemplateBundleFileLoader } from './template-bundle-file-loader.js';
+import {ITemplateBundleLoader} from './template-bundle-file-loader.js';
 import { initLogger } from '../logger.js';
 import fs from 'fs';
 import path from 'path';
@@ -13,7 +13,7 @@ export class TemplateEngine {
     private transformer: CalmTemplateTransformer;
     private static logger = initLogger(process.env.DEBUG === 'true', TemplateEngine.name);
 
-    constructor(fileLoader: TemplateBundleFileLoader, transformer: CalmTemplateTransformer) {
+    constructor(fileLoader: ITemplateBundleLoader, transformer: CalmTemplateTransformer) {
         this.config = fileLoader.getConfig();
         this.transformer = transformer;
         this.templates = this.compileTemplates(fileLoader.getTemplateFiles());


### PR DESCRIPTION
The following changes have been completed on PR

- calm docify and calm template supports --template and --template-dir. 
- CLI validation ensures one (and only one) template flag is used e.g. you can't do --bundle and --template 
- Default behavior for calm-docify remains for `WEBSITE` bundle if no flag provided
- Tests added for both unit and integration coverage for new options. As well as cleaned up some unit test assertions in the cli to confirm the internal template processor is being called. 
