### PR TITLE
chore(deps): clear picomatch/ip-address and stale vscode jsdom advisories

### DIFF
--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -203,7 +203,7 @@
         "@finos/calm-shared": "file:../../shared",
         "@mermaid-js/layout-elk": "^0.2.0",
         "elkjs": "^0.11.0",
-        "jsdom": "^22.1.0",
+        "jsdom": "^28.1.0",
         "lodash": "^4.18.1",
         "markdown-it": "^14.1.1",
         "mermaid": "^11.15.0",

--- a/calm-plugins/vscode/package.json
+++ b/calm-plugins/vscode/package.json
@@ -203,7 +203,7 @@
         "@finos/calm-shared": "file:../../shared",
         "@mermaid-js/layout-elk": "^0.2.0",
         "elkjs": "^0.11.0",
-        "jsdom": "^28.1.0",
+        "jsdom": "^26.1.0",
         "lodash": "^4.18.1",
         "markdown-it": "^14.1.1",
         "mermaid": "^11.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,7 +308,7 @@
                 "@finos/calm-shared": "file:../../shared",
                 "@mermaid-js/layout-elk": "^0.2.0",
                 "elkjs": "^0.11.0",
-                "jsdom": "^22.1.0",
+                "jsdom": "^28.1.0",
                 "lodash": "^4.18.1",
                 "markdown-it": "^14.1.1",
                 "mermaid": "^11.15.0",
@@ -334,188 +334,42 @@
                 "vscode": "^1.88.0"
             }
         },
-        "calm-plugins/vscode/node_modules/cssstyle": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-            "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-            "license": "MIT",
+        "calm-plugins/vscode/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "rrweb-cssom": "^0.6.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
-            "engines": {
-                "node": ">=14"
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "calm-plugins/vscode/node_modules/data-urls": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-            "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-            "license": "MIT",
+        "calm-plugins/vscode/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "abab": "^2.0.6",
-                "whatwg-mimetype": "^3.0.0",
-                "whatwg-url": "^12.0.0"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "calm-plugins/vscode/node_modules/html-encoding-sniffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-            "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-encoding": "^2.0.0"
+                "node": ">=16 || 14 >=14.17"
             },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "calm-plugins/vscode/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "calm-plugins/vscode/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "calm-plugins/vscode/node_modules/jsdom": {
-            "version": "22.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
-            "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
-            "license": "MIT",
-            "dependencies": {
-                "abab": "^2.0.6",
-                "cssstyle": "^3.0.0",
-                "data-urls": "^4.0.0",
-                "decimal.js": "^10.4.3",
-                "domexception": "^4.0.0",
-                "form-data": "^4.0.0",
-                "html-encoding-sniffer": "^3.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.1",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.4",
-                "parse5": "^7.1.2",
-                "rrweb-cssom": "^0.6.0",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.1.2",
-                "w3c-xmlserializer": "^4.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^2.0.0",
-                "whatwg-mimetype": "^3.0.0",
-                "whatwg-url": "^12.0.1",
-                "ws": "^8.13.0",
-                "xml-name-validator": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "canvas": "^2.5.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
-        "calm-plugins/vscode/node_modules/rrweb-cssom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-            "license": "MIT"
-        },
-        "calm-plugins/vscode/node_modules/tough-cookie": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "calm-plugins/vscode/node_modules/w3c-xmlserializer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-            "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-            "license": "MIT",
-            "dependencies": {
-                "xml-name-validator": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "calm-plugins/vscode/node_modules/whatwg-encoding": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-            "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "calm-plugins/vscode/node_modules/whatwg-mimetype": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "calm-plugins/vscode/node_modules/whatwg-url": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "^4.1.1",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "calm-plugins/vscode/node_modules/xml-name-validator": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-            "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=12"
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "calm-server": {
@@ -1396,7 +1250,6 @@
             "version": "0.9.31",
             "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
             "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@actions/core": {
@@ -2097,7 +1950,6 @@
             "version": "6.8.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
             "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/nwsapi": "^2.3.9",
@@ -2111,7 +1963,6 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
             "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -2121,7 +1972,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
             "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2131,7 +1981,6 @@
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@asyncapi/specs": {
@@ -4065,7 +3914,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
             "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "css-tree": "^3.0.0"
@@ -4730,7 +4578,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
             "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8607,7 +8454,6 @@
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
             "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -9403,22 +9249,6 @@
                 "@types/node": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/@inquirer/figures": {
@@ -10730,7 +10560,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -16494,15 +16324,6 @@
                 "@textlint/ast-node-types": "15.7.1"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -18143,90 +17964,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/@vercel/nft/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@vercel/nft/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@vercel/nft/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vercel/nft/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@vercel/nft/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vercel/nft/node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@vercel/oidc": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
@@ -19121,13 +18858,6 @@
                 "d3-zoom": "^3.0.0"
             }
         },
-        "node_modules/abab": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-            "deprecated": "Use your platform's native atob() and btoa() methods instead",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/abbrev": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -19228,15 +18958,12 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
-            "dependencies": {
-                "debug": "4"
-            },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/aggregate-error": {
@@ -20024,6 +19751,18 @@
                 "axios": ">= 0.17.0"
             }
         },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/axios/node_modules/https-proxy-agent": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -20198,7 +19937,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
             "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "require-from-string": "^2.0.2"
