### PR TITLE
feat: add context7.json for Context7 ownership claim

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/finos/architecture-as-code",
+  "public_key": "pk_tACtU34AUVCHURNQ3CyP0",
+  "projectTitle": "FINOS CALM - Common Architecture Language Model",
+  "description": "A declarative, JSON-based modeling language for describing complex software architectures. Includes CLI tooling, schemas, and integrations for architecture-as-code workflows.",
+  "folders": [
+    "calm-ai",
+    "docs/docs",
+    "docs/quick-start",
+    "docs/cli",
+    "docs/calm",
+    "cli",
+    "calm",
+    "shared",
+    "calm-models",
+    "calm-widgets",
+    "calm-hub",
+    "calm-plugins/vscode"
+  ],
+  "excludeFolders": [
+    "node_modules",
+    "**/node_modules",
+    "**/dist",
+    "**/build",
+    "**/coverage",
+    "**/target",
+    "**/.docusaurus",
+    "conferences",
+    "sandbox",
+    "experimental",
+    "brand",
+    "template-bundles",
+    "advent-of-calm"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "LICENSE.md",
+    "CODE_OF_CONDUCT.md",
+    "renovate.json",
+    "pom.xml",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "tsconfig.json",
+    "tsconfig.build.json",
+    "tsconfig.base.json",
+    "eslint.config.mjs",
+    "prettier.config.js"
+  ],
+  "rules": [
+    "CALM architectures must be valid JSON that conforms to the CALM JSON Schema specification",
+    "Use the CALM CLI (@finos/calm-cli) for validating, visualizing, and generating architecture documents",
+    "Nodes must have unique-ids that are referenced in relationships",
+    "Relationships connect nodes using relationship-type and must reference valid node unique-ids",
+    "Interfaces define how nodes communicate and must use the oneOf constraint correctly",
+    "Patterns are reusable architecture templates that can be instantiated into concrete architectures",
+    "Use 'calm validate' to check architectures against schemas and patterns",
+    "Use 'calm visualize' to generate SVG diagrams from architecture documents"
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -7,8 +7,6 @@
   "folders": [
     "calm-ai",
     "docs/docs",
-    "docs/quick-start",
-    "docs/cli",
     "docs/calm",
     "cli",
     "calm",
@@ -49,12 +47,12 @@
   ],
   "rules": [
     "CALM architectures must be valid JSON that conforms to the CALM JSON Schema specification",
-    "Use the CALM CLI (@finos/calm-cli) for validating, visualizing, and generating architecture documents",
+    "Use the CALM CLI (@finos/calm-cli) for validating and generating architecture documents",
     "Nodes must have unique-ids that are referenced in relationships",
     "Relationships connect nodes using relationship-type and must reference valid node unique-ids",
     "Interfaces define how nodes communicate and must use the oneOf constraint correctly",
     "Patterns are reusable architecture templates that can be instantiated into concrete architectures",
     "Use 'calm validate' to check architectures against schemas and patterns",
-    "Use 'calm visualize' to generate SVG diagrams from architecture documents"
+    "Use 'calm docify' to generate documentation websites from architecture documents"
   ]
 }


### PR DESCRIPTION
## Description
Add configuration file to claim ownership of the finos/architecture-as-code project on Context7.com. This enables management of how CALM documentation is indexed and presented to AI coding assistants.

Related to #2014

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
