### PR TITLE
fix(calm-plugins): change publisher to FINOS

### DIFF
--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -3,7 +3,7 @@
     "displayName": "CALM Preview & Tools",
     "description": "Live-visualize CALM architecture models, validate, and generate docs.",
     "version": "0.0.1",
-    "publisher": "local",
+    "publisher": "FINOS",
     "repository": {
         "type": "git",
         "url": "https://github.com/finos/architecture-as-code.git"


### PR DESCRIPTION
## Description
Change the VScode publisher to FINOS to allow publishing to market place

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD


