### PR TITLE
fix(ci): remove broken global npm 11 upgrade from release workflows

### DIFF
--- a/.github/workflows/automated-release-calm-server.yml
+++ b/.github/workflows/automated-release-calm-server.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -240,9 +237,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -389,9 +383,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -457,9 +448,6 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update to npm 11
-        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -244,9 +241,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -393,9 +387,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Update to npm 11
-        run: npm install -g npm@11
-
       - name: Install dependencies
         run: npm ci
 
@@ -461,9 +452,6 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update to npm 11
-        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Description
Removes the `Update to npm 11` step from `automated-release.yml` and `automated-release-calm-server.yml`. The step has been failing on every scheduled run since at least 2026-04-15 because Node 22.22.x ships an npm 10.9.7 whose self-upgrade to npm 11 crashes mid-install with `Cannot find module 'promise-retry'` — see latest failure at https://github.com/finos/architecture-as-code/actions/runs/25098279438/job/73540498734.

The global upgrade is no longer required:
- `package.json` already overrides `@semantic-release/npm` to bundle `npm@11.12.1`, so semantic-release uses npm 11 internally regardless of the global version.
- `npm publish --provenance` is supported on npm 9.5+, so the bundled `npm@10.9.7` is sufficient for the publish step.
- `build-cli.yml` and `build-shared.yml` already run on the bundled npm without performing this upgrade.

This unblocks publication of `@finos/calm-cli` — including the merged docify dependency fix from PR #2324, which is reachable via #2384.

Fixes #2397

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [x] CI/CD

## Commit Message Format ✅
`fix(ci): remove broken global npm 11 upgrade from release workflows`

Note: scope is `ci`, not `cli`, so this PR will not itself trigger a CLI release. After merge, the next scheduled `CLI - Automated Release` run (or a manual `workflow_dispatch`) will produce the version-bump PR.

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified locally that the surviving steps in the affected workflows do not require npm 11:
- `npm ci`, `npm version --no-git-tag-version`, and `npm publish --provenance` all run successfully on the bundled `npm@10.9.7`.
- `npx semantic-release` resolves `@semantic-release/npm` from `node_modules`, where the root `overrides` block forces `npm@11.12.1`.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards