### PR TITLE
feat(calm-hub): add X-Frame-Options: DENY clickjacking protection

### DIFF
--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -18,6 +18,11 @@ quarkus.oidc.tenant-enabled=false
 
 #quarkus.http.port=8081
 
+# Security response headers — applied to all routes
+quarkus.http.filter.security.matches=/.*
+quarkus.http.filter.security.methods=GET,POST,PUT,DELETE,PATCH
+quarkus.http.filter.security.header."X-Frame-Options"=DENY
+
 # MCP Server Configuration
 # Enables the embedded Model Context Protocol (MCP) server exposed at /mcp.
 # Defaults to true. Override at runtime with -Dcalm.mcp.enabled=false or the

--- a/calm-hub/src/test/java/org/finos/calm/security/TestSecurityResponseHeadersShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestSecurityResponseHeadersShould.java
@@ -1,0 +1,45 @@
+package org.finos.calm.security;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.finos.calm.store.NamespaceStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+@ExtendWith(MockitoExtension.class)
+public class TestSecurityResponseHeadersShould {
+
+    @InjectMock
+    NamespaceStore namespaceStore;
+
+    @Test
+    void return_x_frame_options_deny_on_get_request() {
+        when(namespaceStore.getNamespaces()).thenReturn(new ArrayList<>());
+
+        given()
+                .when()
+                .get("/calm/namespaces")
+                .then()
+                .statusCode(200)
+                .header("X-Frame-Options", equalTo("DENY"));
+    }
+
+    @Test
+    void return_x_frame_options_deny_on_post_request() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"test\",\"description\":\"test\"}")
+                .when()
+                .post("/calm/namespaces")
+                .then()
+                .header("X-Frame-Options", equalTo("DENY"));
+    }
+}


### PR DESCRIPTION
## Description
Add `X-Frame-Options: DENY` response header to all CalmHub HTTP responses to prevent clickjacking attacks. Configured via a `quarkus.http.filter` block in `application.properties` so future security headers (CSP, `X-Content-Type-Options`) can be added to the same named filter. Includes REST Assured tests asserting the header is present.

Closes #2439 (part 1 — clickjacking)

<img width="741" height="309" alt="image" src="https://github.com/user-attachments/assets/e469e11b-e6ef-4b48-b686-e38bb4490dbe" />


## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅

`feat(calm-hub): add X-Frame-Options: DENY clickjacking protection`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards