### PR TITLE
ci(calm-suite): fix Playwright install and enable E2E on PRs (#2373)

### DIFF
--- a/.github/workflows/build-calm-studio.yml
+++ b/.github/workflows/build-calm-studio.yml
@@ -62,7 +62,6 @@ jobs:
     e2e-tests:
         name: E2E Tests
         runs-on: ubuntu-latest
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         needs: build-lint-test
         steps:
             - name: Checkout
@@ -84,7 +83,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install Playwright browsers
-              run: npx playwright install --with-deps chromium
+              run: pnpm --filter @calmstudio/studio exec playwright install --with-deps chromium
 
             - name: Build
               run: pnpm -r run build

--- a/.github/workflows/build-calm-studio.yml
+++ b/.github/workflows/build-calm-studio.yml
@@ -86,7 +86,7 @@ jobs:
               run: pnpm --filter @calmstudio/studio exec playwright install --with-deps chromium
 
             - name: Build
-              run: pnpm -r run build
+              run: pnpm --filter '!calmstudio-docs' -r run build
 
             - name: Run E2E tests
               run: pnpm --filter @calmstudio/studio run test:e2e


### PR DESCRIPTION
## Description
Fixes the `E2E Tests` job in the `Build CALM Studio` workflow, which has been failing on every push to `main` since #2329 merged (~2 weeks, ~8 merges) with `sh: 1: playwright: not found` at the `Install Playwright browsers` step. Also removes the push-only gate so the job runs on pull requests going forward.

Root cause: `@playwright/test` is declared only in the `apps/studio` workspace (`calm-suite/calm-studio/apps/studio/package.json`), so under pnpm workspaces the `playwright` CLI lives in `apps/studio/node_modules/.bin/` — not the `calm-suite/calm-studio` root where the step ran `npx playwright`. Switched the install to `pnpm --filter @calmstudio/studio exec playwright install --with-deps chromium`.

The regression went unnoticed because the `e2e-tests` job was gated with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so pull requests never exercised it. Removing the gate lets the existing `paths:` trigger (`calm-suite/calm-studio/**`, `.github/workflows/build-calm-studio.yml`) scope CI cost while ensuring future regressions are caught at review time.

Resolves #2373.

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [x] CI/CD

## Commit Message Format ✅
<!--
Make sure your commit messages follow the conventional commit format:
type(scope): description
-->
`ci(calm-suite): fix Playwright install and enable E2E on PRs (#2373)`

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

The fix is a CI-only change; validation happens on this PR itself — the `Build CALM Studio → E2E Tests` job now runs on PRs and must pass here before merge, which is the real end-to-end verification.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
