### PR TITLE
fix(aoc): remove section 8 from day 20

### DIFF
--- a/advent-of-calm/day-20.md
+++ b/advent-of-calm/day-20.md
@@ -140,15 +140,7 @@ architecture-compliance:
 3. Teams update their architectures to add the new property
 4. No structural patterns needed to change - governance applied universally
 
-### 8. Generate Updated Documentation
-
-```bash
-calm docify -a architectures/generated-webapp.json -o docs/webapp
-```
-
-Review the generated docs to see how Standard properties appear alongside structural information.
-
-### 9. Update Pattern Documentation
+### 8. Update Pattern Documentation
 
 **Prompt:**
 ```text
@@ -162,7 +154,7 @@ Update patterns/README.md to document the multi-pattern validation approach:
    - company-base-pattern.json (standards)
 ```
 
-### 10. Update Project README
+### 9. Update Project README
 
 **Prompt:**
 ```text
@@ -171,7 +163,7 @@ Update README.md to:
 2. Add section about multi-pattern validation approach
 ```
 
-### 11. Commit Your Work
+### 10. Commit Your Work
 
 ```bash
 git add architectures/generated-webapp.json patterns/README.md README.md


### PR DESCRIPTION
## Description
Remove section 8 about updating generated documentation.

Additional Properties don't appear in default docify output.

Discussed with @rocketstack-matt 

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD
- [X] Advent of CALM

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
