### PR TITLE
Resolve continued @types/node regressions

### DIFF
--- a/calm-hub-ui/package.json
+++ b/calm-hub-ui/package.json
@@ -21,7 +21,6 @@
         "@dagrejs/dagre": "^1.1.4",
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.1.4",
-        "@types/node": "^22.19.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react-swc": "^4.0.0",

--- a/calm-models/package.json
+++ b/calm-models/package.json
@@ -43,7 +43,6 @@
     "ajv": "^8.18.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
     "eslint": "^9.39.2",
     "rimraf": "^5.0.0",
     "typescript": "^5.0.0"

--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -185,7 +185,6 @@
     "devDependencies": {
         "@types/lodash": "^4.17.16",
         "@types/markdown-it": "^14.1.2",
-        "@types/node": "^22.0.0",
         "@types/svg-pan-zoom": "^3.3.0",
         "@types/vscode": "^1.88.0",
         "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/calm-widgets/package.json
+++ b/calm-widgets/package.json
@@ -33,7 +33,6 @@
     "@types/json-pointer": "^1.0.34",
     "@types/junit-report-builder": "^3.0.2",
     "@types/lodash": "^4.17.16",
-    "@types/node": "^22.15.0",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "axios-mock-adapter": "^2.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -55,7 +55,6 @@
         "@types/json-pointer": "^1.0.34",
         "@types/junit-report-builder": "^3.0.2",
         "@types/lodash": "^4.17.16",
-        "@types/node": "^22.15.0",
         "@types/supertest": "^6.0.3",
         "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/experimental/calm-explorer/package.json
+++ b/experimental/calm-explorer/package.json
@@ -119,7 +119,6 @@
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@types/vscode": "^1.105.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
             "devDependencies": {
                 "@commitlint/cli": "^20.0.0",
                 "@commitlint/config-conventional": "^20.0.0",
+                "@types/node": "^22.19.2",
                 "@vitest/coverage-v8": "^3.1.1",
                 "@vitest/ui": "^3.1.4",
                 "ajv": "^8.18.0",
@@ -50,7 +51,6 @@
                 "@dagrejs/dagre": "^1.1.4",
                 "@monaco-editor/react": "^4.7.0",
                 "@tailwindcss/vite": "^4.1.4",
-                "@types/node": "^22.19.2",
                 "@types/react": "^18.3.12",
                 "@types/react-dom": "^18.3.1",
                 "@vitejs/plugin-react-swc": "^4.0.0",
@@ -111,15 +111,6 @@
                 "vitest": "^3.0.6"
             }
         },
-        "calm-hub-ui/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
         "calm-hub-ui/node_modules/lucide-react": {
             "version": "0.468.0",
             "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
@@ -137,20 +128,9 @@
                 "ajv": "^8.18.0"
             },
             "devDependencies": {
-                "@types/node": "^22.0.0",
                 "eslint": "^9.39.2",
                 "rimraf": "^5.0.0",
                 "typescript": "^5.0.0"
-            }
-        },
-        "calm-models/node_modules/@types/node": {
-            "version": "20.19.33",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-            "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         },
         "calm-plugins/vscode": {
@@ -171,7 +151,6 @@
             "devDependencies": {
                 "@types/lodash": "^4.17.16",
                 "@types/markdown-it": "^14.1.2",
-                "@types/node": "^22.0.0",
                 "@types/svg-pan-zoom": "^3.3.0",
                 "@types/vscode": "^1.88.0",
                 "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -200,16 +179,6 @@
             },
             "peerDependencies": {
                 "mermaid": "^11.0.2"
-            }
-        },
-        "calm-plugins/vscode/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         },
         "calm-plugins/vscode/node_modules/jsdom": {
@@ -269,7 +238,6 @@
                 "@types/json-pointer": "^1.0.34",
                 "@types/junit-report-builder": "^3.0.2",
                 "@types/lodash": "^4.17.16",
-                "@types/node": "^22.15.0",
                 "@typescript-eslint/eslint-plugin": "^8.29.1",
                 "@typescript-eslint/parser": "^8.29.1",
                 "axios-mock-adapter": "^2.1.0",
@@ -279,16 +247,6 @@
                 "memfs": "^4.17.0",
                 "msw": "^2.7.3",
                 "typescript": "^5.8.3"
-            }
-        },
-        "calm-widgets/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         },
         "cli": {
@@ -317,7 +275,6 @@
                 "@types/json-pointer": "^1.0.34",
                 "@types/junit-report-builder": "^3.0.2",
                 "@types/lodash": "^4.17.16",
-                "@types/node": "^22.15.0",
                 "@types/supertest": "^6.0.3",
                 "@types/xml2js": "^0.4.14",
                 "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -332,16 +289,6 @@
                 "tsup": "^8.4.0",
                 "typescript": "^5.8.3",
                 "xml2js": "^0.6.2"
-            }
-        },
-        "cli/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         },
         "docs": {
@@ -436,7 +383,6 @@
                 "@tailwindcss/typography": "^0.5.16",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.0",
-                "@types/node": "^22.16.5",
                 "@types/react": "^18.3.23",
                 "@types/react-dom": "^18.3.7",
                 "@types/vscode": "^1.105.0",
@@ -460,16 +406,6 @@
             },
             "engines": {
                 "vscode": "^1.85.0"
-            }
-        },
-        "experimental/calm-explorer/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         },
         "experimental/calm-explorer/node_modules/@types/react": {
@@ -44265,7 +44201,6 @@
                 "@types/json-pointer": "^1.0.34",
                 "@types/junit-report-builder": "^3.0.2",
                 "@types/lodash": "^4.17.16",
-                "@types/node": "^22.15.0",
                 "@typescript-eslint/eslint-plugin": "^8.29.1",
                 "@typescript-eslint/parser": "^8.29.1",
                 "axios-mock-adapter": "^2.1.0",
@@ -44275,16 +44210,6 @@
                 "memfs": "^4.17.0",
                 "msw": "^2.7.3",
                 "typescript": "^5.8.3"
-            }
-        },
-        "shared/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "prepare": "husky"
     },
     "devDependencies": {
+        "@types/node": "^22.19.2",
         "ajv": "^8.18.0",
         "@commitlint/cli": "^20.0.0",
         "@commitlint/config-conventional": "^20.0.0",
@@ -58,7 +59,7 @@
         "vitest": "^3.1.1"
     },
     "overrides": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^22.19.2",
         "on-headers": "^1.1.0",
         "node-forge": "^1.3.2",
         "qs": "^6.15.0",

--- a/renovate.json
+++ b/renovate.json
@@ -159,7 +159,8 @@
     {
       "description": "Pin @types/node to v22 to match CI Node version",
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "<23.0.0"
+      "allowedVersions": "<23.0.0",
+      "rangeStrategy": "bump"
     }
   ]
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -61,7 +61,6 @@
         "@types/json-pointer": "^1.0.34",
         "@types/junit-report-builder": "^3.0.2",
         "@types/lodash": "^4.17.16",
-        "@types/node": "^22.15.0",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "axios-mock-adapter": "^2.1.0",


### PR DESCRIPTION
## Description
Dependabot and other changes frequently result in @types/node being 'downgraded' in the package-lock.json files.

This change removes the duplicate declarations and relies on a single declaration at the top level.

The dependency is declared for our projects and as an override to push to transative dependencies.

The "rangeStrategy" has been added to specify "bump" to tell renovatebot to pull version up, tightening the expectation.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
