### PR TITLE
fix(ci): Ensure consistency of dependency check locally and remote

### DIFF
--- a/.github/workflows/cve-scanning-maven.yml
+++ b/.github/workflows/cve-scanning-maven.yml
@@ -36,33 +36,15 @@ jobs:
                   cache: maven
                   distribution: 'adopt'
 
-            - name: Build with Maven
-              run: mvn -U -DskipTests verify -Ddependency-check.skip=true
+            - name: Build and run dependency check with Maven
+              run: mvn -U clean verify -DskipTests -P dependency-check
               working-directory: ${{ matrix.module-folder }}
-
-            - name: Depcheck
-              uses: dependency-check/Dependency-Check_Action@main
-              id: Depcheck
               env:
-                  JAVA_HOME: /opt/jdk
-              with:
-                  project: '${{ matrix.module-folder }}'
-                  path: '${{ matrix.module-folder }}'
-                  format: 'HTML'
-                  out: '${{ matrix.module-folder }}-reports'
-                  args: >
-                      --suppression .github/maven-cve-ignore-list.xml
-                      --failOnCVSS 5
-                      --enableRetired
-                      --exclude "**/package.json"
-                      --exclude "**/package-lock.json"
-                      --disableNodeAudit
-                      --disableYarnAudit
-                      --disableRetireJS
+                  NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
             - name: Upload Test results
               if: ${{ always() }}
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: Depcheck report ${{ github.job }} ${{ matrix.module-folder }}
-                  path: ${{ github.workspace }}/${{ matrix.module-folder }}-reports
+                  path: ${{ github.workspace }}/${{ matrix.module-folder }}/target/dependency-check-report.*

--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -131,33 +131,6 @@
     </dependencies>
     <build>
         <plugins>
-            <!-- OWASP Dependency Check Plugin -->
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>12.1.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <!-- Optional configuration: reuse suppression file if present -->
-                <configuration>
-                    <formats>HTML,JSON</formats>
-                    <failOnError>true</failOnError>
-                    <skipSystemScope>true</skipSystemScope>
-                    <!-- Disable .NET analyzers to avoid dotnet requirement -->
-                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                    <csharpAnalyzerEnabled>false</csharpAnalyzerEnabled>
-                    <!-- Use environment-provided NVD API Key -->
-                    <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
-                    <suppressionFiles>
-                        <suppressionFile>${project.basedir}/../.github/maven-cve-ignore-list.xml</suppressionFile>
-                    </suppressionFiles>
-                </configuration>
-            </plugin>
             <!-- Quarkus Maven Plugin -->
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -364,6 +337,42 @@
                             <includes>
                                 <include>**/*Integration.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dependency-check</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- OWASP Dependency Check Plugin -->
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>12.1.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <!-- Optional configuration: reuse suppression file if present -->
+                        <configuration>
+                            <formats>HTML,JSON</formats>
+                            <failOnError>true</failOnError>
+                            <skipSystemScope>true</skipSystemScope>
+                            <!-- Disable .NET analyzers to avoid dotnet requirement -->
+                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <!-- Use environment-provided NVD API Key, fallback to Maven property -->
+                            <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
+                            <suppressionFiles>
+                                <suppressionFile>${project.basedir}/../.github/maven-cve-ignore-list.xml</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Description
* Add dependency-check plugin and profile to calm-hub pom
* Replace standalone CVE task which reports inconsistent results with the standard checker

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [x] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