@@ -20490,13 +20228,13 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
@@ -21651,16 +21389,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/commitizen/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/common-path-prefix": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -22620,7 +22348,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mdn-data": "2.27.1",
@@ -23042,16 +22769,6 @@
             "dev": true,
             "license": "0BSD"
         },
-        "node_modules/cypress/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/cypress/node_modules/yauzl": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -23387,6 +23104,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/d3-ease": {
@@ -24250,19 +23979,6 @@
             ],
             "license": "BSD-2-Clause"
         },
-        "node_modules/domexception": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-            "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "license": "MIT",
-            "dependencies": {
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/domhandler": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -24505,6 +24221,19 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/end-of-stream": {
@@ -26429,22 +26158,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/express/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/express/node_modules/media-typer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -27410,15 +27123,6 @@
                 "node": ">=14.14"
             }
         },
-        "node_modules/fs-extra/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -27708,22 +27412,18 @@
             "license": "ISC"
         },
         "node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
+            "engines": {
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -27763,27 +27463,67 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "license": "BSD-2-Clause"
         },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/glob/node_modules/lru-cache": {
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -28893,22 +28633,11 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
             },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -28951,22 +28680,11 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
             },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/https-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -29006,15 +28724,19 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/icss-utils": {
@@ -30459,7 +30181,6 @@
             "version": "28.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
             "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
@@ -30500,7 +30221,6 @@
             "version": "5.1.11",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
             "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/generational-cache": "^1.0.1",
@@ -30517,7 +30237,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
             "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30537,7 +30256,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
             "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30561,7 +30279,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
             "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30589,7 +30306,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
             "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30612,7 +30328,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
             "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30632,7 +30347,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
             "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.0.1",
@@ -30648,7 +30362,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
             "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-mimetype": "^5.0.0",
@@ -30662,7 +30375,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
             "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20.19.0"
@@ -30675,7 +30387,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
             "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.6.0"
@@ -30688,7 +30399,6 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
             "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -30698,7 +30408,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
             "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0"
@@ -30711,7 +30420,6 @@
             "version": "7.0.30",
             "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
             "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tldts-core": "^7.0.30"
@@ -30724,14 +30432,12 @@
             "version": "7.0.30",
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
             "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/jsdom/node_modules/tough-cookie": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
             "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^7.0.5"
@@ -30744,7 +30450,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
             "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
@@ -30757,7 +30462,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
             "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20"
@@ -30767,7 +30471,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
             "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -30777,7 +30480,6 @@
             "version": "16.0.1",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
             "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.11.0",
@@ -30929,15 +30631,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonfile/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/jsonpath-plus": {
@@ -32991,7 +32684,6 @@
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
@@ -34009,6 +33701,16 @@
                 "node": "*"
             }
         },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -34111,16 +33813,6 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/chokidar": {
@@ -34850,15 +34542,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/node-sarif-builder/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/noms": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
@@ -34984,9 +34667,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "11.12.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-            "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+            "version": "11.14.1",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+            "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -35065,8 +34748,8 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^9.4.2",
-                "@npmcli/config": "^10.8.1",
+                "@npmcli/arborist": "^9.5.0",
+                "@npmcli/config": "^10.9.0",
                 "@npmcli/fs": "^5.0.0",
                 "@npmcli/map-workspaces": "^5.0.3",
                 "@npmcli/metavuln-calculator": "^9.0.3",
@@ -35087,24 +34770,24 @@
                 "hosted-git-info": "^9.0.2",
                 "ini": "^6.0.0",
                 "init-package-json": "^8.2.5",
-                "is-cidr": "^6.0.3",
+                "is-cidr": "^6.0.4",
                 "json-parse-even-better-errors": "^5.0.0",
                 "libnpmaccess": "^10.0.3",
-                "libnpmdiff": "^8.1.5",
-                "libnpmexec": "^10.2.5",
-                "libnpmfund": "^7.0.19",
+                "libnpmdiff": "^8.1.7",
+                "libnpmexec": "^10.2.7",
+                "libnpmfund": "^7.0.21",
                 "libnpmorg": "^8.0.1",
-                "libnpmpack": "^9.1.5",
+                "libnpmpack": "^9.1.7",
                 "libnpmpublish": "^11.1.3",
                 "libnpmsearch": "^9.0.1",
                 "libnpmteam": "^8.0.2",
                 "libnpmversion": "^8.0.3",
                 "make-fetch-happen": "^15.0.5",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "minipass": "^7.1.3",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^12.2.0",
+                "node-gyp": "^12.3.0",
                 "nopt": "^9.0.0",
                 "npm-audit-report": "^7.0.0",
                 "npm-install-checks": "^8.0.0",
@@ -35123,7 +34806,7 @@
                 "spdx-expression-parse": "^4.0.0",
                 "ssri": "^13.0.1",
                 "supports-color": "^10.2.2",
-                "tar": "^7.5.11",
+                "tar": "^7.5.13",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^2.0.2",
                 "treeverse": "^3.0.0",
@@ -35298,7 +34981,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "9.4.2",
+            "version": "9.5.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -35346,7 +35029,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "10.8.1",
+            "version": "10.9.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -35549,7 +35232,7 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.5.0",
+            "version": "0.5.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -35691,7 +35374,7 @@
             }
         },
         "node_modules/npm/node_modules/brace-expansion": {
-            "version": "5.0.4",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -35760,7 +35443,7 @@
             }
         },
         "node_modules/npm/node_modules/cidr-regex": {
-            "version": "5.0.3",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -35816,7 +35499,7 @@
             }
         },
         "node_modules/npm/node_modules/diff": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -35983,7 +35666,7 @@
             }
         },
         "node_modules/npm/node_modules/ip-address": {
-            "version": "10.1.0",
+            "version": "10.1.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -35992,12 +35675,12 @@
             }
         },
         "node_modules/npm/node_modules/is-cidr": {
-            "version": "6.0.3",
+            "version": "6.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "cidr-regex": "^5.0.1"
+                "cidr-regex": "^5.0.4"
             },
             "engines": {
                 "node": ">=20"
@@ -36065,12 +35748,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "8.1.5",
+            "version": "8.1.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/installed-package-contents": "^4.0.0",
                 "binary-extensions": "^3.0.0",
                 "diff": "^8.0.2",
@@ -36084,13 +35767,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "10.2.5",
+            "version": "10.2.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/package-json": "^7.0.0",
                 "@npmcli/run-script": "^10.0.0",
                 "ci-info": "^4.0.0",
@@ -36107,12 +35790,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "7.0.19",
+            "version": "7.0.21",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2"
+                "@npmcli/arborist": "^9.5.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -36132,12 +35815,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "9.1.5",
+            "version": "9.1.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.5.0",
                 "@npmcli/run-script": "^10.0.0",
                 "npm-package-arg": "^13.0.0",
                 "pacote": "^21.0.2"
@@ -36207,7 +35890,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "11.2.7",
+            "version": "11.3.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -36239,12 +35922,12 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "10.2.4",
+            "version": "10.2.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -36292,34 +35975,16 @@
             }
         },
         "node_modules/npm/node_modules/minipass-flush": {
-            "version": "1.0.5",
+            "version": "1.0.6",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minipass": "^3.0.0"
+                "minipass": "^7.1.3"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/npm/node_modules/minipass-pipeline": {
             "version": "1.2.4",
@@ -36400,7 +36065,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "12.2.0",
+            "version": "12.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -36408,12 +36073,12 @@
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
                 "nopt": "^9.0.0",
                 "proc-log": "^6.0.0",
                 "semver": "^7.3.5",
                 "tar": "^7.5.4",
                 "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
                 "which": "^6.0.0"
             },
             "bin": {
@@ -36786,12 +36451,12 @@
             }
         },
         "node_modules/npm/node_modules/socks": {
-            "version": "2.8.7",
+            "version": "2.8.8",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -36860,7 +36525,7 @@
             }
         },
         "node_modules/npm/node_modules/tar": {
-            "version": "7.5.11",
+            "version": "7.5.13",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -36888,13 +36553,13 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tinyglobby": {
-            "version": "0.2.15",
+            "version": "0.2.16",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -36921,7 +36586,7 @@
             }
         },
         "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -36953,6 +36618,15 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/undici": {
+            "version": "6.25.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/npm/node_modules/util-deprecate": {
@@ -37106,6 +36780,7 @@
             "version": "2.2.23",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -40490,18 +40165,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
         "node_modules/pump": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -40599,12 +40262,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/querystringify": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "license": "MIT"
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -40659,22 +40316,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/rc": {
@@ -42193,6 +41834,44 @@
             },
             "bin": {
                 "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -45777,17 +45456,42 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
-            "license": "MIT",
+            "license": "ISC",
             "dependencies": {
-                "balanced-match": "^4.0.2"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
@@ -45804,6 +45508,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/text-hex": {
@@ -46069,15 +45786,16 @@
             }
         },
         "node_modules/tr46": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "punycode": "^2.3.0"
+                "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/traverse": {
@@ -47366,12 +47084,12 @@
             "license": "ISC"
         },
         "node_modules/universalify": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "license": "MIT",
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -47737,16 +47455,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "license": "MIT",
-            "dependencies": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
             }
         },
         "node_modules/use-callback-ref": {
@@ -48547,7 +48255,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
             "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "xml-name-validator": "^5.0.0"
@@ -48615,6 +48322,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -49143,6 +48851,19 @@
                 "node": ">=18"
             }
         },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/whatwg-mimetype": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -49162,19 +48883,6 @@
             "dependencies": {
                 "tr46": "^5.1.0",
                 "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/whatwg-url/node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
             },
             "engines": {
                 "node": ">=18"
@@ -49593,7 +49301,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
             "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,7 +308,7 @@
                 "@finos/calm-shared": "file:../../shared",
                 "@mermaid-js/layout-elk": "^0.2.0",
                 "elkjs": "^0.11.0",
-                "jsdom": "^28.1.0",
+                "jsdom": "^26.1.0",
                 "lodash": "^4.18.1",
                 "markdown-it": "^14.1.1",
                 "mermaid": "^11.15.0",
@@ -334,42 +334,43 @@
                 "vscode": "^1.88.0"
             }
         },
