### PR TITLE
fix(ci): pin npm to 11.12.1 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "@finos/calm-workspace",
     "version": "0.0.0",
     "private": true,
+    "packageManager": "npm@11.12.1",
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
     },


### PR DESCRIPTION
## Description
Adds `"packageManager": "npm@11.12.1"` to the root `package.json` so Renovate's hosted runner uses npm 11 when regenerating the workspace lockfile.

Closes #2415.

**Sequencing:** depends on #2414 landing first (CI Node 24 / npm 11). Once #2414 merges this is purely additive — only the workspace `package.json` gains one field.

### Why
Renovate currently uses npm 10 by default and raises `EOVERRIDE` when re-resolving the tree against the `dompurify: ^3.4.0` override (and will eventually do the same for any other caret-range entry in `overrides`). The regen aborts; Renovate ships the unrelated `package.json` updates with a stale `package-lock.json`; CI fails on `npm ci`. Most recent breakage: #2410.

npm 11.5+ handles the same scenario without erroring — verified locally that `npm install` against PR #2410's head with npm 11.12.1 produces a clean lockfile in ~15 seconds.

`packageManager` is the Corepack-standard signal and is what Renovate's hosted runner reads to pick its npm version. CI is unaffected by this field — the workflows call `npm` from `actions/setup-node` and don't run `corepack enable`, so they keep using whatever npm ships with the configured Node (npm 11 from Node 24 once #2414 lands). Local dev only sees the pinned npm if the contributor opts into Corepack. The alternative (`renovate.json` `constraints.npm`) would also fix Renovate, but `packageManager` is the more standard and tooling-friendly signal.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [x] CI/CD

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Local verification: `npm install` against PR #2410's head with npm 11.12.1 produces a clean lockfile diff and no EOVERRIDE. Once this PR merges, the next Renovate patch-update PR is the real test — its `npm ci` step should pass.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
