### PR TITLE
Add multi document navigation in VSCode Extension

### DIFF
--- a/calm-plugins/sample-architecture/README.md
+++ b/calm-plugins/sample-architecture/README.md
@@ -1,0 +1,22 @@
+# Sample Architecture for VSCode Extension Testing
+
+This folder contains a set of CALM architecture files designed to test the features of the CALM VSCode Extension, specifically **multi-document navigation**.
+
+## Contents
+
+-   **`system.json`**: The root system definition. Contains a `detailed-architecture` reference to the Payment Service.
+-   **`payment-service.json`**: The detailed architecture for the Payment Service.
+-   **`calm-mapping.json`**: A mapping file used to resolve the `detailed-architecture` URL to the local `payment-service.json` file.
+
+## How to Scale/Test
+
+1.  **Configure Mapping**: Ensure your VSCode settings point to the mapping file:
+    ```json
+    "calm.urlMapping": "calm-plugins/sample-architecture/calm-mapping.json"
+    ```
+2.  **Open Root**: Open `system.json`.
+3.  **Preview**: Open the CALM Preview (`Ctrl+Shift+C` or Command Palette).
+4.  **Navigate**: Click the **Payment Service** node in the preview.
+    -   *Expected Behavior*: `payment-service.json` opens in the primary editor column, keeping the preview visible.
+
+This setup verifies that the extension allows users to navigate distributed architecture models that use unique IDs for linking.

--- a/calm-plugins/sample-architecture/calm-mapping.json
+++ b/calm-plugins/sample-architecture/calm-mapping.json
@@ -1,0 +1,3 @@
+{
+  "https://specs.internal/payment-service": "./payment-service.json"
+}

--- a/calm-plugins/sample-architecture/payment-service.json
+++ b/calm-plugins/sample-architecture/payment-service.json
@@ -1,0 +1,51 @@
+{
+  "nodes": [
+    {
+      "unique-id": "api-gateway",
+      "name": "API Gateway",
+      "node-type": "component",
+      "description": "API Entry point",
+      "interfaces": [
+          { "unique-id": "http-in" }
+      ]
+    },
+    {
+      "unique-id": "payment-processor",
+      "name": "Payment Processor",
+      "node-type": "component",
+      "description": "Business logic",
+      "interfaces": [
+          { "unique-id": "proc-in" }
+      ]
+    },
+    {
+      "unique-id": "payment-db",
+      "name": "Payment DB",
+      "node-type": "database",
+      "description": "Persistence",
+      "interfaces": [
+          { "unique-id": "db-in" }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "gw-to-proc",
+      "relationship-type": {
+        "connects": {
+          "source": { "node": "api-gateway" },
+          "destination": { "node": "payment-processor", "interfaces": ["proc-in"] }
+        }
+      }
+    },
+    {
+      "unique-id": "proc-to-db",
+      "relationship-type": {
+        "connects": {
+           "source": { "node": "payment-processor" },
+           "destination": { "node": "payment-db", "interfaces": ["db-in"] }
+        }
+      }
+    }
+  ]
+}

--- a/calm-plugins/sample-architecture/system.json
+++ b/calm-plugins/sample-architecture/system.json
@@ -1,0 +1,40 @@
+{
+  "nodes": [
+    {
+      "unique-id": "ecommerce-system",
+      "name": "E-Commerce System",
+      "node-type": "system",
+      "description": "Main e-commerce platform"
+    },
+    {
+      "unique-id": "payment-service",
+      "name": "Payment Service",
+      "node-type": "container",
+      "description": "Handles payment processing",
+      "details": {
+        "detailed-architecture": "https://specs.internal/payment-service"
+      }
+    },
+    {
+      "unique-id": "inventory-service",
+      "name": "Inventory Service",
+      "node-type": "container",
+      "description": "Manages product inventory"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "sys-composition",
+      "description": "System Composition",
+      "relationship-type": {
+        "composed-of": {
+          "container": "ecommerce-system",
+          "nodes": [
+            "payment-service",
+            "inventory-service"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/calm-plugins/vscode/AGENTS.md
+++ b/calm-plugins/vscode/AGENTS.md
@@ -60,7 +60,7 @@ src/
 │
 ├── core/                           # Framework-free business logic
 │   ├── ports/                      # Interfaces for dependency inversion
-│   ├── services/                   # Core services (refresh, selection, watch)
+│   ├── services/                   # Core services (refresh, selection, watch, navigation)
 │   ├── mediators/                  # Cross-cutting coordinators
 │   └── emitter.ts                 # Event system (framework-free)
 │
@@ -165,6 +165,11 @@ export class StoreReactionMediator {
     }
 }
 ```
+
+### Navigation Service
+- **Purpose**: Handles navigation between CALM documents via `detailed-architecture` references.
+- **Key Logic**: Uses `DocumentLoader` from `@finos/calm-shared` to resolve URLs/relative paths to local files based on `calm.urlMapping`.
+- **Integration**: Called by `SelectionService` when a node with details is clicked.
 
 ### Features
 
@@ -326,6 +331,7 @@ npm run build:shared    # Builds models, widgets, shared
 4. **Extension Not Activating**: Check `activationEvents` in package.json
 5. **Webview Not Updating**: Remember to postMessage from webview to extension
 6. **toCanonicalSchema adds undefined values**: When using `toCanonicalSchema()` from calm-models, ALL optional properties are added with `undefined` values. Code checking for property existence must check for truthy values, not just key existence. See [calm-widgets/AGENTS.md](../../calm-widgets/AGENTS.md) for details.
+7. **URL Mapping**: To test multi-document navigation, you likely need to configure `calm.urlMapping` in `.vscode/settings.json` to point to a mapping file (e.g. `calm-mapping.json`) in the workspace root.
 
 ## Debugging
 

--- a/calm-plugins/vscode/README.md
+++ b/calm-plugins/vscode/README.md
@@ -37,6 +37,32 @@ Live-visualize CALM architecture models while you edit them. Features an interac
 ![Live Docify Mode](https://raw.githubusercontent.com/finos/architecture-as-code/main/calm-plugins/vscode/docs/LiveDocifyMode.png)
 *Live templating mode with real-time documentation generation*
 
+## Configuration
+    
+The extension can be configured via VS Code settings (`.vscode/settings.json` or User Settings).
+
+### Multi-Document Navigation
+Navigate between related CALM files using `detailed-architecture` references.
+
+1.  Create a mapping file (e.g., `calm-mapping.json`) in your workspace:
+    ```json
+    {
+      "https://specs.internal/payment-service": "./services/payment-service.json",
+      "https://specs.internal/inventory": "./services/inventory.json"
+    }
+    ```
+2.  Configure the extension to use this mapping:
+    ```json
+    "calm.urlMapping": "calm-mapping.json"
+    ```
+
+### File Discovery
+Customize how the extension finds your CALM models and templates.
+
+-   `calm.files.globs`: Patterns for CALM model files (Default: `["calm/**/*.json", "calm/**/*.y?(a)ml"]`)
+-   `calm.template.globs`: Patterns for template files (Default: `["**/*.md", "**/*.hbs", ...]`)
+-   `calm.cli.path`: Path to the CALM CLI executable (Default: `./cli`)
+
 ## Getting Involved
 
 Architecture as Code was developed as part of the [DevOps Automation Special Interest Group](https://devops.finos.org/) before graduating as a top level project in it's own right. Our community Zoom meetups take place on the fourth Tuesday of every month, see [here](https://github.com/finos/architecture-as-code/issues?q=label%3Ameeting) for upcoming and previous meetings. For active contributors we have Office Hours every Thursday, see the [FINOS Event Calendar](http://calendar.finos.org) for meeting details.

--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "calm-vscode-plugin",
     "displayName": "CALM Preview & Tools",
     "description": "Live-visualize CALM architecture models, validate, and generate docs.",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "FINOS",
     "homepage": "https://calm.finos.org",
     "repository": {
@@ -96,6 +96,11 @@
                         "**/*.handlebars"
                     ],
                     "markdownDescription": "Glob patterns for template files that may reference CALM architecture files."
+                },
+                "calm.urlMapping": {
+                    "type": "string",
+                    "description": "Path to a JSON file mapping URLs to local file paths for detailed-architecture navigation.",
+                    "default": ""
                 }
             }
         },

--- a/calm-plugins/vscode/src/core/ports/config.ts
+++ b/calm-plugins/vscode/src/core/ports/config.ts
@@ -7,5 +7,6 @@ export interface Config {
     templateGlobs(): string[]
     previewLayout(): string
     showLabels(): boolean
+    urlMapping(): string | undefined
 }
 

--- a/calm-plugins/vscode/src/core/ports/logger.ts
+++ b/calm-plugins/vscode/src/core/ports/logger.ts
@@ -2,4 +2,5 @@ export interface Logger {
     info(msg: string): void
     warn?(msg: string): void
     error?(msg: string): void
+    debug?(msg: string): void
 }

--- a/calm-plugins/vscode/src/core/services/config-service.ts
+++ b/calm-plugins/vscode/src/core/services/config-service.ts
@@ -21,4 +21,8 @@ export class ConfigService implements Config {
     showLabels(): boolean {
         return this.config.get<boolean>('preview.showLabels', true)
     }
+
+    urlMapping(): string | undefined {
+        return this.config.get<string>('urlMapping')
+    }
 }

--- a/calm-plugins/vscode/src/core/services/logging-service.ts
+++ b/calm-plugins/vscode/src/core/services/logging-service.ts
@@ -26,6 +26,11 @@ export class LoggingService implements Logger {
         if (this.shared?.error) this.shared.error(msg)
     }
 
+    debug(msg: string) {
+        this.output.appendLine('[debug] ' + msg)
+        if (this.shared?.debug) this.shared.debug(msg)
+    }
+
     dispose() {
         this.output.dispose()
     }

--- a/calm-plugins/vscode/src/core/services/navigation-service.ts
+++ b/calm-plugins/vscode/src/core/services/navigation-service.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import {
+    buildDocumentLoader,
+    DocumentLoader,
+    DocumentLoaderOptions
+} from '@finos/calm-shared/dist/document-loader/document-loader'
+import { Config } from '../ports/config'
+import type { Logger } from '../ports/logger'
+
+export class NavigationService {
+    private docLoader: DocumentLoader | undefined
+    private urlToLocalMap: Map<string, string> = new Map()
+
+    constructor(
+        private logger: Logger,
+        private config: Config
+    ) { }
+
+
+
+    /**
+     * Reset service state to force re-initialization on next use
+     * (e.g. when configuration changes)
+     */
+    reset() {
+        this.docLoader = undefined
+        this.urlToLocalMap.clear()
+        this.logger.info?.('[navigation] Configuration reset - will reload on next navigation')
+    }
+
+    private initializeLoader(basePath: string) {
+        const mappingPath = this.config.urlMapping()
+        let urlToLocalMap: Map<string, string> | undefined
+
+        // Load mapping if configured
+        if (mappingPath) {
+            try {
+                // Resolve mapping path relative to workspace root if needed
+                let resolvedMappingPath = mappingPath
+                if (!path.isAbsolute(mappingPath) && vscode.workspace.workspaceFolders?.[0]) {
+                    resolvedMappingPath = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, mappingPath)
+                }
+
+                if (fs.existsSync(resolvedMappingPath)) {
+                    this.logger.info(`[navigation] Loading URL mapping from: ${resolvedMappingPath}`)
+                    const mappingJson = JSON.parse(fs.readFileSync(resolvedMappingPath, 'utf-8'))
+                    urlToLocalMap = new Map(
+                        Object.entries(mappingJson).map(([url, relativePath]) => [
+                            url,
+                            path.resolve(path.dirname(resolvedMappingPath), String(relativePath))
+                        ])
+                    )
+                    this.urlToLocalMap = urlToLocalMap
+                } else {
+                    this.logger.warn?.(`[navigation] URL mapping file not found: ${resolvedMappingPath}`)
+                }
+            } catch (err: any) {
+                this.logger.error?.(`[navigation] Failed to load URL mapping: ${err.message}`)
+            }
+        }
+
+        const opts: DocumentLoaderOptions = {
+            basePath,
+            urlToLocalMap,
+            debug: true // Enable debug logging for troubleshooting
+        }
+
+        this.logger.info('[navigation] Initializing DocumentLoader')
+        this.docLoader = buildDocumentLoader(opts)
+    }
+
+    async navigate(nodeId: string, nodeRaw: any): Promise<boolean> {
+        // Check for detailed-architecture property (direct or nested in details)
+        const detailedArch = nodeRaw?.['detailed-architecture'] || nodeRaw?.details?.['detailed-architecture']
+        
+        if (!detailedArch) {
+            this.logger.info(`[navigation] Node ${nodeId} has no detailed-architecture property`)
+            return false
+        }
+
+        this.logger.info(`[navigation] Attempting to navigate to detailed-architecture: ${detailedArch}`)
+
+        // Initialize loader with current workspace context if needed
+        if (!this.docLoader && vscode.workspace.workspaceFolders?.[0]) {
+            this.initializeLoader(vscode.workspace.workspaceFolders[0].uri.fsPath)
+        }
+
+        if (!this.docLoader) {
+            this.logger.error?.('[navigation] DocumentLoader not initialized (no workspace open?)')
+            return false
+        }
+
+        // Use DocumentLoader to resolve the path (encapsulates mapping and relative path logic)
+        let targetPath = this.docLoader.resolvePath(detailedArch)
+
+        if (targetPath && fs.existsSync(targetPath)) {
+            this.logger.info(`[navigation] Resolved to local file: ${targetPath}`)
+            const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetPath))
+            // Open in Column 1 to avoid replacing the preview panel (which is usually in Column 2)
+            await vscode.window.showTextDocument(doc, vscode.ViewColumn.One)
+            return true
+        } else {
+            this.logger.warn?.(`[navigation] Could not resolve local file for: ${detailedArch}`)
+            
+            // If we have a URL but no mapping, maybe prompt the user?
+            if (detailedArch.startsWith('http')) {
+                vscode.window.showInformationMessage(`No local mapping found for URL: ${detailedArch}. Configure 'calm.urlMapping'.`)
+            } else {
+                 vscode.window.showInformationMessage(`File not found: ${detailedArch}`)
+            }
+            
+            return false
+        }
+    }
+}

--- a/calm-plugins/vscode/src/models/model-index.ts
+++ b/calm-plugins/vscode/src/models/model-index.ts
@@ -39,6 +39,10 @@ export class ModelIndex {
     rangeOf(id: string): any | undefined {
         return this.idToRange.get(id)
     }
+    getNodes() {
+        return this.model.nodes || []
+    }
+
     get nodes() {
         return (this.model.nodes || []).map(n => ({
             id: n.id,

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -67,7 +67,7 @@ describe('CLI Commands', () => {
             expect(fileSystemDocLoaderModule.FileSystemDocumentLoader.prototype.loadMissingDocument).toHaveBeenCalledWith('pattern.json', 'pattern');
             expect(optionsModule.promptUserForOptions).toHaveBeenCalled();
 
-            expect(fileSystemDocLoaderModule.FileSystemDocumentLoader).toHaveBeenCalledWith([CALM_META_SCHEMA_DIRECTORY, 'schemas'], true);
+            expect(fileSystemDocLoaderModule.FileSystemDocumentLoader).toHaveBeenCalledWith([CALM_META_SCHEMA_DIRECTORY, 'schemas'], true, process.cwd());
 
             expect(calmShared.runGenerate).toHaveBeenCalledWith(
                 {}, 'output.json', true, expect.any(calmShared.SchemaDirectory), []

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,7 +258,7 @@
         },
         "calm-plugins/vscode": {
             "name": "calm-vscode-plugin",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dependencies": {
                 "@finos/calm-models": "file:../../calm-models",
                 "@finos/calm-shared": "file:../../shared",
@@ -635,7 +635,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.25.1",
+            "version": "1.26.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -820,7 +820,6 @@
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -1015,7 +1014,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -1042,7 +1040,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -1422,7 +1419,6 @@
             "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.45.0.tgz",
             "integrity": "sha512-nxuCid+Nszs4xqwIMDw11pRJPes2c+Th1yup/+LtpjFH8QWXkr3SirNYSD3OXAeM060HgWWPLA8/Fxk+vwxQOA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@algolia/client-common": "5.45.0",
                 "@algolia/requester-browser-xhr": "5.45.0",
@@ -1822,7 +1818,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -4049,7 +4044,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4092,7 +4086,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4202,7 +4195,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -4624,7 +4616,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -5898,7 +5889,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
             "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -8068,7 +8058,6 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
             "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -8186,7 +8175,6 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -12261,7 +12249,6 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -12490,7 +12477,6 @@
             "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.25"
@@ -13277,7 +13263,8 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -13859,8 +13846,7 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -13953,7 +13939,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
             "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -14004,7 +13989,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -14270,7 +14254,6 @@
             "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.48.0",
                 "@typescript-eslint/types": "8.48.0",
@@ -15388,7 +15371,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -15484,7 +15466,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15553,7 +15534,6 @@
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.45.0.tgz",
             "integrity": "sha512-wrj4FGr14heLOYkBKV3Fbq5ZBGuIFeDJkTilYq/G+hH1CSlQBtYvG2X1j67flwv0fUeQJwnWxxRIunSemAZirA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@algolia/abtesting": "1.11.0",
                 "@algolia/client-abtesting": "5.45.0",
@@ -16084,7 +16064,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
             "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
@@ -16571,7 +16550,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.25",
                 "caniuse-lite": "^1.0.30001754",
@@ -18321,7 +18299,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -18670,7 +18647,6 @@
             "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -19176,7 +19152,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -19380,7 +19355,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
             "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -19798,7 +19772,8 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -20056,8 +20031,7 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/embla-carousel-react": {
             "version": "8.6.0",
@@ -20604,7 +20578,6 @@
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -20685,7 +20658,6 @@
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -21496,7 +21468,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -21859,7 +21830,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -25484,7 +25454,6 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -26743,6 +26712,7 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -35895,6 +35865,7 @@
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -38905,7 +38876,6 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -39200,7 +39170,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -40379,7 +40348,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -41452,7 +41420,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -42060,6 +42027,7 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -42075,6 +42043,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -42413,7 +42382,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -42423,7 +42391,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -42483,7 +42450,6 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
             "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -42509,7 +42475,8 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-json-view-lite": {
             "version": "2.5.0",
@@ -42529,7 +42496,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
             "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             },
@@ -42661,7 +42627,6 @@
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
             "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@remix-run/router": "1.23.1"
             },
@@ -44295,7 +44260,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -44714,7 +44678,6 @@
             "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
                 "@semantic-release/error": "^4.0.0",
@@ -46628,8 +46591,7 @@
             "version": "4.1.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
             "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -47187,7 +47149,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -47525,8 +47486,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tsup": {
             "version": "8.5.1",
@@ -48295,7 +48255,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -48906,7 +48865,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -49263,7 +49221,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
             "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -49466,7 +49423,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -49749,7 +49705,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
             "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -51240,7 +51195,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -62,4 +62,10 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         return document;
     }
 
+    /**
+     * Only local files via a mapping file are currently supported.
+     */
+    resolvePath(_reference: string): string | undefined {
+        return undefined;
+    }
 }

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -53,4 +53,11 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
             });
         }
     }
+
+    /**
+     * Only local files via a mapping file are currently supported.
+     */
+    resolvePath(_reference: string): string | undefined {
+        return undefined;
+    }
 }

--- a/shared/src/document-loader/document-loader.spec.ts
+++ b/shared/src/document-loader/document-loader.spec.ts
@@ -51,7 +51,7 @@ describe('DocumentLoader', () => {
 
         buildDocumentLoader(docLoaderOpts);
 
-        expect(mocks.fsDocLoader).toHaveBeenCalledWith([CALM_META_SCHEMA_DIRECTORY, 'schemas'], false);
+        expect(mocks.fsDocLoader).toHaveBeenCalledWith([CALM_META_SCHEMA_DIRECTORY, 'schemas'], false, process.cwd());
     });
 
     it('should create a CalmHubDocumentLoader when calmHubUrl is defined in loader options', () => {

--- a/shared/src/document-loader/document-loader.ts
+++ b/shared/src/document-loader/document-loader.ts
@@ -13,6 +13,11 @@ export const CALM_HUB_PROTO = 'calm:';
 export interface DocumentLoader {
     initialise(schemaDirectory: SchemaDirectory): Promise<void>;
     loadMissingDocument(documentId: string, type: CalmDocumentType): Promise<object>;
+    /**
+     * Resolve a reference (URL or relative path) to an absolute local file path if possible.
+     * Returns undefined if the loader cannot resolve it to a local file.
+     */
+    resolvePath(reference: string): string | undefined;
 }
 
 export type DocumentLoaderOptions = {
@@ -46,7 +51,11 @@ export function buildDocumentLoader(docLoaderOpts: DocumentLoaderOptions): Docum
     if (docLoaderOpts.schemaDirectoryPath) {
         directoryPaths.push(docLoaderOpts.schemaDirectoryPath);
     }
-    loaders.push(new FileSystemDocumentLoader(directoryPaths, debug));
+    loaders.push(new FileSystemDocumentLoader(
+        directoryPaths,
+        debug,
+        docLoaderOpts.basePath ?? process.cwd()
+    ));
 
     loaders.push(new DirectUrlDocumentLoader(debug));
 

--- a/shared/src/document-loader/mapped-document-loader.spec.ts
+++ b/shared/src/document-loader/mapped-document-loader.spec.ts
@@ -133,28 +133,7 @@ describe('MappedDocumentLoader', () => {
             expect(result).toEqual(exampleSchema1);
         });
 
-        it('should resolve relative paths against basePath', async () => {
-            vol.fromJSON({
-                '/project/subdir/relative.json': JSON.stringify(exampleSchema1)
-            });
 
-            const loader = new MappedDocumentLoader(new Map(), '/project', false);
-            const result = await loader.loadMissingDocument('subdir/relative.json', 'schema');
-
-            expect(result).toEqual(exampleSchema1);
-        });
-
-        it('should resolve parent-relative paths (../)', async () => {
-            vol.fromJSON({
-                '/project/standards/parent.json': JSON.stringify(exampleSchema1)
-            });
-
-            // Base path is a subdirectory
-            const loader = new MappedDocumentLoader(new Map(), '/project/patterns', false);
-            const result = await loader.loadMissingDocument('../standards/parent.json', 'schema');
-
-            expect(result).toEqual(exampleSchema1);
-        });
 
         it('should throw for URLs not in mapping', async () => {
             vol.fromJSON({});

--- a/shared/src/document-loader/mapped-document-loader.ts
+++ b/shared/src/document-loader/mapped-document-loader.ts
@@ -83,15 +83,7 @@ export class MappedDocumentLoader implements DocumentLoader {
             return this.loadDocumentFromPath(absolutePath);
         }
 
-        // 2. Check if it's a relative path
-        if (this.isRelativePath(documentId)) {
-            const absolutePath = path.resolve(this.basePath, documentId);
-            
-            if (existsSync(absolutePath)) {
-                this.logger.debug(`Resolved relative path: ${documentId} -> ${absolutePath}`);
-                return this.loadDocumentFromPath(absolutePath);
-            }
-        }
+
 
         // Cannot resolve - let other loaders try
         throw new DocumentLoadError({
@@ -100,19 +92,7 @@ export class MappedDocumentLoader implements DocumentLoader {
         });
     }
 
-    /**
-     * Check if a path is relative (not absolute and not a URL)
-     */
-    private isRelativePath(ref: string): boolean {
-        if (path.isAbsolute(ref)) {
-            return false;
-        }
-        if (ref.startsWith('http://') || ref.startsWith('https://') || 
-            ref.startsWith('file://') || ref.startsWith('calm:')) {
-            return false;
-        }
-        return true;
-    }
+
 
     /**
      * Resolve a local path to an absolute path using basePath
@@ -144,5 +124,19 @@ export class MappedDocumentLoader implements DocumentLoader {
                 cause: err
             });
         }
+    }
+    /**
+     * Public method to resolve a reference to a local absolute path.
+     * Reuse the logic from loadMissingDocument but return the path instead of loading.
+     */
+    resolvePath(reference: string): string | undefined {
+        // 1. Check URL mapping
+        if (this.urlToLocalMap.has(reference)) {
+            const localPath = this.urlToLocalMap.get(reference);
+            return this.resolveLocalPath(localPath);
+        }
+
+        // Relative path resolution has been moved to FileSystemDocumentLoader
+        return undefined;
     }
 }

--- a/shared/src/document-loader/multi-strategy-document-loader.ts
+++ b/shared/src/document-loader/multi-strategy-document-loader.ts
@@ -56,4 +56,14 @@ export class MultiStrategyDocumentLoader implements DocumentLoader {
         }
         this.logger.error(report);
     }
+
+    resolvePath(reference: string): string | undefined {
+        for (const loader of this.loaders) {
+            const resolved = loader.resolvePath(reference);
+            if (resolved) {
+                return resolved;
+            }
+        }
+        return undefined;
+    }
 }


### PR DESCRIPTION
## Description
Add multi-doc navigation to enable architects to split their architecture into multiple files helping contribute to #1926

Note: only local files are currently supported, not CALM Hub or other remote sources.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [x] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
