### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-calm-hub-coverage.yml
+++ b/.github/workflows/build-calm-hub-coverage.yml
@@ -1,4 +1,6 @@
 name: Build Calm Hub For Unit Test Coverage
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/29](https://github.com/finos/architecture-as-code/security/code-scanning/29)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents, set `contents: read` at the top level of the workflow (just after the `name:` line and before `on:`). This will apply the restriction to all jobs in the workflow. No other changes are needed, as none of the steps require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
