### PR TITLE
Update docusaurus and three dependencies

### DIFF
--- a/calm-suite/calm-studio/docs-site/package.json
+++ b/calm-suite/calm-studio/docs-site/package.json
@@ -24,9 +24,9 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/tsconfig": "3.9.2",
-    "@docusaurus/types": "3.9.2",
+    "@docusaurus/module-type-aliases": "3.10.0",
+    "@docusaurus/tsconfig": "3.10.0",
+    "@docusaurus/types": "3.10.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "typedoc": "^0.28.0",
     "typedoc-plugin-markdown": "^4.10.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,8 +34,8 @@
         "on-headers": "^1.1.0"
     },
     "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/types": "3.9.2",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/types": "3.10.0",
         "express": "^5.2.1",
         "webpack-dev-server": "^5.2.2"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -590,8 +590,8 @@
                 "webpack": "^5.99.5"
             },
             "devDependencies": {
-                "@docusaurus/module-type-aliases": "3.9.2",
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/module-type-aliases": "3.10.0",
+                "@docusaurus/types": "3.10.0",
                 "express": "^5.2.1",
                 "webpack-dev-server": "^5.2.2"
             },
@@ -5225,51 +5225,6 @@
                 }
             }
         },
-        "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/bundler/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/core": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.0.tgz",
@@ -5731,13 +5686,12 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-            "dev": true,
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
+            "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/types": "3.10.0",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -5785,37 +5739,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-blog/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/plugin-content-blog/node_modules/fs-extra": {
             "version": "11.3.4",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -5828,20 +5751,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-content-docs": {
@@ -5877,56 +5786,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-            "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@docusaurus/types": "3.10.0",
-                "@types/history": "^4.7.11",
-                "@types/react": "*",
-                "@types/react-router-config": "*",
-                "@types/react-router-dom": "*",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-            },
-            "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/plugin-content-docs/node_modules/fs-extra": {
             "version": "11.3.4",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -5939,20 +5798,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-content-pages": {
@@ -5978,37 +5823,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-pages/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/plugin-content-pages/node_modules/fs-extra": {
             "version": "11.3.4",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -6021,20 +5835,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-css-cascade-layers": {
@@ -6051,51 +5851,6 @@
             },
             "engines": {
                 "node": ">=20.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-debug": {
@@ -6119,37 +5874,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-debug/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/plugin-debug/node_modules/fs-extra": {
             "version": "11.3.4",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -6162,20 +5886,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-google-analytics": {
@@ -6195,51 +5905,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-analytics/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
@@ -6262,51 +5927,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-gtag/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.0.tgz",
@@ -6324,51 +5944,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-sitemap": {
@@ -6395,37 +5970,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-sitemap/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/plugin-sitemap/node_modules/fs-extra": {
             "version": "11.3.4",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -6438,20 +5982,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-svgr": {
@@ -6475,51 +6005,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/plugin-svgr/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/preset-classic": {
@@ -6550,51 +6035,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/preset-classic/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/react-loadable": {
@@ -6650,56 +6090,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-            "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@docusaurus/types": "3.10.0",
-                "@types/history": "^4.7.11",
-                "@types/react": "*",
-                "@types/react-router-config": "*",
-                "@types/react-router-dom": "*",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-            },
-            "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
-            }
-        },
-        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-classic/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@docusaurus/theme-classic/node_modules/react-router-dom": {
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
@@ -6716,20 +6106,6 @@
             },
             "peerDependencies": {
                 "react": ">=15"
-            }
-        },
-        "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/theme-common": {
@@ -6758,70 +6134,6 @@
                 "@docusaurus/plugin-content-docs": "*",
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-            "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@docusaurus/types": "3.10.0",
-                "@types/history": "^4.7.11",
-                "@types/react": "*",
-                "@types/react-router-config": "*",
-                "@types/react-router-dom": "*",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-            },
-            "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
-            }
-        },
-        "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-common/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
@@ -6898,10 +6210,9 @@
             }
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-            "dev": true,
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
+            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
@@ -6924,7 +6235,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
             "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -6934,7 +6244,6 @@
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
             "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "clone-deep": "^4.0.1",
@@ -6990,51 +6299,6 @@
                 "node": ">=20.0"
             }
         },
-        "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/utils-common/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@docusaurus/utils-validation": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
@@ -7066,37 +6330,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-            "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/mdx": "^3.0.0",
-                "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
-                "@types/react": "*",
-                "commander": "^5.1.0",
-                "joi": "^17.9.2",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-                "utility-types": "^3.10.0",
-                "webpack": "^5.95.0",
-                "webpack-merge": "^5.9.0"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@docusaurus/utils/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/@docusaurus/utils/node_modules/escape-string-regexp": {
@@ -7215,20 +6448,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@dual-bundle/import-meta-resolve": {
@@ -12481,13 +11700,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12499,13 +11716,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12517,13 +11732,11 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12535,13 +11748,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12553,13 +11764,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12571,13 +11780,11 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12589,13 +11796,11 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12607,13 +11812,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12625,13 +11828,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12643,13 +11844,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12661,13 +11860,11 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12679,13 +11876,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }

--- a/shared/src/docify/template-bundles/ants/package.json
+++ b/shared/src/docify/template-bundles/ants/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "three": "^0.183.0"
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "vite": "^6.0.0"


### PR DESCRIPTION
## Description
Perform a subset of the updates proposed by renovate in #2387 

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [X] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [X] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
