### PR TITLE
fix(shared): honour user's selected log level in validation option selection logic

### DIFF
--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -50,7 +50,7 @@ describe('validate E2E', () => {
                 readFileSync(path.join(__dirname, '../../../test_fixtures/command/validate/options/pattern-resolved.json'), 'utf8')
             );
 
-            const newPattern = applyArchitectureOptionsToPattern(architecture, pattern);
+            const newPattern = applyArchitectureOptionsToPattern(architecture, pattern, false);
             expect(newPattern).toStrictEqual(expectedResult);
         });
     });

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -133,7 +133,7 @@ async function validateArchitectureAgainstPattern(architecture: object, pattern:
     let errors = spectralResult.errors;
     const warnings = spectralResult.warnings;
 
-    const patternResolved = applyArchitectureOptionsToPattern(architecture, pattern);
+    const patternResolved = applyArchitectureOptionsToPattern(architecture, pattern, debug);
 
     const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, patternResolved, debug);
     await jsonSchemaValidator.initialize();
@@ -208,14 +208,14 @@ async function validateArchitectureOnly(architecture: object): Promise<Validatio
  * @param pattern Pattern which may contain options.
  * @returns Pattern with options applied and flattened.
  */
-export function applyArchitectureOptionsToPattern(architecture: object, pattern: object): object {
+export function applyArchitectureOptionsToPattern(architecture: object, pattern: object, debug: boolean): object {
 
     const choices: CalmChoice[] = extractChoicesFromArchitecture(architecture);
     if (choices.length === 0) {
         return pattern;
     }
 
-    return selectChoices(pattern, choices, true);
+    return selectChoices(pattern, choices, debug);
 }
 
 export function extractChoicesFromArchitecture(architecture: object): CalmChoice[] {


### PR DESCRIPTION
## Description
The fix for #1574 did not pass the user's chosen debug level down to the option selection code. This meant that debug level logs were output during a `calm validate` command even though `--verbose` had not been specified

This PR fixes that bug.

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [X] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [ ] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [X] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
