### PR TITLE
feat(schema): Deprecate relationship `protocol` replacement is node `interfaces`

### DIFF
--- a/calm/release/1.2/meta/core.json
+++ b/calm/release/1.2/meta/core.json
@@ -166,6 +166,8 @@
       "additionalProperties": true
     },
     "protocol": {
+      "$comment": "'protocol' is deprecated, use node 'interfaces'  instead",
+      "deprecated": true,
       "enum": [
         "HTTP",
         "HTTPS",

--- a/cli/test_fixtures/api-gateway/api-gateway-architecture.json
+++ b/cli/test_fixtures/api-gateway/api-gateway-architecture.json
@@ -58,9 +58,7 @@
             ]
           }
         }
-      },
-      "protocol": "HTTPS",
-      "authentication": "OAuth2"
+      }
     },
     {
       "unique-id": "api-gateway-idp",
@@ -74,9 +72,7 @@
             "node": "idp"
           }
         }
-      },
-      "protocol": "HTTPS",
-      "authentication": "OAuth2"
+      }
     },
     {
       "unique-id": "api-gateway-api-producer",
@@ -93,9 +89,7 @@
             ]
           }
         }
-      },
-      "protocol": "HTTPS",
-      "authentication": "OAuth2"
+      }
     },
     {
       "unique-id": "api-consumer-idp",
@@ -109,9 +103,7 @@
             "node": "idp"
           }
         }
-      },
-      "protocol": "HTTPS",
-      "authentication": "OAuth2"
+      }
     }
   ]
 }

--- a/cli/test_fixtures/api-gateway/api-gateway.json
+++ b/cli/test_fixtures/api-gateway/api-gateway.json
@@ -154,13 +154,7 @@
                 }
               }
             },
-            "parties": {},
-            "protocol": {
-              "const": "HTTPS"
-            },
-            "authentication": {
-              "const": "OAuth2"
-            }
+            "parties": {}
           }
         },
         {
@@ -183,9 +177,6 @@
                   }
                 }
               }
-            },
-            "protocol": {
-              "const": "HTTPS"
             }
           }
         },
@@ -212,9 +203,6 @@
                   }
                 }
               }
-            },
-            "protocol": {
-              "const": "HTTPS"
             }
           }
         },
@@ -238,9 +226,6 @@
                   }
                 }
               }
-            },
-            "protocol": {
-              "const": "HTTPS"
             }
           }
         }

--- a/cli/test_fixtures/generate_output.json
+++ b/cli/test_fixtures/generate_output.json
@@ -44,8 +44,6 @@
     {
       "unique-id": "api-consumer-api-gateway",
       "description": "Issue calculation request",
-      "protocol": "HTTPS",
-      "authentication": "OAuth2",
       "relationship-type": {
         "connects": {
           "source": {
@@ -63,7 +61,6 @@
     {
       "unique-id": "api-gateway-idp",
       "description": "Validate bearer token",
-      "protocol": "HTTPS",
       "relationship-type": {
         "connects": {
           "source": {
@@ -78,7 +75,6 @@
     {
       "unique-id": "api-gateway-api-producer",
       "description": "Forward request",
-      "protocol": "HTTPS",
       "relationship-type": {
         "connects": {
           "source": {
@@ -96,7 +92,6 @@
     {
       "unique-id": "api-consumer-idp",
       "description": "Acquire a bearer token",
-      "protocol": "HTTPS",
       "relationship-type": {
         "connects": {
           "source": {

--- a/cli/test_fixtures/validate_output_junit.xml
+++ b/cli/test_fixtures/validate_output_junit.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="32" failures="0" errors="0" skipped="0">
+<testsuites tests="33" failures="0" errors="0" skipped="0">
     <testsuite name="JSON Schema Validation" tests="1" failures="0"
         errors="0" skipped="0">
         <testcase name="JSON Schema Validation succeeded" />
     </testsuite>
-    <testsuite name="Spectral Suite" tests="31"
+    <testsuite name="Spectral Suite" tests="32"
         failures="0" errors="0" skipped="0">
         <testcase name="architecture-has-nodes-relationships" />
         <testcase name="architecture-has-no-empty-string-properties" />
@@ -23,6 +23,7 @@
             name="unique-ids-must-be-unique-in-architecture" />
         <testcase name="flow-transitions-references-existing-relationship-in-architecture" />
         <testcase name="flow-transitions-have-unique-sequence-numbers" />
+        <testcase name="relationship-protocol-is-deprecated" />
         <testcase name="pattern-has-nodes-relationships" />
         <testcase name="pattern-has-no-empty-properties" />
         <testcase name="pattern-has-no-placeholder-properties-numerical" />

--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -147,8 +147,8 @@ describe('validate E2E', () => {
         expect(protocolWarnings).toHaveLength(1);
         expect(protocolWarnings[0].path).toBe('/relationships/0/protocol');
         expect(protocolWarnings[0].severity).toBe('warning');
-        expect(protocolWarnings[0].message).toContain("'protocol' property on relationships is deprecated");
-        expect(protocolWarnings[0].message).toContain("Use node 'interfaces' instead");
+        expect(protocolWarnings[0].message).toContain('\'protocol\' property on relationships is deprecated');
+        expect(protocolWarnings[0].message).toContain('Use node \'interfaces\' instead');
     });
 
     it.each(TEST_ALL_SCHEMA)('does not report relationship protocol deprecation warning when protocol is absent for schema %s', async (schemaVersion) => {

--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -129,6 +129,44 @@ describe('validate E2E', () => {
         expect(response.hasErrors).toBeFalsy();
     });
 
+    it.each(TEST_ALL_SCHEMA)('reports relationship protocol deprecation warning for schema %s', async (schemaVersion) => {
+        const inputArch = setCalmSchema(
+            JSON.parse(readFileSync(path.join(validationPath, 'relationship-protocol-deprecated.json'), 'utf-8')),
+            schemaVersion
+        );
+        const pattern = await schemaDirectory.getSchema(inputArch['$schema']);
+
+        const response = await validate(inputArch, pattern, undefined, schemaDirectory, false);
+        const protocolWarnings = response.spectralSchemaValidationOutputs.filter(
+            output => output.code === 'relationship-protocol-is-deprecated'
+        );
+
+        expect(response.jsonSchemaValidationOutputs).toHaveLength(0);
+        expect(response.hasErrors).toBeFalsy();
+        expect(response.hasWarnings).toBeTruthy();
+        expect(protocolWarnings).toHaveLength(1);
+        expect(protocolWarnings[0].path).toBe('/relationships/0/protocol');
+        expect(protocolWarnings[0].severity).toBe('warning');
+        expect(protocolWarnings[0].message).toContain("'protocol' property on relationships is deprecated");
+        expect(protocolWarnings[0].message).toContain("Use node 'interfaces' instead");
+    });
+
+    it.each(TEST_ALL_SCHEMA)('does not report relationship protocol deprecation warning when protocol is absent for schema %s', async (schemaVersion) => {
+        const inputArch = setCalmSchema(
+            JSON.parse(readFileSync(path.join(validationPath, 'relationship-without-protocol.json'), 'utf-8')),
+            schemaVersion
+        );
+        const pattern = await schemaDirectory.getSchema(inputArch['$schema']);
+
+        const response = await validate(inputArch, pattern, undefined, schemaDirectory, false);
+        const protocolWarnings = response.spectralSchemaValidationOutputs.filter(
+            output => output.code === 'relationship-protocol-is-deprecated'
+        );
+
+        expect(response.hasErrors).toBeFalsy();
+        expect(protocolWarnings).toHaveLength(0);
+    });
+
     describe('applyArchitectureOptionsToPattern', () => {
         it('works with one options relationship', async () => {
             const architecture = JSON.parse(

--- a/shared/src/spectral/rules-architecture.ts
+++ b/shared/src/spectral/rules-architecture.ts
@@ -176,7 +176,7 @@ const architectureRules: RulesetDefinition = {
 
         'relationship-protocol-is-deprecated': {
             description: 'The protocol property on relationships is deprecated',
-            message: "The 'protocol' property on relationships is deprecated. Use node 'interfaces' instead.",
+            message: "The 'protocol' property on relationships is deprecated and will be removed in a future version. Use node 'interfaces' instead.",
             severity: 'warn',
             given: '$.relationships[*].protocol',
             then: {

--- a/shared/src/spectral/rules-architecture.ts
+++ b/shared/src/spectral/rules-architecture.ts
@@ -172,6 +172,19 @@ const architectureRules: RulesetDefinition = {
             then: {
                 function: sequenceNumbersAreUnique
             }
+        },
+
+        'relationship-protocol-is-deprecated': {
+            description: 'The protocol property on relationships is deprecated',
+            message: "The 'protocol' property on relationships is deprecated. Use node 'interfaces' instead.",
+            severity: 'warn',
+            given: '$.relationships[*].protocol',
+            then: {
+                function: pattern,
+                functionOptions: {
+                    notMatch: '.*',
+                },
+            },
         }
     }
 };

--- a/shared/src/spectral/rules-architecture.ts
+++ b/shared/src/spectral/rules-architecture.ts
@@ -176,7 +176,7 @@ const architectureRules: RulesetDefinition = {
 
         'relationship-protocol-is-deprecated': {
             description: 'The protocol property on relationships is deprecated',
-            message: "The 'protocol' property on relationships is deprecated and will be removed in a future version. Use node 'interfaces' instead.",
+            message: 'The \'protocol\' property on relationships is deprecated and will be removed in a future version. Use node \'interfaces\' instead.',
             severity: 'warn',
             given: '$.relationships[*].protocol',
             then: {

--- a/shared/test_fixtures/command/validate/relationship-protocol-deprecated.json
+++ b/shared/test_fixtures/command/validate/relationship-protocol-deprecated.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0/meta/calm.json",
+  "nodes": [
+    {
+      "unique-id": "node-1",
+      "name": "Frontend Service",
+      "node-type": "service",
+      "description": "Frontend Service"
+    },
+    {
+      "unique-id": "node-2",
+      "name": "Backend Service",
+      "node-type": "service",
+      "description": "Backend Service"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "node-1-to-node-2",
+      "relationship-type": {
+        "connects": {
+          "source": { "node": "node-1" },
+          "destination": { "node": "node-2" }
+        }
+      },
+      "protocol": "HTTPS"
+    }
+  ]
+}

--- a/shared/test_fixtures/command/validate/relationship-without-protocol.json
+++ b/shared/test_fixtures/command/validate/relationship-without-protocol.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://calm.finos.org/release/1.0/meta/calm.json",
+  "nodes": [
+    {
+      "unique-id": "node-1",
+      "name": "Frontend Service",
+      "node-type": "service",
+      "description": "Frontend Service"
+    },
+    {
+      "unique-id": "node-2",
+      "name": "Backend Service",
+      "node-type": "service",
+      "description": "Backend Service"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "node-1-to-node-2",
+      "relationship-type": {
+        "connects": {
+          "source": { "node": "node-1" },
+          "destination": { "node": "node-2" }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Deprecates the `protocol` property on CALM relationships and guides users toward defining protocols through node `interfaces` instead.

Closes finos/architecture-as-code#2376 

### Changes

- Marks relationship `protocol` as deprecated in the CALM 1.2 core schema metadata.
- Adds a Spectral architecture rule, `relationship-protocol-is-deprecated`, that emits a warning when `relationships[*].protocol` is present.
- Keeps validation non-breaking: architectures with relationship `protocol` still pass validation, but now surface migration guidance.
- Adds validation fixtures covering relationships with and without `protocol`.
- Adds E2E validation coverage across supported schema versions to verify:
  - a warning is emitted when relationship `protocol` is used
  - no warning is emitted when `protocol` is absent

## Testing

- Ran `npm run test --workspace shared -- validate.e2e.spec.ts`
- The targeted test file passed: `32 passed`

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [x] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
