### PR TITLE
chore(deps): force mocha to use serialize-javascript@7.0.5 from override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19839,9 +19839,7 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
             "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -34597,16 +34595,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/mocha/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -40490,9 +40478,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
             "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -40624,16 +40610,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/range-parser": {


### PR DESCRIPTION
## Description
Resolves [Dependabot alert #174](https://github.com/finos/architecture-as-code/security/dependabot/174) (GHSA-5c6j-r48x-rmvq — RCE in `serialize-javascript` via `RegExp.flags` / `Date.prototype.toISOString`).

The existing `serialize-javascript: "^7.0.5"` override in `package.json` was already in place, but `package-lock.json` retained a stale `node_modules/mocha/node_modules/serialize-javascript@6.0.2` entry from before the override was added. npm install preserves nested entries even after an override is added, so the vulnerable copy persisted on every install.

This PR removes the stale lockfile entry so npm re-resolves mocha's `serialize-javascript` under the override. After install, mocha now uses the hoisted top-level `serialize-javascript@7.0.5`, and there is no longer a vulnerable copy on disk.

Verified locally:
- `npm ls serialize-javascript` no longer shows any `6.x` entries (the only remaining `6.x` ranges are warnings from npm because consumers' declared range is `^6.x`, but the actual installed version is `7.0.5`)
- `node -e "require('serialize-javascript')"` and `require('mocha')` both load successfully

Two unrelated metadata flips (`dev:true,peer:true` removed from `axios@1.16.0` and `proxy-from-env@2.1.0`) appear in the diff — these are npm's resolver tidying on re-resolve, not behavioural changes.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Dependencies

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards