### PR TITLE
refactor(calm-hub-ui): refactor drawer component

### DIFF
--- a/calm-hub-ui/src/visualizer/components/cytoscape/cytoscape-renderer/CytoscapeRenderer.tsx
+++ b/calm-hub-ui/src/visualizer/components/cytoscape/cytoscape-renderer/CytoscapeRenderer.tsx
@@ -1,7 +1,7 @@
 import './cytoscape.css';
 import { useEffect, useRef } from 'react';
 import cytoscape, { EdgeSingular, NodeSingular } from 'cytoscape';
-import { CytoscapeNode, Edge } from '../../../contracts/contracts.js';
+import { CytoscapeNode, CytoscapeEdge } from '../../../contracts/contracts.js';
 import { LayoutCorrectionService } from '../../../services/layout-correction-service.js';
 import {
     saveNodePositions,
@@ -26,9 +26,9 @@ export interface CytoscapeRendererProps {
     isNodeDescActive: boolean;
     isRelationshipDescActive: boolean;
     nodes: CytoscapeNode[];
-    edges: Edge[];
+    edges: CytoscapeEdge[];
     nodeClickedCallback: (x: CytoscapeNode['data']) => void;
-    edgeClickedCallback: (x: Edge['data']) => void;
+    edgeClickedCallback: (x: CytoscapeEdge['data']) => void;
     backgroundClickedCallback?: () => void;
     selectedItemId?: string;
     calmKey: string;

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -1,70 +1,21 @@
-import { Sidebar } from '../sidebar/Sidebar.js';
 import { useCallback, useEffect, useState } from 'react';
-import {
-    CalmArchitectureSchema,
-    CalmNodeSchema,
-} from '../../../../../calm-models/src/types/core-types.js';
-import { CytoscapeNode, Edge } from '../../contracts/contracts.js';
+import { CalmArchitectureSchema } from '../../../../../calm-models/src/types/core-types.js';
+import { CytoscapeNode, CytoscapeEdge } from '../../contracts/contracts.js';
 import { VisualizerContainer } from '../visualizer-container/VisualizerContainer.js';
 import { Data } from '../../../model/calm.js';
 import { useDropzone } from 'react-dropzone';
+import { convertCalmToCytoscape } from '../../services/calm-to-cytoscape-converter.js';
+import { Sidebar } from '../sidebar/Sidebar.js';
 
 interface DrawerProps {
     data?: Data; // Optional data prop passed in from CALM Hub if user navigates from there
-}
-
-function getComposedOfRelationships(calmInstance: CalmArchitectureSchema) {
-    const composedOfRelationships: {
-        [idx: string]: {
-            type: 'parent' | 'child';
-            parent?: string;
-        };
-    } = {};
-
-    calmInstance.relationships?.forEach((relationship) => {
-        const rel = relationship['relationship-type']['composed-of'];
-        if (rel) {
-            composedOfRelationships[rel!['container']] = { type: 'parent' };
-            rel!['nodes'].forEach((node) => {
-                composedOfRelationships[node] = {
-                    type: 'child',
-                    parent: rel!['container'],
-                };
-            });
-        }
-    });
-
-    return composedOfRelationships;
-}
-
-function getDeployedInRelationships(calmInstance: CalmArchitectureSchema) {
-    const deployedInRelationships: {
-        [idx: string]: {
-            type: 'parent' | 'child';
-            parent?: string;
-        };
-    } = {};
-    calmInstance.relationships?.forEach((relationship) => {
-        const rel = relationship['relationship-type']['deployed-in'];
-        if (rel) {
-            deployedInRelationships[rel['container']] = { type: 'parent' };
-            rel['nodes'].forEach((node) => {
-                deployedInRelationships[node] = {
-                    type: 'child',
-                    parent: rel['container'],
-                };
-            });
-        }
-    });
-
-    return deployedInRelationships;
 }
 
 export function Drawer({ data }: DrawerProps) {
     const [title, setTitle] = useState<string>('');
     const [calmInstance, setCALMInstance] = useState<CalmArchitectureSchema | undefined>(undefined);
     const [fileInstance, setFileInstance] = useState<string | undefined>(undefined);
-    const [selectedNode, setSelectedNode] = useState<CytoscapeNode | Edge | null>(null);
+    const [selectedItem, setSelectedItem] = useState<CytoscapeNode | CytoscapeEdge | null>(null);
 
     const onDrop = useCallback(async (acceptedFiles: File[]) => {
         if (acceptedFiles[0]) {
@@ -85,97 +36,7 @@ export function Drawer({ data }: DrawerProps) {
     }, [fileInstance, data]);
 
     function closeSidebar() {
-        setSelectedNode(null);
-    }
-
-    function generateDisplayPlaceHolderWithoutDesc(node: CalmNodeSchema): string {
-        return `${node.name}\n[${node['node-type']}]`;
-    }
-
-    function getNodes(): CytoscapeNode[] {
-        if (!calmInstance || !calmInstance.relationships) return [];
-
-        const composedOfRelationships = getComposedOfRelationships(calmInstance);
-        const deployedInRelationships = getDeployedInRelationships(calmInstance);
-
-        return (calmInstance.nodes ?? []).map((node) => {
-            const newData: CytoscapeNode = {
-                classes: 'node',
-                data: {
-                    id: node['unique-id'],
-                    name: node.name,
-                    description: node.description,
-                    type: node['node-type'],
-                    cytoscapeProps: {
-                        labelWithDescription: `${generateDisplayPlaceHolderWithoutDesc(node)}\n\n${node.description}\n`,
-                        labelWithoutDescription: `${generateDisplayPlaceHolderWithoutDesc(node)}`,
-                    },
-                },
-            };
-
-            if (node.interfaces) {
-                newData.data.interfaces = node.interfaces;
-            }
-
-            if (node.controls) {
-                newData.data.controls = node.controls;
-            }
-
-            const composedOfRel = composedOfRelationships[node['unique-id']];
-            const deployedInRel = deployedInRelationships[node['unique-id']];
-
-            if (composedOfRel?.type === 'parent' || deployedInRel?.type === 'parent') {
-                newData.classes = 'group';
-            }
-
-            const parentId =
-                composedOfRel?.type === 'child' && composedOfRel.parent
-                    ? composedOfRel.parent
-                    : deployedInRel?.type === 'child' && deployedInRel.parent
-                      ? deployedInRel.parent
-                      : undefined;
-
-            if (parentId) {
-                newData.data.parent = parentId;
-            }
-            return newData;
-        });
-    }
-
-    function getEdges(): Edge[] {
-        if (!calmInstance || !calmInstance.relationships) return [];
-
-        return calmInstance.relationships
-            .filter(
-                (relationship) =>
-                    !relationship['relationship-type']['composed-of'] &&
-                    !relationship['relationship-type']['deployed-in']
-            )
-            .map((relationship) => {
-                if (relationship['relationship-type'].interacts) {
-                    return {
-                        data: {
-                            id: relationship['unique-id'],
-                            label: relationship.description || '',
-                            source: relationship['relationship-type'].interacts.actor,
-                            target: relationship['relationship-type'].interacts.nodes[0],
-                        },
-                    };
-                }
-                if (relationship['relationship-type'].connects) {
-                    const source = relationship['relationship-type'].connects.source.node;
-                    const target = relationship['relationship-type'].connects.destination.node;
-                    return {
-                        data: {
-                            id: relationship['unique-id'],
-                            label: relationship.description || '',
-                            source,
-                            target,
-                        },
-                    };
-                }
-            })
-            .filter((edge): edge is Edge => edge !== undefined);
+        setSelectedItem(null);
     }
 
     function createStorageKey(title: string, data?: Data): string {
@@ -185,18 +46,17 @@ export function Drawer({ data }: DrawerProps) {
         return `${data.name}/${data.calmType}/${data.id}/${data.version}`;
     }
 
-    const edges = getEdges();
-    const nodes = getNodes();
+    const { edges, nodes } = convertCalmToCytoscape(calmInstance);
 
     return (
         <div {...getRootProps()} className="flex-1 flex overflow-hidden h-screen">
             {!calmInstance && <input {...getInputProps()} />}
-            <div className={`drawer drawer-end ${selectedNode ? 'drawer-open' : ''} w-full`}>
+            <div className={`drawer drawer-end ${selectedItem ? 'drawer-open' : ''} w-full`}>
                 <input
                     type="checkbox"
                     aria-label="drawer-toggle"
                     className="drawer-toggle"
-                    checked={!!selectedNode}
+                    checked={!!selectedItem}
                     onChange={closeSidebar}
                 />
                 <div className="drawer-content">
@@ -206,10 +66,10 @@ export function Drawer({ data }: DrawerProps) {
                             nodes={nodes}
                             edges={edges}
                             calmKey={createStorageKey(title, data)}
-                            nodeClickedCallback={(nodeData) => setSelectedNode({ data: nodeData })}
-                            edgeClickedCallback={(edgeData) => setSelectedNode({ data: edgeData })}
+                            nodeClickedCallback={(nodeData) => setSelectedItem({ data: nodeData })}
+                            edgeClickedCallback={(edgeData) => setSelectedItem({ data: edgeData })}
                             backgroundClickedCallback={closeSidebar}
-                            selectedItemId={selectedNode?.data?.id}
+                            selectedItemId={selectedItem?.data?.id}
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full w-full">
@@ -226,8 +86,8 @@ export function Drawer({ data }: DrawerProps) {
                         </div>
                     )}
                 </div>
-                {selectedNode && (
-                    <Sidebar selectedData={selectedNode['data']} closeSidebar={closeSidebar} />
+                {selectedItem && (
+                    <Sidebar selectedData={selectedItem['data']} closeSidebar={closeSidebar} />
                 )}
             </div>
         </div>

--- a/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Sidebar } from './Sidebar.js';
-import { CytoscapeNodeData, Edge } from '../../contracts/contracts.js';
+import { CytoscapeNodeData, CytoscapeEdge } from '../../contracts/contracts.js';
 
 vi.mock('@monaco-editor/react', () => ({
-    Editor: ({ value }: { value: string }) => <textarea value={value} readOnly data-testid="monaco-editor" />
+    Editor: ({ value }: { value: string }) => (
+        <textarea value={value} readOnly data-testid="monaco-editor" />
+    ),
 }));
 
 describe('Sidebar Component', () => {
@@ -37,7 +39,7 @@ describe('Sidebar Component', () => {
         },
     } as CytoscapeNodeData;
 
-    const mockEdgeData: Edge['data'] = {
+    const mockEdgeData: CytoscapeEdge['data'] = {
         id: 'edge-1',
         label: 'Edge 1',
         source: 'node-1',

--- a/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
@@ -1,17 +1,21 @@
 import { IoCloseOutline } from 'react-icons/io5';
-import { CytoscapeNodeData, Edge } from '../../contracts/contracts.js';
+import { CytoscapeNodeData, CytoscapeEdge } from '../../contracts/contracts.js';
 import { JsonRenderer } from '../../../hub/components/json-renderer/JsonRenderer.js';
 
 export interface SidebarProps {
-    selectedData: CytoscapeNodeData | Edge['data'];
+    selectedData: CytoscapeNodeData | CytoscapeEdge['data'];
     closeSidebar: () => void;
 }
 
-function isCALMNodeData(data: CytoscapeNodeData | Edge['data']): data is CytoscapeNodeData {
+function isCALMNodeData(
+    data: CytoscapeNodeData | CytoscapeEdge['data']
+): data is CytoscapeNodeData {
     return data.id != null && data.type != null;
 }
 
-function isCALMEdgeData(data: CytoscapeNodeData | Edge['data']): data is Edge['data'] {
+function isCALMEdgeData(
+    data: CytoscapeNodeData | CytoscapeEdge['data']
+): data is CytoscapeEdge['data'] {
     return (
         'source' in data &&
         'target' in data &&

--- a/calm-hub-ui/src/visualizer/components/visualizer-container/VisualizerContainer.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/visualizer-container/VisualizerContainer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { VisualizerContainer } from './VisualizerContainer.js';
-import { CytoscapeNode, Edge } from '../../contracts/contracts.js';
+import { CytoscapeNode, CytoscapeEdge } from '../../contracts/contracts.js';
 import { SidebarProps } from '../sidebar/Sidebar.js';
 import { CytoscapeRendererProps } from '../cytoscape/cytoscape-renderer/CytoscapeRenderer.js';
 
@@ -34,7 +34,14 @@ vi.mock('../cytoscape/cytoscape-renderer/CytoscapeRenderer.js', () => ({
 describe('VisualizerContainer', () => {
     it('renders without crashing', () => {
         render(
-            <VisualizerContainer title="Test Architecture" calmKey="test" nodes={[]} edges={[]} />
+            <VisualizerContainer
+                title="Test Architecture"
+                calmKey="test"
+                nodes={[]}
+                edges={[]}
+                nodeClickedCallback={() => {}}
+                edgeClickedCallback={() => {}}
+            />
         );
 
         expect(screen.getByTestId('visualizer-container')).toBeInTheDocument();
@@ -67,6 +74,7 @@ describe('VisualizerContainer', () => {
                 calmKey="test"
                 nodes={nodes}
                 edges={[]}
+                edgeClickedCallback={() => {}}
                 nodeClickedCallback={nodeClickedCallback}
             />
         );
@@ -76,7 +84,7 @@ describe('VisualizerContainer', () => {
     });
 
     it('calls edgeClickedCallback when an edge is clicked', () => {
-        const edges: Edge[] = [
+        const edges: CytoscapeEdge[] = [
             {
                 data: {
                     id: 'a',
@@ -96,6 +104,7 @@ describe('VisualizerContainer', () => {
                 nodes={[]}
                 edges={edges}
                 edgeClickedCallback={edgeClickedCallback}
+                nodeClickedCallback={() => {}}
             />
         );
 

--- a/calm-hub-ui/src/visualizer/components/visualizer-container/VisualizerContainer.tsx
+++ b/calm-hub-ui/src/visualizer/components/visualizer-container/VisualizerContainer.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
-import { CytoscapeNode, Edge } from '../../contracts/contracts.js';
+import { CytoscapeNode, CytoscapeEdge } from '../../contracts/contracts.js';
 import { CytoscapeRenderer } from '../cytoscape/cytoscape-renderer/CytoscapeRenderer.js';
 import { DiagramControlPanel } from '../cytoscape/diagram-control-panel/DiagramControlPanel.js';
 
 export interface VisualizerContainerProps {
     title: string;
     nodes: CytoscapeNode[];
-    edges: Edge[];
+    edges: CytoscapeEdge[];
     calmKey: string;
     nodeClickedCallback: (x: CytoscapeNode['data']) => void;
-    edgeClickedCallback: (x: Edge['data']) => void;
+    edgeClickedCallback: (x: CytoscapeEdge['data']) => void;
     backgroundClickedCallback?: () => void;
     selectedItemId?: string;
 }

--- a/calm-hub-ui/src/visualizer/contracts/contracts.ts
+++ b/calm-hub-ui/src/visualizer/contracts/contracts.ts
@@ -1,5 +1,5 @@
 import cytoscape from 'cytoscape';
-import { CalmInterfaceSchema, CalmControlsSchema } from '@finos/calm-models/src/types/control-types.js';
+import { CalmInterfaceSchema, CalmControlsSchema } from '@finos/calm-models/types';
 
 export type CytoscapeNode = {
     classes?: string;
@@ -21,7 +21,7 @@ export type CytoscapeNodeData = {
     parent?: string;
 };
 
-export type Edge = {
+export type CytoscapeEdge = {
     data: {
         id: string;
         label: string;

--- a/calm-hub-ui/src/visualizer/services/calm-to-cytoscape-converter.test.ts
+++ b/calm-hub-ui/src/visualizer/services/calm-to-cytoscape-converter.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect } from 'vitest';
+import { CalmArchitectureSchema, CalmInterfaceSchema, CalmNodeSchema, CalmRelationshipSchema } from '../../../../calm-models/src/types/core-types.js';
+import {
+    convertCalmToCytoscape,
+    convertCalmNodesToCytoscapeNodes,
+    convertCalmRelationshipsToEdges,
+} from './calm-to-cytoscape-converter.js';
+import { CalmControlsSchema } from '../../../../calm-models/src/types/control-types.js';
+
+function createCalmNode(id: string, name: string, nodeType: string, description = ''): CalmNodeSchema {
+    return {
+        'unique-id': id,
+        name,
+        'node-type': nodeType,
+        description,
+    } as CalmNodeSchema;
+}
+
+function createComposedOfRelationship(
+    id: string,
+    container: string,
+    nodes: string[],
+    description = ''
+): CalmRelationshipSchema {
+    return {
+        'unique-id': id,
+        description,
+        'relationship-type': {
+            'composed-of': {
+                container,
+                nodes,
+            },
+        },
+    } as CalmRelationshipSchema;
+}
+
+function createDeployedInRelationship(
+    id: string,
+    container: string,
+    nodes: string[],
+    description = ''
+): CalmRelationshipSchema {
+    return {
+        'unique-id': id,
+        description,
+        'relationship-type': {
+            'deployed-in': {
+                container,
+                nodes,
+            },
+        },
+    } as CalmRelationshipSchema;
+}
+
+function createInteractsRelationship(
+    id: string,
+    actor: string,
+    nodes: string[],
+    description = ''
+): CalmRelationshipSchema {
+    return {
+        'unique-id': id,
+        description,
+        'relationship-type': {
+            interacts: {
+                actor,
+                nodes,
+            },
+        },
+    } as CalmRelationshipSchema;
+}
+
+function createConnectsRelationship(
+    id: string,
+    sourceNode: string,
+    targetNode: string,
+    description = ''
+): CalmRelationshipSchema {
+    return {
+        'unique-id': id,
+        description,
+        'relationship-type': {
+            connects: {
+                source: { node: sourceNode },
+                destination: { node: targetNode },
+            },
+        },
+    } as CalmRelationshipSchema;
+}
+
+describe('convertCalmToCytoscape', () => {
+    describe('Main Converter', () => {
+        it('should return empty arrays when calmInstance is undefined', () => {
+            const result = convertCalmToCytoscape(undefined);
+
+            expect(result).toEqual({ nodes: [], edges: [] });
+        });
+
+        it('should return empty arrays when calmInstance has no nodes or relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {} as CalmArchitectureSchema;
+
+            const result = convertCalmToCytoscape(calmInstance);
+
+            expect(result).toEqual({ nodes: [], edges: [] });
+        });
+
+        it('should convert a simple CALM instance with nodes and edges', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('node1', 'Service A', 'service', 'Main service'),
+                    createCalmNode('node2', 'Database', 'database', 'Data storage'),
+                ],
+                relationships: [
+                    createConnectsRelationship('rel1', 'node1', 'node2', 'Reads from'),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmToCytoscape(calmInstance);
+
+            expect(result.nodes).toHaveLength(2);
+            expect(result.edges).toHaveLength(1);
+            expect(result.nodes[0].data.id).toBe('node1');
+            expect(result.nodes[1].data.id).toBe('node2');
+            expect(result.edges[0].data.source).toBe('node1');
+            expect(result.edges[0].data.target).toBe('node2');
+        });
+    });
+
+    describe('Node Conversion', () => {
+        it('should convert basic node properties correctly', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [createCalmNode('node1', 'Service A', 'service', 'Main service')],
+                relationships: [],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].data.id).toBe('node1');
+            expect(result[0].data.name).toBe('Service A');
+            expect(result[0].data.type).toBe('service');
+            expect(result[0].data.description).toBe('Main service');
+            expect(result[0].classes).toBe('node');
+        });
+
+        it('should generate labels with and without descriptions', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [createCalmNode('node1', 'Service A', 'service', 'Main service')],
+                relationships: [],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            expect(result[0].data.cytoscapeProps.labelWithoutDescription).toBe('Service A\n[service]');
+            expect(result[0].data.cytoscapeProps.labelWithDescription).toBe('Service A\n[service]\n\nMain service\n');
+        });
+
+        it('should mark container nodes as groups in composed-of relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('container1', 'Container', 'system'),
+                    createCalmNode('node1', 'Child Node', 'service'),
+                ],
+                relationships: [createComposedOfRelationship('rel1', 'container1', ['node1'])],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const container = result.find((n) => n.data.id === 'container1');
+            const child = result.find((n) => n.data.id === 'node1');
+
+            expect(container?.classes).toBe('group');
+            expect(child?.classes).toBe('node');
+        });
+
+        it('should mark container nodes as groups in deployed-in relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('environment1', 'Production', 'environment'),
+                    createCalmNode('service1', 'API Service', 'service'),
+                ],
+                relationships: [createDeployedInRelationship('rel1', 'environment1', ['service1'])],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const container = result.find((n) => n.data.id === 'environment1');
+            const child = result.find((n) => n.data.id === 'service1');
+
+            expect(container?.classes).toBe('group');
+            expect(child?.classes).toBe('node');
+        });
+
+        it('should set parent for child nodes in composed-of relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('container1', 'Container', 'system'),
+                    createCalmNode('node1', 'Child Node', 'service'),
+                ],
+                relationships: [createComposedOfRelationship('rel1', 'container1', ['node1'])],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const child = result.find((n) => n.data.id === 'node1');
+
+            expect(child?.data.parent).toBe('container1');
+        });
+
+        it('should set parent for child nodes in deployed-in relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('environment1', 'Production', 'environment'),
+                    createCalmNode('service1', 'API Service', 'service'),
+                ],
+                relationships: [createDeployedInRelationship('rel1', 'environment1', ['service1'])],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const child = result.find((n) => n.data.id === 'service1');
+
+            expect(child?.data.parent).toBe('environment1');
+        });
+
+        it('should handle multiple children in hierarchical relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('container1', 'Container', 'system'),
+                    createCalmNode('node1', 'Child 1', 'service'),
+                    createCalmNode('node2', 'Child 2', 'service'),
+                    createCalmNode('node3', 'Child 3', 'service'),
+                ],
+                relationships: [createComposedOfRelationship('rel1', 'container1', ['node1', 'node2', 'node3'])],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const children = result.filter((n) => n.data.parent === 'container1');
+
+            expect(children).toHaveLength(3);
+            expect(children.map((c) => c.data.id)).toEqual(['node1', 'node2', 'node3']);
+        });
+
+        it('should prioritize composed-of over deployed-in when both exist', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('container1', 'Logical Container', 'system'),
+                    createCalmNode('environment1', 'Environment', 'environment'),
+                    createCalmNode('service1', 'Service', 'service'),
+                ],
+                relationships: [
+                    createComposedOfRelationship('rel1', 'container1', ['service1']),
+                    createDeployedInRelationship('rel2', 'environment1', ['service1']),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const service = result.find((n) => n.data.id === 'service1');
+
+            expect(service?.data.parent).toBe('container1');
+        });
+
+        it('should preserve interfaces and controls if present', () => {
+            const nodeWithExtras = createCalmNode('node1', 'Service', 'service');
+            nodeWithExtras.interfaces = [{ 'unique-id': 'int1' } as CalmInterfaceSchema];
+            nodeWithExtras.controls = { 'control-1': {} } as unknown as CalmControlsSchema;
+
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [nodeWithExtras],
+                relationships: [],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            expect(result[0].data.interfaces).toBeDefined();
+            expect(result[0].data.controls).toBeDefined();
+        });
+
+        it('should handle nodes without parent relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('node1', 'Standalone', 'service'),
+                    createCalmNode('node2', 'Another', 'service'),
+                ],
+                relationships: [],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            expect(result[0].data.parent).toBeUndefined();
+            expect(result[1].data.parent).toBeUndefined();
+            expect(result[0].classes).toBe('node');
+            expect(result[1].classes).toBe('node');
+        });
+    });
+
+    describe('Edge Conversion', () => {
+        it('should convert interacts relationships to edges', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('user1', 'User', 'actor'),
+                    createCalmNode('service1', 'Service', 'service'),
+                ],
+                relationships: [createInteractsRelationship('rel1', 'user1', ['service1'], 'Uses')],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].data.id).toBe('rel1');
+            expect(result[0].data.source).toBe('user1');
+            expect(result[0].data.target).toBe('service1');
+            expect(result[0].data.label).toBe('Uses');
+        });
+
+        it('should convert connects relationships to edges', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('service1', 'Service A', 'service'),
+                    createCalmNode('service2', 'Service B', 'service'),
+                ],
+                relationships: [createConnectsRelationship('rel1', 'service1', 'service2', 'Sends data to')],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].data.id).toBe('rel1');
+            expect(result[0].data.source).toBe('service1');
+            expect(result[0].data.target).toBe('service2');
+            expect(result[0].data.label).toBe('Sends data to');
+        });
+
+        it('should filter out composed-of relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('container1', 'Container', 'system'),
+                    createCalmNode('node1', 'Child', 'service'),
+                ],
+                relationships: [
+                    createComposedOfRelationship('rel1', 'container1', ['node1']),
+                    createConnectsRelationship('rel2', 'container1', 'node1'),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].data.id).toBe('rel2');
+        });
+
+        it('should filter out deployed-in relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('environment1', 'Environment', 'environment'),
+                    createCalmNode('service1', 'Service', 'service'),
+                ],
+                relationships: [
+                    createDeployedInRelationship('rel1', 'environment1', ['service1']),
+                    createConnectsRelationship('rel2', 'environment1', 'service1'),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].data.id).toBe('rel2');
+        });
+
+        it('should handle empty description in relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [createCalmNode('node1', 'A', 'service'), createCalmNode('node2', 'B', 'service')],
+                relationships: [createConnectsRelationship('rel1', 'node1', 'node2', '')],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result[0].data.label).toBe('');
+        });
+
+        it('should handle multiple relationship types together', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('user1', 'User', 'actor'),
+                    createCalmNode('service1', 'Service A', 'service'),
+                    createCalmNode('service2', 'Service B', 'service'),
+                ],
+                relationships: [
+                    createInteractsRelationship('rel1', 'user1', ['service1']),
+                    createConnectsRelationship('rel2', 'service1', 'service2'),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toHaveLength(2);
+            expect(result.map((e) => e.data.id)).toEqual(['rel1', 'rel2']);
+        });
+
+        it('should return empty array when no relationships exist', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [createCalmNode('node1', 'Service', 'service')],
+                relationships: [],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should handle invalid interacts relationships gracefully', () => {
+            const invalidRelationship: CalmRelationshipSchema = {
+                'unique-id': 'rel1',
+                'relationship-type': {
+                    interacts: {
+                        actor: 'user1',
+                        nodes: [], // Empty nodes array
+                    },
+                },
+            } as CalmRelationshipSchema;
+
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [],
+                relationships: [invalidRelationship],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should handle invalid connects relationships gracefully', () => {
+            const invalidRelationship: CalmRelationshipSchema = {
+                'unique-id': 'rel1',
+                'relationship-type': {
+                    connects: {
+                        source: {},
+                        destination: {},
+                    },
+                },
+            } as CalmRelationshipSchema;
+
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [],
+                relationships: [invalidRelationship],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmRelationshipsToEdges(calmInstance);
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('Complex Scenarios', () => {
+        it('should handle nested hierarchies correctly', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('system1', 'System', 'system'),
+                    createCalmNode('subsystem1', 'Subsystem', 'system'),
+                    createCalmNode('service1', 'Service', 'service'),
+                ],
+                relationships: [
+                    createComposedOfRelationship('rel1', 'system1', ['subsystem1']),
+                    createComposedOfRelationship('rel2', 'subsystem1', ['service1']),
+                ],
+            } as CalmArchitectureSchema;
+
+            const result = convertCalmNodesToCytoscapeNodes(calmInstance);
+
+            const system = result.find((n) => n.data.id === 'system1');
+            const subsystem = result.find((n) => n.data.id === 'subsystem1');
+            const service = result.find((n) => n.data.id === 'service1');
+
+            expect(system?.classes).toBe('group');
+            expect(subsystem?.classes).toBe('group');
+            expect(service?.classes).toBe('node');
+
+            expect(subsystem?.data.parent).toBe('system1');
+            expect(service?.data.parent).toBe('subsystem1');
+        });
+
+        it('should handle a complete architecture with mixed relationships', () => {
+            const calmInstance: CalmArchitectureSchema = {
+                nodes: [
+                    createCalmNode('user1', 'User', 'actor'),
+                    createCalmNode('system1', 'Main System', 'system'),
+                    createCalmNode('service1', 'API Service', 'service'),
+                    createCalmNode('db1', 'Database', 'database'),
+                ],
+                relationships: [
+                    createComposedOfRelationship('rel1', 'system1', ['service1', 'db1']),
+                    createInteractsRelationship('rel2', 'user1', ['service1']),
+                    createConnectsRelationship('rel3', 'service1', 'db1'),
+                ],
+            } as CalmArchitectureSchema;
+
+            const { nodes, edges } = convertCalmToCytoscape(calmInstance);
+
+            expect(nodes).toHaveLength(4);
+            expect(edges).toHaveLength(2);
+
+            const system = nodes.find((n) => n.data.id === 'system1');
+            expect(system?.classes).toBe('group');
+
+            const edgeIds = edges.map((e) => e.data.id);
+            expect(edgeIds).toContain('rel2');
+            expect(edgeIds).toContain('rel3');
+            expect(edgeIds).not.toContain('rel1');
+        });
+    });
+});

--- a/calm-hub-ui/src/visualizer/services/calm-to-cytoscape-converter.ts
+++ b/calm-hub-ui/src/visualizer/services/calm-to-cytoscape-converter.ts
@@ -1,0 +1,228 @@
+import { CalmArchitectureSchema, CalmNodeSchema, CalmRelationshipSchema } from '../../../../calm-models/src/types/core-types.js';
+import { CytoscapeNode, CytoscapeEdge } from '../contracts/contracts.js';
+
+type RelationshipMapping = {
+    [nodeId: string]: {
+        isParent?: boolean;
+        isChild?: boolean;
+        parent?: string;
+    };
+};
+
+// Relationship Extraction
+
+function extractHierarchicalRelationships(
+    calmInstance: CalmArchitectureSchema,
+    relationshipKey: 'composed-of' | 'deployed-in'
+): RelationshipMapping {
+    const relationships: RelationshipMapping = {};
+
+    if (!calmInstance.relationships) {
+        return relationships;
+    }
+
+    for (const relationship of calmInstance.relationships) {
+        const rel = relationship['relationship-type'][relationshipKey];
+
+        if (rel) {
+            // Mark container as parent
+            if (!relationships[rel.container]) {
+                relationships[rel.container] = {};
+            }
+            relationships[rel.container].isParent = true;
+
+            // Mark contained nodes as children
+            for (const nodeId of rel.nodes) {
+                if (!relationships[nodeId]) {
+                    relationships[nodeId] = {};
+                }
+                relationships[nodeId].isChild = true;
+                relationships[nodeId].parent = rel.container;
+            }
+        }
+    }
+
+    return relationships;
+}
+
+// Node Conversion
+
+function generateNodeLabel(node: CalmNodeSchema, includeDescription: boolean): string {
+    const baseLabel = `${node.name}\n[${node['node-type']}]`;
+
+    if (includeDescription && node.description) {
+        return `${baseLabel}\n\n${node.description}\n`;
+    }
+
+    return baseLabel;
+}
+
+function isGroupNode(
+    nodeId: string,
+    composedOfRel: RelationshipMapping,
+    deployedInRel: RelationshipMapping
+): boolean {
+    return (
+        composedOfRel[nodeId]?.isParent === true ||
+        deployedInRel[nodeId]?.isParent === true
+    );
+}
+
+function getParentNodeId(
+    nodeId: string,
+    composedOfRel: RelationshipMapping,
+    deployedInRel: RelationshipMapping
+): string | undefined {
+    const composedOfChild = composedOfRel[nodeId];
+    if (composedOfChild?.isChild && composedOfChild.parent) {
+        return composedOfChild.parent;
+    }
+
+    const deployedInChild = deployedInRel[nodeId];
+    if (deployedInChild?.isChild && deployedInChild.parent) {
+        return deployedInChild.parent;
+    }
+
+    return undefined;
+}
+
+function convertCalmNodeToCytoscapeNode(
+    node: CalmNodeSchema,
+    composedOfRel: RelationshipMapping,
+    deployedInRel: RelationshipMapping
+): CytoscapeNode {
+    const nodeId = node['unique-id'];
+
+    const cytoscapeNode: CytoscapeNode = {
+        classes: 'node',
+        data: {
+            id: nodeId,
+            name: node.name,
+            description: node.description,
+            type: node['node-type'],
+            cytoscapeProps: {
+                labelWithDescription: generateNodeLabel(node, true),
+                labelWithoutDescription: generateNodeLabel(node, false),
+            },
+        },
+    };
+
+    if (node.interfaces) {
+        cytoscapeNode.data.interfaces = node.interfaces;
+    }
+
+    if (node.controls) {
+        cytoscapeNode.data.controls = node.controls;
+    }
+
+    if (isGroupNode(nodeId, composedOfRel, deployedInRel)) {
+        cytoscapeNode.classes = 'group';
+    }
+
+    const parentId = getParentNodeId(nodeId, composedOfRel, deployedInRel);
+    if (parentId) {
+        cytoscapeNode.data.parent = parentId;
+    }
+
+    return cytoscapeNode;
+}
+
+export function convertCalmNodesToCytoscapeNodes(
+    calmInstance: CalmArchitectureSchema
+): CytoscapeNode[] {
+    if (!calmInstance?.relationships || !calmInstance.nodes) {
+        return [];
+    }
+
+    const composedOfRel = extractHierarchicalRelationships(calmInstance, 'composed-of');
+    const deployedInRel = extractHierarchicalRelationships(calmInstance, 'deployed-in');
+
+    return calmInstance.nodes.map((node) =>
+        convertCalmNodeToCytoscapeNode(node, composedOfRel, deployedInRel)
+    );
+}
+
+
+// Edge Conversion
+
+function isHierarchicalRelationship(relationship: CalmRelationshipSchema): boolean {
+    return (
+        relationship['relationship-type']['composed-of'] !== undefined ||
+        relationship['relationship-type']['deployed-in'] !== undefined
+    );
+}
+
+function convertInteractsRelationship(relationship: CalmRelationshipSchema): CytoscapeEdge | undefined {
+    const interacts = relationship['relationship-type'].interacts;
+
+    if (!interacts?.nodes?.[0]) {
+        return undefined;
+    }
+
+    return {
+        data: {
+            id: relationship['unique-id'],
+            label: relationship.description || '',
+            source: interacts.actor,
+            target: interacts.nodes[0],
+        },
+    };
+}
+
+function convertConnectsRelationship(relationship: CalmRelationshipSchema): CytoscapeEdge | undefined {
+    const connects = relationship['relationship-type'].connects;
+
+    if (!connects?.source?.node || !connects?.destination?.node) {
+        return undefined;
+    }
+
+    return {
+        data: {
+            id: relationship['unique-id'],
+            label: relationship.description || '',
+            source: connects.source.node,
+            target: connects.destination.node,
+        },
+    };
+}
+
+function convertCalmRelationshipToEdge(relationship: CalmRelationshipSchema): CytoscapeEdge | undefined {
+    const relType = relationship['relationship-type'];
+
+    if (relType.interacts) {
+        return convertInteractsRelationship(relationship);
+    }
+
+    if (relType.connects) {
+        return convertConnectsRelationship(relationship);
+    }
+
+    return undefined;
+}
+
+export function convertCalmRelationshipsToEdges(
+    calmInstance: CalmArchitectureSchema
+): CytoscapeEdge[] {
+    if (!calmInstance?.relationships) {
+        return [];
+    }
+
+    return calmInstance.relationships
+        .filter((relationship) => !isHierarchicalRelationship(relationship))
+        .map((relationship) => convertCalmRelationshipToEdge(relationship))
+        .filter((edge): edge is CytoscapeEdge => edge !== undefined);
+}
+
+export function convertCalmToCytoscape(calmInstance: CalmArchitectureSchema | undefined): {
+    nodes: CytoscapeNode[];
+    edges: CytoscapeEdge[];
+} {
+    if (!calmInstance) {
+        return { nodes: [], edges: [] };
+    }
+
+    return {
+        nodes: convertCalmNodesToCytoscapeNodes(calmInstance),
+        edges: convertCalmRelationshipsToEdges(calmInstance),
+    };
+}


### PR DESCRIPTION
## Description
Refactoring some of CALM Hub UI. Mainly around the 'Drawer' component which has grown to be quite confusing and has too many responsibilities. I believe there are more improvements to be made here, but didn't want to make the PR too big.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [X] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [X] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [X] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
