### PR TITLE
chore(deps): override axios to ^1.15.2 to patch transitive 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,17 +134,6 @@
                 }
             }
         },
-        "calm-hub-ui/node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
         "calm-hub-ui/node_modules/postcss": {
             "version": "8.5.13",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -1366,7 +1355,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.39.0",
+            "version": "1.39.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -1392,18 +1381,6 @@
                 "semantic-release": "^25.0.0",
                 "tsup": "^8.4.0",
                 "xml2js": "^0.6.2"
-            }
-        },
-        "cli/node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
             }
         },
         "docs": {
@@ -20433,14 +20410,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -41085,7 +41062,9 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
             "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -49499,119 +49478,11 @@
             },
             "devDependencies": {}
         },
-        "shared/node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
         "shared/node_modules/lines-and-columns": {
             "version": "2.0.4",
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "calm-suite/calm-guard/node_modules/@vitest/coverage-v8": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.5",
-                "ast-v8-to-istanbul": "^1.0.0",
-                "istanbul-lib-coverage": "^3.2.2",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-reports": "^3.2.0",
-                "magicast": "^0.5.2",
-                "obug": "^2.1.1",
-                "std-env": "^4.0.0-rc.1",
-                "tinyrainbow": "^3.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "@vitest/browser": "4.1.5",
-                "vitest": "4.1.5"
-            },
-            "peerDependenciesMeta": {
-                "@vitest/browser": {
-                    "optional": true
-                }
-            }
-        },
-        "calm-suite/calm-guard/node_modules/@vitest/ui": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
-            "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@vitest/utils": "4.1.5",
-                "fflate": "^0.8.2",
-                "flatted": "^3.4.2",
-                "pathe": "^2.0.3",
-                "sirv": "^3.0.2",
-                "tinyglobby": "^0.2.15",
-                "tinyrainbow": "^3.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "vitest": "4.1.5"
-            }
-        },
-        "calm-suite/calm-guard/node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.31",
-                "estree-walker": "^3.0.3",
-                "js-tokens": "^10.0.0"
-            }
-        },
-        "calm-suite/calm-guard/node_modules/magicast": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-            "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.8.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     },
     "overrides": {
         "@types/node": "^22.19.15",
+        "axios": "^1.15.2",
         "dompurify": "^3.4.0",
         "on-headers": "^1.1.0",
         "node-forge": "^1.3.2",


### PR DESCRIPTION
## Description

The hoisted root `node_modules/axios` was stuck at **1.15.0** even after #2417 bumped the workspace direct deps to 1.15.2. The root copy is pulled in to satisfy `axios-mock-adapter`'s `axios: ">= 0.17.0"` peer dep, and `--workspace`-scoped installs don't update the root tree, so 10 Dependabot alerts (4 high-severity) stayed open against the transitive copy.

This PR adds `axios: ^1.15.2` to the root `overrides` block in `package.json`. After `npm install --package-lock-only` the lockfile collapses the per-workspace `calm-hub-ui/`, `cli/`, and `shared/node_modules/axios` copies into a single hoisted root entry at **1.16.0** (the highest match for `^1.15.2`).

`npm audit` reports axios clean afterwards. Same pattern as the existing `picomatch`, `serialize-javascript`, `qs`, `lodash`, etc. overrides.

### Vulnerabilities resolved

| GHSA | Severity | Summary |
|---|---|---|
| [GHSA-pf86-5x62-jrwf](https://github.com/advisories/GHSA-pf86-5x62-jrwf) | high | Axios: Prototype Pollution Gadgets — Response Tampering, Data Exfiltration, Request Hijacking |
| [GHSA-6chq-wfr3-2hj9](https://github.com/advisories/GHSA-6chq-wfr3-2hj9) | high | Axios: Header Injection via Prototype Pollution |
| [GHSA-pmwg-cvhr-8vh7](https://github.com/advisories/GHSA-pmwg-cvhr-8vh7) | high | Axios: Incomplete fix for CVE-2025-62718 — NO_PROXY bypass via 127.0.0.0/8 in 1.15.0 |
| [GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj) | high | Axios: Prototype pollution read-side gadgets in HTTP adapter |
| [GHSA-445q-vr5w-6q77](https://github.com/advisories/GHSA-445q-vr5w-6q77) | medium | Axios: CRLF Injection in multipart/form-data via unsanitized blob.type |
| [GHSA-m7pr-hjqh-92cm](https://github.com/advisories/GHSA-m7pr-hjqh-92cm) | medium | Axios: no_proxy bypass via IP alias allows SSRF |
| [GHSA-xx6v-rp6x-q39c](https://github.com/advisories/GHSA-xx6v-rp6x-q39c) | medium | Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution |
| [GHSA-w9j2-pvgh-6h63](https://github.com/advisories/GHSA-w9j2-pvgh-6h63) | medium | Axios: Authentication Bypass via Prototype Pollution in `validateStatus` |
| [GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23) | medium | Axios: Invisible JSON Response Tampering via `parseReviver` |
| [GHSA-xhjh-pmcv-23jw](https://github.com/advisories/GHSA-xhjh-pmcv-23jw) | low | Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams |

### Why Dependabot didn't catch this on its own

Run [25385074152](https://github.com/finos/architecture-as-code/actions/runs/25385074152/job/74443787015) was green but raised no PR: it inspected the workspace direct deps (already at 1.15.2 after #2417) and the GroupDependencySelector correctly filtered them out — but Dependabot doesn't re-probe the transitive root tree, so the still-vulnerable hoisted 1.15.0 was never seen.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified locally:
- `npm install --package-lock-only --ignore-scripts` regenerates the lockfile cleanly
- After regeneration: `node_modules/axios` resolves to **1.16.0**, all four nested workspace copies collapse into the root
- `npm audit` reports axios clean (no remaining axios advisories); other unrelated package vulns are out of scope

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards