### PR TITLE
fix(deps): resolve dependabot alert 226 for lodash code injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10590,9 +10590,9 @@
             }
         },
         "node_modules/@stoplight/spectral-cli": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.0.tgz",
-            "integrity": "sha512-FVeQIuqQQnnLfa8vy+oatTKUve7uU+3SaaAfdjpX/B+uB1NcfkKRJYhKT9wMEehDRaMPL5AKIRYMCFerdEbIpw==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.1.tgz",
+            "integrity": "sha512-ev72bUglbaZvFSMWCP5o1Iso5NGgbLZOAuedvRxYrUMey9dVCR83i033tSFvDv6cpj86HsbEmiilh8vwrY/asQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@stoplight/json": "~3.21.0",
@@ -10609,7 +10609,7 @@
                 "chalk": "4.1.2",
                 "fast-glob": "~3.2.12",
                 "hpagent": "~1.2.0",
-                "lodash": "~4.17.21",
+                "lodash": "^4.18.1",
                 "pony-cause": "^1.1.1",
                 "stacktracey": "^2.1.8",
                 "tslib": "^2.8.1",
@@ -10692,12 +10692,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/@stoplight/spectral-cli/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
         },
         "node_modules/@stoplight/spectral-cli/node_modules/supports-color": {
             "version": "7.2.0",


### PR DESCRIPTION
## Description
Resolves Dependabot alert [#226](https://github.com/finos/architecture-as-code/security/dependabot/226) — [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800: lodash code injection via `_.template` `options.imports` key names. Vulnerable range `>= 4.0.0, <= 4.17.23`, patched in `4.18.0`.

The existing top-level `lodash` override (`^4.18.1`) already forced 4.18.1 across most of the dependency tree. The only remaining vulnerable copy was `node_modules/@stoplight/spectral-cli/node_modules/lodash@4.17.23`, kept nested because `@stoplight/spectral-cli@6.15.0` pinned a direct dep of `lodash: ~4.17.21`.

Bumping `@stoplight/spectral-cli` to `6.15.1` (within the existing `^6.14.3` range in `shared/package.json`) switches its direct lodash dep to `^4.18.1`, allowing the nested copy to dedupe to the hoisted `4.18.1`.

Only `package-lock.json` changes — no manifest change required.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verification:
- `npm ls lodash` no longer lists any nested `4.17.x` copy — all resolve to `4.18.1`.
- `npm audit` no longer reports lodash.
- `npm run build:shared` succeeds.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards