### PR TITLE
test(shared): add tests for architecture+pattern spectral rules

### DIFF
--- a/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
@@ -1,0 +1,127 @@
+import { idsAreUnique } from './ids-are-unique';
+
+describe('idsAreUnique', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when there are no duplicate IDs', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            'interfaces': [{'unique-id': 'intf1'}]
+                        },
+                        {
+                            'unique-id': 'node2'
+                        }
+                    ],
+                    relationships: [
+                        {'unique-id': 'rel1'},
+                        {'unique-id': 'rel2'}
+                    ]
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return messages for duplicate IDs within nodes', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {'unique-id': 'node1'},
+                        {'unique-id': 'node1'}
+                    ]
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /nodes/1/unique-id');
+    });
+
+    it('should return messages for duplicate IDs within relationships', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    relationships: [
+                        {'unique-id': 'rel1'},
+                        {'unique-id': 'rel1'}
+                    ]
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /relationships/1/unique-id');
+    });
+
+
+    it('should return messages for duplicate IDs within interfaces', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            'interfaces': [{'unique-id': 'intf1'}]
+                        },
+                        {
+                            'unique-id': 'node2',
+                            'interfaces': [{'unique-id': 'intf1'}]
+                        }
+                    ]
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: intf1, path: /nodes/1/interfaces/0/unique-id');
+    });
+
+
+
+    it('should return messages for duplicate IDs across unique-ids', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {'unique-id': 'node1'},
+                        {'unique-id': 'node2'}
+                    ],
+                    relationships: [
+                        {'unique-id': 'node1'},
+                        {'unique-id': 'rel2'}
+                    ]
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /relationships/0/unique-id');
+    });
+});

--- a/shared/src/spectral/functions/architecture/ids-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.ts
@@ -22,4 +22,4 @@ export function idsAreUnique(input, _, context) {
     detectDuplicates(interfaceIdMatches, seenIds, messages);
 
     return messages;
-};
+}

