### PR TITLE
fix(deps): resolve 3 dependabot security vulnerabilities

### DIFF
--- a/calm-suite/calm-studio/package.json
+++ b/calm-suite/calm-studio/package.json
@@ -18,7 +18,9 @@
     "overrides": {
       "undici": ">=6.24.0",
       "serialize-javascript": ">=7.0.5",
-      "cookie": ">=0.7.0"
+      "cookie": ">=0.7.0",
+      "hono": ">=4.12.14",
+      "follow-redirects": ">=1.16.0"
     }
   },
   "devDependencies": {

--- a/calm-suite/calm-studio/pnpm-lock.yaml
+++ b/calm-suite/calm-studio/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   undici: '>=6.24.0'
   serialize-javascript: '>=7.0.5'
   cookie: '>=0.7.0'
+  hono: '>=4.12.14'
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -2055,7 +2057,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.14'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -5137,8 +5139,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5423,8 +5425,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -11783,9 +11785,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -12055,7 +12057,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -12065,7 +12067,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -15284,7 +15286,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -15662,7 +15664,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hook-std@4.0.0: {}
 
@@ -15794,7 +15796,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/package-lock.json
+++ b/package-lock.json
@@ -19279,9 +19279,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "overrides": {
         "@types/node": "^22.19.15",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.0",
         "on-headers": "^1.1.0",
         "node-forge": "^1.3.2",
         "qs": "^6.15.0",


### PR DESCRIPTION
## Description
Resolve 3 of 5 open Dependabot security vulnerabilities across the monorepo.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Dependencies

## Changes by Area

### Root npm (`package-lock.json`) — 1 alert fixed
- **dompurify** 3.3.3 → 3.4.0 — fixes medium severity ADD_TAGS function form bypass of FORBID_TAGS due to short-circuit evaluation (#273)

### calm-studio (`pnpm-lock.yaml`) — 2 alerts fixed
- Added `pnpm.overrides` for:
  - `hono` >=4.12.14 — fixes medium severity HTML injection in hono/jsx SSR via improper JSX attribute name handling (#272)
  - `follow-redirects` >=1.16.0 — fixes medium severity custom authentication header leak to cross-domain redirect targets (#271)

### Remaining 2 alerts (unfixable without upstream releases)
- **rand** (#268, low): needs semver-breaking 0.8 → 0.9.3 jump, requires Tauri ecosystem update
- **glib** (#256, medium): needs semver-breaking 0.18 → 0.20 jump, requires Tauri ecosystem update

## Commit Message Format ✅
`fix(deps): resolve 3 dependabot security vulnerabilities`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass (373 root tests + 450 calm-studio tests)

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards