### PR TITLE
Remove explicit codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @finos/architecture-as-code-maintainers
 
-/calm/ @finos/calm-schema-governance  @markscott-ms
+/calm/ @finos/calm-schema-governance
 
 /calm-hub/ @jpgough-ms @rocketstack-matt @grahampacker-ms @Thels @markscott-ms @willosborne
 


### PR DESCRIPTION
@markscott should be a codeowner of `calm` via being a member of `@finos/calm-schema-governance` not as an explicit call out
