### PR TITLE
Add auth plugin support to new `calm hub` command suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,10 @@ cd calm-hub && ../mvnw verify  # Java tests with coverage (JaCoCo enabled by def
 npm test                    # TypeScript packages (runs vitest run in each workspace)
 cd calm-hub && ../mvnw test # Java unit tests (still collects coverage data)
 
+# Run tests for just one class
+# NB you must be in the right project to run that file, because you need vitest.config.ts for tests to run
+npx vitest run ${TEST FILE}
+
 # Package-specific tests (from repository root using workspaces)
 npm test --workspace cli
 npm test --workspace calm-plugins/vscode

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -26,6 +26,9 @@ npm test --workspace cli               # Run Vitest tests
 npm run lint --workspace cli           # ESLint check
 npm run lint-fix --workspace cli       # Auto-fix linting issues
 
+# If you want to test just one file run this. Make sure you're in the cli directory or below so it can resolve vitest.config.ts.
+npx vitest run ${TEST FILE}
+
 # Local testing (from repository root)
 npm run link:cli       # Link CLI globally for testing
 calm --help            # Test globally linked CLI

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -456,7 +456,7 @@ describe('CLI Commands', () => {
                 file: 'arch.json',
                 name: 'my-arch',
                 namespace: 'finos',
-                calmHubUrl: 'http://hub',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
             }));
         });
 
@@ -530,7 +530,7 @@ describe('CLI Commands', () => {
                 id: '1',
                 namespace: 'finos',
                 version: '1.0.0',
-                calmHubUrl: 'http://hub',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
             }));
         });
 
@@ -565,7 +565,7 @@ describe('CLI Commands', () => {
 
             expect(hubCommandsModule.runListArchitectures).toHaveBeenCalledWith(expect.objectContaining({
                 namespace: 'finos',
-                calmHubUrl: 'http://hub',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
             }));
         });
 
@@ -605,7 +605,7 @@ describe('CLI Commands', () => {
             ]);
 
             expect(hubCommandsModule.runListNamespaces).toHaveBeenCalledWith(expect.objectContaining({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
             }));
         });
 
@@ -638,7 +638,7 @@ describe('CLI Commands', () => {
             expect(hubCommandsModule.runCreateNamespace).toHaveBeenCalledWith(expect.objectContaining({
                 name: 'my-org',
                 description: 'My organisation',
-                calmHubUrl: 'http://hub',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
             }));
         });
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { promptUserForOptions } from './command-helpers/generate-options';
 import * as cliConfig from './cli-config';
 import path from 'path';
 import { select } from '@inquirer/prompts';
+import { CreateNamespaceOptions, ListArchitecturesOptions, ListNamespacesOptions, PullArchitectureOptions, PushArchitectureOptions, runCreateNamespace, runListArchitectures, runListNamespaces, runPullArchitecture, runPushArchitecture } from './command-helpers/hub-commands';
 
 // Shared options used across multiple commands
 const ARCHITECTURE_OPTION = '-a, --architecture <file>';
@@ -291,8 +292,17 @@ Validation requires:
         .option(HUB_VERSION_OPTION, 'Semver version to create (required when --id is provided)')
         .addOption(hubOutputOption)
         .action(async (architectureFile, options) => {
-            const { runPushArchitecture } = await import('./command-helpers/hub-commands');
-            await runPushArchitecture({ ...options, file: architectureFile, version: options.ver });
+            const pushOptions: PushArchitectureOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                name: options.name,
+                description: options.description,
+                file: architectureFile,
+                id: options.id,
+                version: options.ver,
+                format: options.format
+            };
+            await runPushArchitecture(pushOptions);
         });
 
     // hub pull
@@ -307,8 +317,14 @@ Validation requires:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .option(OUTPUT_OPTION, 'Write output to this file instead of stdout')
         .action(async (options) => {
-            const { runPullArchitecture } = await import('./command-helpers/hub-commands');
-            await runPullArchitecture({ ...options, version: options.ver });
+            const pullOptions: PullArchitectureOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                id: options.id,
+                version: options.ver,
+                output: options.output
+            };
+            await runPullArchitecture(pullOptions);
         });
 
     // hub list
@@ -321,8 +337,12 @@ Validation requires:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .action(async (options) => {
-            const { runListArchitectures } = await import('./command-helpers/hub-commands');
-            await runListArchitectures(options);
+            const listOptions: ListArchitecturesOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                format: options.format
+            };
+            await runListArchitectures(listOptions);
         });
 
     hubListCmd
@@ -331,8 +351,11 @@ Validation requires:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .action(async (options) => {
-            const { runListNamespaces } = await import('./command-helpers/hub-commands');
-            await runListNamespaces(options);
+            const listOptions: ListNamespacesOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                format: options.format
+            };
+            await runListNamespaces(listOptions);
         });
 
     // hub create
@@ -346,8 +369,13 @@ Validation requires:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .action(async (options) => {
-            const { runCreateNamespace } = await import('./command-helpers/hub-commands');
-            await runCreateNamespace(options);
+            const createOptions: CreateNamespaceOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                name: options.name,
+                description: options.description,
+                format: options.format
+            };
+            await runCreateNamespace(createOptions);
         });
 
     program.addCommand(hubCmd);

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as cliConfig from '../cli-config';
 import * as hubOutput from './hub-output';
+import { runCreateNamespace, runListArchitectures, runListNamespaces, 
+    runPullArchitecture, runPushArchitecture,  printPushResult, pushVersioned, 
+    resolveCalmHubOptions, resolveVersionedMetadata  } from './hub-commands';
 
 // We stub the entire @finos/calm-shared module so no real HTTP is made
 vi.mock('@finos/calm-shared', () => {
@@ -62,23 +65,20 @@ describe('hub-commands', () => {
 
     // ── resolveHubUrl ──────────────────────────────────────────────────────
 
-    describe('resolveHubUrl', () => {
+    describe('resolveCalmHubOptions', () => {
         it('uses options.calmHubUrl when provided', async () => {
-            const { resolveHubUrl } = await import('./hub-commands');
-            const url = await resolveHubUrl({ calmHubUrl: 'http://hub.example.com' });
-            expect(url).toBe('http://hub.example.com');
+            const opts = await resolveCalmHubOptions({ calmHubUrl: 'http://hub.example.com' });
+            expect(opts.calmHubUrl).toBe('http://hub.example.com');
         });
 
         it('falls back to ~/.calm.json calmHubUrl', async () => {
             vi.mocked(cliConfig.loadCliConfig).mockResolvedValue({ calmHubUrl: 'http://from-config.example.com' });
-            const { resolveHubUrl } = await import('./hub-commands');
-            const url = await resolveHubUrl({});
-            expect(url).toBe('http://from-config.example.com');
+            const opts = await resolveCalmHubOptions({});
+            expect(opts.calmHubUrl).toBe('http://from-config.example.com');
         });
 
         it('throws when no hub URL is available', async () => {
-            const { resolveHubUrl } = await import('./hub-commands');
-            await expect(resolveHubUrl({})).rejects.toMatchObject({
+            await expect(resolveCalmHubOptions({})).rejects.toMatchObject({
                 name: 'HubCommandError',
                 status: 0,
                 error: 'No CALM Hub URL provided. Use --calm-hub-url or set calmHubUrl in ~/.calm.json',
@@ -98,9 +98,10 @@ describe('hub-commands', () => {
                 id: 1, version: '1.0.0', location: '/calm/namespaces/finos/architectures/1/versions/1.0.0'
             });
 
-            const { runPushArchitecture } = await import('./hub-commands');
             await runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -117,9 +118,10 @@ describe('hub-commands', () => {
                 id: 42, version: '2.0.0', location: '/calm/namespaces/finos/architectures/42/versions/2.0.0'
             });
 
-            const { runPushArchitecture } = await import('./hub-commands');
             await runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub',
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -132,9 +134,10 @@ describe('hub-commands', () => {
         });
 
         it('exits with error when --id is given but --version is missing', async () => {
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 file: 'arch.json',
@@ -144,9 +147,10 @@ describe('hub-commands', () => {
         });
 
         it('exits with error when --id is not a valid integer', async () => {
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -163,9 +167,10 @@ describe('hub-commands', () => {
         });
 
         it('exits with error when --name is missing and no --id is provided', async () => {
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 file: 'arch.json'
             })).rejects.toThrow('process.exit');
@@ -173,9 +178,10 @@ describe('hub-commands', () => {
         });
 
         it('exits with error when --description is missing and no --id is provided', async () => {
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 file: 'arch.json'
@@ -197,9 +203,10 @@ describe('hub-commands', () => {
                 id: 42, version: '2.0.0', location: '/calm/namespaces/finos/architectures/42/versions/2.0.0'
             });
 
-            const { runPushArchitecture } = await import('./hub-commands');
             await runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 file: 'arch.json',
                 id: '42',
@@ -212,9 +219,10 @@ describe('hub-commands', () => {
 
         it('exits when file cannot be read', async () => {
             vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -225,9 +233,10 @@ describe('hub-commands', () => {
 
         it('exits when file is not valid JSON', async () => {
             vi.mocked(fs.readFile).mockResolvedValue('not json' as unknown as Uint8Array);
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -242,9 +251,10 @@ describe('hub-commands', () => {
                 id: 1, version: '1.0.0', location: '/calm/namespaces/finos/architectures/1/versions/1.0.0'
             });
 
-            const { runPushArchitecture } = await import('./hub-commands');
             await runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -262,9 +272,10 @@ describe('hub-commands', () => {
                 new shared.HubClientError(409, 'Version already exists', 'POST /calm/namespaces/finos/architectures')
             );
 
-            const { runPushArchitecture } = await import('./hub-commands');
             await expect(runPushArchitecture({
-                calmHubUrl: 'http://hub',
+                calmHubOptions: {
+                    calmHubUrl: 'http://hub'
+                },
                 namespace: 'finos',
                 name: 'my-arch',
                 description: 'desc',
@@ -283,8 +294,7 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.pullArchitecture).mockResolvedValue({ id: 1, architecture: '{}' });
             const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-            const { runPullArchitecture } = await import('./hub-commands');
-            await runPullArchitecture({ calmHubUrl: 'http://hub', namespace: 'finos', id: '1', version: '1.0.0' });
+            await runPullArchitecture({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '1', version: '1.0.0' });
 
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"id": 1'));
             consoleSpy.mockRestore();
@@ -294,8 +304,7 @@ describe('hub-commands', () => {
             const { mockClient } = await getSharedMocks();
             vi.mocked(mockClient.pullArchitecture).mockResolvedValue({ id: 1 });
 
-            const { runPullArchitecture } = await import('./hub-commands');
-            await runPullArchitecture({ calmHubUrl: 'http://hub', namespace: 'finos', id: '1', version: '1.0.0', output: 'out.json' });
+            await runPullArchitecture({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '1', version: '1.0.0', output: 'out.json' });
 
             expect(fs.writeFile).toHaveBeenCalledWith('out.json', expect.any(String), 'utf-8');
         });
@@ -306,15 +315,13 @@ describe('hub-commands', () => {
                 new shared.HubClientError(404, 'Not found', 'GET /calm/namespaces/finos/architectures/99/versions/1.0.0')
             );
 
-            const { runPullArchitecture } = await import('./hub-commands');
-            await expect(runPullArchitecture({ calmHubUrl: 'http://hub', namespace: 'finos', id: '99', version: '1.0.0' }))
+            await expect(runPullArchitecture({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '99', version: '1.0.0' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Not found', expect.any(String), 'json');
         });
 
         it('exits with error when --id is not a valid integer', async () => {
-            const { runPullArchitecture } = await import('./hub-commands');
-            await expect(runPullArchitecture({ calmHubUrl: 'http://hub', namespace: 'finos', id: 'not-a-number', version: '1.0.0' }))
+            await expect(runPullArchitecture({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: 'not-a-number', version: '1.0.0' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0,
@@ -329,8 +336,7 @@ describe('hub-commands', () => {
 
     describe('runListArchitectures', () => {
         it('prints pretty error when no hub URL is available and format is pretty', async () => {
-            const { runListArchitectures } = await import('./hub-commands');
-            await expect(runListArchitectures({ namespace: 'finos', format: 'pretty' }))
+            await expect(runListArchitectures({ calmHubOptions: {}, namespace: 'finos', format: 'pretty' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0,
@@ -346,8 +352,7 @@ describe('hub-commands', () => {
                 { id: 1, name: 'arch-a', versions: ['1.0.0'] }
             ]);
 
-            const { runListArchitectures } = await import('./hub-commands');
-            await runListArchitectures({ calmHubUrl: 'http://hub', namespace: 'finos' });
+            await runListArchitectures({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos' });
 
             expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([{ id: 1, name: 'arch-a', versions: ['1.0.0'] }]);
         });
@@ -358,8 +363,7 @@ describe('hub-commands', () => {
                 { id: 1, name: 'arch-a', versions: ['1.0.0', '1.1.0'] }
             ]);
 
-            const { runListArchitectures } = await import('./hub-commands');
-            await runListArchitectures({ calmHubUrl: 'http://hub', namespace: 'finos', format: 'pretty' });
+            await runListArchitectures({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', format: 'pretty' });
 
             expect(hubOutput.printTableSuccess).toHaveBeenCalled();
         });
@@ -372,8 +376,7 @@ describe('hub-commands', () => {
             const { mockClient } = await getSharedMocks();
             vi.mocked(mockClient.createNamespace).mockResolvedValue({ name: 'my-org', location: '/calm/namespaces/my-org' });
 
-            const { runCreateNamespace } = await import('./hub-commands');
-            await runCreateNamespace({ calmHubUrl: 'http://hub', name: 'my-org', description: 'My org' });
+            await runCreateNamespace({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'my-org', description: 'My org' });
 
             expect(mockClient.createNamespace).toHaveBeenCalledWith('my-org', 'My org');
             expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith({ name: 'my-org', location: '/calm/namespaces/my-org' });
@@ -385,15 +388,13 @@ describe('hub-commands', () => {
                 new shared.HubClientError(409, 'Namespace already exists', 'POST /calm/namespaces')
             );
 
-            const { runCreateNamespace } = await import('./hub-commands');
-            await expect(runCreateNamespace({ calmHubUrl: 'http://hub', name: 'my-org', description: 'My org' }))
+            await expect(runCreateNamespace({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'my-org', description: 'My org' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Namespace already exists', expect.any(String), 'json');
         });
 
         it('exits when description is missing', async () => {
-            const { runCreateNamespace } = await import('./hub-commands');
-            await expect(runCreateNamespace({ calmHubUrl: 'http://hub', name: 'my-org' }))
+            await expect(runCreateNamespace({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'my-org' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0,
@@ -404,8 +405,7 @@ describe('hub-commands', () => {
         });
 
         it('exits when description is blank', async () => {
-            const { runCreateNamespace } = await import('./hub-commands');
-            await expect(runCreateNamespace({ calmHubUrl: 'http://hub', name: 'my-org', description: '   ' }))
+            await expect(runCreateNamespace({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'my-org', description: '   ' }))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0,
@@ -420,8 +420,7 @@ describe('hub-commands', () => {
 
     describe('runListNamespaces', () => {
         it('prints JSON error when no hub URL is available by default', async () => {
-            const { runListNamespaces } = await import('./hub-commands');
-            await expect(runListNamespaces({})).rejects.toThrow('process.exit');
+            await expect(runListNamespaces({ calmHubOptions: {} })).rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0,
                 'No CALM Hub URL provided. Use --calm-hub-url or set calmHubUrl in ~/.calm.json',
@@ -436,8 +435,7 @@ describe('hub-commands', () => {
                 { name: 'finos', description: 'FINOS' }
             ]);
 
-            const { runListNamespaces } = await import('./hub-commands');
-            await runListNamespaces({ calmHubUrl: 'http://hub' });
+            await runListNamespaces({ calmHubOptions: { calmHubUrl: 'http://hub' } });
 
             expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([{ name: 'finos', description: 'FINOS' }]);
         });
@@ -446,8 +444,7 @@ describe('hub-commands', () => {
             const { mockClient } = await getSharedMocks();
             vi.mocked(mockClient.listNamespaces).mockResolvedValue([{ name: 'finos', description: '' }]);
 
-            const { runListNamespaces } = await import('./hub-commands');
-            await runListNamespaces({ calmHubUrl: 'http://hub', format: 'pretty' });
+            await runListNamespaces({ calmHubOptions: { calmHubUrl: 'http://hub' }, format: 'pretty' });
 
             expect(hubOutput.printTableSuccess).toHaveBeenCalled();
         });
@@ -457,7 +454,6 @@ describe('hub-commands', () => {
 
     describe('printPushResult', () => {
         it('calls printTableSuccess with correct columns when format is pretty', async () => {
-            const { printPushResult } = await import('./hub-commands');
             printPushResult({ id: 1, version: '1.0.0', location: '/calm/namespaces/finos/architectures/1/versions/1.0.0' }, 'pretty');
 
             expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
@@ -473,7 +469,6 @@ describe('hub-commands', () => {
         });
 
         it('defaults version to empty string when version is undefined', async () => {
-            const { printPushResult } = await import('./hub-commands');
             printPushResult({ id: 2, location: '/calm/namespaces/finos/architectures/2' }, 'pretty');
 
             expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
@@ -483,7 +478,6 @@ describe('hub-commands', () => {
         });
 
         it('calls printJsonSuccess when format is json', async () => {
-            const { printPushResult } = await import('./hub-commands');
             const result = { id: 1, version: '1.0.0', location: '/loc' };
             printPushResult(result, 'json');
 
@@ -497,8 +491,6 @@ describe('hub-commands', () => {
     describe('resolveVersionedMetadata', () => {
         it('returns provided name and description without fetching when both are supplied', async () => {
             const { mockClient } = await getSharedMocks();
-            const { resolveVersionedMetadata } = await import('./hub-commands');
-
             const result = await resolveVersionedMetadata(mockClient, 'finos', 1, 'my-arch', 'my-desc', 'json');
 
             expect(result).toEqual({ name: 'my-arch', description: 'my-desc' });
@@ -510,8 +502,6 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.listArchitectures).mockResolvedValue([
                 { id: 1, name: 'fetched-arch', description: 'fetched-desc', versions: ['1.0.0'] }
             ]);
-            const { resolveVersionedMetadata } = await import('./hub-commands');
-
             const result = await resolveVersionedMetadata(mockClient, 'finos', 1, undefined, 'my-desc', 'json');
 
             expect(mockClient.listArchitectures).toHaveBeenCalledWith('finos');
@@ -523,8 +513,6 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.listArchitectures).mockResolvedValue([
                 { id: 1, name: 'fetched-arch', description: 'fetched-desc', versions: ['1.0.0'] }
             ]);
-            const { resolveVersionedMetadata } = await import('./hub-commands');
-
             const result = await resolveVersionedMetadata(mockClient, 'finos', 1, 'my-arch', undefined, 'json');
 
             expect(mockClient.listArchitectures).toHaveBeenCalledWith('finos');
@@ -536,8 +524,6 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.listArchitectures).mockResolvedValue([
                 { id: 99, name: 'other-arch', description: 'other', versions: ['1.0.0'] }
             ]);
-            const { resolveVersionedMetadata } = await import('./hub-commands');
-
             await expect(resolveVersionedMetadata(mockClient, 'finos', 1, undefined, undefined, 'json'))
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(
@@ -553,7 +539,6 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.listArchitectures).mockRejectedValue(
                 new shared.HubClientError(500, 'Server error', 'GET /calm/namespaces/finos/architectures')
             );
-            const { resolveVersionedMetadata } = await import('./hub-commands');
 
             await expect(resolveVersionedMetadata(mockClient, 'finos', 1, undefined, undefined, 'json'))
                 .rejects.toThrow('process.exit');
@@ -566,11 +551,10 @@ describe('hub-commands', () => {
     describe('pushVersioned', () => {
         it('exits when --version is missing', async () => {
             const { mockClient } = await getSharedMocks();
-            const { pushVersioned } = await import('./hub-commands');
 
             await expect(pushVersioned(
                 mockClient,
-                { namespace: 'finos', file: 'arch.json', id: '1' },
+                { calmHubOptions: {}, namespace: 'finos', file: 'arch.json', id: '1' },
                 '{}',
                 'json'
             )).rejects.toThrow('process.exit');
@@ -581,11 +565,10 @@ describe('hub-commands', () => {
 
         it('exits when --id is not a valid integer', async () => {
             const { mockClient } = await getSharedMocks();
-            const { pushVersioned } = await import('./hub-commands');
 
             await expect(pushVersioned(
                 mockClient,
-                { namespace: 'finos', file: 'arch.json', id: 'not-a-number', version: '1.0.0' },
+                { calmHubOptions: {}, namespace: 'finos', file: 'arch.json', id: 'not-a-number', version: '1.0.0' },
                 '{}',
                 'json'
             )).rejects.toThrow('process.exit');
@@ -599,11 +582,10 @@ describe('hub-commands', () => {
             vi.mocked(mockClient.pushArchitectureVersion).mockResolvedValue({
                 id: 5, version: '2.0.0', location: '/calm/namespaces/finos/architectures/5/versions/2.0.0'
             });
-            const { pushVersioned } = await import('./hub-commands');
 
             const result = await pushVersioned(
                 mockClient,
-                { namespace: 'finos', file: 'arch.json', id: '5', version: '2.0.0', name: 'my-arch', description: 'desc' },
+                { calmHubOptions: {}, namespace: 'finos', file: 'arch.json', id: '5', version: '2.0.0', name: 'my-arch', description: 'desc' },
                 '{"nodes":[]}',
                 'json'
             );

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -87,6 +87,16 @@ describe('hub-commands', () => {
             expect(hubOutput.printError).not.toHaveBeenCalled();
             expect(exitSpy).not.toHaveBeenCalled();
         });
+        
+        it('loads plugin when configured', async () => {
+            vi.mocked(cliConfig.loadCliConfig).mockResolvedValue({ calmHubUrl: 'http://from-config.example.com', authPluginPath: './auth-plugin.js' });
+            const plugin = { getAuthHeaders: vi.fn().mockResolvedValue({ 'Authorization': 'Bearer token' }) };
+            vi.mocked(cliConfig.loadAuthPlugin).mockResolvedValue(plugin);
+
+            const opts = await resolveCalmHubOptions({});
+            expect(cliConfig.loadAuthPlugin).toHaveBeenCalledWith('./auth-plugin.js', false);
+            expect(opts.authPlugin).toBe(plugin);
+        })
     });
 
     // ── runPushArchitecture ────────────────────────────────────────────────

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -96,7 +96,7 @@ describe('hub-commands', () => {
             const opts = await resolveCalmHubOptions({});
             expect(cliConfig.loadAuthPlugin).toHaveBeenCalledWith('./auth-plugin.js', false);
             expect(opts.authPlugin).toBe(plugin);
-        })
+        });
     });
 
     // ── runPushArchitecture ────────────────────────────────────────────────

--- a/cli/src/command-helpers/hub-commands.ts
+++ b/cli/src/command-helpers/hub-commands.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
-import { CalmHubClient, HubArchitectureSummary, HubClientError } from '@finos/calm-shared';
+import { CalmHubClient, CalmHubOptions, HubArchitectureSummary, HubClientError } from '@finos/calm-shared';
 import { OutputFormat, parseOutputFormat, printError, printJsonSuccess, printTableSuccess } from './hub-output';
 import * as cliConfig from '../cli-config';
 
@@ -16,23 +16,36 @@ class HubCommandError extends Error {
     }
 }
 
-export async function resolveHubUrl(options: { calmHubUrl?: string }): Promise<string> {
-    if (options.calmHubUrl) return options.calmHubUrl;
-
+/**
+ * Fully resolve the calmhub options. If we have CLI params, prefer those, and fill in any missing values from the config file if present.
+ * @param options The options to populate
+ * @returns Fully-resolved options with config file options set.
+ */
+export async function resolveCalmHubOptions(inputOptions: CalmHubOptions): Promise<CalmHubOptions> {
+    const options = { ...inputOptions };
     const config = await cliConfig.loadCliConfig();
-    if (config?.calmHubUrl) return config.calmHubUrl;
+    // set the options from config if they are not already set from command line
+    if (config && config.calmHubUrl && !options.calmHubUrl) {
+        options.calmHubUrl = config.calmHubUrl;
+    }
+    if (config && config.authPluginPath && !options.authPlugin) {
+        options.authPlugin = await cliConfig.loadAuthPlugin(config.authPluginPath, false); // TODO logging
+    }
 
-    throw new HubCommandError(
-        0,
-        'No CALM Hub URL provided. Use --calm-hub-url or set calmHubUrl in ~/.calm.json',
-        'resolve hub URL'
-    );
+    if (!options.calmHubUrl) {
+        throw new HubCommandError(
+            0,
+            'No CALM Hub URL provided. Use --calm-hub-url or set calmHubUrl in ~/.calm.json',
+            'resolve hub URL'
+        );
+    }
+    return options;
 }
 
 // ── push architecture ─────────────────────────────────────────────────────────
 
 export interface PushArchitectureOptions {
-    calmHubUrl?: string;
+    calmHubOptions: CalmHubOptions;
     namespace: string;
     name?: string;
     description?: string;
@@ -129,6 +142,14 @@ export async function pushVersioned(
     );
 }
 
+async function handleOptionsLoadError(opts: CalmHubOptions, format: OutputFormat = 'json'): Promise<CalmHubOptions> {
+    try {
+        return await resolveCalmHubOptions(opts);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
 export async function runPushArchitecture(options: PushArchitectureOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
 
@@ -142,13 +163,8 @@ export async function runPushArchitecture(options: PushArchitectureOptions): Pro
         process.exit(1);
     }
 
-    let hubUrl: string;
-    try {
-        hubUrl = await resolveHubUrl(options);
-    } catch (err) {
-        handleHubError(err, format);
-    }
-    const client = new CalmHubClient(hubUrl);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
 
     let fileContent: string;
     try {
@@ -179,7 +195,7 @@ export async function runPushArchitecture(options: PushArchitectureOptions): Pro
 // ── pull architecture ─────────────────────────────────────────────────────────
 
 export interface PullArchitectureOptions {
-    calmHubUrl?: string;
+    calmHubOptions: CalmHubOptions;
     namespace: string;
     id: string;
     version: string;
@@ -187,13 +203,8 @@ export interface PullArchitectureOptions {
 }
 
 export async function runPullArchitecture(options: PullArchitectureOptions): Promise<void> {
-    let hubUrl: string;
-    try {
-        hubUrl = await resolveHubUrl(options);
-    } catch (err) {
-        handleHubError(err, 'json');
-    }
-    const client = new CalmHubClient(hubUrl);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions);
+    const client = new CalmHubClient(calmHubOptions);
 
     const parsedId = parseInt(options.id, 10);
     if (!Number.isFinite(parsedId)) {
@@ -218,20 +229,15 @@ export async function runPullArchitecture(options: PullArchitectureOptions): Pro
 // ── list architectures ────────────────────────────────────────────────────────
 
 export interface ListArchitecturesOptions {
-    calmHubUrl?: string;
+    calmHubOptions: CalmHubOptions;
     namespace: string;
     format?: string;
 }
 
 export async function runListArchitectures(options: ListArchitecturesOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
-    let hubUrl: string;
-    try {
-        hubUrl = await resolveHubUrl(options);
-    } catch (err) {
-        handleHubError(err, format);
-    }
-    const client = new CalmHubClient(hubUrl);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
 
     try {
         const architectures = await client.listArchitectures(options.namespace);
@@ -256,7 +262,7 @@ export async function runListArchitectures(options: ListArchitecturesOptions): P
 // ── create namespace ──────────────────────────────────────────────────────────
 
 export interface CreateNamespaceOptions {
-    calmHubUrl?: string;
+    calmHubOptions: CalmHubOptions;
     name: string;
     description?: string;
     format?: string;
@@ -267,13 +273,8 @@ export async function runCreateNamespace(options: CreateNamespaceOptions): Promi
     if (!options.description?.trim()) {
         handleHubError(new Error('--description is required and must not be blank'), format);
     }
-    let hubUrl: string;
-    try {
-        hubUrl = await resolveHubUrl(options);
-    } catch (err) {
-        handleHubError(err, format);
-    }
-    const client = new CalmHubClient(hubUrl);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
 
     try {
         const result = await client.createNamespace(options.name, options.description);
@@ -298,19 +299,14 @@ export async function runCreateNamespace(options: CreateNamespaceOptions): Promi
 // ── list namespaces ───────────────────────────────────────────────────────────
 
 export interface ListNamespacesOptions {
-    calmHubUrl?: string;
+    calmHubOptions: CalmHubOptions;
     format?: string;
 }
 
 export async function runListNamespaces(options: ListNamespacesOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
-    let hubUrl: string;
-    try {
-        hubUrl = await resolveHubUrl(options);
-    } catch (err) {
-        handleHubError(err, format);
-    }
-    const client = new CalmHubClient(hubUrl);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
 
     try {
         const namespaces = await client.listNamespaces();

--- a/shared/AGENTS.md
+++ b/shared/AGENTS.md
@@ -10,6 +10,8 @@ The `shared` package contains common utilities, helpers, and core logic used acr
 
 ## Critical Development Rules
 
+Also include all rules from [../AGENTS.md](the root level AGENTS.md.)
+
 ### 1. Impact Analysis
 **WARNING**: Changes in this package affect multiple downstream projects.
 - **ALWAYS** run the full test suite (`npm run test` from root) after making changes here.
@@ -26,6 +28,9 @@ npm test --workspace shared
 
 # Run tests for ALL packages (REQUIRED before PR)
 npm test
+
+# If you want to test just one file run this. Make sure you're in the shared directory so it can resolve vitest.config.ts.
+npx vitest run ${TEST FILE}
 ```
 
 ## Key Components

--- a/shared/src/hub/calm-hub-client.spec.ts
+++ b/shared/src/hub/calm-hub-client.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import { CalmHubClient, HubClientError } from './calm-hub-client';
@@ -10,7 +10,7 @@ describe('CalmHubClient', () => {
     beforeEach(() => {
         const ax = axios.create({ baseURL: 'http://localhost:8080' });
         mock = new AxiosMockAdapter(ax);
-        client = new CalmHubClient('http://localhost:8080', ax);
+        client = new CalmHubClient({ calmHubUrl: 'http://localhost:8080' }, ax);
     });
 
     // ── createNamespace ──────────────────────────────────────────────────────
@@ -199,6 +199,106 @@ describe('CalmHubClient', () => {
         it('throws HubClientError(404) when not found', async () => {
             mock.onGet('/calm/namespaces/finos/architectures/99/versions/1.0.0').reply(404, 'Invalid architecture provided: 99');
             await expect(client.pullArchitecture('finos', 99, '1.0.0')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── auth plugin ──────────────────────────────────────────────────────────
+
+    describe('auth plugin', () => {
+        let authClient: CalmHubClient;
+        let authMock: AxiosMockAdapter;
+        let getAuthHeaders: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            getAuthHeaders = vi.fn().mockResolvedValue({ Authorization: 'Bearer test-token' });
+            const ax = axios.create({ baseURL: 'http://localhost:8080' });
+            authMock = new AxiosMockAdapter(ax);
+            authClient = new CalmHubClient(
+                { calmHubUrl: 'http://localhost:8080', authPlugin: { getAuthHeaders } },
+                ax
+            );
+        });
+
+        it('injects auth headers on createNamespace', async () => {
+            authMock.onPost('/calm/namespaces').reply(201, null, { location: '/calm/namespaces/my-org' });
+
+            await authClient.createNamespace('my-org', 'My org');
+
+            expect(getAuthHeaders).toHaveBeenCalledOnce();
+            const [url] = getAuthHeaders.mock.calls[0];
+            expect(url).toContain('/calm/namespaces');
+            expect(authMock.history.post[0].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('injects auth headers on listNamespaces', async () => {
+            authMock.onGet('/calm/namespaces').reply(200, { values: [] });
+
+            await authClient.listNamespaces();
+
+            expect(getAuthHeaders).toHaveBeenCalledOnce();
+            expect(authMock.history.get[0].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('injects auth headers on pushArchitecture', async () => {
+            authMock.onPost('/calm/namespaces/finos/architectures').reply(201, null, {
+                location: '/calm/namespaces/finos/architectures/1/versions/1.0.0'
+            });
+
+            await authClient.pushArchitecture('finos', 'arch', 'desc', '{}');
+
+            expect(getAuthHeaders).toHaveBeenCalledOnce();
+            expect(authMock.history.post[0].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('injects auth headers on pushArchitectureVersion', async () => {
+            authMock.onPost('/calm/namespaces/finos/architectures/1/versions/2.0.0').reply(201, null, {
+                location: '/calm/namespaces/finos/architectures/1/versions/2.0.0'
+            });
+
+            await authClient.pushArchitectureVersion('finos', 1, '2.0.0', 'arch', 'desc', '{}');
+
+            expect(getAuthHeaders).toHaveBeenCalledOnce();
+            expect(authMock.history.post[0].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('injects auth headers on listArchitectures (including version sub-requests)', async () => {
+            authMock.onGet('/calm/namespaces/finos/architectures').reply(200, {
+                values: [{ id: 1, name: 'arch-a', description: '' }]
+            });
+            authMock.onGet('/calm/namespaces/finos/architectures/1/versions').reply(200, { values: ['1.0.0'] });
+
+            await authClient.listArchitectures('finos');
+
+            expect(getAuthHeaders).toHaveBeenCalledTimes(2);
+            expect(authMock.history.get[0].headers?.Authorization).toBe('Bearer test-token');
+            expect(authMock.history.get[1].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('injects auth headers on pullArchitecture', async () => {
+            authMock.onGet('/calm/namespaces/finos/architectures/1/versions/1.0.0').reply(200, { nodes: [] });
+
+            await authClient.pullArchitecture('finos', 1, '1.0.0');
+
+            expect(getAuthHeaders).toHaveBeenCalledOnce();
+            expect(authMock.history.get[0].headers?.Authorization).toBe('Bearer test-token');
+        });
+
+        it('does not call getAuthHeaders when no auth plugin is configured', async () => {
+            mock.onGet('/calm/namespaces').reply(200, { values: [] });
+
+            await client.listNamespaces();
+
+            expect(getAuthHeaders).not.toHaveBeenCalled();
+        });
+
+        it('passes the request body to getAuthHeaders', async () => {
+            const body = { name: 'my-org', description: 'My org' };
+            authMock.onPost('/calm/namespaces').reply(201, null, { location: '/calm/namespaces/my-org' });
+
+            await authClient.createNamespace('my-org', 'My org');
+
+            const [, requestBody] = getAuthHeaders.mock.calls[0];
+            expect(requestBody).toMatchObject(body);
         });
     });
 });

--- a/shared/src/hub/calm-hub-client.ts
+++ b/shared/src/hub/calm-hub-client.ts
@@ -1,4 +1,10 @@
 import axios, { Axios } from 'axios';
+import { AuthPlugin } from '../auth/auth-plugin';
+
+export interface CalmHubOptions {
+    calmHubUrl?: string;
+    authPlugin?: AuthPlugin;
+}
 
 export interface HubNamespaceSummary {
     name: string;
@@ -37,7 +43,9 @@ export class HubClientError extends Error {
 export class CalmHubClient {
     private readonly ax: Axios;
 
-    constructor(baseUrl: string, axiosInstance?: Axios) {
+    constructor(options: CalmHubOptions, axiosInstance?: Axios) {
+        const baseUrl = options.calmHubUrl;
+       
         if (axiosInstance) {
             this.ax = axiosInstance;
         } else {
@@ -47,6 +55,15 @@ export class CalmHubClient {
                 headers: {
                     'Content-Type': 'application/json'
                 }
+            });
+        }
+        
+        if (options.authPlugin) {
+            this.ax.interceptors.request.use(async (config) => {
+                const fullUrl = (config.baseURL || '') + (config.url || '');
+                const authHeaders = await options.authPlugin.getAuthHeaders(fullUrl, config.data);
+                Object.assign(config.headers, authHeaders);
+                return config;
             });
         }
     }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -52,7 +52,8 @@ export {
     type HubNamespaceSummary,
     type HubArchitectureSummary,
     type HubCreateResult,
-    type HubNamespaceCreateResult
+    type HubNamespaceCreateResult,
+    type CalmHubOptions
 } from './hub/calm-hub-client.js';
 export {
     enrichWithDocumentPositions,


### PR DESCRIPTION
## Description
Currently `calm hub *` cannot use the auth plugin.
This enhances the `CalmHubClient` and cli code to wire the plugin if it's configured.

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
