### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/s3-docs-sync.yml
+++ b/.github/workflows/s3-docs-sync.yml
@@ -1,4 +1,6 @@
 name: Sync Docs to S3
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/37](https://github.com/finos/architecture-as-code/security/code-scanning/37)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimal required permissions for the GITHUB_TOKEN. In this case, the workflow only needs to check out code and interact with AWS (using secrets), but does not need to write to the repository or interact with issues, pull requests, or other resources. Therefore, setting `contents: read` is sufficient and recommended. The best place to add this is at the top level of the workflow file, just after the `name` field, so it applies to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
