### PR TITLE
docs(advent-of-calm): add Handlebars syntax and helper documentation to Day 11

### DIFF
--- a/advent-of-calm/day-11.md
+++ b/advent-of-calm/day-11.md
@@ -53,7 +53,7 @@ When done, press `Ctrl+C` to stop the server and return to your project root:
 cd ../../..
 ```
 
-### 5. Understand Handlebars Templates
+### 4. Understand Handlebars Templates
 
 Docify uses [Handlebars](https://handlebarsjs.com/) as its templating engine. Handlebars provides a simple way to generate text output from your architecture data using mustache-style `{{expressions}}`.
 
@@ -115,7 +115,7 @@ CALM's docify command registers several custom Handlebars helpers to make templa
 {{/each}}
 ```
 
-### 6. Create a Custom Template
+### 5. Create a Custom Template
 
 Now let's create custom templates using these Handlebars features.
 
@@ -181,7 +181,7 @@ No controls defined yet.
 *Generated from CALM architecture on {{metadata.created}}*
 ```
 
-### 7. Generate Documentation Using Custom Template
+### 6. Generate Documentation Using Custom Template
 
 ```bash
 calm docify \
@@ -192,7 +192,7 @@ calm docify \
 
 Open `docs/generated/architecture-summary.md` - it's a markdown summary!
 
-### 8. Create a Node Catalog Template
+### 7. Create a Node Catalog Template
 
 **File:** `templates/node-catalog.md`
 
@@ -250,7 +250,7 @@ No interfaces defined.
 {{/each}}
 ```
 
-### 9. Generate Node Catalog
+### 8. Generate Node Catalog
 
 ```bash
 calm docify \
@@ -259,11 +259,11 @@ calm docify \
   --output docs/generated/node-catalog.md
 ```
 
-### 10. Update Your README
+### 9. Update Your README
 
 Document Day 11 progress in your README: mark the checklist, describe the new documentation outputs, and link to `docs/generated/README.md` or the screenshots so stakeholders know where to browse the generated sites.
 
-### 11. Commit Your Work
+### 10. Commit Your Work
 
 ```bash
 git add templates/ docs/generated/ README.md


### PR DESCRIPTION
## Description
Added new section explaining:
- Basic Handlebars syntax (expressions, each, if/else, @key, this)
- CALM docify custom helpers (eq, or, json, lookup, kebabCase, etc.)
- Common template patterns for filtering and handling missing data

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