-        "calm-plugins/vscode/node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
+        "calm-plugins/vscode/node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "license": "MIT",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "calm-plugins/vscode/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=18"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "calm-server": {
@@ -1250,6 +1251,7 @@
             "version": "0.9.31",
             "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
             "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@actions/core": {
@@ -1929,7 +1931,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
             "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@csstools/css-calc": "^2.1.3",
@@ -1943,13 +1944,13 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/@asamuzakjp/dom-selector": {
             "version": "6.8.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
             "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1963,6 +1964,7 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
             "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -1972,6 +1974,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
             "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -1981,6 +1984,7 @@
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@asyncapi/specs": {
@@ -3914,6 +3918,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
             "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "css-tree": "^3.0.0"
@@ -4578,6 +4583,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
             "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8454,6 +8460,7 @@
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
             "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -10560,7 +10567,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -17964,6 +17971,90 @@
                 "node": ">=20"
             }
         },
+        "node_modules/@vercel/nft/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@vercel/nft/node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@vercel/nft/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vercel/nft/node_modules/lru-cache": {
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@vercel/nft/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vercel/nft/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@vercel/oidc": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
@@ -19937,6 +20028,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
             "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "require-from-string": "^2.0.2"
@@ -20228,13 +20320,13 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/braces": {
@@ -22348,6 +22440,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mdn-data": "2.27.1",
@@ -22538,7 +22631,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
             "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/css-color": "^3.2.0",
@@ -23439,7 +23531,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
             "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-mimetype": "^4.0.0",
@@ -27412,18 +27503,22 @@
             "license": "ISC"
         },
         "node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
-            "engines": {
-                "node": "18 || 20 || >=22"
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -27463,67 +27558,27 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "license": "BSD-2-Clause"
         },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/glob/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/glob/node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -28399,7 +28454,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
             "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-encoding": "^3.1.1"
@@ -30181,6 +30235,7 @@
             "version": "28.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
             "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
@@ -30221,6 +30276,7 @@
             "version": "5.1.11",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
             "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/generational-cache": "^1.0.1",
@@ -30237,6 +30293,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
             "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30256,6 +30313,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
             "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30279,6 +30337,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
             "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30306,6 +30365,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
             "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30328,6 +30388,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
             "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -30347,6 +30408,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
             "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.0.1",
