### PR TITLE
fix(deps): override rollup 2.x to 2.80.0 to resolve CVE-2026-27606

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,7 +251,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.34.0",
+            "version": "1.34.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -12171,21 +12171,6 @@
             },
             "engines": {
                 "node": "^12.20 || >=14.13"
-            }
-        },
-        "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/rollup": {
-            "version": "2.79.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-            "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-            "license": "MIT",
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/@stoplight/spectral-ruleset-migrator": {
@@ -36455,7 +36440,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
             "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
         "node-forge": "^1.3.2",
         "qs": "^6.15.0",
         "lodash": "^4.17.23",
-        "lodash-es": "^4.17.23"
+        "lodash-es": "^4.17.23",
+        "@stoplight/spectral-ruleset-bundler@1.6.x": {
+            "rollup": "2.80.0"
+        }
     },
     "dependencies": {
         "@finos/calm-shared": "^0.2.2",


### PR DESCRIPTION
## Description
@stoplight/spectral-ruleset-bundler@1.6.3 hard-pins rollup ~2.79.2 which is vulnerable (< 2.80.0) and there is no upstream fix available. Added a scoped npm override to force resolution to 2.80.0.

Also updates transitive rollup 4.x dependencies to 4.59.0.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Shared (`shared/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
