### PR TITLE
fix: use secret instead of var for CloudFront distribution ID

### DIFF
--- a/.github/workflows/build-and-sync-advent.yml
+++ b/.github/workflows/build-and-sync-advent.yml
@@ -43,4 +43,4 @@ jobs:
 
             - name: Invalidate CloudFront cache
               run: |
-                  aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/advent/*"
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/advent/*"

--- a/.github/workflows/s3-docs-sync.yml
+++ b/.github/workflows/s3-docs-sync.yml
@@ -42,4 +42,4 @@ jobs:
 
             - name: Invalidate CloudFront cache
               run: |
-                  aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/s3-sync.yml
+++ b/.github/workflows/s3-sync.yml
@@ -46,4 +46,4 @@ jobs:
 
             - name: Invalidate CloudFront cache
               run: |
-                  aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/draft/*" "/release/*" "/getting-started/*" "/interfaces/*" "/controls/*"
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/draft/*" "/release/*" "/getting-started/*" "/interfaces/*" "/controls/*"

--- a/.github/workflows/s3-video-sync.yml
+++ b/.github/workflows/s3-video-sync.yml
@@ -30,4 +30,4 @@ jobs:
 
             - name: Invalidate CloudFront cache
               run: |
-                  aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/video/*"
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/video/*"


### PR DESCRIPTION
AWS_CLOUDFRONT_DISTRIBUTION_ID was added as a secret rather than a variable