### PR TITLE
fix(aoc): unlock days based on December 2025

### DIFF
--- a/advent-of-calm/website/src/components/Calendar.astro
+++ b/advent-of-calm/website/src/components/Calendar.astro
@@ -111,8 +111,7 @@ const days = Array.from({ length: 24 }, (_, i) => ({
   // Client-side unlock based on user's local date
   function isUnlocked(day: number): boolean {
     const now = new Date();
-    const currentYear = now.getFullYear();
-    const unlockDate = new Date(currentYear, 11, day); // Month 11 = December
+    const unlockDate = new Date(2025, 11, day); // Month 11 = December
     return now >= unlockDate;
   }
 

--- a/advent-of-calm/website/src/pages/day/[day].astro
+++ b/advent-of-calm/website/src/pages/day/[day].astro
@@ -289,8 +289,8 @@ const nextDay = dayNum < 24 ? dayNum + 1 : null;
   // Client-side unlock for next day navigation based on user's local date
   function isUnlocked(day: number): boolean {
     const now = new Date();
-    const currentYear = now.getFullYear();
-    const unlockDate = new Date(currentYear, 11, day); // Month 11 = December
+
+    const unlockDate = new Date(2025, 11, day); // Month 11 = December
     return now >= unlockDate;
   }
 

--- a/advent-of-calm/website/src/utils/calendar.ts
+++ b/advent-of-calm/website/src/utils/calendar.ts
@@ -36,9 +36,8 @@ export function getDayTitle(day: number): string {
 
 export function isUnlocked(day: number): boolean {
   const now = new Date();
-  const currentYear = now.getFullYear();
-  const unlockDate = new Date(currentYear, 11, day); // Month 11 = December
-  
+  const unlockDate = new Date(2025, 11, day); // Month 11 = December
+
   return now >= unlockDate;
 }
 


### PR DESCRIPTION
## Description
All Advent of CALM days are currently locked, because the lock test is made against December of the current year.

It's now 2026, so it locked everything for the next 11 months. This is a little unfair and undesired.

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD
- [X] Advent of CALM

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [ ] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
