### PR TITLE
chore(deps): patch 4 outstanding security vulnerabilities

### DIFF
--- a/calm-suite/calm-guard/package.json
+++ b/calm-suite/calm-guard/package.json
@@ -80,7 +80,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.1.4",
     "eslint": "^9.18.0",
-    "eslint-config-next": "^15.5.0",
+    "eslint-config-next": "^15.5.18",
     "husky": "^9.1.7",
     "jsdom": "^28.1.0",
     "license-checker": "^25.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,7 +555,7 @@
                 "@types/react-dom": "^19.0.0",
                 "@vitejs/plugin-react": "^5.1.4",
                 "eslint": "^9.18.0",
-                "eslint-config-next": "^15.5.0",
+                "eslint-config-next": "^15.5.18",
                 "husky": "^9.1.7",
                 "jsdom": "^28.1.0",
                 "license-checker": "^25.0.1",
@@ -2327,7 +2327,7 @@
                 "@calmstudio/calm-core": "file:../calm-core",
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "elkjs": "^0.11.1",
-                "elkjs-svg": "*",
+                "elkjs-svg": "latest",
                 "zod": "^3.24.0"
             },
             "bin": {
@@ -2392,7 +2392,7 @@
             },
             "devDependencies": {
                 "@types/vscode": "^1.99.0",
-                "@vscode/vsce": "*",
+                "@vscode/vsce": "latest",
                 "esbuild": "^0.25.0",
                 "typescript": "^5.7.0",
                 "vitest": "^3.0.8"
@@ -4728,9 +4728,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.28.6",
@@ -7431,6 +7431,22 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/@cypress/request/node_modules/qs": {
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/@cypress/request/node_modules/tldts": {
@@ -13005,9 +13021,9 @@
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "15.5.15",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.15.tgz",
-            "integrity": "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==",
+            "version": "15.5.18",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.18.tgz",
+            "integrity": "sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -27957,13 +27973,13 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "15.5.15",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.15.tgz",
-            "integrity": "sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==",
+            "version": "15.5.18",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.18.tgz",
+            "integrity": "sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "15.5.15",
+                "@next/eslint-plugin-next": "15.5.18",
                 "@rushstack/eslint-patch": "^1.10.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -29224,9 +29240,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
                     "type": "github",
@@ -35583,16 +35599,16 @@
             }
         },
         "node_modules/mermaid/node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/methods": {
@@ -49122,9 +49138,9 @@
             "license": "MIT"
         },
         "node_modules/systeminformation": {
-            "version": "5.31.5",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
-            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
+            "version": "5.31.6",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+            "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
             "dev": true,
             "license": "MIT",
             "os": [

--- a/package.json
+++ b/package.json
@@ -79,9 +79,11 @@
         "vitest": "^3.1.1"
     },
     "overrides": {
+        "@babel/plugin-transform-modules-systemjs": "^7.29.4",
         "@types/node": "^22.19.15",
         "axios": "^1.15.2",
         "dompurify": "^3.4.0",
+        "fast-uri": "^3.1.2",
         "on-headers": "^1.1.0",
         "node-forge": "^1.3.2",
         "qs": "^6.15.0",
@@ -89,6 +91,7 @@
         "lodash-es": "^4.18.1",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
+        "systeminformation": "^5.31.6",
         "@semantic-release/npm": {
             "npm": "11.12.1"
         },


### PR DESCRIPTION
## Description

Closes 4 remaining open Dependabot security alerts that were not covered by the recently-merged dep PRs (#2458, #2462, #2465). Originally this PR closed 33 alerts, but those merges cascaded most of them — see *Already closed elsewhere* below.

| Advisory | Package | Severity | From → To | Method |
| --- | --- | --- | --- | --- |
| [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) | @babel/plugin-transform-modules-systemjs | high | 7.29.0 → 7.29.4 | override + npm update |
| [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) | fast-uri | high | 3.1.0 → 3.1.2 | override + npm update |
| [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) | fast-uri | high | 3.1.1 → 3.1.2 | override + npm update |
| [GHSA-hvx9-hwr7-wjj9](https://github.com/advisories/GHSA-hvx9-hwr7-wjj9) | systeminformation | high | 5.31.5 → 5.31.6 | override + npm update |
| [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) | uuid (under mermaid) | moderate | 11.1.0 → 14.0.0 | npm update (carried by mermaid ^11.15.0 already on main) |

Also bumps `eslint-config-next` ^15.5.0 → ^15.5.18 in `calm-suite/calm-guard` to realign the manifest with the `next` ^15.5.18 bump that landed in #2458. No GHSA targets `eslint-config-next` directly.

All caret ranges per repo convention.

## Already closed elsewhere (no longer in this PR)

These alerts the original revision of this PR was going to close have since been resolved on `main` and are dropped from scope:

- **Next.js (13 alerts)** — `#2458` bumped `next` ^15.5.0 → ^15.5.18 in `calm-suite/calm-guard`.
- **Svelte (4 alerts)** — `#2465` bumped svelte to 5.55.7.
- **Mermaid (4 alerts)** — `#2458` bumped `mermaid` ^11.0.0 → ^11.15.0 in `calm-plugins/vscode`.
- **devalue advent-of-calm** — `#2458`/`#2465` updated the advent-of-calm lockfile to devalue 5.8.1.
- **ip-address** — already at 10.2.0 on `main` via lockfile drift.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Dependencies
- [x] CALM Guard (`calm-suite/calm-guard/`) — manifest realignment only

## Commit Message Format ✅
`chore(deps): patch 4 outstanding security vulnerabilities`

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass

Verified locally on `fix/security-deps-2026-05-18`:
- `npm install` — clean
- `npm audit` — 21 → 18 vulnerabilities
- `npm run build` — exit 0 across all workspaces

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] My changes follow the project's coding standards

## Not addressed

The 18 remaining `npm audit` findings are deliberately out of scope for this PR:

**Transitive-blocked (no patch path available without an upstream release or a breaking change):**
- `undici` < 6.24.0 / `@actions/http-client` 2.x / `@actions/github` 6.x — `@actions/http-client@2.2.3` pins `undici ^5.x`; the override cannot intersect the 5.x range. Will resolve when `@actions/*` ships an undici 6+ release.
- `next` (moderate, via bundled `postcss` 8.4.31) — Next.js pins postcss exactly at `8.4.31` internally; the root `postcss` override cannot reach the nested copy. Will resolve when Next bumps its bundled postcss.
- `cookie` < 0.7.0 (low) — pulled via `@sveltejs/kit@2.59.1`. Waiting on a SvelteKit release that updates its `cookie` dep.

**Internal to bundled npm CLI (`node_modules/npm/node_modules/...`) — not addressable from this repo's `package.json`:**
- `brace-expansion` (moderate) — inside npm's bundled deps
- `ip-address` (moderate) — inside npm's bundled deps
- `picomatch` (high) — inside `npm/node_modules/tinyglobby/node_modules/picomatch`

**Major-version bumps deliberately deferred (needs human review):**
- `commitizen` 3.0.0 → 4.x, `cz-conventional-changelog` 3.0.1 → 4.x, plus their cascaded transitives (`external-editor`, `inquirer`, `tmp`).
- `@sveltejs/adapter-auto`, `@sveltejs/adapter-static`, `@sveltejs/adapter-vercel`, `@sveltejs/kit` — npm audit lists 0.x current versions, but these are false positives from npm's audit resolver (actual installed versions are 3.x/6.x/2.x).

**Out of scope (npm-workspaces only):**
- `glib`, `rand`, `tauri` — Rust/Cargo alerts on `calm-suite/calm-studio/apps/studio/src-tauri/Cargo.lock`.

**Suppressed (per `.github/node-cve-ignore-list.xml`):**
- `opener` (snyk false positive), `json-pointer` CVE-2022-4742, `braces` (fixed upstream), `micromatch` CVE-2024-4067, `async` CVE-2024-39249, `ejs` CVE-2023-29827, `express` CVE-2024-10491.
