### PR TITLE
feat(cli): support pattern generation options passed on command line

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -55,6 +55,7 @@ Options:
   -o, --output <file>           Path location at which to output the generated file. (default: "architecture.json")
   -s, --schema-directory <path>  Path to the directory containing the meta schemas to use. (default: "../calm/release")
   -c, --calm-hub-url <url>      URL to CalmHub to use when loading documents.
+  --option-choices <choices>    Pre-defined option choices as a JSON object mapping option unique-ids to choice descriptions. Skips interactive prompts.
   -v, --verbose                 Enable verbose logging. (default: false)
   -h, --help                    display help for command
 ```
@@ -63,6 +64,30 @@ The most simple way to use this command is to call it with only the pattern opti
 
 ```shell
 % calm generate -p ./conferences/osff-ln-2025/workshop/conference-signup.pattern.json
+```
+
+#### Pattern options
+
+Some CALM patterns define **options** — decision points where the architecture can vary. When a pattern contains options, the `generate` command will prompt you interactively to make your selections. At the end of the prompts, the CLI prints the choices you made in a format you can save and reuse:
+
+```
+info: Selected choices (reusable with --option-choices): {"connection-options":"Application A connects to Application C","node-options":["Node 1","Node 2"]}
+```
+
+To skip the interactive prompts, pass your choices via `--option-choices` as an inline JSON string or a path to a JSON file.
+
+- For a **`oneOf`** option (pick exactly one), supply a string value.
+- For an **`anyOf`** option (pick one or more), supply a string or an array of strings.
+
+```shell
+# Inline JSON — single oneOf choice
+% calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C"}'
+
+# Inline JSON — mixed oneOf and anyOf
+% calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C", "node-options": ["Node 1", "Node 2"]}'
+
+# From a saved choices file
+% calm generate -p pattern.json --option-choices ./my-choices.json
 ```
 
 ### Validating a CALM architecture

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -86,10 +86,10 @@ describe('CLI Commands', () => {
                 'node', 'cli.js', 'generate',
                 '-p', 'pattern.json',
                 '-o', 'output.json',
-                '--option-choices', '["Use HTTP"]',
+                '--option-choices', '{"connection-options": "Use HTTP"}',
             ]);
 
-            expect(optionsModule.loadChoicesFromInput).toHaveBeenCalledWith('["Use HTTP"]', {}, false);
+            expect(optionsModule.loadChoicesFromInput).toHaveBeenCalledWith('{"connection-options": "Use HTTP"}', {}, false);
             expect(optionsModule.promptUserForOptions).not.toHaveBeenCalled();
             expect(calmShared.runGenerate).toHaveBeenCalledWith(
                 {}, 'output.json', false, expect.any(calmShared.SchemaDirectory), preDefinedChoices

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -77,6 +77,24 @@ describe('CLI Commands', () => {
                 {}, 'output.json', true, expect.any(calmShared.SchemaDirectory), []
             );
         });
+
+        it('should use pre-defined choices and skip prompting when --option-choices is provided', async () => {
+            const preDefinedChoices = [{ description: 'Use HTTP', nodes: ['node-a'], relationships: ['rel-a'] }];
+            vi.spyOn(optionsModule, 'loadChoicesFromInput').mockReturnValue(preDefinedChoices);
+
+            await program.parseAsync([
+                'node', 'cli.js', 'generate',
+                '-p', 'pattern.json',
+                '-o', 'output.json',
+                '--option-choices', '["Use HTTP"]',
+            ]);
+
+            expect(optionsModule.loadChoicesFromInput).toHaveBeenCalledWith('["Use HTTP"]', {}, false);
+            expect(optionsModule.promptUserForOptions).not.toHaveBeenCalled();
+            expect(calmShared.runGenerate).toHaveBeenCalledWith(
+                {}, 'output.json', false, expect.any(calmShared.SchemaDirectory), preDefinedChoices
+            );
+        });
     });
 
     describe('Validate Command', () => {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -56,7 +56,7 @@ export function setupCLI(program: Command) {
         .option(SCHEMAS_OPTION, 'Path to the directory containing the meta schemas to use.')
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .option(URL_MAPPING_OPTION, 'Path to mapping file which maps URLs to local paths')
-        .option(OPTION_CHOICES_OPTION, 'Pre-defined option choices as a JSON array of description strings, or a path to a JSON file. Skips interactive prompts.')
+        .option(OPTION_CHOICES_OPTION, 'Pre-defined option choices as a JSON object mapping option unique-ids to choice descriptions, or a path to a JSON file. Skips interactive prompts.')
         .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
         .action(async (options) => {
             const debug = !!options.verbose;

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import { CALM_META_SCHEMA_DIRECTORY, DocifyMode, initLogger, runGenerate, SchemaDirectory, TemplateProcessingMode, CalmChoice, buildDocumentLoader, DocumentLoader, DocumentLoaderOptions } from '@finos/calm-shared';
 import { Option, Command } from 'commander';
 import { version } from '../package.json';
-import { promptUserForOptions } from './command-helpers/generate-options';
+import { promptUserForOptions, loadChoicesFromInput } from './command-helpers/generate-options';
 import * as cliConfig from './cli-config';
 import path from 'path';
 import { select } from '@inquirer/prompts';
@@ -17,6 +17,7 @@ const VERBOSE_OPTION = '-v, --verbose';
 // Generate command options
 const PATTERN_OPTION = '-p, --pattern <file>';
 const CALMHUB_URL_OPTION = '-c, --calm-hub-url <url>';
+const OPTION_CHOICES_OPTION = '--option-choices <choices>';
 
 // Validate command options
 const FORMAT_OPTION = '-f, --format <format>';
@@ -55,6 +56,7 @@ export function setupCLI(program: Command) {
         .option(SCHEMAS_OPTION, 'Path to the directory containing the meta schemas to use.')
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .option(URL_MAPPING_OPTION, 'Path to mapping file which maps URLs to local paths')
+        .option(OPTION_CHOICES_OPTION, 'Pre-defined option choices as a JSON array of description strings, or a path to a JSON file. Skips interactive prompts.')
         .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
         .action(async (options) => {
             const debug = !!options.verbose;
@@ -65,7 +67,9 @@ export function setupCLI(program: Command) {
             const docLoader = buildDocumentLoader(docLoaderOpts);
             const schemaDirectory = await buildSchemaDirectory(docLoader, debug);
             const pattern: object = await docLoader.loadMissingDocument(options.pattern, 'pattern');
-            const choices: CalmChoice[] = await promptUserForOptions(pattern, options.verbose);
+            const choices: CalmChoice[] = options.optionChoices
+                ? loadChoicesFromInput(options.optionChoices, pattern, debug)
+                : await promptUserForOptions(pattern, options.verbose);
             await runGenerate(pattern, options.output, debug, schemaDirectory, choices);
         });
 

--- a/cli/src/command-helpers/generate-options.spec.ts
+++ b/cli/src/command-helpers/generate-options.spec.ts
@@ -1,11 +1,13 @@
 import { CalmChoice } from '@finos/calm-shared';
-import { promptUserForOptions } from './generate-options';
+import { promptUserForOptions, loadChoicesFromInput } from './generate-options';
 
 const mocks = vi.hoisted(() => {
     return {
         extractOptions: vi.fn(),
         select: vi.fn(),
-        checkbox: vi.fn()
+        checkbox: vi.fn(),
+        existsSync: vi.fn(),
+        readFileSync: vi.fn()
     };
 });
 
@@ -17,9 +19,14 @@ vi.mock('@finos/calm-shared', async () => {
     };
 });
 
-vi.mock('@inquirer/prompts', () => ({ 
+vi.mock('@inquirer/prompts', () => ({
     select: mocks.select,
     checkbox: mocks.checkbox
+}));
+
+vi.mock('fs', () => ({
+    existsSync: mocks.existsSync,
+    readFileSync: mocks.readFileSync
 }));
 
 const choice1 = { description: 'Option 1', nodes: ['option1'], relationships: ['relationship1'] };
@@ -29,6 +36,52 @@ const choiceA = { description: 'Option A', nodes: ['optionA'], relationships: ['
 const choiceB = { description: 'Option B', nodes: ['optionB'], relationships: ['relationshipB'] };
 
 const pattern = {}; // pattern doesn't matter since we're mocking the extractOptions function
+
+describe('loadChoicesFromInput', () => {
+    beforeEach(() => {
+        mocks.extractOptions.mockReturnValue([
+            { optionType: 'oneOf', prompt: 'Choose an option:', choices: [choice1, choice2] },
+            { optionType: 'anyOf', prompt: 'Select any:', choices: [choiceA, choiceB] }
+        ]);
+    });
+
+    it('should resolve choices from inline JSON string', () => {
+        mocks.existsSync.mockReturnValue(false);
+        const result = loadChoicesFromInput('["Option 1", "Option A"]', pattern);
+        expect(result).toEqual([choice1, choiceA]);
+    });
+
+    it('should resolve choices from a JSON file', () => {
+        mocks.existsSync.mockReturnValue(true);
+        mocks.readFileSync.mockReturnValue('["Option 2"]');
+        const result = loadChoicesFromInput('choices.json', pattern);
+        expect(result).toEqual([choice2]);
+    });
+
+    it('should return empty array when given empty array', () => {
+        mocks.existsSync.mockReturnValue(false);
+        const result = loadChoicesFromInput('[]', pattern);
+        expect(result).toEqual([]);
+    });
+
+    it('should throw when a choice description is not in the pattern', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('["Invalid Choice"]', pattern))
+            .toThrow('The choice of [Invalid Choice] is not a valid choice in the pattern.');
+    });
+
+    it('should throw when input is not a JSON array', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('{"key": "value"}', pattern))
+            .toThrow('Option choices must be a JSON array of description strings.');
+    });
+
+    it('should throw when input is invalid JSON', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('not-json', pattern))
+            .toThrow('Failed to parse option choices:');
+    });
+});
 
 describe('promptUserForOptions', () => {
     it('should prompt user for options and return selected choices', async () => {

--- a/cli/src/command-helpers/generate-options.spec.ts
+++ b/cli/src/command-helpers/generate-options.spec.ts
@@ -40,40 +40,46 @@ const pattern = {}; // pattern doesn't matter since we're mocking the extractOpt
 describe('loadChoicesFromInput', () => {
     beforeEach(() => {
         mocks.extractOptions.mockReturnValue([
-            { optionType: 'oneOf', prompt: 'Choose an option:', choices: [choice1, choice2] },
-            { optionType: 'anyOf', prompt: 'Select any:', choices: [choiceA, choiceB] }
+            { optionType: 'oneOf', optionId: 'option-1', prompt: 'Choose an option:', choices: [choice1, choice2] },
+            { optionType: 'anyOf', optionId: 'option-a', prompt: 'Select any:', choices: [choiceA, choiceB] }
         ]);
     });
 
     it('should resolve choices from inline JSON string', () => {
         mocks.existsSync.mockReturnValue(false);
-        const result = loadChoicesFromInput('["Option 1", "Option A"]', pattern);
+        const result = loadChoicesFromInput('{"option-1": "Option 1", "option-a": "Option A"}', pattern);
         expect(result).toEqual([choice1, choiceA]);
     });
 
     it('should resolve choices from a JSON file', () => {
         mocks.existsSync.mockReturnValue(true);
-        mocks.readFileSync.mockReturnValue('["Option 2"]');
+        mocks.readFileSync.mockReturnValue('{"option-1": "Option 2"}');
         const result = loadChoicesFromInput('choices.json', pattern);
         expect(result).toEqual([choice2]);
     });
 
-    it('should return empty array when given empty array', () => {
+    it('should return empty object when given empty object', () => {
         mocks.existsSync.mockReturnValue(false);
-        const result = loadChoicesFromInput('[]', pattern);
+        const result = loadChoicesFromInput('{}', pattern);
         expect(result).toEqual([]);
     });
 
-    it('should throw when a choice description is not in the pattern', () => {
+    it('should throw when the option id is not in the pattern', () => {
         mocks.existsSync.mockReturnValue(false);
-        expect(() => loadChoicesFromInput('["Invalid Choice"]', pattern))
-            .toThrow('The choice of [Invalid Choice] is not a valid choice in the pattern.');
+        expect(() => loadChoicesFromInput('{"invalid-option": "Option 1"}', pattern))
+            .toThrow('The option id [invalid-option] is not a valid option in the pattern.');
     });
 
-    it('should throw when input is not a JSON array', () => {
+    it('should throw when a choice description is not valid for the option', () => {
         mocks.existsSync.mockReturnValue(false);
-        expect(() => loadChoicesFromInput('{"key": "value"}', pattern))
-            .toThrow('Option choices must be a JSON array of description strings.');
+        expect(() => loadChoicesFromInput('{"option-1": "Invalid Choice"}', pattern))
+            .toThrow('The choice of [Invalid Choice] is not a valid choice for option [option-1].');
+    });
+
+    it('should throw when input is not a JSON object', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('["Option 1"]', pattern))
+            .toThrow('Option choices must be a JSON object mapping option ids to choice descriptions.');
     });
 
     it('should throw when input is invalid JSON', () => {
@@ -88,11 +94,13 @@ describe('promptUserForOptions', () => {
         mocks.extractOptions.mockReturnValue([
             {
                 optionType: 'oneOf',
+                optionId: 'option-1',
                 prompt: 'Choose an option:',
                 choices: [choice1, choice2]
             },
             {
                 optionType: 'anyOf',
+                optionId: 'option-a',
                 prompt: 'Select any of these options:',
                 choices: [choiceA, choiceB]
             }
@@ -107,6 +115,7 @@ describe('promptUserForOptions', () => {
     it('should return empty list when user selects nothing', async () => {
         mocks.extractOptions.mockReturnValue([{
             optionType: 'anyOf',
+            optionId: 'option-a',
             prompt: 'Select any of these options:',
             choices: [choiceA, choiceB]
         }]);
@@ -118,6 +127,7 @@ describe('promptUserForOptions', () => {
     it('should throw an error when user selects an option thats not in the pattern', async () => {
         mocks.extractOptions.mockReturnValue([{
             optionType: 'oneOf',
+            optionId: 'option-1',
             prompt: 'Choose an option:',
             choices: [choice1, choice2]
         }]);

--- a/cli/src/command-helpers/generate-options.spec.ts
+++ b/cli/src/command-helpers/generate-options.spec.ts
@@ -87,6 +87,36 @@ describe('loadChoicesFromInput', () => {
         expect(() => loadChoicesFromInput('not-json', pattern))
             .toThrow('Failed to parse option choices:');
     });
+
+    it('should resolve multiple choices for an anyOf option when given a string array', () => {
+        mocks.existsSync.mockReturnValue(false);
+        const result = loadChoicesFromInput('{"option-a": ["Option A", "Option B"]}', pattern);
+        expect(result).toEqual([choiceA, choiceB]);
+    });
+
+    it('should resolve a single-element string array for an anyOf option', () => {
+        mocks.existsSync.mockReturnValue(false);
+        const result = loadChoicesFromInput('{"option-a": ["Option A"]}', pattern);
+        expect(result).toEqual([choiceA]);
+    });
+
+    it('should resolve mixed string and string array values', () => {
+        mocks.existsSync.mockReturnValue(false);
+        const result = loadChoicesFromInput('{"option-1": "Option 1", "option-a": ["Option A", "Option B"]}', pattern);
+        expect(result).toEqual([choice1, choiceA, choiceB]);
+    });
+
+    it('should throw when a string array is supplied for a oneOf option', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('{"option-1": ["Option 1", "Option 2"]}', pattern))
+            .toThrow('The option [option-1] is a oneOf option and only accepts a single choice, not an array.');
+    });
+
+    it('should throw when a choice description in an array is not valid for the option', () => {
+        mocks.existsSync.mockReturnValue(false);
+        expect(() => loadChoicesFromInput('{"option-a": ["Option A", "Invalid Choice"]}', pattern))
+            .toThrow('The choice of [Invalid Choice] is not a valid choice for option [option-a].');
+    });
 });
 
 describe('promptUserForOptions', () => {
@@ -134,5 +164,18 @@ describe('promptUserForOptions', () => {
         mocks.select.mockReturnValue(Promise.resolve('Invalid Option'));
 
         await expect(promptUserForOptions(pattern)).rejects.toThrow('The choice of [Invalid Option] is not a valid choice in the pattern.');
+    });
+
+    it('should return all selected choices when checkbox returns multiple answers for an anyOf option', async () => {
+        mocks.extractOptions.mockReturnValue([{
+            optionType: 'anyOf',
+            optionId: 'option-a',
+            prompt: 'Select any of these options:',
+            choices: [choiceA, choiceB]
+        }]);
+        mocks.checkbox.mockReturnValue(Promise.resolve(['Option A', 'Option B']));
+
+        const expectedChoices: CalmChoice[] = [choiceA, choiceB];
+        await expect(promptUserForOptions(pattern)).resolves.toEqual(expectedChoices);
     });
 });

--- a/cli/src/command-helpers/generate-options.ts
+++ b/cli/src/command-helpers/generate-options.ts
@@ -1,5 +1,6 @@
 import { CalmChoice, CalmOption, extractOptions, initLogger } from '@finos/calm-shared';
 import { select, checkbox } from '@inquirer/prompts';
+import { readFileSync, existsSync } from 'fs';
 
 type InquirerQuestion = {
     type: 'list' | 'checkbox',
@@ -44,6 +45,46 @@ async function getAnswersFromUser(questions: InquirerQuestion[]): Promise<string
         }
     }
     return answers;
+}
+
+/**
+ * Loads pre-defined option choices from a file path or inline JSON string.
+ * The input should be a JSON array of choice description strings,
+ * e.g. ["Use HTTP", "Application A connects to C"]
+ */
+export function loadChoicesFromInput(optionChoicesInput: string, pattern: object, debug: boolean = false): CalmChoice[] {
+    const logger = initLogger(debug, 'calm-generate-options');
+
+    let descriptions: string[];
+    try {
+        const jsonString = existsSync(optionChoicesInput)
+            ? readFileSync(optionChoicesInput, 'utf-8')
+            : optionChoicesInput;
+        const parsed = JSON.parse(jsonString);
+        if (!Array.isArray(parsed)) {
+            throw new Error('Option choices must be a JSON array of description strings.');
+        }
+        descriptions = parsed;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to parse option choices: ${message}`);
+    }
+
+    const patternOptions: CalmOption[] = extractOptions(pattern);
+    const allChoices: CalmChoice[] = patternOptions.flatMap(option => option.choices);
+
+    logger.debug('Resolving pre-defined choices: ' + JSON.stringify(descriptions));
+
+    const resolved: CalmChoice[] = [];
+    for (const description of descriptions) {
+        const found = allChoices.find(choice => choice.description === description);
+        if (!found) {
+            throw new Error(`The choice of [${description}] is not a valid choice in the pattern.`);
+        }
+        resolved.push(found);
+    }
+
+    return resolved;
 }
 
 export async function promptUserForOptions(pattern: object, debug: boolean = false): Promise<CalmChoice[]> {

--- a/cli/src/command-helpers/generate-options.ts
+++ b/cli/src/command-helpers/generate-options.ts
@@ -49,37 +49,40 @@ async function getAnswersFromUser(questions: InquirerQuestion[]): Promise<string
 
 /**
  * Loads pre-defined option choices from a file path or inline JSON string.
- * The input should be a JSON array of choice description strings,
- * e.g. ["Use HTTP", "Application A connects to C"]
+ * The input should be a JSON object mapping option unique-ids to choice descriptions,
+ * e.g. {"connection-options": "Application A connects to C"}
  */
 export function loadChoicesFromInput(optionChoicesInput: string, pattern: object, debug: boolean = false): CalmChoice[] {
     const logger = initLogger(debug, 'calm-generate-options');
 
-    let descriptions: string[];
+    let choiceMap: Record<string, string>;
     try {
         const jsonString = existsSync(optionChoicesInput)
             ? readFileSync(optionChoicesInput, 'utf-8')
             : optionChoicesInput;
         const parsed = JSON.parse(jsonString);
-        if (!Array.isArray(parsed)) {
-            throw new Error('Option choices must be a JSON array of description strings.');
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            throw new Error('Option choices must be a JSON object mapping option ids to choice descriptions.');
         }
-        descriptions = parsed;
+        choiceMap = parsed;
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(`Failed to parse option choices: ${message}`);
     }
 
     const patternOptions: CalmOption[] = extractOptions(pattern);
-    const allChoices: CalmChoice[] = patternOptions.flatMap(option => option.choices);
 
-    logger.debug('Resolving pre-defined choices: ' + JSON.stringify(descriptions));
+    logger.debug('Resolving pre-defined choices: ' + JSON.stringify(choiceMap));
 
     const resolved: CalmChoice[] = [];
-    for (const description of descriptions) {
-        const found = allChoices.find(choice => choice.description === description);
+    for (const [optionId, choiceDescription] of Object.entries(choiceMap)) {
+        const option = patternOptions.find(opt => opt.optionId === optionId);
+        if (!option) {
+            throw new Error(`The option id [${optionId}] is not a valid option in the pattern.`);
+        }
+        const found = option.choices.find(choice => choice.description === choiceDescription);
         if (!found) {
-            throw new Error(`The choice of [${description}] is not a valid choice in the pattern.`);
+            throw new Error(`The choice of [${choiceDescription}] is not a valid choice for option [${optionId}].`);
         }
         resolved.push(found);
     }

--- a/cli/src/command-helpers/generate-options.ts
+++ b/cli/src/command-helpers/generate-options.ts
@@ -2,60 +2,16 @@ import { CalmChoice, CalmOption, extractOptions, initLogger } from '@finos/calm-
 import { select, checkbox } from '@inquirer/prompts';
 import { readFileSync, existsSync } from 'fs';
 
-type InquirerQuestion = {
-    type: 'list' | 'checkbox',
-    name: string,
-    message: string,
-    choices: string[]
-}
-
-function createQuestionsFromPatternOptions(patternOptions: CalmOption[]): InquirerQuestion[] {
-    const questions: InquirerQuestion[] = [];
-
-    for (const option of patternOptions) {
-        const choiceDescriptions = option.choices.map(choice => choice.description);
-        questions.push(
-            {
-                type: option.optionType === 'oneOf' ? 'list' : 'checkbox',
-                name: `${patternOptions.indexOf(option)}`,
-                message: option.prompt,
-                choices: choiceDescriptions
-            }
-        );
-    }
-
-    return questions;
-}
-
-async function getAnswersFromUser(questions: InquirerQuestion[]): Promise<string[]> {
-    const answers = [];
-    for (const question of questions) {
-        if (question.type === 'list') {
-            const answer = await select<string>({
-                message: question.message,
-                choices: question.choices
-            });
-            answers.push(answer);
-        } else if (question.type === 'checkbox') {
-            const answer = await checkbox<string>({
-                message: question.message,
-                choices: question.choices,
-            });
-            answers.push(...answer);
-        }
-    }
-    return answers;
-}
-
 /**
  * Loads pre-defined option choices from a file path or inline JSON string.
- * The input should be a JSON object mapping option unique-ids to choice descriptions,
- * e.g. {"connection-options": "Application A connects to C"}
+ * The input should be a JSON object mapping option unique-ids to choice descriptions.
+ * For oneOf options supply a single string; for anyOf options supply a string or string[].
+ * e.g. {"connection-options": "Application A connects to C", "node-options": ["Node 1", "Node 2"]}
  */
 export function loadChoicesFromInput(optionChoicesInput: string, pattern: object, debug: boolean = false): CalmChoice[] {
     const logger = initLogger(debug, 'calm-generate-options');
 
-    let choiceMap: Record<string, string>;
+    let choiceMap: Record<string, string | string[]>;
     try {
         const jsonString = existsSync(optionChoicesInput)
             ? readFileSync(optionChoicesInput, 'utf-8')
@@ -75,16 +31,22 @@ export function loadChoicesFromInput(optionChoicesInput: string, pattern: object
     logger.debug('Resolving pre-defined choices: ' + JSON.stringify(choiceMap));
 
     const resolved: CalmChoice[] = [];
-    for (const [optionId, choiceDescription] of Object.entries(choiceMap)) {
+    for (const [optionId, value] of Object.entries(choiceMap)) {
         const option = patternOptions.find(opt => opt.optionId === optionId);
         if (!option) {
             throw new Error(`The option id [${optionId}] is not a valid option in the pattern.`);
         }
-        const found = option.choices.find(choice => choice.description === choiceDescription);
-        if (!found) {
-            throw new Error(`The choice of [${choiceDescription}] is not a valid choice for option [${optionId}].`);
+        if (Array.isArray(value) && option.optionType === 'oneOf') {
+            throw new Error(`The option [${optionId}] is a oneOf option and only accepts a single choice, not an array.`);
         }
-        resolved.push(found);
+        const descriptions = Array.isArray(value) ? value : [value];
+        for (const description of descriptions) {
+            const found = option.choices.find(choice => choice.description === description);
+            if (!found) {
+                throw new Error(`The choice of [${description}] is not a valid choice for option [${optionId}].`);
+            }
+            resolved.push(found);
+        }
     }
 
     return resolved;
@@ -96,19 +58,33 @@ export async function promptUserForOptions(pattern: object, debug: boolean = fal
     const patternOptions: CalmOption[] = extractOptions(pattern);
     logger.debug('Pattern options extracted from pattern: ' + JSON.stringify(patternOptions));
 
-    const questions = createQuestionsFromPatternOptions(patternOptions);
-    const answers: string[] = await getAnswersFromUser(questions);
+    const compactChoices: Record<string, string | string[]> = {};
+    const allChosenChoices: CalmChoice[] = [];
 
-    const allChoices: CalmChoice[] = patternOptions.flatMap(option => option.choices);
+    for (const option of patternOptions) {
+        const choiceDescriptions = option.choices.map(c => c.description);
 
-    // this shouldn't happen, but in case something goes wrong and the user is able to select an invalid option, we throw an error
-    answers.forEach(answer => {
-        const found = allChoices.find(choice => choice.description === answer);
-        if (!found) {
-            throw new Error(`The choice of [${answer}] is not a valid choice in the pattern.`);
+        if (option.optionType === 'oneOf') {
+            const answer = await select<string>({ message: option.prompt, choices: choiceDescriptions });
+            compactChoices[option.optionId] = answer;
+            const found = option.choices.find(c => c.description === answer);
+            if (!found) {
+                throw new Error(`The choice of [${answer}] is not a valid choice in the pattern.`);
+            }
+            allChosenChoices.push(found);
+        } else {
+            const answers = await checkbox<string>({ message: option.prompt, choices: choiceDescriptions });
+            compactChoices[option.optionId] = answers;
+            for (const answer of answers) {
+                const found = option.choices.find(c => c.description === answer);
+                if (!found) {
+                    throw new Error(`The choice of [${answer}] is not a valid choice in the pattern.`);
+                }
+                allChosenChoices.push(found);
+            }
         }
-    });
+    }
 
-    const allChosenChoices: CalmChoice[] = allChoices.filter(choice => answers.find(answer => answer === choice.description));
+    logger.info('Selected choices (reusable with --option-choices): ' + JSON.stringify(compactChoices));
     return allChosenChoices;
 }

--- a/docs/docs/working-with-calm/generate.md
+++ b/docs/docs/working-with-calm/generate.md
@@ -25,6 +25,7 @@ This will create an architecture in the current working directory with the defau
 - **`-s, --schema-directory <path>`**: Path to the directory containing schemas to use in architecture.
 - **`-c, --calm-hub-url <url>`**: URL to CALMHub instance.
 - **`-u, --url-to-local-file-mapping <path>`**: Path to a JSON file that maps URLs to local file paths (see [URL Mapping](#url-to-local-file-mapping) below).
+- **`--option-choices <choices>`**: Pre-defined option choices as a JSON object, or a path to a JSON file. Skips interactive prompts (see [Pattern Options](#pattern-options) below).
 - **`-v, --verbose`**: Enable verbose logging.
 
 ## Example of Generating an architecture
@@ -36,6 +37,46 @@ calm generate -p calm/pattern/microservices.json -o my-architecture.json
 ```
 
 This command uses the `microservices.json` pattern and outputs the result to `my-architecture.json`.
+
+## Pattern Options
+
+Some CALM patterns contain `options` relationships that present a choice of which nodes and relationships to include in the generated architecture. When you run `calm generate` against such a pattern, the CLI will interactively prompt you to make each choice.
+
+### Interactive prompts
+
+For each options relationship in the pattern, the CLI will ask you to select a choice:
+
+- **`oneOf`** options present a single-select prompt — you must pick exactly one.
+- **`anyOf`** options present a multi-select prompt — you can pick zero or more.
+
+### Pre-defining choices non-interactively
+
+You can skip the interactive prompts by passing `--option-choices` with a JSON object that maps each option's `unique-id` to the chosen description:
+
+```shell
+calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C"}'
+```
+
+To supply choices for multiple options, include all of them in the same object:
+
+```shell
+calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C", "node-options": "Use Node 1"}'
+```
+
+You can also save the choices to a file - in the same JSON format - and pass the path instead:
+
+```json
+{
+  "connection-options": "Application A connects to Application C",
+  "node-options": "Use Node 1"
+}
+```
+
+```shell
+calm generate -p pattern.json --option-choices choices.json
+```
+
+The keys in the object must match the `unique-id` of the options relationship in the pattern. The values must match the `description` of one of the available choices within that option.
 
 ## URL to Local File Mapping
 

--- a/docs/docs/working-with-calm/generate.md
+++ b/docs/docs/working-with-calm/generate.md
@@ -51,24 +51,28 @@ For each options relationship in the pattern, the CLI will ask you to select a c
 
 ### Pre-defining choices non-interactively
 
-You can skip the interactive prompts by passing `--option-choices` with a JSON object that maps each option's `unique-id` to the chosen description:
+You can skip the interactive prompts by passing `--option-choices` with a JSON object that maps each option's `unique-id` to the chosen description(s).
+
+- For **`oneOf`** options, supply a **string** (exactly one choice).
+- For **`anyOf`** options, supply a **string** or an **array of strings** (one or more choices).
 
 ```shell
+# oneOf option — single string
 calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C"}'
+
+# anyOf option — array of strings
+calm generate -p pattern.json --option-choices '{"node-options": ["Node 1", "Node 2"]}'
+
+# Mixed oneOf and anyOf
+calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C", "node-options": ["Node 1", "Node 2"]}'
 ```
 
-To supply choices for multiple options, include all of them in the same object:
-
-```shell
-calm generate -p pattern.json --option-choices '{"connection-options": "Application A connects to Application C", "node-options": "Use Node 1"}'
-```
-
-You can also save the choices to a file - in the same JSON format - and pass the path instead:
+You can also save the choices to a file in the same JSON format and pass the path instead:
 
 ```json
 {
   "connection-options": "Application A connects to Application C",
-  "node-options": "Use Node 1"
+  "node-options": ["Node 1", "Node 2"]
 }
 ```
 
@@ -76,7 +80,15 @@ You can also save the choices to a file - in the same JSON format - and pass the
 calm generate -p pattern.json --option-choices choices.json
 ```
 
-The keys in the object must match the `unique-id` of the options relationship in the pattern. The values must match the `description` of one of the available choices within that option.
+The keys in the object must match the `unique-id` of the options relationship in the pattern. The values must match the `description` of one or more of the available choices within that option.
+
+:::tip
+After running `calm generate` interactively, the CLI prints your selections in the `--option-choices` format so you can save them for later use:
+
+```
+info: Selected choices (reusable with --option-choices): {"connection-options":"Application A connects to Application C","node-options":["Node 1","Node 2"]}
+```
+:::
 
 ## URL to Local File Mapping
 

--- a/shared/src/commands/generate/components/options.spec.ts
+++ b/shared/src/commands/generate/components/options.spec.ts
@@ -154,6 +154,7 @@ describe('Pattern Options', () => {
 
             const expectedOptions: CalmOption[] = [{
                 optionType: 'oneOf',
+                optionId: 'option-id',
                 prompt: 'The choice of nodes and relationships in the pattern',
                 choices: [applicationAtoC, applicationBtoC]
             }];
@@ -166,13 +167,14 @@ describe('Pattern Options', () => {
                 [],
                 [buildPatternOptionRelationship(
                     'option-id',
-                    'The choice of nodes and relationships in the pattern', 
+                    'The choice of nodes and relationships in the pattern',
                     buildPatternOption('anyOf', buildPatternChoice(applicationAtoC), buildPatternChoice(applicationBtoC))
                 )]
             );
 
             const expectedOptions: CalmOption[] = [{
                 optionType: 'anyOf',
+                optionId: 'option-id',
                 prompt: 'The choice of nodes and relationships in the pattern',
                 choices: [applicationAtoC, applicationBtoC]
             }];
@@ -212,11 +214,13 @@ describe('Pattern Options', () => {
             const expectedOptions: CalmOption[] = [
                 {
                     optionType: 'oneOf',
+                    optionId: 'option-id',
                     prompt: 'The choice of node A or node B connecting to node C',
                     choices: [applicationAtoC, applicationBtoC]
                 },
                 {
                     optionType: 'anyOf',
+                    optionId: 'option-id-2',
                     prompt: 'The choice of node X or node Y connecting to node Z',
                     choices: [applicationXtoZ, applicationYtoZ]
                 }
@@ -313,6 +317,7 @@ describe('Pattern Options', () => {
 
             const expectedOptions: CalmOption[] = [{
                 optionType: 'oneOf',
+                optionId: 'option-id',
                 prompt: 'Choose connection type',
                 choices: [applicationAtoC, applicationBtoC]
             }];
@@ -353,6 +358,7 @@ describe('Pattern Options', () => {
 
             const expectedOptions: CalmOption[] = [{
                 optionType: 'anyOf',
+                optionId: 'option-id',
                 prompt: 'Choose from base',
                 choices: [applicationXtoZ, applicationYtoZ]
             }];

--- a/shared/src/commands/generate/components/options.ts
+++ b/shared/src/commands/generate/components/options.ts
@@ -8,6 +8,7 @@ export interface CalmChoice {
 
 export interface CalmOption {
     optionType: 'oneOf' | 'anyOf',
+    optionId: string,
     prompt: string,
     choices: CalmChoice[],
 }
@@ -26,6 +27,7 @@ function extractOptionsFromBlock(optionsRelationship: object, blockType: 'oneOf'
         .map((prefixItem: object) => prefixItem[blockType] as object[])
         .map((choices: object[]) => ({
             optionType: blockType,
+            optionId: optionsRelationship['properties']['unique-id']['const'],
             prompt: optionsRelationship['properties']['description']['const'],
             choices: choices.map(choice => ({
                 description: choice['properties']['description']['const'],


### PR DESCRIPTION
## Description
Resolves #1951 opened by @niamhg-ms 

This pull request adds support for providing pre-defined option choices to the CLI's `generate` command, allowing users to skip interactive prompts by specifying choices via a JSON array or file. It also includes robust tests and error handling for this new feature.

**New CLI feature: Pre-defined option choices**
- Added a new `--option-choices` flag to the `generate` command, allowing users to provide option choices as a JSON array of descriptions or as a path to a JSON file. When this flag is used, the CLI skips interactive prompts and uses the provided choices. [[1]](diffhunk://#diff-7df7f1d62fa3c76f85d505ce2e31e90be502bc64b55235aa03e4bd463f8d7dcdR19) [[2]](diffhunk://#diff-7df7f1d62fa3c76f85d505ce2e31e90be502bc64b55235aa03e4bd463f8d7dcdR51) [[3]](diffhunk://#diff-7df7f1d62fa3c76f85d505ce2e31e90be502bc64b55235aa03e4bd463f8d7dcdL60-R64)

**Implementation and logic**
- Implemented the `loadChoicesFromInput` function in `generate-options.ts` to parse and validate pre-defined choices, ensuring they match valid options in the pattern and providing clear error messages for invalid input. [[1]](diffhunk://#diff-4af7cc7488226bfb0c6c1dcc8cc2cf8bdef483c514905a29f1acc4db20360bafR3) [[2]](diffhunk://#diff-4af7cc7488226bfb0c6c1dcc8cc2cf8bdef483c514905a29f1acc4db20360bafR50-R89)

**Testing**
- Added comprehensive unit tests for `loadChoicesFromInput`, covering scenarios for inline JSON, JSON files, empty arrays, invalid choices, non-array input, and malformed JSON. [[1]](diffhunk://#diff-3cb7ce79c4795125eec429663f4288ccaa909fc9f20d779cd6284788bbd72b2aL2-R10) [[2]](diffhunk://#diff-3cb7ce79c4795125eec429663f4288ccaa909fc9f20d779cd6284788bbd72b2aR27-R31) [[3]](diffhunk://#diff-3cb7ce79c4795125eec429663f4288ccaa909fc9f20d779cd6284788bbd72b2aR40-R85)
- Added a CLI-level test to verify that providing `--option-choices` correctly skips interactive prompts and uses the specified choices.


## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [X] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
