### PR TITLE
fix: upgrade vsce to @vscode/vsce to fix xml2js vulnerability

### DIFF
--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "calm-vscode-plugin",
     "displayName": "CALM Preview & Tools",
     "description": "Live-visualize CALM architecture models, validate, and generate docs.",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "publisher": "FINOS",
     "homepage": "https://calm.finos.org",
     "repository": {
@@ -137,7 +137,7 @@
         "test:coverage": "vitest run --coverage",
         "lint": "eslint src",
         "lint-fix": "eslint src --fix",
-        "package": "npm run build && vsce package --no-dependencies",
+        "package": "npm run build && npx @vscode/vsce package --no-dependencies",
         "vscode:prepublish": "npm run build"
     },
     "devDependencies": {
@@ -154,7 +154,7 @@
         "globals": "^16.0.0",
         "tsup": "^8.2.4",
         "typescript": "^5.6.2",
-        "vsce": "^2.15.0"
+        "@vscode/vsce": "^3.7.1"
     },
     "dependencies": {
         "@finos/calm-models": "file:../../calm-models",

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,12 +279,12 @@
                 "@typescript-eslint/eslint-plugin": "^8.29.1",
                 "@typescript-eslint/parser": "^8.29.1",
                 "@vscode/dts": "^0.4.1",
+                "@vscode/vsce": "^3.7.1",
                 "eslint": "^9.24.0",
                 "eslint-plugin-import": "^2.32.0",
                 "globals": "^16.0.0",
                 "tsup": "^8.2.4",
-                "typescript": "^5.6.2",
-                "vsce": "^2.15.0"
+                "typescript": "^5.6.2"
             },
             "engines": {
                 "vscode": "^1.88.0"
@@ -298,6 +298,167 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "calm-plugins/vscode/node_modules/@vscode/vsce": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
+            "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@azure/identity": "^4.1.0",
+                "@secretlint/node": "^10.1.2",
+                "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+                "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+                "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+                "@vscode/vsce-sign": "^2.0.0",
+                "azure-devops-node-api": "^12.5.0",
+                "chalk": "^4.1.2",
+                "cheerio": "^1.0.0-rc.9",
+                "cockatiel": "^3.1.2",
+                "commander": "^12.1.0",
+                "form-data": "^4.0.0",
+                "glob": "^11.0.0",
+                "hosted-git-info": "^4.0.2",
+                "jsonc-parser": "^3.2.0",
+                "leven": "^3.1.0",
+                "markdown-it": "^14.1.0",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "secretlint": "^10.1.2",
+                "semver": "^7.5.2",
+                "tmp": "^0.2.3",
+                "typed-rest-client": "^1.8.4",
+                "url-join": "^4.0.1",
+                "xml2js": "^0.5.0",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
+            },
+            "bin": {
+                "vsce": "vsce"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "optionalDependencies": {
+                "keytar": "^7.7.0"
+            }
+        },
+        "calm-plugins/vscode/node_modules/@vscode/vsce/node_modules/markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "calm-plugins/vscode/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "calm-plugins/vscode/node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "calm-plugins/vscode/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "calm-plugins/vscode/node_modules/glob": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "calm-plugins/vscode/node_modules/glob/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "calm-plugins/vscode/node_modules/jackspeak": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "calm-plugins/vscode/node_modules/jsdom": {
@@ -340,6 +501,98 @@
                 "canvas": {
                     "optional": true
                 }
+            }
+        },
+        "calm-plugins/vscode/node_modules/jsonc-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "calm-plugins/vscode/node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
+        "calm-plugins/vscode/node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "calm-plugins/vscode/node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "calm-plugins/vscode/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "calm-plugins/vscode/node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "calm-plugins/vscode/node_modules/url-join": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "calm-plugins/vscode/node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "calm-plugins/vscode/node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "calm-widgets": {
@@ -1358,6 +1611,23 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.11"
+            }
+        },
+        "node_modules/@azu/format-text": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+            "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@azu/style-format": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+            "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+            "dev": true,
+            "license": "WTFPL",
+            "dependencies": {
+                "@azu/format-text": "^1.0.1"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -7328,6 +7598,29 @@
                 }
             }
         },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -10404,6 +10697,210 @@
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
             "license": "MIT"
         },
