### PR TITLE
Potential fix for code scanning alert no. 54: Server-side request forgery

### DIFF
--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -5,6 +5,11 @@ import { DocumentLoadError } from './document-loader';
 import { Logger, initLogger } from '../logger';
 
 export class DirectUrlDocumentLoader implements DocumentLoader {
+    private static readonly ALLOWED_HOSTS: string[] = (process.env.CALM_SCHEMA_ALLOWED_HOSTS ?? '')
+        .split(',')
+        .map(host => host.trim().toLowerCase())
+        .filter(host => host.length > 0);
+
     private readonly ax: Axios;
     private logger: Logger;
 
@@ -22,6 +27,28 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
         if (debug) {
             this.addAxiosDebug();
         }
+    }
+
+    private isAllowedUrl(urlString: string): boolean {
+        let url: URL;
+        try {
+            url = new URL(urlString);
+        } catch {
+            return false;
+        }
+
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return false;
+        }
+
+        const hostname = url.hostname.toLowerCase();
+
+        if (DirectUrlDocumentLoader.ALLOWED_HOSTS.length === 0) {
+            // If no allow-list is configured, do not allow any remote hosts.
+            return false;
+        }
+
+        return DirectUrlDocumentLoader.ALLOWED_HOSTS.includes(hostname);
     }
 
     addAxiosDebug() {
@@ -42,6 +69,13 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
     }
 
     async loadMissingDocument(documentId: string, _type: CalmDocumentType): Promise<object> {
+        if (!this.isAllowedUrl(documentId)) {
+            throw new DocumentLoadError({
+                name: 'INVALID_DOCUMENT_URL',
+                message: `Refusing to load document from disallowed URL: ${documentId}`
+            });
+        }
+
         try {
             const response = await this.ax.get(documentId);
             return response.data;


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/54](https://github.com/finos/architecture-as-code/security/code-scanning/54)

In general, to fix this SSRF issue we must ensure that user-controlled values cannot freely determine the full URL used in outbound HTTP requests. The typical mitigations are: (a) restrict URLs to a well-defined allow‑list of hosts and schemes; and/or (b) avoid making network calls at all for untrusted `$schema` IDs, instead only resolving against pre‑registered local schemas.

In this codebase, the minimal, targeted fix is to harden `DirectUrlDocumentLoader.loadMissingDocument`. We keep its interface the same but validate `documentId` before calling `this.ax.get(documentId)`. Concretely:

- Parse `documentId` as a URL using Node’s built‑in `URL` class.
- Enforce that:
  - The protocol is `http:` or `https:`.
  - The hostname is in an explicit allow‑list that the server owner can configure via environment variables or a constant in this module (for example, only your schema host(s)).
- If validation fails (cannot parse, disallowed protocol or host), throw a `DocumentLoadError` indicating an invalid or disallowed URL and do not perform the request.
- Optionally, log rejected URLs at debug/info level (not required for security, but useful operationally).

This keeps all existing calling code unchanged (`SchemaDirectory` and the validation routes still invoke `getSchema` / `loadMissingDocument` the same way) but prevents arbitrary outbound requests even when `$schema` is attacker‑controlled. The change is confined to `shared/src/document-loader/direct-url-document-loader.ts`; the other files do not need modification for the SSRF fix.

Implementation details:

- Add a small helper inside `DirectUrlDocumentLoader` (e.g. `private isAllowedUrl(urlString: string): boolean`) that:
  - Tries to construct `new URL(urlString)`.
  - Checks `url.protocol` against `['http:', 'https:']`.
  - Checks `url.hostname` against an allow‑list array, e.g.:

    ```ts
    private static readonly ALLOWED_HOSTS = (process.env.CALM_SCHEMA_ALLOWED_HOSTS ?? '')
        .split(',')
        .map(h => h.trim().toLowerCase())
        .filter(Boolean);
    ```

    falling back to a safe default (for example, an empty allow‑list that causes all remote URLs to be rejected unless configured).
- In `loadMissingDocument`, call this helper before `this.ax.get(documentId)`. On failure, throw a `DocumentLoadError` with a distinct `name` such as `'INVALID_DOCUMENT_URL'` and a clear message; this will be handled by existing callers like `SchemaDirectory.getSchema` similarly to other `DocumentLoadError`s.
- No new external dependencies are required; `URL` and `process.env` are standard Node/JS features.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
