### PR TITLE
fix: resolve all open CodeQL security alerts

### DIFF
--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -37,7 +37,7 @@ export async function fetchPatternIDs(
         const data = await res.json();
         setPatternIDs(data.values.map((num: number) => num.toString()));
     } catch (error) {
-        console.error(`Error fetching pattern IDs for namespace ${namespace}:`, error);
+        console.error('Error fetching pattern IDs for namespace:', namespace, error);
     }
 }
 
@@ -54,7 +54,7 @@ export async function fetchFlowIDs(namespace: string, setFlowIDs: (flowIDs: stri
         const data = await res.json();
         setFlowIDs(data.values.map((id: number) => id.toString()));
     } catch (error) {
-        console.error(`Error fetching flow IDs for namespace ${namespace}:`, error);
+        console.error('Error fetching flow IDs for namespace:', namespace, error);
     }
 }
 
@@ -75,7 +75,7 @@ export async function fetchPatternVersions(
         const data = await res.json();
         setVersions(data.values);
     } catch (error) {
-        console.error(`Error fetching versions for pattern ID ${patternID}:`, error);
+        console.error('Error fetching versions for pattern ID:', patternID, error);
     }
 }
 
@@ -96,7 +96,7 @@ export async function fetchFlowVersions(
         const data = await res.json();
         setFlowVersions(data.values);
     } catch (error) {
-        console.error(`Error fetching versions for flow ID ${flowID}:`, error);
+        console.error('Error fetching versions for flow ID:', flowID, error);
     }
 }
 
@@ -129,7 +129,7 @@ export async function fetchPattern(
         setPattern(data);
     } catch (error) {
         console.error(
-            `Error fetching pattern for namespace ${namespace}, pattern ID ${patternID}, version ${version}:`,
+            'Error fetching pattern for namespace:', namespace, 'pattern ID:', patternID, 'version:', version,
             error
         );
     }
@@ -164,7 +164,7 @@ export async function fetchFlow(
         setFlow(data);
     } catch (error) {
         console.error(
-            `Error fetching flow for namespace ${namespace}, flow ID ${flowID}, version ${version}:`,
+            'Error fetching flow for namespace:', namespace, 'flow ID:', flowID, 'version:', version,
             error
         );
     }
@@ -186,7 +186,7 @@ export async function fetchArchitectureIDs(
         const data = await res.json();
         setArchitectureIDs(data.values.map((id: number) => id.toString()));
     } catch (error) {
-        console.error(`Error fetching architecture IDs for namespace ${namespace}:`, error);
+        console.error('Error fetching architecture IDs for namespace:', namespace, error);
     }
 }
 
@@ -210,7 +210,7 @@ export async function fetchArchitectureVersions(
         const data = await res.json();
         setVersions(data.values);
     } catch (error) {
-        console.error(`Error fetching versions for architecture ID ${architectureID}:`, error);
+        console.error('Error fetching versions for architecture ID:', architectureID, error);
     }
 }
 
@@ -243,7 +243,7 @@ export async function fetchArchitecture(
         setArchitecture(data);
     } catch (error) {
         console.error(
-            `Error fetching architecture for namespace ${namespace}, architecture ID ${architectureID}, version ${version}:`,
+            'Error fetching architecture for namespace:', namespace, 'architecture ID:', architectureID, 'version:', version,
             error
         );
     }

--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -47,4 +47,10 @@ describe('calmhub-document-loader', () => {
         await expect(calmHubDocumentLoader.loadMissingDocument(traversalUrl, 'schema'))
             .rejects.toThrow('directory traversal');
     });
+
+    it('rejects paths with disallowed characters', async () => {
+        const maliciousUrl = 'calm:/schemas/%00malicious';
+        await expect(calmHubDocumentLoader.loadMissingDocument(maliciousUrl, 'schema'))
+            .rejects.toThrow('disallowed characters');
+    });
 });

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -59,8 +59,7 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         }
         const path = url.pathname;
 
-        const SAFE_PATH_PATTERN = CalmHubDocumentLoader.SAFE_PATH_PATTERN;
-        if (!SAFE_PATH_PATTERN.test(path)) {
+        if (!CalmHubDocumentLoader.SAFE_PATH_PATTERN.test(path)) {
             throw new Error(`CalmHubDocumentLoader rejected path with disallowed characters: ${path}`);
         }
 

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -4,6 +4,7 @@ import { CalmDocumentType, DocumentLoader, CALM_HUB_PROTO } from './document-loa
 import { initLogger, Logger } from '../logger';
 
 export class CalmHubDocumentLoader implements DocumentLoader {
+    private static readonly SAFE_PATH_PATTERN = /^[a-zA-Z0-9/_\-.]+(\.json)?$/;
     private readonly ax: Axios;
     private readonly logger: Logger;
 
@@ -58,7 +59,7 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         }
         const path = url.pathname;
 
-        const SAFE_PATH_PATTERN = /^[a-zA-Z0-9/_\-.]+(\.json)?$/;
+        const SAFE_PATH_PATTERN = CalmHubDocumentLoader.SAFE_PATH_PATTERN;
         if (!SAFE_PATH_PATTERN.test(path)) {
             throw new Error(`CalmHubDocumentLoader rejected path with disallowed characters: ${path}`);
         }

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -58,6 +58,11 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         }
         const path = url.pathname;
 
+        const SAFE_PATH_PATTERN = /^[a-zA-Z0-9/_\-.]+(\.json)?$/;
+        if (!SAFE_PATH_PATTERN.test(path)) {
+            throw new Error(`CalmHubDocumentLoader rejected path with disallowed characters: ${path}`);
+        }
+
         this.logger.debug(`Loading CALM schema from ${this.calmHubUrl}${path}`);
 
         // TODO gracefully handle 404s and other errors

--- a/shared/src/document-loader/direct-url-document-loader.spec.ts
+++ b/shared/src/document-loader/direct-url-document-loader.spec.ts
@@ -45,4 +45,40 @@ describe('direct-url-document-loader', () => {
         await expect(directUrlDocumentLoader.loadMissingDocument(ftpUrl, 'schema'))
             .rejects.toThrow('Only HTTP and HTTPS are allowed');
     });
+
+    it('rejects URLs targeting localhost', async () => {
+        const url = 'http://localhost/admin';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting 127.x.x.x', async () => {
+        const url = 'http://127.0.0.1/secret';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting 10.x private range', async () => {
+        const url = 'https://10.0.0.1/internal';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting 192.168.x private range', async () => {
+        const url = 'https://192.168.1.1/admin';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting 172.16-31.x private range', async () => {
+        const url = 'https://172.16.0.1/internal';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting link-local addresses', async () => {
+        const url = 'http://169.254.169.254/latest/meta-data';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
 });

--- a/shared/src/document-loader/direct-url-document-loader.spec.ts
+++ b/shared/src/document-loader/direct-url-document-loader.spec.ts
@@ -81,4 +81,29 @@ describe('direct-url-document-loader', () => {
         await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
             .rejects.toThrow('private or internal network addresses are not allowed');
     });
+
+    it('rejects URLs targeting IPv6 loopback', async () => {
+        const url = 'http://[::1]/admin';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting IPv6 private (fc00::)', async () => {
+        const url = 'http://[fc00::1]/internal';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('rejects URLs targeting IPv6 link-local (fe80::)', async () => {
+        const url = 'http://[fe80::1]/internal';
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('private or internal network addresses are not allowed');
+    });
+
+    it('does not block legitimate hostnames starting with IP-like prefixes', async () => {
+        const url = 'https://10.example.com/document.json';
+        // Should NOT throw "private or internal" - it's a DNS name, not an IP
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.not.toThrow('private or internal network addresses are not allowed');
+    });
 });

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -4,6 +4,24 @@ import { CalmDocumentType, DocumentLoader } from './document-loader';
 import { DocumentLoadError } from './document-loader';
 import { Logger, initLogger } from '../logger';
 
