### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/s3-video-sync.yml
+++ b/.github/workflows/s3-video-sync.yml
@@ -1,4 +1,6 @@
 name: Sync Videos to S3
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/26](https://github.com/finos/architecture-as-code/security/code-scanning/26)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and syncs files to S3 (using AWS credentials, not the `GITHUB_TOKEN`), it only needs `contents: read` permission. The best place to add this is at the top level of the workflow, just after the `name` field, so it applies to all jobs. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