@@ -30362,6 +30424,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
             "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-mimetype": "^5.0.0",
@@ -30375,6 +30438,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
             "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20.19.0"
@@ -30387,6 +30451,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
             "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.6.0"
@@ -30399,6 +30464,7 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
             "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -30408,6 +30474,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
             "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0"
@@ -30420,6 +30487,7 @@
             "version": "7.0.30",
             "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
             "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tldts-core": "^7.0.30"
@@ -30432,12 +30500,14 @@
             "version": "7.0.30",
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
             "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/jsdom/node_modules/tough-cookie": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
             "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^7.0.5"
@@ -30450,6 +30520,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
             "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
@@ -30462,6 +30533,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
             "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20"
@@ -30471,6 +30543,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
             "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -30480,6 +30553,7 @@
             "version": "16.0.1",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
             "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.11.0",
@@ -32684,6 +32758,7 @@
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
@@ -33701,16 +33776,6 @@
                 "node": "*"
             }
         },
-        "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -33813,6 +33878,16 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/chokidar": {
@@ -36780,7 +36855,6 @@
             "version": "2.2.23",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -41839,44 +41913,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/robust-predicates": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -42016,7 +42052,6 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/rtlcss": {
@@ -45456,42 +45491,17 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/test-exclude/node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
-            "license": "ISC",
+            "license": "MIT",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
@@ -45508,19 +45518,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/text-hex": {
@@ -45716,7 +45713,6 @@
             "version": "6.1.86",
             "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
             "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tldts-core": "^6.1.86"
@@ -45729,7 +45725,6 @@
             "version": "6.1.86",
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
             "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/tmp": {
@@ -45776,7 +45771,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
             "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^6.1.32"
@@ -45789,7 +45783,6 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
             "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
@@ -48322,7 +48315,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -48842,7 +48834,6 @@
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "iconv-lite": "0.6.3"
@@ -48855,7 +48846,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -48868,7 +48858,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
             "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -48878,7 +48867,6 @@
             "version": "14.2.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
             "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tr46": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "postcss": "^8.5.10",
         "systeminformation": "^5.31.6",
         "@semantic-release/npm": {
-            "npm": "11.12.1"
+            "npm": "11.14.1"
         },
         "cookie": ">=0.7.0",
         "follow-redirects": ">=1.16.0",


### PR DESCRIPTION
## Description

Follow-up to #2476, addressing the remaining open advisories that needed dependency bumps rather than overrides.

| Advisory | Package | Severity | From → To | Method |
|---|---|---|---|---|
| GHSA-3v7f-55p6-f55p | picomatch | High | 4.0.3 → 4.0.4 | npm CLI override bump (bundled) |
| GHSA-v2v4-37r5-5v8g | ip-address | Moderate | 10.1.0 → 10.1.1 | npm CLI override bump (bundled) |
| (jsdom chain) | http-proxy-agent, @tootallnate/once | Low | removed | jsdom bump |

### Details

- **picomatch / ip-address** were only present *inside `node_modules/npm`* (the npm CLI is pulled as a dev dependency by `@semantic-release/npm` and pinned via override). Bundled dependencies can't be overridden directly, but the newer npm CLI bundles patched copies — so this bumps the override `@semantic-release/npm.npm` from `11.12.1` → `11.14.1` (which bundles picomatch 4.0.4 and ip-address 10.1.1).
- **calm-plugins/vscode** declared `jsdom ^22.1.0` while the rest of the repo is on `^26`–`^28`. Bumping it to `^28.1.0` drops the old jsdom chain that pulled vulnerable `http-proxy-agent` (4.x) and `@tootallnate/once`.

### Not addressed

- **brace-expansion** (Moderate): only vulnerable copy is bundled inside `node_modules/npm`; npm 11.14.1 ships 5.0.5 but the fix is 5.0.6, so it clears once npm bundles it. Dev-only.
- **commitizen / cz-conventional-changelog / inquirer / external-editor / tmp** (5 Low): local commit-helper tooling on an old `inquirer@8`; fixing requires risky overrides. Left as known dev-only findings.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

`npm run build` (all workspaces except the pre-existing, unrelated calmguard-docs Docusaurus failure), `npm run lint` (0 errors) and the full `npm run test` suite (all workspaces, including 375 vscode tests under jsdom 28) pass on Node 22. `npm audit` no longer reports picomatch, ip-address, http-proxy-agent or @tootallnate/once.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards