### PR TITLE
fix(vscode): correct focusing for all  relationship types and increase test coverage

### DIFF
--- a/calm-plugins/vscode/src/cli/template-service.spec.ts
+++ b/calm-plugins/vscode/src/cli/template-service.spec.ts
@@ -74,6 +74,26 @@ describe('TemplateService', () => {
         expect(result).toBe('REL shared-id')
     })
 
+    it('should return flow-focus template when graph edge type is flow', async () => {
+        const loadTemplateSpy = vi
+            .spyOn(service as any, 'loadTemplate')
+            .mockResolvedValue('FLOW {{focused-flow-id}}')
+        const readModelSpy = vi.spyOn((service as any).modelService, 'readModelAsync')
+
+        const result = await service.generateTemplateContent(
+            'flow-edge-1',
+            { nodes: [], edges: [{ id: 'flow-edge-1', type: 'flow' }] },
+            '/path/to/model.json',
+            true,
+            false,
+            undefined
+        )
+
+        expect(loadTemplateSpy).toHaveBeenCalledWith('flow-focus-template.hbs', true)
+        expect(readModelSpy).not.toHaveBeenCalled()
+        expect(result).toBe('FLOW flow-edge-1')
+    })
+
     it('should return flow-focus template when flow unique-id matches model', async () => {
         const loadTemplateSpy = vi
             .spyOn(service as any, 'loadTemplate')

--- a/calm-plugins/vscode/src/cli/template-service.ts
+++ b/calm-plugins/vscode/src/cli/template-service.ts
@@ -74,6 +74,13 @@ export class TemplateService {
 
       const edge = graph.edges?.find((x: any) => x.id === selectedId)
       if (edge) {
+        if (edge.type === 'flow') {
+          const template = await this.loadTemplate('flow-focus-template.hbs', showLabels)
+          return this.processor.replacePlaceholders(template, {
+            'focused-flow-id': selectedId
+          })
+        }
+
         const template = await this.loadTemplate('relationship-focus-template.hbs', showLabels)
         return this.processor.replacePlaceholders(template, {
           'focused-relationship-id': selectedId


### PR DESCRIPTION
## Description
Fixes a bug reported directly to me, that VSCode extension failed to focus its preview on relationships of type `deployed-in` or `composed-of`. Research also indicated that `interacts` relationships did not work either.

This pull request adds new unit tests for the `TemplateService` class and updates the implementation to improve how templates are selected based on the model data. The main focus is ensuring that the correct template is chosen when a given ID matches either a relationship or a flow.

Key changes:

**Testing improvements:**

* Added a comprehensive test suite for `TemplateService` in `template-service.spec.ts`, covering cases for selecting relationship or flow templates, and ensuring relationship matches take precedence when IDs overlap.

**Template selection logic:**

* Updated `generateTemplateContent` in `template-service.ts` to:
  - Use the asynchronous `readModelAsync` method (synchronous method is deprecated)
  - Look in the _model_ for a matching `selectedId` of a relationship. The bug occurred because the graph `id` for `interacts`, `composed-of` and `deployed-in` is NOT the `unique-id`, and so line 75 fails to match the relationship `selectedId`.

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [X] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [X] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
