### PR TITLE
fix(calm-widgets): render primitive arrays inline with comma separator list for for MDX compatibility (#2080)

### DIFF
--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "calm-vscode-plugin",
     "displayName": "CALM",
     "description": "Live-visualize CALM architecture models, validate, and generate docs.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "publisher": "FINOS",
     "homepage": "https://calm.finos.org",
     "repository": {

--- a/calm-widgets/src/widgets.e2e.spec.ts
+++ b/calm-widgets/src/widgets.e2e.spec.ts
@@ -96,6 +96,15 @@ describe('Widgets E2E - Handlebars Integration', () => {
 
             expectToBeSameIgnoringLineEndings(result, expected);
         });
+
+        it('renders primitive arrays inline with comma separator (MDX-safe)', () => {
+            const { context, template, expected } = fixtures.loadFixture('table-widget', 'metadata-primitive-array');
+
+            const compiledTemplate = handlebars.compile(template);
+            const result = compiledTemplate(context);
+
+            expectToBeSameIgnoringLineEndings(result, expected);
+        });
     });
 
     describe('List Widget', () => {

--- a/calm-widgets/src/widgets/table/row-template.html
+++ b/calm-widgets/src/widgets/table/row-template.html
@@ -18,7 +18,7 @@
         {{> table-template.html rows=(objectEntries this) headers=false flatTable=false hasRows=true isNested=true}}
 
         {{else}}
-        {{this}}
+        {{this}}{{#unless @last}}, {{/unless}}
         {{/if}}
         {{/each}}
         {{else}}

--- a/calm-widgets/src/widgets/table/table-vertical.html
+++ b/calm-widgets/src/widgets/table/table-vertical.html
@@ -18,8 +18,7 @@
         {{> table-template.html rows=(objectEntries cellValue) headers=false flatTable=false hasRows=true isNested=true}}
         {{else if (isArray cellValue)}}{{#each cellValue}}{{#if (isObject this)}}
         {{> table-template.html rows=(objectEntries this) headers=false flatTable=false hasRows=true isNested=true}}
-        {{else}}{{this}}
-        {{/if}}{{/each}}{{else}}{{cellValue}}{{/if}}</td>
+        {{else}}{{this}}{{#unless @last}}, {{/unless}}{{/if}}{{/each}}{{else}}{{cellValue}}{{/if}}</td>
 </tr>
 {{/with}}
 {{/with}}

--- a/calm-widgets/test-fixtures/combined-widgets/comprehensive-documentation/expected.md
+++ b/calm-widgets/test-fixtures/combined-widgets/comprehensive-documentation/expected.md
@@ -184,8 +184,8 @@
                         <tr>
                             <td><b>Value</b></td>
                             <td>
-                                Product Catalog
-                                Inventory Management
+                                Product Catalog, 
+                                Inventory Management, 
                                 Price Calculation
                             </td>
                         </tr>
@@ -347,8 +347,8 @@
                         <tr>
                             <td><b>Value</b></td>
                             <td>
-                                Order Processing
-                                Payment Integration
+                                Order Processing, 
+                                Payment Integration, 
                                 Order Tracking
                             </td>
                         </tr>

--- a/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/context.json
+++ b/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/context.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "operations": ["add", "subtract", "multiply", "divide"],
+    "tags": ["payment", "financial", "api"],
+    "version": "1.0.0"
+  }
+}

--- a/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/expected.md
+++ b/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/expected.md
@@ -1,0 +1,24 @@
+<div class="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th>Key</th>
+            <th>Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <th>Operations</th>
+            <td>add, subtract, multiply, divide</td>
+        </tr>
+        <tr>
+            <th>Tags</th>
+            <td>payment, financial, api</td>
+        </tr>
+        <tr>
+            <th>Version</th>
+            <td>1.0.0</td>
+        </tr>
+        </tbody>
+    </table>
+</div>

--- a/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/template.hbs
+++ b/calm-widgets/test-fixtures/table-widget/metadata-primitive-array/template.hbs
@@ -1,0 +1,1 @@
+{{table metadata orientation="vertical"}}

--- a/cli/test_fixtures/template/expected-output/widget-tests/sad-test.md
+++ b/cli/test_fixtures/template/expected-output/widget-tests/sad-test.md
@@ -942,8 +942,8 @@ The system follows a microservices architecture pattern deployed on Kubernetes, 
                                                         <tr>
                                                             <td><b>Nodes</b></td>
                                                             <td>
-                                                                load-balancer
-                                                                attendees
+                                                                load-balancer, 
+                                                                attendees, 
                                                                 attendees-store
                                                             </td>
                                                         </tr>

--- a/cli/test_fixtures/template/expected-output/widget-tests/table-test.md
+++ b/cli/test_fixtures/template/expected-output/widget-tests/table-test.md
@@ -911,8 +911,8 @@ url-to-local-file-mapping: ../../../getting-started/url-to-local-file-mapping.js
                                                         <tr>
                                                             <td><b>Nodes</b></td>
                                                             <td>
-                                                                load-balancer
-                                                                attendees
+                                                                load-balancer, 
+                                                                attendees, 
                                                                 attendees-store
                                                             </td>
                                                         </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -569,7 +569,7 @@
         },
         "calm-plugins/vscode": {
             "name": "calm-vscode-plugin",
-            "version": "0.4.0",
+            "version": "0.4.2",
             "dependencies": {
                 "@finos/calm-models": "file:../../calm-models",
                 "@finos/calm-shared": "file:../../shared",


### PR DESCRIPTION
## Description

Fix MDX compilation error when metadata contains arrays of primitive values.

When relationships have metadata with array values (e.g., `"operations": ["add", "subtract", "multiply", "divide"]`), the generated documentation site fails to compile with:
```
Expected a closing tag for `<td>` before the end of `paragraph`
```

This was caused by array values being rendered with newlines inside `<td>` elements, which MDX interprets as paragraph breaks.

The fix renders primitive arrays inline with comma separators: `add, subtract, multiply, divide`

Example in #2080  now renders appropriately

<img width="1229" height="1276" alt="image" src="https://github.com/user-attachments/assets/06e815d7-48b4-4365-b725-423cad337da8" />


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components

- [x] CALM Widgets (`calm-widgets/`)
- [x] Vscode (`calm-plugins\vsscode`)
- [x] Cli (`cli`)

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added new test fixture `metadata-primitive-array` to verify MDX-safe array rendering.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards



