### PR TITLE
fix(ci): bump CI Node.js to 24 to restore npm 11 trusted publishing

### DIFF
--- a/.github/workflows/automated-release-calm-server.yml
+++ b/.github/workflows/automated-release-calm-server.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -235,7 +235,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -381,7 +381,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -446,7 +446,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/automated-release-calm-studio.yml
+++ b/.github/workflows/automated-release-calm-studio.yml
@@ -40,7 +40,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
                   cache-dependency-path: calm-suite/calm-studio/pnpm-lock.yaml
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -239,7 +239,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -385,7 +385,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -450,7 +450,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/build-and-sync-advent.yml
+++ b/.github/workflows/build-and-sync-advent.yml
@@ -19,7 +19,7 @@ jobs:
 
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/build-calm-guard.yml
+++ b/.github/workflows/build-calm-guard.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: package-lock.json
 
@@ -58,7 +58,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: package-lock.json
 
@@ -81,7 +81,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: package-lock.json
 

--- a/.github/workflows/build-calm-hub-ui.yml
+++ b/.github/workflows/build-calm-hub-ui.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-calm-models.yml
+++ b/.github/workflows/build-calm-models.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-calm-server.yml
+++ b/.github/workflows/build-calm-server.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-calm-studio-desktop.yml
+++ b/.github/workflows/build-calm-studio-desktop.yml
@@ -44,7 +44,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
                   cache-dependency-path: calm-suite/calm-studio/pnpm-lock.yaml
             - run: pnpm install --frozen-lockfile
@@ -94,7 +94,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
                   cache-dependency-path: calm-suite/calm-studio/pnpm-lock.yaml
             - run: cd calm-suite/calm-studio && pnpm install --frozen-lockfile

--- a/.github/workflows/build-calm-studio.yml
+++ b/.github/workflows/build-calm-studio.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
                   cache-dependency-path: calm-suite/calm-studio/pnpm-lock.yaml
 
@@ -75,7 +75,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
                   cache-dependency-path: calm-suite/calm-studio/pnpm-lock.yaml
 

--- a/.github/workflows/build-calm-widgets.yml
+++ b/.github/workflows/build-calm-widgets.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: package-lock.json
 

--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci
@@ -65,7 +65,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci
@@ -94,7 +94,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci

--- a/.github/workflows/cve-scanning-node.yml
+++ b/.github/workflows/cve-scanning-node.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Set up Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
             - name: Build project with NPM
               run: npm install --omit=dev --ignore-scripts
               working-directory: ${{ matrix.module-folder }}

--- a/.github/workflows/license-scanning-node.yml
+++ b/.github/workflows/license-scanning-node.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: ['22.x']
+                node-version: ['24.x']
                 module-folder: ['cli', 'docs', 'shared']
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/s3-docs-sync.yml
+++ b/.github/workflows/s3-docs-sync.yml
@@ -19,7 +19,7 @@ jobs:
 
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 22
+                  node-version: 24
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: 24
 
       - name: Validate platform bindings in lockfile
         run: node scripts/validate-lockfile-platforms.js

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: 24
           cache: 'npm'
           
       - name: Install Renovate CLI

--- a/.github/workflows/validate-spectral.yml
+++ b/.github/workflows/validate-spectral.yml
@@ -32,7 +32,7 @@ jobs:
             # Run Spectral
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: v22
+                  node-version: 24
 
             - name: Install workspace
               run: npm ci


### PR DESCRIPTION
## Description

Bumps the Node.js version pinned in every CI workflow from 22 to 24 to restore npm Trusted Publishing (OIDC), which has been silently broken since #2397 was merged.

### Root cause

`@finos/calm-cli@1.39.0` did not publish to npm on 2026-05-02 (run [25255770432](https://github.com/finos/architecture-as-code/actions/runs/25255770432)). The `Publish to NPM` step failed with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@finos%2fcalm-cli - Not found
npm error 404 '@finos/calm-cli@1.39.0' is not in this registry.
```

This is npm's masked-403 response when the auth identity is not authorized to publish a scoped package. Querying the registry confirms the last successful publish (1.37.0, 2026-04-01) used Trusted Publishing rather than the bearer token:

```
$ npm view @finos/calm-cli
_npmUser: GitHub Actions <npm-oidc-no-reply@github.com>
```

OIDC trusted publishing requires npm 11.5+. Node 22.22.x ships npm 10.9.7, so since #2397 removed the `npm install -g npm@11` step the publish job has been quietly falling back to bearer-token auth.

### Why Node 24 (not re-add the global upgrade)

The `npm install -g npm@11` step was removed in #2397 because it crashed mid-install on Node 22 with `Cannot find module 'promise-retry'` - a known regression in npm 10.9.7's self-upgrade path. Reintroducing it would flip back to the previously-broken state. Node 24 ships npm 11 in-the-box, ending the cycle.

Other notes:
- Root `package.json` already declares `node: \"^22.14.0 || >=24.10.0\"`, so no engines change is required.
- Per-workspace engines fields (`docs`, `calm-suite/calm-studio`, `calm-suite/calm-studio/docs-site`, `calm-suite/calm-guard/docs`) all accept `>=20`.
- Node 22 reaches EOL in April 2027; Node 24 is the current Active LTS line.

### Normalization

While here, the mix of `node-version: v22`, `22`, `'22'`, and `['22.x']` across 21 workflow files has been normalized to a single `node-version: 24` (matrix entry kept as `['24.x']`).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

CI on this PR will exercise every affected workflow. To fully verify the publish path, after merge the next `cli-v1.x.x` release run should show `_npmUser: GitHub Actions <npm-oidc-no-reply@github.com>` again on the published version. Recommend cutting `cli-v1.39.1` to re-exercise the path - the `cli-v1.39.0` git tag and GitHub Release already exist (publish silently dropped at the npm step), and a patch release is cleaner than retrofit-publishing the same version.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

## Related

Re-fixes #2397 (the previous fix's premise that the global npm 11 upgrade was unnecessary turned out to be incorrect).