### PR TITLE
chore(deps): override ip-address and postcss to clear Dependabot alerts

### DIFF
--- a/calm-server/package.json
+++ b/calm-server/package.json
@@ -33,7 +33,7 @@
         "commander": "^14.0.0",
         "copyfiles": "^2.4.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.2.2"
+        "express-rate-limit": "^8.5.0"
     },
     "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,35 +134,6 @@
                 }
             }
         },
-        "calm-hub-ui/node_modules/postcss": {
-            "version": "8.5.13",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "calm-models": {
             "name": "@finos/calm-models",
             "version": "1.0.0",
@@ -481,7 +452,7 @@
                 "commander": "^14.0.0",
                 "copyfiles": "^2.4.1",
                 "express": "^4.18.2",
-                "express-rate-limit": "^8.2.2"
+                "express-rate-limit": "^8.5.0"
             },
             "bin": {
                 "calm-server": "dist/index.js"
@@ -1090,34 +1061,6 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
-        "calm-suite/calm-guard/node_modules/postcss": {
-            "version": "8.5.13",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "calm-suite/calm-guard/node_modules/react-refresh": {
@@ -19839,9 +19782,7 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
             "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -25940,12 +25881,12 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-            "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+            "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
             "license": "MIT",
             "dependencies": {
-                "ip-address": "10.1.0"
+                "ip-address": "^10.2.0"
             },
             "engines": {
                 "node": ">= 16"
@@ -28724,9 +28665,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -34926,34 +34867,6 @@
                 "tslib": "^2.8.0"
             }
         },
-        "node_modules/next/node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/nimma": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
@@ -40490,9 +40403,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
             "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "lodash": "^4.18.1",
         "lodash-es": "^4.18.1",
         "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
         "@semantic-release/npm": {
             "npm": "11.12.1"
         },


### PR DESCRIPTION
## Description
Clears two Dependabot alerts on the root `package-lock.json`.

| Alert | Package | Approach |
|---|---|---|
| [#303](https://github.com/finos/architecture-as-code/security/dependabot/303) (GHSA-v2v4-37r5-5v8g) | `ip-address` | Bump `calm-server`'s `express-rate-limit` pin from `^8.2.2` → `^8.5.0`. The new version declares `ip-address: ^10.2.0` directly, so npm installs a patched copy at the top level — no override needed. |
| [#287](https://github.com/finos/architecture-as-code/security/dependabot/287) (GHSA-qx2v-qp2m-jg93) | `postcss` | Add `postcss: ^8.5.10` override. Top-level `postcss` was already at 8.5.10; the vulnerable copy was `node_modules/next/node_modules/postcss@8.4.31` (Next 15.5.15 pins exact 8.4.31). The stale lockfile entry has been removed so npm re-resolves under the override — next now uses the hoisted top-level `postcss@8.5.10`. |

### Note on the ip-address approach
A previous version of this PR used `ip-address: ^10.1.1` as an override and surgically removed the top-level lockfile entry. That approach broke the calm-server test suite in CI: `express-rate-limit` imports `ip-address` at runtime, and removing the lockfile entry left it unresolvable (locally it was masked by an `ip-address` package in a parent directory). Bumping `express-rate-limit` to a version that pulls in a patched `ip-address` directly is cleaner and avoids the override-anchor problem entirely.

## Out of scope
- **`uuid` (alert [#301](https://github.com/finos/architecture-as-code/security/dependabot/301))** — the only vulnerable copy is `node_modules/mermaid/node_modules/uuid@11.1.0`. A global `uuid: ^11.1.1` override forces v11 onto v8 consumers (`@cypress/request`, `@azure/msal-node`, `sockjs`); a scoped `mermaid: { uuid: ... }` override caused mermaid to dedupe to the v8 hoisted copy and broke resolution. The advisory (GHSA-w5hq-g745-h8pq) is a missing buffer bounds check in the v3/v5/v6 generator path when a `buf` argument is provided — mermaid only generates v4 IDs and does not exercise that path, so real-world risk is essentially nil. Recommend dismissing this alert with a `tolerable_risk` justification.
- **`ip-address` bundled inside npm CLI** (`node_modules/npm/node_modules/ip-address@10.1.0`, `inBundle:true`) — not reachable via overrides. Bundled npm CLI is a release-time tool, not a runtime consumer; recommend dismiss-with-justification if Dependabot flags it.
- **`calm-suite/calm-studio`** — separate pnpm-managed workspace, intentionally out of scope.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CALM Server (`calm-server/`)
- [x] Dependencies

## Testing
- [x] I have tested my changes locally (`npm run test:calm-server` passes — all 11 tests; `npm install` resolves cleanly; postcss/ip-address verified at correct versions in the lockfile)
- [ ] I have added/updated unit tests (n/a — dependency-only change)
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards