### PR TITLE
fix(shared): update validate() signature to accept undefined

### DIFF
--- a/cli/src/command-helpers/validate.ts
+++ b/cli/src/command-helpers/validate.ts
@@ -34,9 +34,9 @@ export async function runValidate(options: ValidateOptions) {
         const schemaDirectory = await buildSchemaDirectory(docLoader, options.verbose);
         await schemaDirectory.loadSchemas();
 
-        let architecture: object | undefined;
-        let pattern: object | undefined;
-        let timeline: object | undefined;
+        let architecture: object | undefined = undefined;
+        let pattern: object | undefined = undefined;
+        let timeline: object | undefined = undefined;
 
         if (options.timelinePath) {
             const result = await loadTimeline(

--- a/cli/src/command-helpers/validate.ts
+++ b/cli/src/command-helpers/validate.ts
@@ -60,6 +60,9 @@ export async function runValidate(options: ValidateOptions) {
             pattern = result.pattern;
         }
         const documentContexts = buildDocumentContexts(options, logger);
+        if (!architecture && !pattern && !timeline) {
+            throw new Error('You must provide an architecture, a pattern, or a timeline');
+        }
         const outcome = await validate(architecture, pattern, timeline, schemaDirectory, options.verbose);
         enrichWithDocumentPositions(outcome, documentContexts);
         const content = getFormattedOutput(outcome, options.outputFormat, toFormattingOptions(documentContexts));

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -98,9 +98,9 @@ async function runSpectralValidations(
 
 /**
  * Validation - with simple input parameters and output validation outcomes.
- * @param architecture The architecture as a JS object
- * @param patternOrSchema The pattern (or schema) as a JS object
- * @param timeline The timeline as a JS object
+ * @param architecture The architecture as a JS object, or undefined if not provided
+ * @param patternOrSchema The pattern (or schema) as a JS object, or undefined if not provided
+ * @param timeline The timeline as a JS object, or undefined if not provided
  * @param schemaDirectory SchemaDirectory instance for schema resolution
  * @param debug Whether to log at debug level
  * @returns Validation report

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -106,8 +106,8 @@ async function runSpectralValidations(
  * @returns Validation report
  */
 export async function validate(
-    architecture: object,
-    patternOrSchema: object,
+    architecture: object | undefined,
+    patternOrSchema: object | undefined,
     timeline: object | undefined,
     schemaDirectory?: SchemaDirectory,
     debug: boolean = false


### PR DESCRIPTION
## Summary
- Updates `validate()` in `shared` to accept `object | undefined` for `architecture` and `patternOrSchema` parameters, matching the function's existing runtime behaviour (it already handles undefined via truthiness checks)
- Adds an explicit runtime guard in the CLI caller, replacing unsafe `as object` type assertions

## Context
Raised by Copilot review on #2186 — the `as object` casts in the CLI were bypassing TypeScript's type safety. The root cause was that `validate()`'s signature declared both parameters as non-nullable `object`, even though the function already handles `undefined` internally.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes across all workspaces (shared change requires full test run)
- [x] No downstream type breakage in CLI or VS Code plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)