+const PRIVATE_HOST_PATTERNS = [
+    /^localhost$/i,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^0\./,
+    /^169\.254\./,
+    /^\[::1\]$/,
+    /^\[fc/i,
+    /^\[fd/i,
+    /^\[fe80:/i,
+];
+
+function isPrivateHost(hostname: string): boolean {
+    return PRIVATE_HOST_PATTERNS.some(p => p.test(hostname));
+}
+
 export class DirectUrlDocumentLoader implements DocumentLoader {
     private readonly ax: Axios;
     private logger: Logger;
@@ -51,7 +69,14 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
                     message: `Unsupported URL protocol '${parsedUrl.protocol}' in document URL. Only HTTP and HTTPS are allowed.`,
                 });
             }
-            const response = await this.ax.get(parsedUrl.toString());
+            if (isPrivateHost(parsedUrl.hostname)) {
+                throw new DocumentLoadError({
+                    name: 'UNKNOWN',
+                    message: `Requests to private or internal network addresses are not allowed: ${parsedUrl.hostname}`,
+                });
+            }
+            const sanitizedUrl = parsedUrl.toString();
+            const response = await this.ax.get(sanitizedUrl);
             return response.data;
         } catch (error) {
             if (error instanceof DocumentLoadError) {

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -1,25 +1,36 @@
 import axios, { Axios } from 'axios';
+import { isIP } from 'net';
 import { SchemaDirectory } from '../schema-directory';
 import { CalmDocumentType, DocumentLoader } from './document-loader';
 import { DocumentLoadError } from './document-loader';
 import { Logger, initLogger } from '../logger';
 
-const PRIVATE_HOST_PATTERNS = [
-    /^localhost$/i,
+const PRIVATE_IPV4_PATTERNS = [
     /^127\./,
     /^10\./,
     /^172\.(1[6-9]|2\d|3[01])\./,
     /^192\.168\./,
     /^0\./,
     /^169\.254\./,
-    /^\[::1\]$/,
-    /^\[fc/i,
-    /^\[fd/i,
-    /^\[fe80:/i,
+];
+
+const PRIVATE_IPV6_PATTERNS = [
+    /^::1$/,
+    /^fc/i,
+    /^fd/i,
+    /^fe80:/i,
 ];
 
 function isPrivateHost(hostname: string): boolean {
-    return PRIVATE_HOST_PATTERNS.some(p => p.test(hostname));
+    if (/^localhost$/i.test(hostname)) return true;
+    // URL.hostname wraps IPv6 in brackets; strip them for isIP/pattern checks
+    const bare = hostname.startsWith('[') && hostname.endsWith(']')
+        ? hostname.slice(1, -1)
+        : hostname;
+    const ipVersion = isIP(bare);
+    if (ipVersion === 4) return PRIVATE_IPV4_PATTERNS.some(p => p.test(bare));
+    if (ipVersion === 6) return PRIVATE_IPV6_PATTERNS.some(p => p.test(bare));
+    return false;
 }
 
 export class DirectUrlDocumentLoader implements DocumentLoader {
@@ -75,8 +86,8 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
                     message: `Requests to private or internal network addresses are not allowed: ${parsedUrl.hostname}`,
                 });
             }
-            const sanitizedUrl = parsedUrl.toString();
-            const response = await this.ax.get(sanitizedUrl);
+            const targetUrl = parsedUrl.toString();
+            const response = await this.ax.get(targetUrl, { maxRedirects: 0 });
             return response.data;
         } catch (error) {
             if (error instanceof DocumentLoadError) {


### PR DESCRIPTION
## Summary

Fixes all 11 open CodeQL code scanning alerts:

- **2 critical SSRF vulnerabilities** (`js/request-forgery`):
  - `DirectUrlDocumentLoader`: Added private/internal network address blocking (localhost, 127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x, IPv6 loopback/private/link-local) to prevent server-side request forgery
  - `CalmHubDocumentLoader`: Added strict path character allowlist regex to prevent path injection into the CalmHub base URL

- **9 high-severity tainted format string vulnerabilities** (`js/tainted-format-string`):
  - `calm-service.tsx`: Replaced all template literals in `console.error()` first arguments with static strings, passing user-controlled values as separate arguments to prevent format string injection

## Test plan

- [x] All existing tests pass (15/15 in document-loader specs)
- [x] 6 new tests for SSRF private IP blocking in `direct-url-document-loader.spec.ts` (localhost, 127.x, 10.x, 192.168.x, 172.16.x, 169.254.x link-local)
- [x] 1 new test for path character validation in `calmhub-document-loader.spec.ts`
- [ ] CodeQL re-scan confirms alerts resolved

Resolves CodeQL alerts: #53, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)