### PR TITLE
fix(vscode): preview panel can now reopen after being closed

### DIFF
--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "calm-vscode-plugin",
     "displayName": "CALM Preview & Tools",
     "description": "Live-visualize CALM architecture models, validate, and generate docs.",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "publisher": "FINOS",
     "homepage": "https://calm.finos.org",
     "repository": {

--- a/calm-plugins/vscode/src/commands/open-preview-command.ts
+++ b/calm-plugins/vscode/src/commands/open-preview-command.ts
@@ -18,11 +18,10 @@ export function createOpenPreviewCommand(store: ApplicationStoreApi) {
             return
         }
 
-        // Set a flag to indicate this is a user-initiated preview opening
-        // This will trigger the StoreReactionMediator to force-create the panel
         const state = store.getState()
-        state.setForceCreatePreview(true)
         
+        // Set document first, then force flag - order matters because each setter triggers the subscription
+        // The forceCreatePreview check uses currentDocumentUri, so it must be set first
         state.setCurrentDocument(doc.uri)
         
         if (fileInfo.type === FileType.TemplateFile && fileInfo.isValid) {
@@ -35,5 +34,9 @@ export function createOpenPreviewCommand(store: ApplicationStoreApi) {
         if (elementId) {
             state.setSelectedElement(elementId)
         }
+
+        // Set force flag last - this triggers the StoreReactionMediator to create the panel
+        // with the correct document URI already in place
+        state.setForceCreatePreview(true)
     })
 }

--- a/calm-plugins/vscode/src/core/mediators/store-reaction-mediator.ts
+++ b/calm-plugins/vscode/src/core/mediators/store-reaction-mediator.ts
@@ -32,6 +32,14 @@ export class StoreReactionMediator {
 
     // Subscribe to all store changes and react appropriately
     const unsubscribe = this.store.subscribe((state) => {
+      // React to forceCreatePreview flag (user explicitly requested preview)
+      // This must be checked first and independently of document changes
+      if (state.forceCreatePreview && state.currentDocumentUri) {
+        previousDocument = state.currentDocumentUri
+        this.handleDocumentChange(state.currentDocumentUri)
+        return // handleDocumentChange will clear the flag
+      }
+
       // React to document changes
       if (state.currentDocumentUri !== previousDocument) {
         previousDocument = state.currentDocumentUri

--- a/calm-plugins/vscode/src/features/preview/preview-panel.ts
+++ b/calm-plugins/vscode/src/features/preview/preview-panel.ts
@@ -270,6 +270,8 @@ export class CalmPreviewPanel {
 
   dispose() {
     this.viewModel.setVisible(false)
+    this.viewModel.setReady(false)  // Reset ready state so new panel can trigger state changes
+    this.viewModel.clearCurrentUri()  // Clear URI so reopening will trigger proper data loading
     CalmPreviewPanel.currentPanel = undefined
     while (this.disposables.length) {
       const d = this.disposables.pop()

--- a/calm-plugins/vscode/src/features/preview/preview.view-model.ts
+++ b/calm-plugins/vscode/src/features/preview/preview.view-model.ts
@@ -206,6 +206,14 @@ export class PreviewViewModel implements PreviewViewModelInterface {
     }
 
     /**
+     * Clear current URI (called when panel is disposed)
+     * This ensures that reopening the preview will trigger proper data loading
+     */
+    clearCurrentUri(): void {
+        this.currentUri = undefined
+    }
+
+    /**
      * Set extension version for announcements
      */
     setExtensionVersion(version: string): void {


### PR DESCRIPTION
## Description
The CALM Preview panel would not reopen after being closed due to three issues:

1. The PreviewViewModel's isReady state was not reset on dispose, preventing
   the new webview from triggering state changes when it sent the ready message

2. The PreviewViewModel's currentUri was not cleared on dispose, so reopening
   on the same file wouldn't trigger data loading

3. The open-preview-command set forceCreatePreview before setCurrentDocument,
   causing the mediator to use the stale URI when creating the panel

Fixes:
- Reset isReady and clear currentUri in CalmPreviewPanel.dispose()
- Add clearCurrentUri() method to PreviewViewModel
- Check forceCreatePreview flag independently in StoreReactionMediator
- Reorder open-preview-command to set document URI before force flag

Resolves #1916

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
