### PR TITLE
fix(shared): identify unique-ids in complex patterns

### DIFF
--- a/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
@@ -146,4 +146,166 @@ describe('idsAreUnique', () => {
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/relationships/prefixItems/0/properties/unique-id/const');
     });
+
+    it('should return messages for duplicate IDs when a node inside anyOf duplicates a regular node', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}},
+                                {
+                                    'anyOf': [
+                                        {'properties': {'unique-id': {'const': 'node1'}}},
+                                        {'properties': {'unique-id': {'const': 'node2'}}}
+                                    ]
+                                }
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'rel1'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/nodes/prefixItems/1/anyOf/0/properties/unique-id/const');
+    });
+
+    it('should return messages for duplicate IDs when a relationship inside oneOf duplicates a regular relationship', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}}
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'rel1'}}},
+                                {
+                                    'oneOf': [
+                                        {'properties': {'unique-id': {'const': 'rel1'}}},
+                                        {'properties': {'unique-id': {'const': 'rel2'}}}
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /properties/relationships/prefixItems/1/oneOf/0/properties/unique-id/const');
+    });
+
+    it('should not return messages when anyOf node IDs are all unique', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}},
+                                {
+                                    'anyOf': [
+                                        {'properties': {'unique-id': {'const': 'node2'}}},
+                                        {'properties': {'unique-id': {'const': 'node3'}}}
+                                    ]
+                                }
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'rel1'}}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should not return messages for duplicate IDs that are siblings within the same oneOf block', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}}
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {
+                                    'oneOf': [
+                                        {'properties': {'unique-id': {'const': 'rel1'}}},
+                                        {'properties': {'unique-id': {'const': 'rel1'}}}
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result).toEqual([]);
+    });
+
+    it('should return messages for duplicate IDs across different oneOf blocks', () => {
+        const input = {};
+        const context = {
+            document: {
+                data: {
+                    properties: {
+                        nodes: {
+                            prefixItems: [
+                                {'properties': {'unique-id': {'const': 'node1'}}}
+                            ]
+                        },
+                        relationships: {
+                            prefixItems: [
+                                {
+                                    'oneOf': [
+                                        {'properties': {'unique-id': {'const': 'rel1'}}},
+                                        {'properties': {'unique-id': {'const': 'rel2'}}}
+                                    ]
+                                },
+                                {
+                                    'oneOf': [
+                                        {'properties': {'unique-id': {'const': 'rel1'}}},
+                                        {'properties': {'unique-id': {'const': 'rel3'}}}
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = idsAreUnique(input, null, context);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /properties/relationships/prefixItems/1/oneOf/0/properties/unique-id/const');
+    });
 });

--- a/shared/src/spectral/functions/pattern/ids-are-unique.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.ts
@@ -1,24 +1,54 @@
 import { JSONPath } from 'jsonpath-plus';
-import { detectDuplicates } from '../helper-functions';
+
 /**
- * Checks that the input value exists as a node with a matching unique ID.
+ * Returns the oneOf/anyOf group key for a JSON pointer, or null if the path is
+ * not inside a oneOf/anyOf block.  Two pointers with the same group key are
+ * siblings within the same choice block — only one will be instantiated, so
+ * sharing a unique-id between them is intentional and should not be reported.
+ */
+function getChoiceGroup(pointer: string): string | null {
+    // Greedily match up to the last oneOf/anyOf keyword, capturing the path up to
+    // (but not including) the alternative index.
+    const match = pointer.match(/^(.*\/(?:oneOf|anyOf))\/\d+\//);
+    return match ? match[1] : null;
+}
+
+/**
+ * Checks that all unique-ids in the pattern are unique across nodes, relationships,
+ * and interfaces, including those defined inside anyOf/oneOf blocks.
+ * Duplicate unique-ids within the same oneOf/anyOf block are allowed because
+ * only one alternative will ever be instantiated.
  */
 export default (input, _, context) => {
     if (!input) {
         return [];
     }
-    // get uniqueIds of all nodes
-    const nodeIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
-    const relationshipIdMatches = JSONPath({path: '$.properties.relationships.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
-    const interfaceIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
+    // Use recursive descent to find all unique-id const values in the pattern,
+    // including those nested inside anyOf/oneOf blocks.
+    const allIdMatches = JSONPath({path: '$..*["unique-id"].const', json: context.document.data, resultType: 'all'});
 
-    const seenIds = new Set();
-
+    // Map from id → the choice group it was first seen in (null = definite/unconditional).
+    const seenIds = new Map<string, string | null>();
     const messages = [];
 
-    detectDuplicates(nodeIdMatches, seenIds, messages);
-    detectDuplicates(relationshipIdMatches, seenIds, messages);
-    detectDuplicates(interfaceIdMatches, seenIds, messages);
+    for (const match of allIdMatches) {
+        const id = match['value'];
+        const group = getChoiceGroup(match['pointer']);
+
+        if (seenIds.has(id)) {
+            const existingGroup = seenIds.get(id);
+            // Siblings within the same oneOf/anyOf block may share a unique-id.
+            if (group !== null && group === existingGroup) {
+                continue;
+            }
+            messages.push({
+                message: `Duplicate unique-id detected. ID: ${id}, path: ${match['pointer']}`,
+                path: [match['pointer']]
+            });
+        } else {
+            seenIds.set(id, group);
+        }
+    }
 
     return messages;
 };


### PR DESCRIPTION
## Description
fixes #2230 - @aidanm3341 you didn't include an example failure on your bug report, and CALM validate correctly identifies duplicate unique-ids, assuming a pattern does not use `oneOf` or `anyOf`, so this is an educated (AI-assisted) guess at what your problem is. Look at the test cases to see if I've caught your actual issue.

This pull request updates the logic for checking uniqueness of `unique-id` values in pattern schemas, particularly improving support for nodes and relationships defined inside `oneOf` and `anyOf` blocks. The main change is that duplicate IDs are now only flagged if they occur outside of, or across, different choice groups—duplicate IDs within the same `oneOf` or `anyOf` block are allowed, since only one alternative will be instantiated. The test suite has been expanded to cover these scenarios.

**Enhancements to unique-id detection logic:**

* Refactored `ids-are-unique.ts` to recursively detect all `unique-id` values, including those nested within `oneOf` and `anyOf` blocks, and to allow duplicates within the same choice group but not across different groups. Introduced a helper function `getChoiceGroup` to determine group membership by JSON pointer.

**Test coverage improvements:**

* Added multiple test cases in `ids-are-unique.spec.ts` to verify correct handling of duplicate IDs inside and across `anyOf`/`oneOf` blocks, including:
  - Duplicates between regular nodes and those inside `anyOf`/`oneOf`
  - No error for duplicates within the same choice group
  - Errors for duplicates across different groups

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [X] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [X] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
