### PR TITLE
ci(calm-server): fix build order in release job

### DIFF
--- a/.github/workflows/automated-release-calm-server.yml
+++ b/.github/workflows/automated-release-calm-server.yml
@@ -237,7 +237,7 @@ jobs:
           node-version: 22
 
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:calm-server
 
       - name: Create version update PR
         run: |


### PR DESCRIPTION
## Problem
The calm-server release workflow was failing because the `create-version-pr` job ran `npm run build` (full workspace build) before calm-server package dependencies were built. In clean CI environments where `shared/dist` doesn't exist yet, this caused `@finos/calm-shared` module resolution to fail.

## Solution
Changed the build step in the create-version-pr job from `npm run build` to `npm run build:calm-server`, which explicitly builds dependencies in the correct order:
- calm-models
- calm-widgets  
- calm-shared
- calm-server

This ensures `@finos/calm-shared` is available when calm-server is built, regardless of workspace order.

## Validation
✅ Build succeeds from clean state (shared/dist removed)
✅ All calm-server tests pass (11/11)
✅ Package builds and publishes correctly