### PR TITLE
Potential fix for code scanning alert no. 55: Use of externally-controlled format string

### DIFF
--- a/calm-hub-ui/src/service/adr-service/adr-service.tsx
+++ b/calm-hub-ui/src/service/adr-service/adr-service.tsx
@@ -24,7 +24,7 @@ export class AdrService {
             .then((res) => res.data.values)
             .catch((error) => {
                 const errorMessage = `Error fetching adr IDs for namespace ${namespace}:`;
-                console.error(errorMessage, error);
+                console.error('Error fetching adr IDs for namespace %s:', namespace, error);
                 return Promise.reject(new Error(errorMessage));
             });
     }
@@ -41,7 +41,7 @@ export class AdrService {
             .then((res) => res.data.values)
             .catch((error) => {
                 const errorMessage = `Error fetching revisions for ADR ID ${adrID}:`;
-                console.error(errorMessage, error);
+                console.error('Error fetching revisions for ADR ID %s:', adrID, error);
                 return Promise.reject(new Error(errorMessage));
             });
     }
@@ -58,7 +58,7 @@ export class AdrService {
             .then((res) => res.data)
             .catch((error) => {
                 const errorMessage = `Error fetching adr for namespace ${namespace}, adr ID ${adrID}, revision ${revision}:`;
-                console.error(errorMessage, error);
+                console.error('Error fetching adr for namespace %s, adr ID %s, revision %s:', namespace, adrID, revision, error);
                 return Promise.reject(new Error(errorMessage));
             });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/finos/architecture-as-code/security/code-scanning/55](https://github.com/finos/architecture-as-code/security/code-scanning/55)

Generally, to fix externally controlled format string issues in `console.*` calls, avoid constructing the first argument from unsanitized input. Instead, use a constant format string containing `%s` placeholders and pass all untrusted values as separate arguments. This ensures the runtime treats the first argument as the only format string, not the concatenated user input.

In this file, the vulnerable pattern is:

```ts
const errorMessage = `Error fetching adr IDs for namespace ${namespace}:`;
console.error(errorMessage, error);
```

Here, `errorMessage` (containing user-controlled `namespace`) is the first argument, and `error` is the second argument, so if the console interprets `%` sequences inside `errorMessage`, it may attempt to format `error` unexpectedly. The best minimal fix is to make the format string constant and pass `namespace` (and other variables like `adrID`, `revision`) as additional arguments to `console.error`. Concretely:

- In `fetchAdrIDs`, replace the template-literal construction with an explicit format string:  
  `console.error('Error fetching adr IDs for namespace %s:', namespace, error);`
- In `fetchAdrRevisions`, similarly:  
  `console.error('Error fetching revisions for ADR ID %s:', adrID, error);`
- In `fetchAdr`, similarly:  
  `console.error('Error fetching adr for namespace %s, adr ID %s, revision %s:', namespace, adrID, revision, error);`

These changes are all within `calm-hub-ui/src/service/adr-service/adr-service.tsx`, lines 26–27, 43–44, and 60–61. No new imports or helpers are needed. The surrounding logic, returned promises, and error messages remain semantically equivalent; only the formatting mechanism for logging changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
