### PR TITLE
fix(deps): resolve dependabot alert 170 for rollup path traversal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10971,9 +10971,9 @@
             }
         },
         "node_modules/@stoplight/spectral-ruleset-bundler": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.6.3.tgz",
-            "integrity": "sha512-AQFRO6OCKg8SZJUupnr3+OzI1LrMieDTEUHsYgmaRpNiDRPvzImE3bzM1KyQg99q58kTQyZ8kpr7sG8Lp94RRA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.7.0.tgz",
+            "integrity": "sha512-PpIdj5Wje0T7ktxY8EUzBWLU0+mGGQHznT8nlQxTMnRhWLNYsm6HvSZDXLtMi+86yqvTuf7loJy6JvLBDzHGAA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@rollup/plugin-commonjs": "~22.0.2",
@@ -10989,7 +10989,7 @@
                 "@stoplight/types": "^13.6.0",
                 "@types/node": "*",
                 "pony-cause": "1.1.1",
-                "rollup": "~2.79.2",
+                "rollup": "~2.80.0",
                 "tslib": "^2.8.1",
                 "validate-npm-package-name": "3.0.0"
             },
@@ -11088,9 +11088,9 @@
             }
         },
         "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/rollup": {
-            "version": "2.79.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-            "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+            "version": "2.80.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+            "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
             "license": "MIT",
             "bin": {
                 "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -85,9 +85,7 @@
             "npm": "11.12.1"
         },
         "serialize-javascript": "^7.0.5",
-        "@stoplight/spectral-ruleset-bundler@1.6.x": {
-            "rollup": "2.80.0"
-        },
+        "@stoplight/spectral-ruleset-bundler": "1.7.0",
         "eslint": {
             "minimatch": "^3.1.4"
         },


### PR DESCRIPTION
## Description
Resolves Dependabot alert [#170](https://github.com/finos/architecture-as-code/security/dependabot/170) — [GHSA-mw96-cpmx-2vgc](https://github.com/advisories/GHSA-mw96-cpmx-2vgc) / CVE-2026-27606: arbitrary file write via path traversal in `rollup < 2.80.0`.

Chain: `@stoplight/spectral-cli@6.15.0` → `@stoplight/spectral-ruleset-bundler@1.6.3` → `rollup@2.79.2`.

Upgrading the bundler to `1.7.0` (which is within `spectral-cli`'s existing `^1.6.0` range) pins `rollup: ~2.80.0`, clearing the alert. The prior version-keyed override `"@stoplight/spectral-ruleset-bundler@1.6.x": { "rollup": "2.80.0" }` was not being applied by npm, so it has been replaced with a direct bundler pin.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verification:
- `npm ls rollup` now shows `rollup@2.80.0` under `@stoplight/spectral-ruleset-bundler@1.7.0` (top-level rollup remains `4.60.1`, already patched for the same CVE).
- `npm audit` no longer reports rollup.
- `npm run build:shared` succeeds.
- Full `npm run test:shared` passes except for one pre-existing failure in `docusaurus/package.spec.ts` that reproduces on `main` and is unrelated to this change.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards