### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/s3-sync.yml
+++ b/.github/workflows/s3-sync.yml
@@ -1,5 +1,8 @@
 name: Sync CALM to S3
 
+permissions:
+    contents: read
+
 on:
     workflow_dispatch: {}
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/39](https://github.com/finos/architecture-as-code/security/code-scanning/39)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimal required permissions for the job. Since the workflow only checks out code and syncs files to S3 (using AWS credentials, not the GITHUB_TOKEN), it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow file (before `jobs:`), which will apply to all jobs in the workflow unless overridden. No changes to the steps or AWS credentials are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
