### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-spectral.yml
+++ b/.github/workflows/validate-spectral.yml
@@ -1,4 +1,6 @@
 name: Validation of CALM Samples
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/28](https://github.com/finos/architecture-as-code/security/code-scanning/28)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The minimal starting point recommended by CodeQL is `contents: read`, which is sufficient for most workflows that only need to read repository contents. Since the workflow only checks out code and runs local validation (Spectral linting), it does not appear to require any write permissions. The best way to fix this is to add the following block at the root level of the workflow (just after the `name:` line and before the `on:` block):

```yaml
permissions:
  contents: read
```

This change should be made in `.github/workflows/validate-spectral.yml` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
