### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-scanning-node.yml
+++ b/.github/workflows/license-scanning-node.yml
@@ -1,4 +1,6 @@
 name: License Scanning for Node.js
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/30](https://github.com/finos/architecture-as-code/security/code-scanning/30)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs local commands, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` block. This will apply the permission restriction to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