+        "node_modules/@secretlint/config-creator": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+            "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/config-loader": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+            "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/resolver": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "ajv": "^8.17.1",
+                "debug": "^4.4.1",
+                "rc-config-loader": "^4.1.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/core": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+            "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "debug": "^4.4.1",
+                "structured-source": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/formatter": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+            "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/resolver": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "@textlint/linter-formatter": "^15.2.0",
+                "@textlint/module-interop": "^15.2.0",
+                "@textlint/types": "^15.2.0",
+                "chalk": "^5.4.1",
+                "debug": "^4.4.1",
+                "pluralize": "^8.0.0",
+                "strip-ansi": "^7.1.0",
+                "table": "^6.9.0",
+                "terminal-link": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/formatter/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@secretlint/formatter/node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@secretlint/node": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+            "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/config-loader": "^10.2.2",
+                "@secretlint/core": "^10.2.2",
+                "@secretlint/formatter": "^10.2.2",
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/source-creator": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "debug": "^4.4.1",
+                "p-map": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/profiler": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+            "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@secretlint/resolver": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+            "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@secretlint/secretlint-formatter-sarif": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+            "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-sarif-builder": "^3.2.0"
+            }
+        },
+        "node_modules/@secretlint/secretlint-formatter-sarif/node_modules/node-sarif-builder": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.3.1.tgz",
+            "integrity": "sha512-8z5dAbhpxmk/WRQHXlv4V0h+9Y4Ugk+w08lyhV/7E/CQX9yDdBc3025/EG+RSMJU2aPFh/IQ7XDV7Ti5TLt/TA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/sarif": "^2.1.7",
+                "fs-extra": "^11.1.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+            "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+            "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/source-creator": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+            "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2",
+                "istextorbinary": "^9.5.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/types": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+            "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@semantic-release/changelog": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -12624,6 +13121,108 @@
             },
             "peerDependencies": {
                 "@testing-library/dom": ">=7.21.4"
+            }
+        },
+        "node_modules/@textlint/ast-node-types": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.4.0.tgz",
+            "integrity": "sha512-IqY8i7IOGuvy05wZxISB7Me1ZyrvhaQGgx6DavfQjH3cfwpPFdDbDYmMXMuSv2xLS1kDB1kYKBV7fL2Vi16lRA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/linter-formatter": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.4.0.tgz",
+            "integrity": "sha512-rfqOZmnI1Wwc/Pa4LK+vagvVPmvxf9oRsBRqIOB04DwhucingZyAIJI/TyG18DIDYbP2aFXBZ3oOvyAxHe/8PQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@azu/format-text": "^1.0.2",
+                "@azu/style-format": "^1.0.1",
+                "@textlint/module-interop": "15.4.0",
+                "@textlint/resolver": "15.4.0",
+                "@textlint/types": "15.4.0",
+                "chalk": "^4.1.2",
+                "debug": "^4.4.3",
+                "js-yaml": "^3.14.1",
+                "lodash": "^4.17.21",
+                "pluralize": "^2.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "table": "^6.9.0",
+                "text-table": "^0.2.0"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+            "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/module-interop": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.4.0.tgz",
+            "integrity": "sha512-uGf+SFIfzOLCbZI0gp+2NLsrkSArsvEWulPP6lJuKp7yRHadmy7Xf/YHORe46qhNyyxc8PiAfiixHJSaHGUrGg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/resolver": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.4.0.tgz",
+            "integrity": "sha512-Vh/QceKZQHFJFG4GxxIsKM1Xhwv93mbtKHmFE5/ybal1mIKHdqF03Z9Guaqt6Sx/AeNUshq0hkMOEhEyEWnehQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/types": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.4.0.tgz",
+            "integrity": "sha512-ZMwJgw/xjxJufOD+IB7I2Enl9Si4Hxo04B76RwUZ5cKBKzOPcmd6WvGe2F7jqdgmTdGnfMU+Bo/joQrjPNIWqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@textlint/ast-node-types": "15.4.0"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -15364,6 +15963,16 @@
             "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
             "license": "MIT"
         },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/astring": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -15663,6 +16272,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/binaryextensions": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+            "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "editions": "^6.21.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -15762,6 +16387,13 @@
             "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/boundary": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+            "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/boxen": {
             "version": "6.2.1",
@@ -16429,7 +17061,8 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
@@ -19374,6 +20007,23 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/editions": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+            "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "version-range": "^4.15.0"
+            },
+            "engines": {
+                "ecmascript": ">= es5",
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -19499,6 +20149,7 @@
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -20800,6 +21451,7 @@
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true,
             "license": "(MIT OR WTFPL)",
+            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -21715,7 +22367,8 @@
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fs-extra": {
             "version": "11.3.2",
@@ -21972,7 +22625,8 @@
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/github-slugger": {
             "version": "1.5.0",
@@ -24392,6 +25046,24 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istextorbinary": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+            "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "binaryextensions": "^6.11.0",
+                "editions": "^6.21.0",
+                "textextensions": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/iterator.prototype": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -25092,6 +25764,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "node-addon-api": "^4.3.0",
                 "prebuild-install": "^7.0.1"
@@ -25724,6 +26397,13 @@
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
             "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.truncate": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.uniq": {
@@ -35167,7 +35847,8 @@
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/mlly": {
             "version": "1.8.0",
@@ -35372,7 +36053,8 @@
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -35438,6 +36120,7 @@
             "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -35450,7 +36133,8 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
             "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/node-emoji": {
             "version": "2.2.0",
@@ -39621,6 +40305,16 @@
                 "pathe": "^2.0.1"
             }
         },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/pony-cause": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
@@ -41273,6 +41967,7 @@
             "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
@@ -41501,6 +42196,7 @@
             "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -41510,6 +42206,16 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -41645,6 +42351,19 @@
             },
             "bin": {
                 "rc": "cli.js"
+            }
+        },
+        "node_modules/rc-config-loader": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
+            "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "js-yaml": "^4.1.0",
+                "json5": "^2.2.2",
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/rc/node_modules/ini": {
@@ -43833,6 +44552,98 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/secretlint": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+            "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/config-creator": "^10.2.2",
+                "@secretlint/formatter": "^10.2.2",
+                "@secretlint/node": "^10.2.2",
+                "@secretlint/profiler": "^10.2.2",
+                "debug": "^4.4.1",
+                "globby": "^14.1.0",
+                "read-pkg": "^9.0.1"
+            },
+            "bin": {
+                "secretlint": "bin/secretlint.js"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/secretlint/node_modules/@sindresorhus/merge-streams": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/secretlint/node_modules/globby": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^2.1.0",
+                "fast-glob": "^3.3.3",
+                "ignore": "^7.0.3",
+                "path-type": "^6.0.0",
+                "slash": "^5.1.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/secretlint/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/secretlint/node_modules/path-type": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/secretlint/node_modules/slash": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/section-matter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -44731,7 +45542,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/simple-eval": {
             "version": "1.0.1",
@@ -44765,6 +45577,7 @@
                 }
             ],
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
@@ -44836,6 +45649,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/snake-case": {
@@ -45439,6 +46270,16 @@
             "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
             "license": "MIT"
         },
+        "node_modules/structured-source": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+            "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boundary": "^2.0.0"
+            }
+        },
         "node_modules/style-to-js": {
             "version": "1.1.21",
             "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -45710,6 +46551,23 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "license": "MIT"
         },
+        "node_modules/table": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "ajv": "^8.0.1",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/tagged-tag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -45767,6 +46625,7 @@
             "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -45780,6 +46639,7 @@
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -45797,6 +46657,7 @@
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -45812,6 +46673,7 @@
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -45866,6 +46728,39 @@
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+            "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "supports-hyperlinks": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link/node_modules/ansi-escapes": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -46049,6 +46944,22 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "license": "MIT"
+        },
+        "node_modules/textextensions": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+            "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "editions": "^6.21.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -47200,6 +48111,7 @@
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -48200,6 +49112,19 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/version-range": {
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+            "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/vfile": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -48648,232 +49573,6 @@
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
             "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
             "license": "MIT"
-        },
-        "node_modules/vsce": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.15.0.tgz",
-            "integrity": "sha512-P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==",
-            "deprecated": "vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "azure-devops-node-api": "^11.0.1",
-                "chalk": "^2.4.2",
-                "cheerio": "^1.0.0-rc.9",
-                "commander": "^6.1.0",
-                "glob": "^7.0.6",
-                "hosted-git-info": "^4.0.2",
-                "keytar": "^7.7.0",
-                "leven": "^3.1.0",
-                "markdown-it": "^12.3.2",
-                "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
-                "parse-semver": "^1.1.1",
-                "read": "^1.0.7",
-                "semver": "^5.1.0",
-                "tmp": "^0.2.1",
-                "typed-rest-client": "^1.8.4",
-                "url-join": "^4.0.1",
-                "xml2js": "^0.4.23",
-                "yauzl": "^2.3.1",
-                "yazl": "^2.2.2"
-            },
-            "bin": {
-                "vsce": "vsce"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/vsce/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/azure-devops-node-api": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-            "integrity": "sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tunnel": "0.0.6",
-                "typed-rest-client": "^1.8.4"
-            }
-        },
-        "node_modules/vsce/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/vsce/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/vsce/node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/vsce/node_modules/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/vsce/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/vsce/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^1.0.1"
-            }
-        },
-        "node_modules/vsce/node_modules/markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/vsce/node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/vsce/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/vsce/node_modules/url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/vsce/node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/vsce/node_modules/xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            }
         },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",


### PR DESCRIPTION
## Description
Replaces deprecated vsce@2.15.0 with @vscode/vsce@3.7.1 which uses xml2js@0.5.0+ that is patched against prototype pollution.

Fixes Dependabot alert #78 (CVE-2023-0842)

https://github.com/finos/architecture-as-code/security/dependabot/78

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
