### PR TITLE
feat(cli): add init-config command and clearer remote-host errors

### DIFF
--- a/cli/src/cli-config.ts
+++ b/cli/src/cli-config.ts
@@ -1,5 +1,5 @@
 import { initLogger } from '@finos/calm-shared';
-import { readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -8,9 +8,15 @@ export interface CLIConfig {
     allowedRemoteHosts?: string[]
 }
 
-function getUserConfigLocation(): string {
+export function getUserConfigLocation(): string {
     const homeDir = homedir();
     return join(homeDir, '.calm.json');
+}
+
+export async function saveCliConfig(config: CLIConfig): Promise<void> {
+    const configFilePath = getUserConfigLocation();
+    const json = JSON.stringify(config, null, 2) + '\n';
+    await writeFile(configFilePath, json, 'utf8');
 }
 
 export async function loadCliConfig(): Promise<CLIConfig | null> {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,5 +1,5 @@
 import { CALM_META_SCHEMA_DIRECTORY, DocifyMode, initLogger, runGenerate, SchemaDirectory, TemplateProcessingMode, CalmChoice, buildDocumentLoader, DocumentLoader, DocumentLoaderOptions } from '@finos/calm-shared';
-import { Option, Command, program } from 'commander';
+import { Option, Command } from 'commander';
 import { version } from '../package.json';
 import { promptUserForOptions } from './command-helpers/generate-options';
 import * as cliConfig from './cli-config';
@@ -239,31 +239,31 @@ Validation requires:
             await setupAiTools(selectedProvider, options.directory, !!options.verbose);
         });
 
-program
-    .command('init-config')
-    .description('Create or update the CALM CLI configuration file (~/.calm.json).')
-    .option('--allowed-remote-hosts <hosts>', 'Comma-separated list of trusted remote hosts to allow for direct URL loading')
-    .option('--calm-hub-url <url>', 'URL to a trusted file location (e.g. CALMHub) to allow for direct URL loading of CALM documents')
-    .action(async (options) => {
-        const existingConfig = await cliConfig.loadCliConfig() ?? {};
+    program
+        .command('init-config')
+        .description('Create or update the CALM CLI configuration file (~/.calm.json).')
+        .option('--allowed-remote-hosts <hosts>', 'Comma-separated list of trusted remote hosts to allow for direct URL loading')
+        .option('--calm-hub-url <url>', 'URL to a trusted file location (e.g. CALMHub) to allow for direct URL loading of CALM documents')
+        .action(async (options) => {
+            const existingConfig = await cliConfig.loadCliConfig() ?? {};
 
-        if(options.allowedRemoteHosts) {
-            const newHosts = (options.allowedRemoteHosts as string).split(',').map((h: string) => h.trim()).filter(Boolean);
-            const existingHosts = existingConfig.allowedRemoteHosts ?? [];
-            const merged = [...new Set([...existingHosts, ...newHosts])];
-            existingConfig.allowedRemoteHosts = merged;
-        }
+            if (options.allowedRemoteHosts) {
+                const newHosts = (options.allowedRemoteHosts as string).split(',').map((h: string) => h.trim()).filter(Boolean);
+                const existingHosts = existingConfig.allowedRemoteHosts ?? [];
+                const merged = [...new Set([...existingHosts, ...newHosts])];
+                existingConfig.allowedRemoteHosts = merged;
+            }
 
-        if (options.calmHubUrl) {
-            existingConfig.calmHubUrl = options.calmHubUrl;
-        }
+            if (options.calmHubUrl) {
+                existingConfig.calmHubUrl = options.calmHubUrl;
+            }
 
-        const configPath = cliConfig.getUserConfigLocation();
-        await cliConfig.saveCliConfig(existingConfig);
-        console.log(`✅ Configuration saved to ${configPath}`);
-        console.log(JSON.stringify(existingConfig, null, 2));
-    });
-    
+            const configPath = cliConfig.getUserConfigLocation();
+            await cliConfig.saveCliConfig(existingConfig);
+            console.log(`✅ Configuration saved to ${configPath}`);
+            console.log(JSON.stringify(existingConfig, null, 2));
+        });
+
 }
 
 interface ParseDocumentLoaderOptions {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,5 +1,5 @@
 import { CALM_META_SCHEMA_DIRECTORY, DocifyMode, initLogger, runGenerate, SchemaDirectory, TemplateProcessingMode, CalmChoice, buildDocumentLoader, DocumentLoader, DocumentLoaderOptions } from '@finos/calm-shared';
-import { Option, Command } from 'commander';
+import { Option, Command, program } from 'commander';
 import { version } from '../package.json';
 import { promptUserForOptions } from './command-helpers/generate-options';
 import * as cliConfig from './cli-config';
@@ -239,6 +239,31 @@ Validation requires:
             await setupAiTools(selectedProvider, options.directory, !!options.verbose);
         });
 
+program
+    .command('init-config')
+    .description('Create or update the CALM CLI configuration file (~/.calm.json).')
+    .option('--allowed-remote-hosts <hosts>', 'Comma-separated list of trusted remote hosts to allow for direct URL loading')
+    .option('--calm-hub-url <url>', 'URL to a trusted file location (e.g. CALMHub) to allow for direct URL loading of CALM documents')
+    .action(async (options) => {
+        const existingConfig = await cliConfig.loadCliConfig() ?? {};
+
+        if(options.allowedRemoteHosts) {
+            const newHosts = (options.allowedRemoteHosts as string).split(',').map((h: string) => h.trim()).filter(Boolean);
+            const existingHosts = existingConfig.allowedRemoteHosts ?? [];
+            const merged = [...new Set([...existingHosts, ...newHosts])];
+            existingConfig.allowedRemoteHosts = merged;
+        }
+
+        if (options.calmHubUrl) {
+            existingConfig.calmHubUrl = options.calmHubUrl;
+        }
+
+        const configPath = cliConfig.getUserConfigLocation();
+        await cliConfig.saveCliConfig(existingConfig);
+        console.log(`✅ Configuration saved to ${configPath}`);
+        console.log(JSON.stringify(existingConfig, null, 2));
+    });
+    
 }
 
 interface ParseDocumentLoaderOptions {

--- a/cli/src/index.spec.ts
+++ b/cli/src/index.spec.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 // Mock commander and setupCLI
 vi.mock('commander', () => ({
-    program: { parse: vi.fn() },
+    program: { parseAsync: vi.fn().mockResolvedValue(undefined) },
 }));
 vi.mock('./cli', () => ({
     setupCLI: vi.fn(),
@@ -13,7 +13,7 @@ import { program } from 'commander';
 import { setupCLI } from './cli';
 import './index';
 
-test('calls setupCLI and program.parse', () => {
+test('calls setupCLI and program.parseAsync', () => {
     expect(setupCLI).toHaveBeenCalledWith(program);
-    expect(program.parse).toHaveBeenCalled();
+    expect(program.parseAsync).toHaveBeenCalled();
 });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,4 +2,12 @@ import { program } from 'commander';
 import { setupCLI } from './cli';
 
 setupCLI(program);
-program.parse(process.argv);
+program.parseAsync(process.argv).catch(err => {
+    if (err && err.message) {
+        console.error('\n' + err.message);
+    }
+    else {
+        console.error('\nAn unexpected error occurred:', err);
+    }
+    process.exit(1);
+});

--- a/shared/src/document-loader/direct-url-document-loader.spec.ts
+++ b/shared/src/document-loader/direct-url-document-loader.spec.ts
@@ -114,10 +114,12 @@ describe('direct-url-document-loader', () => {
             .rejects.not.toThrow('private or internal network addresses are not allowed');
     });
 
-    it('rejects non-allowlisted public hosts', async () => {
+    it('rejects non-allowlisted public hosts with helpful guidance', async () => {
         const url = 'https://example.com/public-schema.json';
         await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
             .rejects.toThrow('is not allowlisted');
+        await expect(directUrlDocumentLoader.loadMissingDocument(url, 'schema'))
+            .rejects.toThrow('calm init-config --allowed-remote-hosts example.com');
     });
 
     it('allows loading from configured allowlisted host', async () => {

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -106,7 +106,10 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
             if (!this.allowedRemoteHosts.has(normalizedHost)) {
                 throw new DocumentLoadError({
                     name: 'UNKNOWN',
-                    message: `Direct URL loading is restricted to approved hosts. Host '${parsedUrl.hostname}' is not allowlisted.`,
+                    message: `Direct URL loading is restricted to approved hosts. Host '${parsedUrl.hostname}' is not allowlisted.\n\n`
+                        + `To allow this host, run:\n\n`
+                        + `  calm init-config --allowed-remote-hosts ${parsedUrl.hostname}\n\n`
+                        + `Only add hosts you trust.`,
                 });
             }
             if (parsedUrl.username || parsedUrl.password) {

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -107,9 +107,9 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
                 throw new DocumentLoadError({
                     name: 'UNKNOWN',
                     message: `Direct URL loading is restricted to approved hosts. Host '${parsedUrl.hostname}' is not allowlisted.\n\n`
-                        + `To allow this host, run:\n\n`
+                        + 'To allow this host, run:\n\n'
                         + `  calm init-config --allowed-remote-hosts ${parsedUrl.hostname}\n\n`
-                        + `Only add hosts you trust.`,
+                        + 'Only add hosts you trust.',
                 });
             }
             if (parsedUrl.username || parsedUrl.password) {

--- a/shared/src/document-loader/multi-strategy-document-loader.ts
+++ b/shared/src/document-loader/multi-strategy-document-loader.ts
@@ -42,10 +42,10 @@ export class MultiStrategyDocumentLoader implements DocumentLoader {
         }
         this.logger.error(`All document loaders failed to load document: ${documentId}. See report below:`);
         this.printErrorMessages(errors);
+        const lastError = errors[errors.length - 1].error;
         throw new DocumentLoadError({
             name: 'UNKNOWN',
-            message: `All document loaders failed to load document: ${documentId}`,
-            cause: errors[errors.length - 1].error
+            message: lastError?.message ?? `Failed to load document: ${documentId}`,
         });
     }
 
@@ -54,7 +54,7 @@ export class MultiStrategyDocumentLoader implements DocumentLoader {
         for (const { loaderName, error } of errors) {
             report += `Loader ${loaderName} FAILED with error: ${error?.message}\n`;
         }
-        this.logger.error(report);
+        this.logger.debug(report);
     }
 
     resolvePath(reference: string): string | undefined {


### PR DESCRIPTION
## Description
Adds a `calm init-config` subcommand to create or update `~/.calm.json`, and improves the direct-URL document loader error so it tells users exactly what to run when a host isn't allowlisted.

- `calm init-config --allowed-remote-hosts <hosts>` merges into the existing list (deduped), and `--calm-hub-url <url>` sets the CALM Hub URL. Existing config is preserved.
- `DirectUrlDocumentLoader` now embeds the exact `calm init-config --allowed-remote-hosts <host>` command in its rejection message, instead of just saying the host is not allowlisted.
- `MultiStrategyDocumentLoader` now surfaces the last loader's actual error message instead of a generic "all loaders failed" wrapper, and demotes the per-loader failure report to debug-level logging.
- `index.ts` switches to `program.parseAsync` so async command handlers (like the new `init-config`) propagate errors cleanly with a non-zero exit code.

Closes #2434.

### Example error message
Before, attempting to load a document from a non-allowlisted host produced a generic message. Now the loader surfaces the actionable command directly:

```
Direct URL loading is restricted to approved hosts. Host 'example.com' is not allowlisted.

To allow this host, run:

  calm init-config --allowed-remote-hosts example.com

Only add hosts you trust.
```

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CLI (`cli/`)
- [x] Shared (`shared/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified locally:
- `npm run build:cli` clean.
- `npm run test --workspace cli` — 139/139 pass (updated `index.spec.ts` to mock `parseAsync`).
- `npm run test --workspace shared` — 634/635 pass; the one failure is the pre-existing `docify/template-bundles/docusaurus/package.spec.ts` peer-dep `npm install --dry-run` check, unrelated to these changes.
- `calm init-config --allowed-remote-hosts a,b --calm-hub-url https://...` writes `~/.calm.json`; re-running merges and dedupes additional hosts.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards