### PR TITLE
feat(shared): validate response data is JSON object

### DIFF
--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import { CalmHubDocumentLoader } from './calmhub-document-loader';
+import { DocumentLoadError } from './document-loader';
 import { SchemaDirectory } from '../schema-directory';
 
 const calmHubBaseUrl = 'http://local-calmhub';
@@ -56,19 +57,22 @@ describe('calmhub-document-loader', () => {
 
     it('throws when response is a string instead of an object', async () => {
         mock.onGet('/schemas/2025-03/meta/string-response.json').reply(200, 'just a string');
-        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/string-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/string-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 
     it('throws when response is null', async () => {
         mock.onGet('/schemas/2025-03/meta/null-response.json').reply(200, null);
-        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/null-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/null-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 
     it('throws when response is an array', async () => {
         mock.onGet('/schemas/2025-03/meta/array-response.json').reply(200, [{ '$id': 'foo' }]);
-        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/array-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/array-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 });

--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -53,4 +53,22 @@ describe('calmhub-document-loader', () => {
         await expect(calmHubDocumentLoader.loadMissingDocument(maliciousUrl, 'schema'))
             .rejects.toThrow('disallowed characters');
     });
+
+    it('throws when response is a string instead of an object', async () => {
+        mock.onGet('/schemas/2025-03/meta/string-response.json').reply(200, 'just a string');
+        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/string-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
+
+    it('throws when response is null', async () => {
+        mock.onGet('/schemas/2025-03/meta/null-response.json').reply(200, null);
+        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/null-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
+
+    it('throws when response is an array', async () => {
+        mock.onGet('/schemas/2025-03/meta/array-response.json').reply(200, [{ '$id': 'foo' }]);
+        await expect(calmHubDocumentLoader.loadMissingDocument('calm:/schemas/2025-03/meta/array-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
 });

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -1,6 +1,6 @@
 import axios, { Axios } from 'axios';
 import { SchemaDirectory } from '../schema-directory';
-import { CalmDocumentType, DocumentLoader, CALM_HUB_PROTO } from './document-loader';
+import { CalmDocumentType, DocumentLoader, CALM_HUB_PROTO, assertJsonObject } from './document-loader';
 import { initLogger, Logger } from '../logger';
 
 export class CalmHubDocumentLoader implements DocumentLoader {
@@ -68,6 +68,7 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         // TODO gracefully handle 404s and other errors
         const response = await this.ax.get(path);
         const document = response.data;
+        assertJsonObject(document, documentId);
         this.logger.debug('Successfully loaded document from CALMHub with id ' + documentId);
         return document;
     }

--- a/shared/src/document-loader/direct-url-document-loader.spec.ts
+++ b/shared/src/document-loader/direct-url-document-loader.spec.ts
@@ -150,4 +150,22 @@ describe('direct-url-document-loader', () => {
         await expect(directUrlDocumentLoader.loadMissingDocument('https://user:secret@calm.finos.org/core.json', 'schema'))
             .rejects.toThrow('Credentials in URL are not allowed');
     });
+
+    it('throws when response is a string instead of an object', async () => {
+        mock.onGet('/string-response.json').reply(200, 'just a string');
+        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/string-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
+
+    it('throws when response is null', async () => {
+        mock.onGet('/null-response.json').reply(200, null);
+        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/null-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
+
+    it('throws when response is an array', async () => {
+        mock.onGet('/array-response.json').reply(200, [{ '$id': 'foo' }]);
+        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/array-response.json', 'schema'))
+            .rejects.toThrow('Expected a JSON object');
+    });
 });

--- a/shared/src/document-loader/direct-url-document-loader.spec.ts
+++ b/shared/src/document-loader/direct-url-document-loader.spec.ts
@@ -155,19 +155,22 @@ describe('direct-url-document-loader', () => {
 
     it('throws when response is a string instead of an object', async () => {
         mock.onGet('/string-response.json').reply(200, 'just a string');
-        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/string-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/string-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 
     it('throws when response is null', async () => {
         mock.onGet('/null-response.json').reply(200, null);
-        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/null-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/null-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 
     it('throws when response is an array', async () => {
         mock.onGet('/array-response.json').reply(200, [{ '$id': 'foo' }]);
-        await expect(directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/array-response.json', 'schema'))
-            .rejects.toThrow('Expected a JSON object');
+        const promise = directUrlDocumentLoader.loadMissingDocument('https://calm.finos.org/array-response.json', 'schema');
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toThrow('Expected a JSON object');
     });
 });

--- a/shared/src/document-loader/direct-url-document-loader.ts
+++ b/shared/src/document-loader/direct-url-document-loader.ts
@@ -1,8 +1,7 @@
 import axios, { Axios } from 'axios';
 import { isIP } from 'net';
 import { SchemaDirectory } from '../schema-directory';
-import { CalmDocumentType, DocumentLoader } from './document-loader';
-import { DocumentLoadError } from './document-loader';
+import { CalmDocumentType, DocumentLoader, DocumentLoadError, assertJsonObject } from './document-loader';
 import { Logger, initLogger } from '../logger';
 
 const DEFAULT_ALLOWED_REMOTE_HOSTS = ['calm.finos.org'];
@@ -122,6 +121,7 @@ export class DirectUrlDocumentLoader implements DocumentLoader {
                 maxRedirects: 0,
                 allowAbsoluteUrls: false
             });
+            assertJsonObject(response.data, documentId);
             return response.data;
         } catch (error) {
             if (error instanceof DocumentLoadError) {

--- a/shared/src/document-loader/document-loader.ts
+++ b/shared/src/document-loader/document-loader.ts
@@ -66,9 +66,10 @@ export function buildDocumentLoader(docLoaderOpts: DocumentLoaderOptions): Docum
 
 export function assertJsonObject(data: unknown, source: string): asserts data is object {
     if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+        const kind = data === null ? 'null' : Array.isArray(data) ? 'array' : typeof data;
         throw new DocumentLoadError({
             name: 'UNKNOWN',
-            message: `Expected a JSON object from ${source} but received: ${typeof data}`
+            message: `Expected a JSON object from ${source} but received: ${kind}`
         });
     }
 }

--- a/shared/src/document-loader/document-loader.ts
+++ b/shared/src/document-loader/document-loader.ts
@@ -64,6 +64,15 @@ export function buildDocumentLoader(docLoaderOpts: DocumentLoaderOptions): Docum
     return new MultiStrategyDocumentLoader(loaders, debug);
 }
 
+export function assertJsonObject(data: unknown, source: string): asserts data is object {
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+        throw new DocumentLoadError({
+            name: 'UNKNOWN',
+            message: `Expected a JSON object from ${source} but received: ${typeof data}`
+        });
+    }
+}
+
 type ErrorName = 'OPERATION_NOT_IMPLEMENTED' | 'UNKNOWN';
 
 export class DocumentLoadError extends Error {


### PR DESCRIPTION
## Description
This pull request improves the robustness of the document loaders by ensuring that only valid JSON objects are accepted as loaded documents. It introduces a shared utility for validating responses and adds comprehensive test coverage for edge cases where the response is not a JSON object.

**Type-confusion safety:** downstream code that assumes the loaded document is an object (e.g. calling `Object.keys(doc)` or accessing `doc.$id`) will no longer receive unexpected behaviour if a remote server returns a string, `null`, or an array. The validation guarantees the shape contract is met before the document is used anywhere in the pipeline.


**Validation improvements:**

* Added a new utility function `assertJsonObject` in `document-loader.ts` to verify that loaded data is a non-null JSON object and not an array; throws a `DocumentLoadError` if validation fails.
* Integrated `assertJsonObject` into both `CalmHubDocumentLoader` and `DirectUrlDocumentLoader` to enforce response validation after fetching documents. [[1]](diffhunk://#diff-eb3d49a4aff3b7b3783ec28c8aa2b7165d29ef57d1bfb5caa38625f01520f1a1R71) [[2]](diffhunk://#diff-9788a5e16c3c66572200702785ded095c237a805d371d49ba84427942e5d1240R124)
* Updated imports in `calmhub-document-loader.ts` and `direct-url-document-loader.ts` to include the new utility. [[1]](diffhunk://#diff-eb3d49a4aff3b7b3783ec28c8aa2b7165d29ef57d1bfb5caa38625f01520f1a1L3-R3) [[2]](diffhunk://#diff-9788a5e16c3c66572200702785ded095c237a805d371d49ba84427942e5d1240L4-R4)

**Test coverage:**

* Added tests in `calmhub-document-loader.spec.ts` and `direct-url-document-loader.spec.ts` to ensure an error is thrown when the response is a string, null, or an array, improving reliability and correctness. [[1]](diffhunk://#diff-4873ba57b2429a3fe359bec455d110ae287fc89f4d933c2634ddf9f3d4e867deR56-R73) [[2]](diffhunk://#diff-d6194dcdff95b132094fa0543dff241a6e13e6fbba872461b21f4dcf89f19703R153-R170)

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [X] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [X] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards