### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -1,4 +1,6 @@
 name: Semgrep
+permissions:
+  contents: read
 on:
   workflow_dispatch: {}
   pull_request: {}


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/27](https://github.com/finos/architecture-as-code/security/code-scanning/27)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only runs Semgrep, which analyzes code and does not need to write to the repository, the minimal required permission is `contents: read`. This can be set either at the workflow level (applies to all jobs) or at the job level (applies only to the `semgrep` job). The best way to fix this is to add the following block at the top level of the workflow file, just after the `name` field and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
