### PR TITLE
fix(calm-hub): CalmHub UI Colour Improvements Refactor MCP Sever Tools

### DIFF
--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -99,8 +99,8 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
             <div className="flex-1 min-h-0 bg-base-100 rounded-2xl overflow-hidden flex flex-col shadow-xl">
                 {/* Requirement breadcrumb header */}
                 <div className="bg-base-200 px-6 py-2 flex items-center justify-between border-b border-base-300">
-                    <h2 className="text-sm font-bold flex items-center gap-2 text-blue-700">
-                        <IoShieldCheckmarkOutline className="text-blue-700" />
+                    <h2 className="text-sm font-bold flex items-center gap-2 text-primary">
+                        <IoShieldCheckmarkOutline className="text-primary" />
                         <span>{controlData.controlName}</span>
                         <span className="text-gray-400">/</span>
                         <span>Requirement</span>
@@ -115,14 +115,14 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                     <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
                         <button
                             role="tab"
-                            className={`tab ${reqViewMode === 'readable' ? 'tab-active !bg-blue-700 !text-white' : ''}`}
+                            className={`tab ${reqViewMode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                             onClick={() => setReqViewMode('readable')}
                         >
                             Readable
                         </button>
                         <button
                             role="tab"
-                            className={`tab ${reqViewMode === 'raw' ? 'tab-active !bg-blue-700 !text-white' : ''}`}
+                            className={`tab ${reqViewMode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                             onClick={() => setReqViewMode('raw')}
                         >
                             Raw JSON
@@ -138,7 +138,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                                 <button
                                     key={v}
                                     role="tab"
-                                    className={`tab gap-1 rounded-lg ${selectedReqVersion === v ? 'tab-active !bg-blue-700 !text-white' : ''}`}
+                                    className={`tab gap-1 rounded-lg ${selectedReqVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                                     onClick={() => handleReqVersionClick(v)}
                                 >
                                     {v}
@@ -185,14 +185,14 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                     <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
                         <button
                             role="tab"
-                            className={`tab ${cfgViewMode === 'readable' ? 'tab-active !bg-accent !text-white' : ''}`}
+                            className={`tab ${cfgViewMode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                             onClick={() => setCfgViewMode('readable')}
                         >
                             Readable
                         </button>
                         <button
                             role="tab"
-                            className={`tab ${cfgViewMode === 'raw' ? 'tab-active !bg-accent !text-white' : ''}`}
+                            className={`tab ${cfgViewMode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                             onClick={() => setCfgViewMode('raw')}
                         >
                             Raw JSON
@@ -208,7 +208,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                             <button
                                 key={cid}
                                 role="tab"
-                                className={`tab gap-1 rounded-lg ${selectedConfigId === cid ? 'tab-active !bg-accent !text-white' : ''}`}
+                                className={`tab gap-1 rounded-lg ${selectedConfigId === cid ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                                 onClick={() => handleConfigClick(cid)}
                             >
                                 Config {cid}
@@ -225,7 +225,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                                     <button
                                         key={v}
                                         role="tab"
-                                        className={`tab gap-1 rounded-lg ${selectedConfigVersion === v ? 'tab-active !bg-accent !text-white' : ''}`}
+                                        className={`tab gap-1 rounded-lg ${selectedConfigVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
                                         onClick={() => handleConfigVersionClick(v)}
                                     >
                                         {v}

--- a/calm-hub/src/integration-test/java/integration/MongoMcpIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMcpIntegration.java
@@ -66,8 +66,25 @@ public class MongoMcpIntegration {
             }
             """;
 
+    private static final String CONTROL_REQUIREMENT_JSON = """
+            {
+                "control-id": "mcp-test-control",
+                "name": "MCP Test Control",
+                "description": "Integration test control requirement"
+            }
+            """;
+
+    private static final String CONTROL_CONFIGURATION_JSON = """
+            {
+                "control-id": "mcp-test-control",
+                "value": "enforced",
+                "environment": "integration-test"
+            }
+            """;
+
     private static int createdArchitectureId;
     private static int createdDecoratorId;
+    private static int createdControlId;
 
     @Inject
     ArchitectureTools architectureTools;
@@ -349,5 +366,71 @@ public class MongoMcpIntegration {
         ToolResponse result = decoratorTools.listDecorators("finos", null, "deployment\n");
         assertThat(result.isError(), is(true));
         assertThat(text(result), containsString("Type filter"));
+    }
+
+    // --- Control Tools (create paths) ---
+
+    @Test
+    @Order(26)
+    void mcp_create_control_requirement() {
+        ToolResponse result = controlTools.createControlRequirement(
+                "security", "MCP Test Control", "Integration test control requirement", CONTROL_REQUIREMENT_JSON);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("created successfully"));
+
+        Matcher matcher = ID_PATTERN.matcher(text(result));
+        assertThat("Response should contain control ID", matcher.find());
+        createdControlId = Integer.parseInt(matcher.group(1));
+        logger.info("Created control with ID: {}", createdControlId);
+    }
+
+    @Test
+    @Order(27)
+    void mcp_list_controls_contains_created() {
+        ToolResponse result = controlTools.listControls("security");
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("MCP Test Control"));
+    }
+
+    @Test
+    @Order(28)
+    void mcp_list_control_versions_after_create() {
+        ToolResponse result = controlTools.listControlVersions("security", createdControlId);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("1.0.0"));
+    }
+
+    @Test
+    @Order(29)
+    void mcp_get_control_after_create() {
+        ToolResponse result = controlTools.getControl("security", createdControlId, "1.0.0");
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("mcp-test-control"));
+    }
+
+    @Test
+    @Order(30)
+    void mcp_create_control_configuration() {
+        ToolResponse result = controlTools.createControlConfiguration(
+                "security", createdControlId, CONTROL_CONFIGURATION_JSON);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("created successfully"));
+    }
+
+    @Test
+    @Order(31)
+    void mcp_create_control_configuration_for_missing_control_returns_error() {
+        ToolResponse result = controlTools.createControlConfiguration(
+                "security", 99999, CONTROL_CONFIGURATION_JSON);
+        assertThat(result.isError(), is(true));
+        assertThat(text(result), containsString("not found"));
+    }
+
+    @Test
+    @Order(32)
+    void mcp_create_control_requirement_rejects_invalid_json() {
+        ToolResponse result = controlTools.createControlRequirement(
+                "security", "Bad", "desc", "not-json");
+        assertThat(result.isError(), is(true));
     }
 }

--- a/calm-hub/src/integration-test/java/integration/NitriteMcpIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteMcpIntegration.java
@@ -60,8 +60,25 @@ public class NitriteMcpIntegration {
             }
             """;
 
+    private static final String CONTROL_REQUIREMENT_JSON = """
+            {
+                "control-id": "mcp-nitrite-control",
+                "name": "MCP Nitrite Control",
+                "description": "Nitrite integration test control requirement"
+            }
+            """;
+
+    private static final String CONTROL_CONFIGURATION_JSON = """
+            {
+                "control-id": "mcp-nitrite-control",
+                "value": "enforced",
+                "environment": "nitrite-test"
+            }
+            """;
+
     private static int createdArchitectureId;
     private static int createdDecoratorId;
+    private static int createdControlId;
 
     @Inject
     ArchitectureTools architectureTools;
@@ -309,5 +326,71 @@ public class NitriteMcpIntegration {
         ToolResponse result = decoratorTools.listDecorators("finos", null, "deployment\n");
         assertThat(result.isError(), is(true));
         assertThat(text(result), containsString("Type filter"));
+    }
+
+    // --- Control Tools (create paths) ---
+
+    @Test
+    @Order(26)
+    void mcp_create_control_requirement() {
+        ToolResponse result = controlTools.createControlRequirement(
+                "security", "MCP Nitrite Control", "Nitrite integration test control requirement", CONTROL_REQUIREMENT_JSON);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("created successfully"));
+
+        Matcher matcher = ID_PATTERN.matcher(text(result));
+        assertThat("Response should contain control ID", matcher.find());
+        createdControlId = Integer.parseInt(matcher.group(1));
+        logger.info("Created control with ID: {}", createdControlId);
+    }
+
+    @Test
+    @Order(27)
+    void mcp_list_controls_contains_created() {
+        ToolResponse result = controlTools.listControls("security");
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("MCP Nitrite Control"));
+    }
+
+    @Test
+    @Order(28)
+    void mcp_list_control_versions_after_create() {
+        ToolResponse result = controlTools.listControlVersions("security", createdControlId);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("1.0.0"));
+    }
+
+    @Test
+    @Order(29)
+    void mcp_get_control_after_create() {
+        ToolResponse result = controlTools.getControl("security", createdControlId, "1.0.0");
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("mcp-nitrite-control"));
+    }
+
+    @Test
+    @Order(30)
+    void mcp_create_control_configuration() {
+        ToolResponse result = controlTools.createControlConfiguration(
+                "security", createdControlId, CONTROL_CONFIGURATION_JSON);
+        assertThat(result.isError(), is(false));
+        assertThat(text(result), containsString("created successfully"));
+    }
+
+    @Test
+    @Order(31)
+    void mcp_create_control_configuration_for_missing_control_returns_error() {
+        ToolResponse result = controlTools.createControlConfiguration(
+                "security", 99999, CONTROL_CONFIGURATION_JSON);
+        assertThat(result.isError(), is(true));
+        assertThat(text(result), containsString("not found"));
+    }
+
+    @Test
+    @Order(32)
+    void mcp_create_control_requirement_rejects_invalid_json() {
+        ToolResponse result = controlTools.createControlRequirement(
+                "security", "Bad", "desc", "not-json");
+        assertThat(result.isError(), is(true));
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/ArchitectureTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/ArchitectureTools.java
@@ -138,7 +138,7 @@ public class ArchitectureTools {
         Optional<ToolResponse> err = McpValidationHelper.firstError(
                 () -> McpValidationHelper.checkEnabled(mcpEnabled),
                 () -> McpValidationHelper.validateNamespace(namespace),
-                () -> McpValidationHelper.validateMaxLength(name, 200, "Architecture name"),
+                () -> McpValidationHelper.validateMaxLength(name, McpValidationHelper.MAX_NAME_LENGTH, "Architecture name"),
                 () -> McpValidationHelper.validateDescriptionLength(description, "Architecture description"),
                 () -> McpValidationHelper.validateNotBlank(architectureJson, "Architecture JSON"),
                 () -> McpValidationHelper.validateJson(architectureJson, "Architecture JSON"));

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
@@ -127,30 +127,17 @@ public class ControlTools {
             @ToolArg(description = "The name of the control requirement") String name,
             @ToolArg(description = "A description of the control requirement") String description,
             @ToolArg(description = "The full control requirement JSON content") String requirementJson) {
-        String error = McpValidationHelper.checkEnabled(mcpEnabled);
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateDomain(domain);
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateNotBlank(name, "Name");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateNotBlank(description, "Description");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateNotBlank(requirementJson, "Requirement JSON");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateJson(requirementJson, "Requirement JSON");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
+        Optional<ToolResponse> err = McpValidationHelper.firstError(
+                () -> McpValidationHelper.checkEnabled(mcpEnabled),
+                () -> McpValidationHelper.validateDomain(domain),
+                () -> McpValidationHelper.validateNotBlank(name, "Name"),
+                () -> McpValidationHelper.validateMaxLength(name, 200, "Name"),
+                () -> McpValidationHelper.validateNotBlank(description, "Description"),
+                () -> McpValidationHelper.validateDescriptionLength(description, "Description"),
+                () -> McpValidationHelper.validateNotBlank(requirementJson, "Requirement JSON"),
+                () -> McpValidationHelper.validateMaxLength(requirementJson, McpValidationHelper.MAX_JSON_PAYLOAD_LENGTH, "Requirement JSON"),
+                () -> McpValidationHelper.validateJson(requirementJson, "Requirement JSON"));
+        if (err.isPresent()) return err.get();
 
         try {
             CreateControlRequirement request = new CreateControlRequirement(name, description, requirementJson);
@@ -168,26 +155,14 @@ public class ControlTools {
             @ToolArg(description = "The domain containing the control (e.g. 'security')") String domain,
             @ToolArg(description = "The control ID (positive integer) to create a configuration for") int controlId,
             @ToolArg(description = "The full control configuration JSON content") String configurationJson) {
-        String error = McpValidationHelper.checkEnabled(mcpEnabled);
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateDomain(domain);
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validatePositiveId(controlId, "Control ID");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateNotBlank(configurationJson, "Configuration JSON");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
-        error = McpValidationHelper.validateJson(configurationJson, "Configuration JSON");
-        if (error != null) {
-            return ToolResponse.error(error);
-        }
+        Optional<ToolResponse> err = McpValidationHelper.firstError(
+                () -> McpValidationHelper.checkEnabled(mcpEnabled),
+                () -> McpValidationHelper.validateDomain(domain),
+                () -> McpValidationHelper.validatePositiveId(controlId, "Control ID"),
+                () -> McpValidationHelper.validateNotBlank(configurationJson, "Configuration JSON"),
+                () -> McpValidationHelper.validateMaxLength(configurationJson, McpValidationHelper.MAX_JSON_PAYLOAD_LENGTH, "Configuration JSON"),
+                () -> McpValidationHelper.validateJson(configurationJson, "Configuration JSON"));
+        if (err.isPresent()) return err.get();
 
         try {
             CreateControlConfiguration request = new CreateControlConfiguration(configurationJson);

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
@@ -131,7 +131,7 @@ public class ControlTools {
                 () -> McpValidationHelper.checkEnabled(mcpEnabled),
                 () -> McpValidationHelper.validateDomain(domain),
                 () -> McpValidationHelper.validateNotBlank(name, "Name"),
-                () -> McpValidationHelper.validateMaxLength(name, 200, "Name"),
+                () -> McpValidationHelper.validateMaxLength(name, McpValidationHelper.MAX_NAME_LENGTH, "Name"),
                 () -> McpValidationHelper.validateNotBlank(description, "Description"),
                 () -> McpValidationHelper.validateDescriptionLength(description, "Description"),
                 () -> McpValidationHelper.validateNotBlank(requirementJson, "Requirement JSON"),

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
@@ -20,6 +20,8 @@ final class McpValidationHelper {
     static final String MCP_DISABLED_MESSAGE =
             "Error: MCP tools are currently disabled. Set the environment variable CALM_MCP_ENABLED=true to enable.";
 
+    static final int MAX_NAME_LENGTH = 200;
+
     private static final int MAX_DESCRIPTION_LENGTH = 1024;
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
@@ -21,6 +21,14 @@ final class McpValidationHelper {
             "Error: MCP tools are currently disabled. Set the environment variable CALM_MCP_ENABLED=true to enable.";
 
     private static final int MAX_DESCRIPTION_LENGTH = 1024;
+
+    /**
+     * Default upper bound for JSON payloads accepted by MCP create tools.
+     * Sized for typical CALM control / decorator / architecture documents
+     * while preventing an authenticated client from storing unbounded blobs.
+     */
+    static final int MAX_JSON_PAYLOAD_LENGTH = 100_000;
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private McpValidationHelper() {

--- a/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestControlToolsShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestControlToolsShould.java
@@ -388,13 +388,13 @@ class TestControlToolsShould {
 
     @Test
     void reject_oversized_name_for_create_requirement() {
-        String name = "x".repeat(201);
+        String name = "x".repeat(McpValidationHelper.MAX_NAME_LENGTH + 1);
 
         ToolResponse response = controlTools.createControlRequirement("security", name, "d", "{\"x\":1}");
 
         assertThat(response.isError(), is(true));
         assertThat(text(response), containsString("Name"));
-        assertThat(text(response), containsString("200"));
+        assertThat(text(response), containsString(String.valueOf(McpValidationHelper.MAX_NAME_LENGTH)));
         verifyNoInteractions(controlStore);
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestControlToolsShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestControlToolsShould.java
@@ -383,4 +383,51 @@ class TestControlToolsShould {
         assertThat(response.isError(), is(true));
         verifyNoInteractions(controlStore);
     }
+
+    // --- max-length validation ---
+
+    @Test
+    void reject_oversized_name_for_create_requirement() {
+        String name = "x".repeat(201);
+
+        ToolResponse response = controlTools.createControlRequirement("security", name, "d", "{\"x\":1}");
+
+        assertThat(response.isError(), is(true));
+        assertThat(text(response), containsString("Name"));
+        assertThat(text(response), containsString("200"));
+        verifyNoInteractions(controlStore);
+    }
+
+    @Test
+    void reject_oversized_description_for_create_requirement() {
+        String description = "x".repeat(1025);
+
+        ToolResponse response = controlTools.createControlRequirement("security", "n", description, "{\"x\":1}");
+
+        assertThat(response.isError(), is(true));
+        assertThat(text(response), containsString("Description"));
+        verifyNoInteractions(controlStore);
+    }
+
+    @Test
+    void reject_oversized_requirement_json() {
+        String json = "{\"x\":\"" + "y".repeat(McpValidationHelper.MAX_JSON_PAYLOAD_LENGTH) + "\"}";
+
+        ToolResponse response = controlTools.createControlRequirement("security", "n", "d", json);
+
+        assertThat(response.isError(), is(true));
+        assertThat(text(response), containsString("Requirement JSON"));
+        verifyNoInteractions(controlStore);
+    }
+
+    @Test
+    void reject_oversized_configuration_json() {
+        String json = "{\"x\":\"" + "y".repeat(McpValidationHelper.MAX_JSON_PAYLOAD_LENGTH) + "\"}";
+
+        ToolResponse response = controlTools.createControlConfiguration("security", 1, json);
+
+        assertThat(response.isError(), is(true));
+        assertThat(text(response), containsString("Configuration JSON"));
+        verifyNoInteractions(controlStore);
+    }
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
