### PR TITLE
fix(cli): remove extraneous messages going to stdout during flow validation

### DIFF
--- a/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
@@ -7,8 +7,6 @@ export function sequenceNumbersAreUnique(input, _, context) {
     if (!input) {
         return [];
     }
-    console.log(JSON.stringify(input));
-    console.log('context' + JSON.stringify(context.path));
     // get sequence-number of all transitions
     const sequenceNumbers = JSONPath({path: '$[*].sequence-number', json: input, resultType: 'all'});
 


### PR DESCRIPTION
## Description
An issue with PR #1872 where validation of flows is noisy due to some `console.log` statements left back in whilst debugging.

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [X] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