--- a/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
@@ -1,0 +1,127 @@
+import { interfaceIdExistsOnNode } from './interface-id-exists-on-node';
+
+describe('interfaceIdExistsOnNode', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when input has no interfaces', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when input is a connect relationship missing a node', () => {
+        const input = { interfaces: ['intf1'] };
+        const context = {
+            document: {
+                data: {}
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe('Invalid connects relationship - no node defined.');
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+
+    it('should return an empty array when the node and interface exists', () => {
+        const input = { node: 'node1', interfaces: ['intf1'] };
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            'interfaces': [
+                                {'unique-id': 'intf1'} // will match this interface
+                            ]
+                        }
+                    ]
+                }
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when the target node has no interfaces', () => {
+        const input = { node: 'node1', interfaces: ['intf2'] };
+        const context = {
+            document: {
+                data: {
+                    nodes: [{'unique-id': 'node1'}]
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Node with unique-id ${input.node} has no interfaces defined, expected interfaces [${input.interfaces}].`);
+    });
+
+    it('should return a message when the interface does not exist', () => {
+        const input = { node: 'node1', interfaces: ['intf2'] };
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            'interfaces': [
+                                {'unique-id': 'intf1'}
+                            ]
+                        }
+                    ]
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[0]}' was not defined on the node with ID '${input.node}'.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+
+    it('should return a message when one interface does not exist', () => {
+        const input = { node: 'node1', interfaces: ['intf1', 'intf2'] };
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            'interfaces': [
+                                {'unique-id': 'intf1'}
+                            ]
+                        }
+                    ]
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[1]}' was not defined on the node with ID '${input.node}'.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+});

--- a/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
@@ -1,0 +1,60 @@
+import { interfaceIdExists } from './interface-id-exists';
+
+describe('interfaceIdExists', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when the ID exists', () => {
+        const input = 'intf1';
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            interfaces: [
+                                {'unique-id': 'intf1'}
+                            ]
+                        }
+                    ]
+                }
+            }
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when the ID does not exist', () => {
+        const input = 'intf2';
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {
+                            'unique-id': 'node1',
+                            interfaces: [
+                                {'unique-id': 'intf1'}
+                            ]
+                        }
+                    ]
+                }
+            },
+            path: ['/relationships/0/connects/destination/interface']
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing interface.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination/interface']);
+    });
+});

--- a/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
@@ -1,0 +1,50 @@
+import { nodeIdExists } from './node-id-exists';
+
+describe('nodeIdExists', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = nodeIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when the ID exists', () => {
+        const input = 'node1';
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {'unique-id': 'node1'}
+                    ]
+                }
+            }
+        };
+
+        const result = nodeIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when the ID does not exist', () => {
+        const input = 'node2';
+        const context = {
+            document: {
+                data: {
+                    nodes: [
+                        {'unique-id': 'node1'}
+                    ]
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = nodeIdExists(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing node.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+});

--- a/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
@@ -1,0 +1,149 @@
+import idsAreUnique from './ids-are-unique';
+
+describe('idsAreUnique', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when there are no duplicate IDs', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {
+                                    'unique-id': {'const': 'node1'},
+                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                },
+                                {'properties': {'unique-id': {'const': 'node2'}}}
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'rel1'}}},
+                                {'properties': {'unique-id': {'const': 'rel2'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return messages for duplicate IDs within nodes', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}},
+                                {'properties': {'unique-id': {'const': 'node1'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/nodes/prefixItems/1/properties/unique-id/const');
+    });
+
+    it('should return messages for duplicate IDs within relationships', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'rel1'}}},
+                                {'properties': {'unique-id': {'const': 'rel1'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /properties/relationships/prefixItems/1/properties/unique-id/const');
+    });
+
+
+    it('should return messages for duplicate IDs within interfaces', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {
+                                    'unique-id': {'const': 'node1'},
+                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                },
+                                {'properties': {
+                                    'unique-id': {'const': 'node2'},
+                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: intf1, path: /properties/nodes/prefixItems/1/properties/interfaces/prefixItems/0/properties/unique-id/const');
+    });
+
+
+
+    it('should return messages for duplicate IDs across unique-ids', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}},
+                                {'properties': {'unique-id': {'const': 'node2'}}}
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}},
+                                {'properties': {'unique-id': {'const': 'rel2'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/relationships/prefixItems/0/properties/unique-id/const');
+    });
+});

--- a/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
@@ -1,0 +1,161 @@
+import { interfaceIdExistsOnNode } from './interface-id-exists-on-node';
+
+describe('interfaceIdExistsOnNode', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when input has no interfaces', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when input is a connect relationship missing a node', () => {
+        const input = { interfaces: ['intf1'] };
+        const context = {
+            document: {
+                data: {}
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe('Invalid connects relationship - no node defined.');
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+
+    it('should return an empty array when the node and interface exists', () => {
+        const input = { node: 'node1', interfaces: ['intf1'] };
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {
+                                    properties: {
+                                        'unique-id': {const: 'node1'},
+                                        'interfaces': {
+                                            prefixItems: [
+                                                {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when the target node has no interfaces', () => {
+        const input = { node: 'node1', interfaces: ['intf2'] };
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {
+                                    properties: {
+                                        'unique-id': {const: 'node1'}
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Node with unique-id ${input.node} has no interfaces defined, expected interfaces [${input.interfaces}]`);
+    });
+
+    it('should return a message when the interface does not exist', () => {
+        const input = { node: 'node1', interfaces: ['intf2'] };
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {
+                                    properties: {
+                                        'unique-id': {const: 'node1'},
+                                        'interfaces': {
+                                            prefixItems: [
+                                                {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[0]}' was not defined on the node with ID '${input.node}'.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+
+    it('should return a message when one interface does not exist', () => {
+        const input = { node: 'node1', interfaces: ['intf1', 'intf2'] };
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {
+                                    properties: {
+                                        'unique-id': {const: 'node1'},
+                                        'interfaces': {
+                                            prefixItems: [
+                                                {properties: {'unique-id': {const: 'intf1'}}}
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            path: ['/relationships/0/connects/destination']
+        };
+
+        const result = interfaceIdExistsOnNode(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[1]}' was not defined on the node with ID '${input.node}'.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
+    });
+});

--- a/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
@@ -1,0 +1,54 @@
+import { interfaceIdExists } from './interface-id-exists';
+
+describe('interfaceIdExists', () => {
+    it('should return an empty array when there is no input', () => {
+        const input = null;
+        const context = {
+            document: {
+                data: {}
+            }
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when the ID exists', () => {
+        const input = 'intf1';
+        const context = {
+            document: {
+                data: {
+                    interfaces: {
+                        prefixItems: [
+                            {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                        ]
+                    }
+                }
+            }
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return a message when the ID does not exist', () => {
+        const input = 'intf2';
+        const context = {
+            document: {
+                data: {
+                    interfaces: {
+                        prefixItems: [
+                            {properties: {'unique-id': {const: 'intf1'}}}
+                        ]
+                    }
+                }
+            },
+            path: ['/relationships/0/connects/destination/interface']
+        };
+
+        const result = interfaceIdExists(input, null, context);
+        expect(result.length).toBe(1);
+        expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing interface.`);
+        expect(result[0].path).toEqual(['/relationships/0/connects/destination/interface']);
+    });
+});


### PR DESCRIPTION
## Description
Add tests for spectral rules relating to architectures and patterns.

This increases the overall test coverage for the `shared` module above 90%.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [X] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [X] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
