### PR TITLE
feat(calm-hub-ui): version compare in the main architecture view

### DIFF
--- a/calm-hub-ui/src/diff/components/DiffGraph.tsx
+++ b/calm-hub-ui/src/diff/components/DiffGraph.tsx
@@ -1,50 +1,103 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import ReactFlow, {
     Background,
     Controls,
     MiniMap,
+    ReactFlowProvider,
     useNodesState,
     useEdgesState,
+    useReactFlow,
+    useNodesInitialized,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { FloatingEdge } from '../../visualizer/components/reactflow/FloatingEdge.js';
 import { CustomNode } from '../../visualizer/components/reactflow/CustomNode.js';
 import { SystemGroupNode } from '../../visualizer/components/reactflow/SystemGroupNode.js';
+import { THEME } from '../../visualizer/components/reactflow/theme.js';
 import { parseCALMDataWithDiff } from './utils/diffTransformer.js';
 import type { DiffGraphProps } from '../model/diff-ui-types.js';
 
 const edgeTypes = { custom: FloatingEdge };
 const nodeTypes = { custom: CustomNode, group: SystemGroupNode };
 
-export function DiffGraph({ architecture, diffResult, isFirst }: DiffGraphProps) {
-    const { nodes: initialNodes, edges: initialEdges } = useMemo(() => {
-        return parseCALMDataWithDiff(architecture, diffResult, isFirst);
-    }, [architecture, diffResult, isFirst]);
+function DiffGraphInner({ architecture, diffResult, isFirst }: DiffGraphProps) {
+    const [nodes, setNodes, onNodesChange] = useNodesState([]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+    const { fitView } = useReactFlow();
+    const nodesInitialized = useNodesInitialized();
+    const containerRef = useRef<HTMLDivElement>(null);
 
-    const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-    const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+    // Fit on the next animation frame so ReactFlow has picked up the container's
+    // final dimensions first — the compare panels reach their final (narrower) width
+    // after the diagram first renders, and a synchronous fitView uses the stale size.
+    const scheduleFit = useCallback(() => {
+        requestAnimationFrame(() => fitView({ padding: 0.2 }));
+    }, [fitView]);
 
     useEffect(() => {
-        setNodes(initialNodes);
-        setEdges(initialEdges);
-    }, [initialNodes, initialEdges, setNodes, setEdges]);
+        const { nodes: parsedNodes, edges: parsedEdges } = parseCALMDataWithDiff(architecture, diffResult, isFirst);
+        setNodes(parsedNodes);
+        setEdges(parsedEdges);
+    }, [architecture, diffResult, isFirst, setNodes, setEdges]);
+
+    useEffect(() => {
+        if (nodesInitialized) {
+            scheduleFit();
+        }
+    }, [nodesInitialized, scheduleFit]);
+
+    // ReactFlow does not refit on container resize on its own; refit when the panel
+    // settles to its final size.
+    useEffect(() => {
+        const el = containerRef.current;
+        if (!el) return;
+        const observer = new ResizeObserver(() => scheduleFit());
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [scheduleFit]);
 
     return (
+        <div ref={containerRef} style={{ height: '100%', width: '100%' }}>
+        <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+            minZoom={0.1}
+            attributionPosition="bottom-left"
+            style={{ background: THEME.colors.background }}
+        >
+            <Background color={THEME.colors.border} gap={16} />
+            <Controls
+                style={{
+                    background: THEME.colors.card,
+                    border: `1px solid ${THEME.colors.border}`,
+                    borderRadius: '8px',
+                }}
+            />
+            <MiniMap
+                style={{
+                    background: THEME.colors.backgroundSecondary,
+                    border: `1px solid ${THEME.colors.border}`,
+                }}
+                nodeColor={THEME.colors.accent}
+                maskColor={`${THEME.colors.background}cc`}
+            />
+        </ReactFlow>
+        </div>
+    );
+}
+
+export function DiffGraph(props: DiffGraphProps) {
+    return (
         <div style={{ height: '100%', width: '100%' }}>
-            <ReactFlow
-                nodes={nodes}
-                edges={edges}
-                onNodesChange={onNodesChange}
-                onEdgesChange={onEdgesChange}
-                nodeTypes={nodeTypes}
-                edgeTypes={edgeTypes}
-                fitView
-                attributionPosition="bottom-left"
-            >
-                <Background />
-                <Controls />
-                <MiniMap />
-            </ReactFlow>
+            <ReactFlowProvider>
+                <DiffGraphInner {...props} />
+            </ReactFlowProvider>
         </div>
     );
 }

--- a/calm-hub-ui/src/diff/components/DiffGraph.tsx
+++ b/calm-hub-ui/src/diff/components/DiffGraph.tsx
@@ -26,13 +26,20 @@ function DiffGraphInner({ architecture, diffResult, isFirst }: DiffGraphProps) {
     const { fitView } = useReactFlow();
     const nodesInitialized = useNodesInitialized();
     const containerRef = useRef<HTMLDivElement>(null);
+    const fitFrameRef = useRef<number>();
 
     // Fit on the next animation frame so ReactFlow has picked up the container's
     // final dimensions first — the compare panels reach their final (narrower) width
     // after the diagram first renders, and a synchronous fitView uses the stale size.
+    // The frame is tracked so it can be cancelled if the graph unmounts first.
     const scheduleFit = useCallback(() => {
-        requestAnimationFrame(() => fitView({ padding: 0.2 }));
+        if (fitFrameRef.current !== undefined) cancelAnimationFrame(fitFrameRef.current);
+        fitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
     }, [fitView]);
+
+    useEffect(() => () => {
+        if (fitFrameRef.current !== undefined) cancelAnimationFrame(fitFrameRef.current);
+    }, []);
 
     useEffect(() => {
         const { nodes: parsedNodes, edges: parsedEdges } = parseCALMDataWithDiff(architecture, diffResult, isFirst);
@@ -94,10 +101,8 @@ function DiffGraphInner({ architecture, diffResult, isFirst }: DiffGraphProps) {
 
 export function DiffGraph(props: DiffGraphProps) {
     return (
-        <div style={{ height: '100%', width: '100%' }}>
-            <ReactFlowProvider>
-                <DiffGraphInner {...props} />
-            </ReactFlowProvider>
-        </div>
+        <ReactFlowProvider>
+            <DiffGraphInner {...props} />
+        </ReactFlowProvider>
     );
 }

--- a/calm-hub-ui/src/diff/components/DiffPanel.tsx
+++ b/calm-hub-ui/src/diff/components/DiffPanel.tsx
@@ -2,14 +2,14 @@ import type { DiffPanelProps, DiffSectionProps } from '../model/diff-ui-types.js
 import { getRelationshipTypeDisplayString } from '../../visualizer/components/reactflow/utils/calmHelpers.js';
 import '../Diff.css';
 
-export function DiffPanel({ diffResult }: DiffPanelProps) {
+export function DiffPanel({ diffResult, emptyMessage }: DiffPanelProps) {
     if (!diffResult) {
         return (
             <div className="diff-panel">
                 <div className="diff-summary">
                     <h3 className="text-lg font-semibold mb-4">Diff Summary</h3>
                     <p className="text-gray-600">
-                        Upload two CALM architecture files to see the differences.
+                        {emptyMessage ?? 'Upload two CALM architecture files to see the differences.'}
                     </p>
                 </div>
             </div>

--- a/calm-hub-ui/src/diff/components/utils/diffTransformer.test.ts
+++ b/calm-hub-ui/src/diff/components/utils/diffTransformer.test.ts
@@ -73,7 +73,7 @@ describe('diffTransformer', () => {
         expect(result.nodes).toHaveLength(9);
         expect(result.nodes.find(n => n.id === 'audit-service')?.data.diffStatus).toBe('added');
         //check styles
-        expect(result.nodes.find(n => n.id === 'audit-service')?.style).toEqual({ borderColor: '#16a34a', borderWidth: 2 });
+        expect(result.nodes.find(n => n.id === 'audit-service')?.style).toEqual({ boxShadow: '0 0 0 3px #16a34a', borderRadius: '12px' });
     });
 
     it('should handle modified nodes correctly', () => {
@@ -112,7 +112,8 @@ describe('diffTransformer', () => {
         expect(result.nodes).toHaveLength(8);
         expect(result.nodes.find(n => n.id === 'api-gateway')?.data.diffStatus).toBe('modified');
         //check styles
-        expect(result.nodes.find(n => n.id === 'api-gateway')?.style).toEqual({ borderColor: "#d97706", borderWidth: 2, });
+        // Diff highlight is merged on top of the main viewer's node styling (preserved).
+        expect(result.nodes.find(n => n.id === 'api-gateway')?.style).toMatchObject({ boxShadow: '0 0 0 3px #d97706', borderRadius: '12px' });
     });
 
     it('should handle unchanged nodes correctly', () => {
@@ -165,11 +166,11 @@ describe('diffTransformer', () => {
         expect(result.nodes.find(n => n.id === 'payment-service')?.data.diffStatus).toBe('unchanged');
         expect(result.nodes.find(n => n.id === 'user-db')?.data.diffStatus).toBe('unchanged');
         expect(result.nodes.find(n => n.id === 'trader')?.data.diffStatus).toBe('unchanged');
-        //check styles
-        expect(result.nodes.find(n => n.id === 'api-gateway')?.style).toEqual({});
-        expect(result.nodes.find(n => n.id === 'payment-service')?.style).toEqual({});
-        expect(result.nodes.find(n => n.id === 'user-db')?.style).toEqual({});
-        expect(result.nodes.find(n => n.id === 'trader')?.style).toEqual({});
+        // Unchanged nodes carry no diff highlight (their base styling is left untouched).
+        expect(result.nodes.find(n => n.id === 'api-gateway')?.style?.boxShadow).toBeUndefined();
+        expect(result.nodes.find(n => n.id === 'payment-service')?.style?.boxShadow).toBeUndefined();
+        expect(result.nodes.find(n => n.id === 'user-db')?.style?.boxShadow).toBeUndefined();
+        expect(result.nodes.find(n => n.id === 'trader')?.style?.boxShadow).toBeUndefined();
     });
 
     it('should handle nodes removed correctly', () => {
@@ -202,7 +203,7 @@ describe('diffTransformer', () => {
         expect(result.nodes).toHaveLength(7);
         expect(result.nodes.find(n => n.id === 'user-db')?.data.diffStatus).toBe('removed');
         //check styles
-        expect(result.nodes.find(n => n.id === 'user-db')?.style).toEqual({ borderColor: "#dc2626", borderWidth: 2, opacity: 0.6, });
+        expect(result.nodes.find(n => n.id === 'user-db')?.style).toEqual({ boxShadow: '0 0 0 3px #dc2626', borderRadius: '12px', opacity: 0.6 });
     });
 
     it('should handle empty nodes correctly', () => {
@@ -387,7 +388,8 @@ describe('diffTransformer', () => {
         expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment-renamed')?.data.diffStatus).toBe('renamed');
         expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment-renamed')?.data.originalId).toBe('gateway-to-payment');
         //check styles
-        expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment')?.style).toEqual({});
+        // Unchanged edge keeps the main viewer's base styling; renamed edge is recoloured.
+        expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment')?.style).toEqual({ stroke: '#007dff', strokeWidth: 2.5 });
         expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment-renamed')?.style).toEqual({ stroke: '#6366f1', strokeWidth: 3 });
     });
 
@@ -446,9 +448,9 @@ describe('diffTransformer', () => {
         expect(result.edges.find(e => e.data?.['unique-id'] === 'trader-to-gateway')?.data.diffStatus).toBe('unchanged');
         expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment')?.data.diffStatus).toBe('unchanged');
         expect(result.edges.find(e => e.data?.['unique-id'] === 'payment-to-db')?.data.diffStatus).toBe('unchanged');
-        //check styles
-        expect(result.edges.find(e => e.data?.['unique-id'] === 'trader-to-gateway')?.style).toEqual({});
-        expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment')?.style).toEqual({});
-        expect(result.edges.find(e => e.data?.['unique-id'] === 'payment-to-db')?.style).toEqual({});
+        // Unchanged edges retain the main viewer's base styling (no diff recolouring).
+        expect(result.edges.find(e => e.data?.['unique-id'] === 'trader-to-gateway')?.style).toEqual({ stroke: '#007dff', strokeWidth: 2.5 });
+        expect(result.edges.find(e => e.data?.['unique-id'] === 'gateway-to-payment')?.style).toEqual({ stroke: '#007dff', strokeWidth: 2.5 });
+        expect(result.edges.find(e => e.data?.['unique-id'] === 'payment-to-db')?.style).toEqual({ stroke: '#007dff', strokeWidth: 2.5 });
     });
 });

--- a/calm-hub-ui/src/diff/components/utils/diffTransformer.ts
+++ b/calm-hub-ui/src/diff/components/utils/diffTransformer.ts
@@ -49,7 +49,9 @@ export function parseCALMDataWithDiff(
                 diffStatus,
                 originalId,
             } as DiffNodeData,
-            style: getNodeStyle(diffStatus),
+            // Merge the diff highlight on top of the styling produced by the main
+            // viewer's transformer (e.g. system-group dimensions) rather than replacing it.
+            style: { ...node.style, ...getNodeStyle(diffStatus) },
         };
     });
 
@@ -87,7 +89,9 @@ export function parseCALMDataWithDiff(
                 diffStatus,
                 originalId,
             } as DiffEdgeData,
-            style: getEdgeStyle(diffStatus),
+            // Merge the diff colour over the main viewer's edge styling (dash, width)
+            // rather than replacing it, so unchanged edges look identical to the main view.
+            style: { ...edge.style, ...getEdgeStyle(diffStatus) },
         };
     });
 
@@ -98,15 +102,21 @@ export function parseCALMDataWithDiff(
 }
 
 function getNodeStyle(diffStatus?: string): React.CSSProperties {
+    // CustomNode draws its own bordered box, so the diff highlight is a coloured ring
+    // (box-shadow) around the node wrapper — visible without affecting layout/size.
+    const ring = (color: string): React.CSSProperties => ({
+        boxShadow: `0 0 0 3px ${color}`,
+        borderRadius: '12px',
+    });
     switch (diffStatus) {
     case 'added':
-        return { borderColor: '#16a34a', borderWidth: 2 };
+        return ring('#16a34a');
     case 'removed':
-        return { borderColor: '#dc2626', borderWidth: 2, opacity: 0.6 };
+        return { ...ring('#dc2626'), opacity: 0.6 };
     case 'modified':
-        return { borderColor: '#d97706', borderWidth: 2 };
+        return ring('#d97706');
     case 'renamed':
-        return { borderColor: '#6366f1', borderWidth: 2 };
+        return ring('#6366f1');
     case 'unchanged':
     default:
         return {};

--- a/calm-hub-ui/src/diff/model/diff-ui-types.ts
+++ b/calm-hub-ui/src/diff/model/diff-ui-types.ts
@@ -39,4 +39,6 @@ export interface DiffGraphPanelProps {
 
 export interface DiffPanelProps {
     diffResult: DiffResult | null;
+    /** Message shown when there is no diff yet. Defaults to the upload-route wording. */
+    emptyMessage?: string;
 }

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
@@ -270,7 +270,7 @@ describe('DiagramSection', () => {
     });
 
     describe('compare mode', () => {
-        it('renders a Compare button for both architectures and patterns', () => {
+        it('renders a Compare button for architectures but not patterns', () => {
             const { rerender } = render(
                 <MemoryRouter>
                     <DiagramSection data={architectureData} />
@@ -283,7 +283,7 @@ describe('DiagramSection', () => {
                     <DiagramSection data={patternData} />
                 </MemoryRouter>
             );
-            expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /compare versions/i })).not.toBeInTheDocument();
         });
 
         it('enters compare mode when Compare is clicked', async () => {

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { DiagramSection } from './DiagramSection.js';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
@@ -7,6 +7,7 @@ import { Data } from '../../../model/calm.js';
 
 const calmServiceMock = {
     fetchDecoratorValues: vi.fn().mockResolvedValue([]),
+    fetchVersionsByCustomId: vi.fn().mockResolvedValue(['1.0.0', '2.0.0']),
 };
 
 vi.mock('react-router-dom', async () => {
@@ -25,9 +26,14 @@ vi.mock('../../../visualizer/components/drawer/Drawer.js', () => ({
     Drawer: ({ data }: { data: Data }) => <div data-testid="drawer">Drawer for {data.id}</div>
 }));
 
+vi.mock('./compare/CompareView.js', () => ({
+    CompareView: ({ data }: { data: Data }) => <div data-testid="compare-view">Compare for {data.id}</div>
+}));
+
 vi.mock('../../../service/calm-service.js', () => ({
     CalmService: vi.fn().mockImplementation(() => ({
         fetchDecoratorValues: calmServiceMock.fetchDecoratorValues,
+        fetchVersionsByCustomId: calmServiceMock.fetchVersionsByCustomId,
     })),
 }));
 
@@ -51,6 +57,7 @@ describe('DiagramSection', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         calmServiceMock.fetchDecoratorValues.mockResolvedValue([]);
+        calmServiceMock.fetchVersionsByCustomId.mockResolvedValue(['1.0.0', '2.0.0']);
     });
 
     describe('with architecture data', () => {
@@ -224,6 +231,108 @@ describe('DiagramSection', () => {
 
             expect(jsonTab).toHaveClass('tab-active');
             expect(diagramTab).not.toHaveClass('tab-active');
+        });
+    });
+
+    describe('version selector', () => {
+        it('renders the version as a dropdown listing all versions', async () => {
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            const select = (await screen.findByLabelText('Version')) as HTMLSelectElement;
+            expect(select.value).toBe('1.0.0');
+            expect(Array.from(select.querySelectorAll('option')).map((o) => o.value)).toEqual([
+                '2.0.0',
+                '1.0.0',
+            ]);
+        });
+
+        it('navigates to the selected version', async () => {
+            const navigate = vi.fn();
+            vi.mocked(useNavigate).mockReturnValue(navigate);
+
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            const select = await screen.findByLabelText('Version');
+            fireEvent.change(select, { target: { value: '2.0.0' } });
+
+            await waitFor(() => {
+                expect(navigate).toHaveBeenCalledWith('/arch-namespace/architectures/test-arch/2.0.0');
+            });
+        });
+    });
+
+    describe('compare mode', () => {
+        it('renders a Compare button for both architectures and patterns', () => {
+            const { rerender } = render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+            expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+
+            rerender(
+                <MemoryRouter>
+                    <DiagramSection data={patternData} />
+                </MemoryRouter>
+            );
+            expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+        });
+
+        it('enters compare mode when Compare is clicked', async () => {
+            const user = userEvent.setup();
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            expect(screen.getByTestId('drawer')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /compare versions/i }));
+
+            expect(screen.getByTestId('compare-view')).toBeInTheDocument();
+            expect(screen.queryByTestId('drawer')).not.toBeInTheDocument();
+        });
+
+        it('toggles back to the regular view when Compare is clicked again', async () => {
+            const user = userEvent.setup();
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            const compareButton = screen.getByRole('button', { name: /compare versions/i });
+            await user.click(compareButton);
+            expect(screen.getByTestId('compare-view')).toBeInTheDocument();
+
+            await user.click(compareButton);
+            expect(screen.queryByTestId('compare-view')).not.toBeInTheDocument();
+            expect(screen.getByTestId('drawer')).toBeInTheDocument();
+        });
+
+        it('exits compare mode when a tab is clicked', async () => {
+            const user = userEvent.setup();
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            await user.click(screen.getByRole('button', { name: /compare versions/i }));
+            expect(screen.getByTestId('compare-view')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('tab', { name: /diagram/i }));
+            expect(screen.queryByTestId('compare-view')).not.toBeInTheDocument();
+            expect(screen.getByTestId('drawer')).toBeInTheDocument();
         });
     });
 });

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline } from 'react-icons/io5';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoGitCompareOutline } from 'react-icons/io5';
 import { Data } from '../../../model/calm.js';
+import { sortVersionsDescending } from '../../../model/version.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { Drawer } from '../../../visualizer/components/drawer/Drawer.js';
 import { SectionHeader } from '../section-header/SectionHeader.js';
 import { DeploymentPanel } from '../../../visualizer/components/reactflow/DeploymentPanel.js';
+import { CompareView } from './compare/CompareView.js';
+import { fetchVersionList } from './compare/compareData.js';
 import { CalmService } from '../../../service/calm-service.js';
 import type { DeploymentDecorator, SelectedItem } from '../../../visualizer/contracts/contracts.js';
 
@@ -24,16 +27,44 @@ type DiagramTabType = 'diagram' | 'json' | 'deployments';
 
 export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramSectionProps) {
     const [searchParams, setSearchParams] = useSearchParams();
+    const navigate = useNavigate();
     const tabParam = searchParams.get('tab') as DiagramTabType | null;
     const activeTab: DiagramTabType = tabParam ?? 'diagram';
     const calmService = useMemo(() => new CalmService(), []);
     const [decorators, setDecorators] = useState<DeploymentDecorator[]>([]);
+    const [compareMode, setCompareMode] = useState(false);
+    const [versions, setVersions] = useState<string[]>([]);
 
     const setActiveTab = (tab: DiagramTabType) => {
+        setCompareMode(false);
         setSearchParams({ tab }, { replace: true });
     };
 
     const isArchitecture = data.calmType === 'Architectures';
+    const urlType = isArchitecture ? 'architectures' : 'patterns';
+
+    const handleVersionChange = (version: string) => {
+        if (version === data.version) return;
+        navigate(`/${data.name}/${urlType}/${data.id}/${version}`);
+    };
+
+    useEffect(() => {
+        setCompareMode(false);
+    }, [data.name, data.id, data.calmType]);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetchVersionList(calmService, data.name, data.calmType, data.id)
+            .then((list) => {
+                if (!cancelled) setVersions(sortVersionsDescending(list));
+            })
+            .catch(() => {
+                if (!cancelled) setVersions([]);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [calmService, data.name, data.calmType, data.id]);
 
     useEffect(() => {
         if (!isArchitecture) {
@@ -51,7 +82,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
             <button
                 role="tab"
-                className={`tab gap-1 rounded-lg ${activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
+                className={`tab gap-1 rounded-lg ${!compareMode && activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
                 onClick={() => setActiveTab('diagram')}
             >
                 <IoEyeOutline />
@@ -59,7 +90,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             </button>
             <button
                 role="tab"
-                className={`tab gap-1 rounded-lg ${activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
+                className={`tab gap-1 rounded-lg ${!compareMode && activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
                 onClick={() => setActiveTab('json')}
             >
                 <IoCodeOutline />
@@ -68,7 +99,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             {isArchitecture && (
                 <button
                     role="tab"
-                    className={`tab gap-1 rounded-lg ${activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
+                    className={`tab gap-1 rounded-lg ${!compareMode && activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
                     onClick={() => setActiveTab('deployments')}
                 >
                     <IoRocketOutline />
@@ -76,6 +107,18 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                 </button>
             )}
         </div>
+    );
+
+    const compareButton = (
+        <button
+            className={`btn btn-sm gap-1 ${compareMode ? 'btn-active' : 'btn-ghost'}`}
+            onClick={() => setCompareMode((m) => !m)}
+            aria-label="Compare versions"
+            title={compareMode ? 'Exit compare' : 'Compare versions'}
+        >
+            <IoGitCompareOutline />
+            Compare
+        </button>
     );
 
     return (
@@ -86,11 +129,16 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                     namespace={data.name}
                     id={data.id}
                     version={data.version}
+                    versions={versions}
+                    onVersionChange={handleVersionChange}
+                    titleActions={compareButton}
                     rightContent={tabs}
                 />
 
                 <div className="flex-1 min-h-0 overflow-hidden">
-                    {activeTab === 'diagram' ? (
+                    {compareMode ? (
+                        <CompareView data={data} onExit={() => setCompareMode(false)} />
+                    ) : activeTab === 'diagram' ? (
                         <div className="w-full h-full">
                             <Drawer data={data} onItemSelect={onItemSelect} decorators={decorators} />
                         </div>

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -45,7 +45,9 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
 
     const handleVersionChange = (version: string) => {
         if (version === data.version) return;
-        navigate(`/${data.name}/${urlType}/${data.id}/${version}`);
+        // Preserve the active tab when switching version.
+        const query = activeTab !== 'diagram' ? `?tab=${activeTab}` : '';
+        navigate(`/${data.name}/${urlType}/${data.id}/${version}${query}`);
     };
 
     useEffect(() => {
@@ -131,13 +133,13 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                     version={data.version}
                     versions={versions}
                     onVersionChange={handleVersionChange}
-                    titleActions={compareButton}
+                    titleActions={isArchitecture ? compareButton : undefined}
                     rightContent={tabs}
                 />
 
                 <div className="flex-1 min-h-0 overflow-hidden">
-                    {compareMode ? (
-                        <CompareView data={data} onExit={() => setCompareMode(false)} />
+                    {compareMode && data.calmType === 'Architectures' ? (
+                        <CompareView data={data} versions={versions} onExit={() => setCompareMode(false)} />
                     ) : activeTab === 'diagram' ? (
                         <div className="w-full h-full">
                             <Drawer data={data} onItemSelect={onItemSelect} decorators={decorators} />

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareBar.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CompareBar } from './CompareBar.js';
+
+const versions = ['2.0.0', '1.5.0', '1.0.0'];
+
+describe('CompareBar', () => {
+    it('renders both version selectors with all versions', () => {
+        render(
+            <CompareBar
+                versions={versions}
+                versionA="1.0.0"
+                versionB="2.0.0"
+                onChangeA={vi.fn()}
+                onChangeB={vi.fn()}
+                onExit={vi.fn()}
+            />
+        );
+
+        const baseline = screen.getByLabelText('Baseline version') as HTMLSelectElement;
+        const comparison = screen.getByLabelText('Comparison version') as HTMLSelectElement;
+        expect(baseline.value).toBe('1.0.0');
+        expect(comparison.value).toBe('2.0.0');
+        expect(baseline.querySelectorAll('option')).toHaveLength(3);
+    });
+
+    it('fires onChangeA when the baseline version changes', () => {
+        const onChangeA = vi.fn();
+        render(
+            <CompareBar
+                versions={versions}
+                versionA="1.0.0"
+                versionB="2.0.0"
+                onChangeA={onChangeA}
+                onChangeB={vi.fn()}
+                onExit={vi.fn()}
+            />
+        );
+
+        fireEvent.change(screen.getByLabelText('Baseline version'), { target: { value: '1.5.0' } });
+        expect(onChangeA).toHaveBeenCalledWith('1.5.0');
+    });
+
+    it('fires onExit when the close button is clicked', () => {
+        const onExit = vi.fn();
+        render(
+            <CompareBar
+                versions={versions}
+                versionA="1.0.0"
+                versionB="2.0.0"
+                onChangeA={vi.fn()}
+                onChangeB={vi.fn()}
+                onExit={onExit}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Exit compare'));
+        expect(onExit).toHaveBeenCalled();
+    });
+});

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareBar.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareBar.tsx
@@ -1,0 +1,57 @@
+import { IoGitCompareOutline, IoArrowForwardOutline, IoCloseOutline } from 'react-icons/io5';
+
+interface CompareBarProps {
+    versions: string[];
+    versionA: string;
+    versionB: string;
+    onChangeA: (version: string) => void;
+    onChangeB: (version: string) => void;
+    onExit: () => void;
+}
+
+export function CompareBar({ versions, versionA, versionB, onChangeA, onChangeB, onExit }: CompareBarProps) {
+    return (
+        <div
+            className="bg-base-200 px-6 py-2 flex items-center gap-3 border-b border-base-300"
+            data-testid="compare-bar"
+        >
+            <span className="flex items-center gap-2 text-sm font-medium text-base-content/70 shrink-0">
+                <IoGitCompareOutline />
+                Compare
+            </span>
+            <select
+                className="select select-sm select-bordered font-mono text-xs"
+                value={versionA}
+                onChange={(e) => onChangeA(e.target.value)}
+                aria-label="Baseline version"
+            >
+                {versions.map((version) => (
+                    <option key={version} value={version}>
+                        {version}
+                    </option>
+                ))}
+            </select>
+            <IoArrowForwardOutline className="text-base-content/50 shrink-0" />
+            <select
+                className="select select-sm select-bordered font-mono text-xs"
+                value={versionB}
+                onChange={(e) => onChangeB(e.target.value)}
+                aria-label="Comparison version"
+            >
+                {versions.map((version) => (
+                    <option key={version} value={version}>
+                        {version}
+                    </option>
+                ))}
+            </select>
+            <button
+                className="btn btn-ghost btn-sm btn-circle ml-auto"
+                onClick={onExit}
+                aria-label="Exit compare"
+                title="Exit compare"
+            >
+                <IoCloseOutline />
+            </button>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi, Mock } from 'vitest';
+import { CompareView } from './CompareView.js';
+import { Data } from '../../../../model/calm.js';
+import { diffArchitectures } from '@finos/calm-models/diff';
+
+let calmServiceInstance: {
+    fetchVersionsByCustomId: Mock;
+    fetchArchitectureVersions: Mock;
+    fetchPatternVersions: Mock;
+    fetchResourceByCustomId: Mock;
+    fetchArchitecture: Mock;
+    fetchPattern: Mock;
+} | undefined;
+
+vi.mock('../../../../service/calm-service.js', () => ({
+    CalmService: vi.fn().mockImplementation(() => {
+        calmServiceInstance = {
+            fetchVersionsByCustomId: vi.fn().mockResolvedValue(['1.0.0', '2.0.0', '1.5.0']),
+            fetchArchitectureVersions: vi.fn().mockResolvedValue([]),
+            fetchPatternVersions: vi.fn().mockResolvedValue(['1.0.0', '2.0.0']),
+            fetchResourceByCustomId: vi.fn().mockResolvedValue({
+                id: 'test-arch',
+                version: '0.0.0',
+                name: 'arch-namespace',
+                calmType: 'Architectures',
+                data: { nodes: [], relationships: [] },
+            }),
+            fetchArchitecture: vi.fn().mockResolvedValue({}),
+            fetchPattern: vi.fn().mockResolvedValue({}),
+        };
+        return calmServiceInstance;
+    }),
+}));
+
+vi.mock('../../../../diff/components/DiffGraph.js', () => ({
+    DiffGraph: ({ isFirst }: { isFirst: boolean }) => (
+        <div data-testid={isFirst ? 'diff-graph-a' : 'diff-graph-b'}>graph</div>
+    ),
+}));
+
+vi.mock('../../../../diff/components/DiffPanel.js', () => ({
+    DiffPanel: () => <div data-testid="diff-panel">panel</div>,
+}));
+
+vi.mock('@finos/calm-models/diff', () => ({
+    diffArchitectures: vi.fn(() => ({ marker: 'diff' })),
+}));
+
+const architectureData: Data & { calmType: 'Architectures' } = {
+    id: 'test-arch',
+    version: '2.0.0',
+    name: 'arch-namespace',
+    calmType: 'Architectures',
+    data: undefined,
+};
+
+const patternData: Data & { calmType: 'Patterns' } = {
+    id: 'test-pattern',
+    version: '2.0.0',
+    name: 'pattern-namespace',
+    calmType: 'Patterns',
+    data: undefined,
+};
+
+describe('CompareView', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('defaults to comparing the next-older version against the current version', async () => {
+        render(<CompareView data={architectureData} onExit={vi.fn()} />);
+
+        await waitFor(() => {
+            expect((screen.getByLabelText('Baseline version') as HTMLSelectElement).value).toBe('1.5.0');
+            expect((screen.getByLabelText('Comparison version') as HTMLSelectElement).value).toBe('2.0.0');
+        });
+    });
+
+    it('renders both architecture graphs and computes the diff', async () => {
+        render(<CompareView data={architectureData} onExit={vi.fn()} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('diff-graph-a')).toBeInTheDocument();
+            expect(screen.getByTestId('diff-graph-b')).toBeInTheDocument();
+            expect(screen.getByTestId('diff-panel')).toBeInTheDocument();
+            expect(diffArchitectures).toHaveBeenCalled();
+        });
+    });
+
+    it('shows a coming-soon placeholder for patterns and does not diff', async () => {
+        render(<CompareView data={patternData} onExit={vi.fn()} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('pattern-compare-placeholder')).toBeInTheDocument();
+        });
+        expect(diffArchitectures).not.toHaveBeenCalled();
+        expect(calmServiceInstance?.fetchResourceByCustomId).not.toHaveBeenCalled();
+    });
+});

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.test.tsx
@@ -1,24 +1,17 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, it, expect, vi, Mock } from 'vitest';
 import { CompareView } from './CompareView.js';
 import { Data } from '../../../../model/calm.js';
 import { diffArchitectures } from '@finos/calm-models/diff';
 
 let calmServiceInstance: {
-    fetchVersionsByCustomId: Mock;
-    fetchArchitectureVersions: Mock;
-    fetchPatternVersions: Mock;
     fetchResourceByCustomId: Mock;
     fetchArchitecture: Mock;
-    fetchPattern: Mock;
 } | undefined;
 
 vi.mock('../../../../service/calm-service.js', () => ({
     CalmService: vi.fn().mockImplementation(() => {
         calmServiceInstance = {
-            fetchVersionsByCustomId: vi.fn().mockResolvedValue(['1.0.0', '2.0.0', '1.5.0']),
-            fetchArchitectureVersions: vi.fn().mockResolvedValue([]),
-            fetchPatternVersions: vi.fn().mockResolvedValue(['1.0.0', '2.0.0']),
             fetchResourceByCustomId: vi.fn().mockResolvedValue({
                 id: 'test-arch',
                 version: '0.0.0',
@@ -27,7 +20,6 @@ vi.mock('../../../../service/calm-service.js', () => ({
                 data: { nodes: [], relationships: [] },
             }),
             fetchArchitecture: vi.fn().mockResolvedValue({}),
-            fetchPattern: vi.fn().mockResolvedValue({}),
         };
         return calmServiceInstance;
     }),
@@ -47,19 +39,13 @@ vi.mock('@finos/calm-models/diff', () => ({
     diffArchitectures: vi.fn(() => ({ marker: 'diff' })),
 }));
 
+const versions = ['2.0.0', '1.5.0', '1.0.0'];
+
 const architectureData: Data & { calmType: 'Architectures' } = {
     id: 'test-arch',
     version: '2.0.0',
     name: 'arch-namespace',
     calmType: 'Architectures',
-    data: undefined,
-};
-
-const patternData: Data & { calmType: 'Patterns' } = {
-    id: 'test-pattern',
-    version: '2.0.0',
-    name: 'pattern-namespace',
-    calmType: 'Patterns',
     data: undefined,
 };
 
@@ -69,7 +55,7 @@ describe('CompareView', () => {
     });
 
     it('defaults to comparing the next-older version against the current version', async () => {
-        render(<CompareView data={architectureData} onExit={vi.fn()} />);
+        render(<CompareView data={architectureData} versions={versions} onExit={vi.fn()} />);
 
         await waitFor(() => {
             expect((screen.getByLabelText('Baseline version') as HTMLSelectElement).value).toBe('1.5.0');
@@ -78,7 +64,7 @@ describe('CompareView', () => {
     });
 
     it('renders both architecture graphs and computes the diff', async () => {
-        render(<CompareView data={architectureData} onExit={vi.fn()} />);
+        render(<CompareView data={architectureData} versions={versions} onExit={vi.fn()} />);
 
         await waitFor(() => {
             expect(screen.getByTestId('diff-graph-a')).toBeInTheDocument();
@@ -88,13 +74,21 @@ describe('CompareView', () => {
         });
     });
 
-    it('shows a coming-soon placeholder for patterns and does not diff', async () => {
-        render(<CompareView data={patternData} onExit={vi.fn()} />);
+    it('auto-selects the previous version when both selectors would match', async () => {
+        render(<CompareView data={architectureData} versions={versions} onExit={vi.fn()} />);
+
+        // Defaults: baseline 1.5.0, comparison 2.0.0.
+        await waitFor(() => {
+            expect((screen.getByLabelText('Baseline version') as HTMLSelectElement).value).toBe('1.5.0');
+        });
+
+        // Set the comparison version to match the baseline (1.5.0) — baseline should
+        // move to the adjacent (next-older) version, 1.0.0.
+        fireEvent.change(screen.getByLabelText('Comparison version'), { target: { value: '1.5.0' } });
 
         await waitFor(() => {
-            expect(screen.getByTestId('pattern-compare-placeholder')).toBeInTheDocument();
+            expect((screen.getByLabelText('Comparison version') as HTMLSelectElement).value).toBe('1.5.0');
+            expect((screen.getByLabelText('Baseline version') as HTMLSelectElement).value).toBe('1.0.0');
         });
-        expect(diffArchitectures).not.toHaveBeenCalled();
-        expect(calmServiceInstance?.fetchResourceByCustomId).not.toHaveBeenCalled();
     });
 });

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CalmArchitectureSchema } from '@finos/calm-models/types';
+import { diffArchitectures, type DiffResult } from '@finos/calm-models/diff';
+import { CalmService } from '../../../../service/calm-service.js';
+import { Data } from '../../../../model/calm.js';
+import { compareVersions, sortVersionsDescending } from '../../../../model/version.js';
+import { DiffGraph } from '../../../../diff/components/DiffGraph.js';
+import { DiffPanel } from '../../../../diff/components/DiffPanel.js';
+import '../../../../diff/Diff.css';
+import { CompareBar } from './CompareBar.js';
+import { fetchVersionList, fetchVersionData, type ComparableType } from './compareData.js';
+
+interface CompareViewProps {
+    data: Data & { calmType: ComparableType };
+    onExit: () => void;
+}
+
+export function CompareView({ data, onExit }: CompareViewProps) {
+    const calmService = useMemo(() => new CalmService(), []);
+    const [versions, setVersions] = useState<string[]>([]);
+    const [versionA, setVersionA] = useState('');
+    const [versionB, setVersionB] = useState('');
+    const [archA, setArchA] = useState<CalmArchitectureSchema | null>(null);
+    const [archB, setArchB] = useState<CalmArchitectureSchema | null>(null);
+    const [diffResult, setDiffResult] = useState<DiffResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const isArchitecture = data.calmType === 'Architectures';
+
+    // Load the version list and choose sensible defaults: B is the current
+    // (latest) version, A is the next-older version.
+    useEffect(() => {
+        let cancelled = false;
+        fetchVersionList(calmService, data.name, data.calmType, data.id)
+            .then((list) => {
+                if (cancelled) return;
+                const sorted = sortVersionsDescending(list);
+                setVersions(sorted);
+                const b = sorted.includes(data.version) ? data.version : (sorted[0] ?? '');
+                const older = sorted.filter((v) => compareVersions(v, b) < 0);
+                setVersionB(b);
+                setVersionA(older[0] ?? b);
+            })
+            .catch(() => {
+                if (!cancelled) setError('Failed to load versions');
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [calmService, data.name, data.calmType, data.id, data.version]);
+
+    // Fetch both selected versions and compute the diff (architectures only).
+    useEffect(() => {
+        if (!isArchitecture || !versionA || !versionB) return;
+        let cancelled = false;
+        setError(null);
+        Promise.all([
+            fetchVersionData(calmService, data.name, data.calmType, data.id, versionA),
+            fetchVersionData(calmService, data.name, data.calmType, data.id, versionB),
+        ])
+            .then(([a, b]) => {
+                if (cancelled) return;
+                const archAData = (a.data ?? null) as CalmArchitectureSchema | null;
+                const archBData = (b.data ?? null) as CalmArchitectureSchema | null;
+                setArchA(archAData);
+                setArchB(archBData);
+                setDiffResult(archAData && archBData ? diffArchitectures(archAData, archBData) : null);
+            })
+            .catch(() => {
+                if (!cancelled) setError('Failed to load architecture versions');
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [calmService, data.name, data.calmType, data.id, versionA, versionB, isArchitecture]);
+
+    return (
+        <div className="h-full flex flex-col">
+            <CompareBar
+                versions={versions}
+                versionA={versionA}
+                versionB={versionB}
+                onChangeA={setVersionA}
+                onChangeB={setVersionB}
+                onExit={onExit}
+            />
+            {!isArchitecture ? (
+                <div
+                    className="flex-1 flex items-center justify-center text-base-content/60 p-8 text-center"
+                    data-testid="pattern-compare-placeholder"
+                >
+                    Pattern comparison is coming soon. Compare is currently available for architectures.
+                </div>
+            ) : error ? (
+                <div className="flex-1 flex items-center justify-center text-error" data-testid="compare-error">
+                    {error}
+                </div>
+            ) : (
+                <div className="flex-1 flex min-h-0">
+                    <div className="diff-graph-panel">
+                        <div className="architectures-container">
+                            <div className="architecture-panel">
+                                <div className="architecture-header">Baseline: {versionA}</div>
+                                <div className="architecture-graph">
+                                    {archA && (
+                                        <DiffGraph key={`a-${versionA}`} architecture={archA} diffResult={diffResult} isFirst={true} />
+                                    )}
+                                </div>
+                            </div>
+                            <div className="architecture-panel">
+                                <div className="architecture-header">Comparison: {versionB}</div>
+                                <div className="architecture-graph">
+                                    {archB && (
+                                        <DiffGraph key={`b-${versionB}`} architecture={archB} diffResult={diffResult} isFirst={false} />
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <DiffPanel diffResult={diffResult} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
@@ -114,7 +114,7 @@ export function CompareView({ data, versions, onExit }: CompareViewProps) {
                             </div>
                         </div>
                     </div>
-                    <DiffPanel diffResult={diffResult} />
+                    <DiffPanel diffResult={diffResult} emptyMessage="Select two versions to compare." />
                 </div>
             )}
         </div>

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/CompareView.tsx
@@ -3,21 +3,22 @@ import type { CalmArchitectureSchema } from '@finos/calm-models/types';
 import { diffArchitectures, type DiffResult } from '@finos/calm-models/diff';
 import { CalmService } from '../../../../service/calm-service.js';
 import { Data } from '../../../../model/calm.js';
-import { compareVersions, sortVersionsDescending } from '../../../../model/version.js';
+import { compareVersions } from '../../../../model/version.js';
 import { DiffGraph } from '../../../../diff/components/DiffGraph.js';
 import { DiffPanel } from '../../../../diff/components/DiffPanel.js';
 import '../../../../diff/Diff.css';
 import { CompareBar } from './CompareBar.js';
-import { fetchVersionList, fetchVersionData, type ComparableType } from './compareData.js';
+import { fetchVersionData } from './compareData.js';
 
 interface CompareViewProps {
-    data: Data & { calmType: ComparableType };
+    data: Data & { calmType: 'Architectures' };
+    /** Available versions for this resource, sorted newest-first. */
+    versions: string[];
     onExit: () => void;
 }
 
-export function CompareView({ data, onExit }: CompareViewProps) {
+export function CompareView({ data, versions, onExit }: CompareViewProps) {
     const calmService = useMemo(() => new CalmService(), []);
-    const [versions, setVersions] = useState<string[]>([]);
     const [versionA, setVersionA] = useState('');
     const [versionB, setVersionB] = useState('');
     const [archA, setArchA] = useState<CalmArchitectureSchema | null>(null);
@@ -25,33 +26,19 @@ export function CompareView({ data, onExit }: CompareViewProps) {
     const [diffResult, setDiffResult] = useState<DiffResult | null>(null);
     const [error, setError] = useState<string | null>(null);
 
-    const isArchitecture = data.calmType === 'Architectures';
-
-    // Load the version list and choose sensible defaults: B is the current
-    // (latest) version, A is the next-older version.
+    // Choose sensible defaults: B is the currently-viewed version, A is the
+    // next-older version.
     useEffect(() => {
-        let cancelled = false;
-        fetchVersionList(calmService, data.name, data.calmType, data.id)
-            .then((list) => {
-                if (cancelled) return;
-                const sorted = sortVersionsDescending(list);
-                setVersions(sorted);
-                const b = sorted.includes(data.version) ? data.version : (sorted[0] ?? '');
-                const older = sorted.filter((v) => compareVersions(v, b) < 0);
-                setVersionB(b);
-                setVersionA(older[0] ?? b);
-            })
-            .catch(() => {
-                if (!cancelled) setError('Failed to load versions');
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [calmService, data.name, data.calmType, data.id, data.version]);
+        if (versions.length === 0) return;
+        const b = versions.includes(data.version) ? data.version : versions[0];
+        const older = versions.filter((v) => compareVersions(v, b) < 0);
+        setVersionB(b);
+        setVersionA(older[0] ?? b);
+    }, [versions, data.version]);
 
-    // Fetch both selected versions and compute the diff (architectures only).
+    // Fetch both selected versions and compute the diff.
     useEffect(() => {
-        if (!isArchitecture || !versionA || !versionB) return;
+        if (!versionA || !versionB) return;
         let cancelled = false;
         setError(null);
         Promise.all([
@@ -72,7 +59,24 @@ export function CompareView({ data, onExit }: CompareViewProps) {
         return () => {
             cancelled = true;
         };
-    }, [calmService, data.name, data.calmType, data.id, versionA, versionB, isArchitecture]);
+    }, [calmService, data.name, data.calmType, data.id, versionA, versionB]);
+
+    // Keep the two selectors on different versions: when a change would make them
+    // equal, move the other selector to the adjacent (preferring previous/older) version.
+    const adjacentVersion = (version: string): string => {
+        const idx = versions.indexOf(version);
+        return versions[idx + 1] ?? versions[idx - 1] ?? version;
+    };
+
+    const handleChangeA = (version: string) => {
+        setVersionA(version);
+        if (version === versionB) setVersionB(adjacentVersion(version));
+    };
+
+    const handleChangeB = (version: string) => {
+        setVersionB(version);
+        if (version === versionA) setVersionA(adjacentVersion(version));
+    };
 
     return (
         <div className="h-full flex flex-col">
@@ -80,18 +84,11 @@ export function CompareView({ data, onExit }: CompareViewProps) {
                 versions={versions}
                 versionA={versionA}
                 versionB={versionB}
-                onChangeA={setVersionA}
-                onChangeB={setVersionB}
+                onChangeA={handleChangeA}
+                onChangeB={handleChangeB}
                 onExit={onExit}
             />
-            {!isArchitecture ? (
-                <div
-                    className="flex-1 flex items-center justify-center text-base-content/60 p-8 text-center"
-                    data-testid="pattern-compare-placeholder"
-                >
-                    Pattern comparison is coming soon. Compare is currently available for architectures.
-                </div>
-            ) : error ? (
+            {error ? (
                 <div className="flex-1 flex items-center justify-center text-error" data-testid="compare-error">
                     {error}
                 </div>

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/compareData.test.ts
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/compareData.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchVersionList, fetchVersionData } from './compareData.js';
+import { CalmService } from '../../../../service/calm-service.js';
+
+function makeService() {
+    return {
+        fetchVersionsByCustomId: vi.fn().mockResolvedValue(['1.0.0']),
+        fetchArchitectureVersions: vi.fn().mockResolvedValue(['2.0.0']),
+        fetchPatternVersions: vi.fn().mockResolvedValue(['3.0.0']),
+        fetchResourceByCustomId: vi.fn().mockResolvedValue({ id: 'slug' }),
+        fetchArchitecture: vi.fn().mockResolvedValue({ id: 'arch' }),
+        fetchPattern: vi.fn().mockResolvedValue({ id: 'pattern' }),
+    } as unknown as CalmService & {
+        fetchVersionsByCustomId: ReturnType<typeof vi.fn>;
+        fetchArchitectureVersions: ReturnType<typeof vi.fn>;
+        fetchPatternVersions: ReturnType<typeof vi.fn>;
+        fetchResourceByCustomId: ReturnType<typeof vi.fn>;
+        fetchArchitecture: ReturnType<typeof vi.fn>;
+        fetchPattern: ReturnType<typeof vi.fn>;
+    };
+}
+
+describe('fetchVersionList', () => {
+    it('uses the custom-id endpoint for slug identifiers', async () => {
+        const svc = makeService();
+        await fetchVersionList(svc, 'ns', 'Architectures', 'my-arch');
+        expect(svc.fetchVersionsByCustomId).toHaveBeenCalledWith('ns', 'my-arch');
+        expect(svc.fetchArchitectureVersions).not.toHaveBeenCalled();
+    });
+
+    it('uses the architecture endpoint for numeric architecture ids', async () => {
+        const svc = makeService();
+        await fetchVersionList(svc, 'ns', 'Architectures', '42');
+        expect(svc.fetchArchitectureVersions).toHaveBeenCalledWith('ns', '42');
+    });
+
+    it('uses the pattern endpoint for numeric pattern ids', async () => {
+        const svc = makeService();
+        await fetchVersionList(svc, 'ns', 'Patterns', '42');
+        expect(svc.fetchPatternVersions).toHaveBeenCalledWith('ns', '42');
+    });
+});
+
+describe('fetchVersionData', () => {
+    it('uses the custom-id endpoint for slug identifiers, passing the type', async () => {
+        const svc = makeService();
+        await fetchVersionData(svc, 'ns', 'Architectures', 'my-arch', '1.0.0');
+        expect(svc.fetchResourceByCustomId).toHaveBeenCalledWith('ns', 'my-arch', '1.0.0', 'Architectures');
+    });
+
+    it('uses the architecture endpoint for numeric architecture ids', async () => {
+        const svc = makeService();
+        await fetchVersionData(svc, 'ns', 'Architectures', '42', '1.0.0');
+        expect(svc.fetchArchitecture).toHaveBeenCalledWith('ns', '42', '1.0.0');
+    });
+
+    it('uses the pattern endpoint for numeric pattern ids', async () => {
+        const svc = makeService();
+        await fetchVersionData(svc, 'ns', 'Patterns', '42', '1.0.0');
+        expect(svc.fetchPattern).toHaveBeenCalledWith('ns', '42', '1.0.0');
+    });
+});

--- a/calm-hub-ui/src/hub/components/diagram-section/compare/compareData.ts
+++ b/calm-hub-ui/src/hub/components/diagram-section/compare/compareData.ts
@@ -1,0 +1,41 @@
+import { CalmService } from '../../../../service/calm-service.js';
+import { Data, isSlug } from '../../../../model/calm.js';
+
+export type ComparableType = 'Architectures' | 'Patterns';
+
+/**
+ * Fetch the list of available versions for an architecture or pattern, handling
+ * both slug (custom-id) and numeric resource identifiers.
+ */
+export async function fetchVersionList(
+    calmService: CalmService,
+    namespace: string,
+    calmType: ComparableType,
+    id: string,
+): Promise<string[]> {
+    if (isSlug(id)) {
+        return calmService.fetchVersionsByCustomId(namespace, id);
+    }
+    return calmType === 'Architectures'
+        ? calmService.fetchArchitectureVersions(namespace, id)
+        : calmService.fetchPatternVersions(namespace, id);
+}
+
+/**
+ * Fetch a specific version of an architecture or pattern, handling both slug
+ * (custom-id) and numeric resource identifiers.
+ */
+export async function fetchVersionData(
+    calmService: CalmService,
+    namespace: string,
+    calmType: ComparableType,
+    id: string,
+    version: string,
+): Promise<Data> {
+    if (isSlug(id)) {
+        return calmService.fetchResourceByCustomId(namespace, id, version, calmType);
+    }
+    return calmType === 'Architectures'
+        ? calmService.fetchArchitecture(namespace, id, version)
+        : calmService.fetchPattern(namespace, id, version);
+}

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -8,9 +8,14 @@ interface SectionHeaderProps {
     id: string;
     version: string;
     rightContent?: ReactNode;
+    /** When provided (and non-empty), the version renders as a selectable dropdown. */
+    versions?: string[];
+    onVersionChange?: (version: string) => void;
+    /** Rendered inline immediately after the version (e.g. a Compare button). */
+    titleActions?: ReactNode;
 }
 
-export function SectionHeader({ icon, namespace, id, version, rightContent }: SectionHeaderProps) {
+export function SectionHeader({ icon, namespace, id, version, rightContent, versions, onVersionChange, titleActions }: SectionHeaderProps) {
     const [copied, setCopied] = useState(false);
     const [pinned, setPinned] = useState(false);
     const showShareBar = isSlug(id);
@@ -28,10 +33,27 @@ export function SectionHeader({ icon, namespace, id, version, rightContent }: Se
     return (
         <div>
             <div className="bg-base-200 px-6 py-4 flex items-center justify-between border-b border-base-300">
-                <h2 className="text-xl font-semibold flex items-center gap-2">
+                <h2 className="text-xl font-semibold flex items-center gap-2 whitespace-nowrap">
                     {icon}
                     {namespace} <span className="text-gray-400">/</span> {id}{' '}
-                    <span className="text-gray-400">/</span> {version}
+                    <span className="text-gray-400">/</span>{' '}
+                    {versions && versions.length > 0 ? (
+                        <select
+                            className="select select-ghost text-xl font-semibold !h-auto !min-h-0 !py-0 !pl-1 !pr-6 !leading-tight !border-0 focus:!outline-none"
+                            value={version}
+                            onChange={(e) => onVersionChange?.(e.target.value)}
+                            aria-label="Version"
+                        >
+                            {(versions.includes(version) ? versions : [version, ...versions]).map((v) => (
+                                <option key={v} value={v}>
+                                    {v}
+                                </option>
+                            ))}
+                        </select>
+                    ) : (
+                        <span>{version}</span>
+                    )}
+                    {titleActions}
                 </h2>
                 {rightContent}
             </div>

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TreeNavigation, buildNamespaceTree } from './TreeNavigation.js';
 import { CalmService } from '../../../service/calm-service.js';
 import { ControlService } from '../../../service/control-service.js';
 import { InterfaceService } from '../../../service/interface-service.js';
-import { MemoryRouter, useParams } from 'react-router-dom';
+import { MemoryRouter, useParams, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
 
 // Mock react-router-dom
@@ -169,7 +169,6 @@ describe('TreeNavigation', () => {
         await waitFor(() => {
             expect(calmServiceInstance?.fetchNamespaces).toHaveBeenCalled();
             expect(calmServiceInstance?.fetchPatternSummaries).toHaveBeenCalledWith('test-namespace');
-            expect(calmServiceInstance?.fetchPatternVersions).toHaveBeenCalledWith('test-namespace', '102');
             expect(calmServiceInstance?.fetchPattern).toHaveBeenCalledWith('test-namespace', '102', 'v2.0');
         });
     });
@@ -189,7 +188,6 @@ describe('TreeNavigation', () => {
         await waitFor(() => {
             expect(calmServiceInstance?.fetchNamespaces).toHaveBeenCalled();
             expect(calmServiceInstance?.fetchArchitectureSummaries).toHaveBeenCalledWith('test-namespace');
-            expect(calmServiceInstance?.fetchArchitectureVersions).toHaveBeenCalledWith('test-namespace', '201');
             expect(calmServiceInstance?.fetchArchitecture).toHaveBeenCalledWith('test-namespace', '201', 'v2.0');
         });
     });
@@ -209,7 +207,6 @@ describe('TreeNavigation', () => {
         await waitFor(() => {
             expect(calmServiceInstance?.fetchNamespaces).toHaveBeenCalled();
             expect(calmServiceInstance?.fetchFlowSummaries).toHaveBeenCalledWith('test-namespace');
-            expect(calmServiceInstance?.fetchFlowVersions).toHaveBeenCalledWith('test-namespace', '201');
             expect(calmServiceInstance?.fetchFlow).toHaveBeenCalledWith('test-namespace', '201', 'v2.0');
         });
     });
@@ -228,7 +225,6 @@ describe('TreeNavigation', () => {
 
         await waitFor(() => {
             expect(adrServiceInstance?.fetchAdrSummaries).toHaveBeenCalledWith('test-namespace');
-            expect(adrServiceInstance?.fetchAdrRevisions).toHaveBeenCalledWith('test-namespace', '201');
             expect(adrServiceInstance?.fetchAdr).toHaveBeenCalledWith('test-namespace', '201', 'v2.0');
         });
     });
@@ -295,6 +291,42 @@ describe('TreeNavigation', () => {
                 controlName: 'Test Control',
                 controlDescription: 'A control',
             });
+        });
+    });
+
+    it('navigates to the latest version when a resource is clicked', async () => {
+        vi.mocked(useParams).mockReturnValue({});
+        const navigate = vi.fn();
+        vi.mocked(useNavigate).mockReturnValue(navigate);
+        vi.mocked(CalmService).mockImplementationOnce(() => ({
+            fetchNamespaces: vi.fn().mockResolvedValue(['test-namespace']),
+            fetchPatternSummaries: vi.fn().mockResolvedValue([]),
+            fetchFlowSummaries: vi.fn().mockResolvedValue([]),
+            fetchStandardSummaries: vi.fn().mockResolvedValue([]),
+            fetchArchitectureSummaries: vi.fn().mockResolvedValue([{ id: 201, name: 'arch-a', description: '' }]),
+            fetchPatternVersions: vi.fn().mockResolvedValue([]),
+            fetchFlowVersions: vi.fn().mockResolvedValue([]),
+            fetchStandardVersions: vi.fn().mockResolvedValue([]),
+            fetchArchitectureVersions: vi.fn().mockResolvedValue(['1.0.0', '2.0.0', '1.5.0']),
+            fetchPattern: vi.fn().mockResolvedValue({}),
+            fetchFlow: vi.fn().mockResolvedValue({}),
+            fetchStandard: vi.fn().mockResolvedValue({}),
+            fetchArchitecture: vi.fn().mockResolvedValue({}),
+            fetchMappings: vi.fn().mockResolvedValue([]),
+            fetchVersionsByCustomId: vi.fn().mockResolvedValue([]),
+            fetchResourceByCustomId: vi.fn().mockResolvedValue({}),
+        }) as unknown as InstanceType<typeof CalmService>);
+
+        render(<MemoryRouter initialEntries={["/"]}>
+            <TreeNavigation {...mockProps} />
+        </MemoryRouter>);
+
+        fireEvent.click(await screen.findByText('test-namespace'));
+        fireEvent.click(await screen.findByText('Architectures'));
+        fireEvent.click(await screen.findByText('arch-a'));
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('/test-namespace/architectures/201/2.0.0');
         });
     });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -685,14 +685,11 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
             console.warn('No versions found for resource %s; nothing to load', resourceID);
             return;
         }
-        const resourceIDForRoute = type === 'Architectures'
-            ? architectureSummaries
-                .find((summary) => (summary.customId ?? summary.id.toString()) === resourceID || summary.name === resourceID)
-                ?.id
-                ?.toString() ?? resourceID
-            : resourceID;
-        navigate(`${basePath}/${selectedNamespace}/${mapTypeInUIToTypeInUrl(type as TypeInUI)}/${resourceIDForRoute}/${latest}`);
-    }, [navigate, selectedNamespace, calmService, adrService, architectureSummaries]);
+        // Route with the displayed id (slug when present) so the deep-link loads the
+        // same resource and the tree keeps it highlighted. The loader resolves slug vs
+        // numeric ids itself.
+        navigate(`${basePath}/${selectedNamespace}/${mapTypeInUIToTypeInUrl(type as TypeInUI)}/${resourceID}/${latest}`);
+    }, [navigate, selectedNamespace, calmService, adrService]);
 
     const getResourceIDs = (type: string): string[] => {
         const toId = (s: ResourceSummary) => s.customId ?? s.id.toString();

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -680,7 +680,11 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
         setSelectedResourceID(resourceID);
         const versions = await fetchVersionsForResource(resourceID, type, selectedNamespace, calmService, adrService);
         const latest = pickLatestVersion(versions);
-        if (!latest) return;
+        if (!latest) {
+            // arg1 is %s to prevent format string injection from `resourceID`.
+            console.warn('No versions found for resource %s; nothing to load', resourceID);
+            return;
+        }
         const resourceIDForRoute = type === 'Architectures'
             ? architectureSummaries
                 .find((summary) => (summary.customId ?? summary.id.toString()) === resourceID || summary.name === resourceID)

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -5,6 +5,7 @@ import { ControlService } from '../../../service/control-service.js';
 import { InterfaceService } from '../../../service/interface-service.js';
 import { AdrService } from '../../../service/adr-service/adr-service.js';
 import { Data, Adr, ResourceSummary, AdrSummary, ResourceMapping, isSlug } from '../../../model/calm.js';
+import { pickLatestVersion } from '../../../model/version.js';
 
 function mapCalmTypeToResourceType(type: string): string {
     switch (type) {
@@ -42,19 +43,6 @@ interface LoadResourceIdsOptions {
     setAdrSummaries: (summaries: AdrSummary[]) => void;
 }
 
-interface LoadVersionsOptions {
-    resourceID: string;
-    type: string;
-    namespace: string;
-    calmService: CalmService;
-    setArchitectureVersions: (versions: string[]) => void;
-    setPatternVersions: (versions: string[]) => void;
-    setFlowVersions: (versions: string[]) => void;
-    setStandardVersions: (versions: string[]) => void;
-    adrService: AdrService;
-    setAdrRevisions: (revisions: string[]) => void;
-}
-
 interface LoadResourceOptions {
     version: string;
     type: string;
@@ -77,21 +65,12 @@ interface TreeNavigationProps {
     onCollapse?: () => void;
 }
 
-interface VersionItemProps {
-    version: string;
-    isSelected: boolean;
-    onVersionClick: (version: string) => void;
-}
-
 interface ResourceItemProps {
     resourceID: string;
     displayName?: string;
     type: string;
     isSelected: boolean;
-    versions: string[];
-    selectedVersion: string;
     onResourceClick: (resourceID: string, type: string) => void;
-    onVersionClick: (version: string, type: string) => void;
 }
 
 interface ResourceTypeProps {
@@ -100,11 +79,8 @@ interface ResourceTypeProps {
     resourceIDs: string[];
     resourceNames?: Record<string, string>;
     selectedResourceID: string;
-    versions: string[];
-    selectedVersion: string;
     onTypeClick: (type: string) => void;
     onResourceClick: (resourceID: string, type: string) => void;
-    onVersionClick: (version: string, type: string) => void;
 }
 
 interface NamespaceItemProps {
@@ -112,16 +88,13 @@ interface NamespaceItemProps {
     selectedNamespace: string;
     selectedType: string;
     selectedResourceID: string;
-    selectedVersion: string;
     getResourceIDs: (type: string) => string[];
     getResourceNames: (type: string) => Record<string, string>;
-    getVersions: (type: string) => string[];
     namespaceInterfaces: InterfaceDetail[];
     selectedInterfaceId: number | null;
     onNamespaceClick: (namespace: string) => void;
     onTypeClick: (type: string) => void;
     onResourceClick: (resourceID: string, type: string) => void;
-    onVersionClick: (version: string, type: string) => void;
     onInterfaceClick: (iface: InterfaceDetail) => void;
 }
 
@@ -217,50 +190,22 @@ function mapTypeInUIToTypeInUrl(uiType: TypeInUI): TypeInUrl {
     }
 }
 
-function VersionItem({ version, isSelected, onVersionClick }: VersionItemProps) {
-    return (
-        <li>
-            <a className={isSelected ? 'active' : ''} onClick={() => onVersionClick(version)}>
-                {version}
-            </a>
-        </li>
-    );
-}
-
 function ResourceItem({
     resourceID,
     displayName,
     type,
     isSelected,
-    versions,
-    selectedVersion,
     onResourceClick,
-    onVersionClick,
 }: ResourceItemProps) {
     const label = displayName ?? resourceID;
-    if (isSelected) {
-        return (
-            <li>
-                <details open={true}>
-                    <summary className="active">{label}</summary>
-                    <ul>
-                        {versions.map((version) => (
-                            <VersionItem
-                                key={version}
-                                version={version}
-                                isSelected={selectedVersion === version}
-                                onVersionClick={(v) => onVersionClick(v, type)}
-                            />
-                        ))}
-                    </ul>
-                </details>
-            </li>
-        );
-    }
-
     return (
         <li>
-            <a onClick={() => onResourceClick(resourceID, type)}>{label}</a>
+            <a
+                className={isSelected ? 'active' : ''}
+                onClick={() => onResourceClick(resourceID, type)}
+            >
+                {label}
+            </a>
         </li>
     );
 }
@@ -271,11 +216,8 @@ function ResourceType({
     resourceIDs,
     resourceNames,
     selectedResourceID,
-    versions,
-    selectedVersion,
     onTypeClick,
     onResourceClick,
-    onVersionClick,
 }: ResourceTypeProps) {
     if (isSelected) {
         return (
@@ -290,10 +232,7 @@ function ResourceType({
                                 displayName={resourceNames?.[resourceID]}
                                 type={type}
                                 isSelected={selectedResourceID === resourceID}
-                                versions={versions}
-                                selectedVersion={selectedVersion}
                                 onResourceClick={onResourceClick}
-                                onVersionClick={onVersionClick}
                             />
                         ))}
                     </ul>
@@ -314,16 +253,13 @@ function NamespaceItem({
     selectedNamespace,
     selectedType,
     selectedResourceID,
-    selectedVersion,
     getResourceIDs,
     getResourceNames,
-    getVersions,
     namespaceInterfaces,
     selectedInterfaceId,
     onNamespaceClick,
     onTypeClick,
     onResourceClick,
-    onVersionClick,
     onInterfaceClick,
 }: NamespaceItemProps) {
     const resourceTypes = ['Architectures', 'Patterns', 'Flows', 'Standards', 'ADRs', 'Interfaces'];
@@ -396,11 +332,8 @@ function NamespaceItem({
                                     resourceIDs={getResourceIDs(type)}
                                     resourceNames={getResourceNames(type)}
                                     selectedResourceID={selectedResourceID}
-                                    versions={getVersions(type)}
-                                    selectedVersion={selectedVersion}
                                     onTypeClick={onTypeClick}
                                     onResourceClick={onResourceClick}
-                                    onVersionClick={onVersionClick}
                                 />
                             );
                         })}
@@ -411,16 +344,13 @@ function NamespaceItem({
                                 selectedNamespace={selectedNamespace}
                                 selectedType={selectedType}
                                 selectedResourceID={selectedResourceID}
-                                selectedVersion={selectedVersion}
                                 getResourceIDs={getResourceIDs}
                                 getResourceNames={getResourceNames}
-                                getVersions={getVersions}
                                 namespaceInterfaces={namespaceInterfaces}
                                 selectedInterfaceId={selectedInterfaceId}
                                 onNamespaceClick={onNamespaceClick}
                                 onTypeClick={onTypeClick}
                                 onResourceClick={onResourceClick}
-                                onVersionClick={onVersionClick}
                                 onInterfaceClick={onInterfaceClick}
                             />
                         ))}
@@ -455,22 +385,6 @@ function loadResourceIds({
     }
 }
 
-function loadVersionsForId(
-    resourceID: string,
-    type: string,
-    namespace: string,
-    calmService: CalmService,
-    setVersions: { setArchitectureVersions: (v: string[]) => void; setPatternVersions: (v: string[]) => void; setFlowVersions: (v: string[]) => void; setStandardVersions: (v: string[]) => void; },
-) {
-    if (isSlug(resourceID)) {
-        const setter = type === 'Architectures' ? setVersions.setArchitectureVersions
-            : type === 'Patterns' ? setVersions.setPatternVersions
-            : type === 'Flows' ? setVersions.setFlowVersions
-            : setVersions.setStandardVersions;
-        calmService.fetchVersionsByCustomId(namespace, resourceID).then(setter);
-    }
-}
-
 function loadResourceForId(
     version: string,
     type: string,
@@ -484,30 +398,29 @@ function loadResourceForId(
     }
 }
 
-function loadVersions({ 
-    resourceID, 
-    type, 
-    namespace,
-    calmService,
-    setArchitectureVersions, 
-    setPatternVersions, 
-    setFlowVersions, 
-    setStandardVersions,
-    adrService, 
-    setAdrRevisions 
-}: LoadVersionsOptions) {
-    if (type === 'Architectures') {
-        calmService.fetchArchitectureVersions(namespace, resourceID).then(setArchitectureVersions);
-    } else if (type === 'Patterns') {
-        calmService.fetchPatternVersions(namespace, resourceID).then(setPatternVersions);
-    } else if (type === 'Flows') {
-        calmService.fetchFlowVersions(namespace, resourceID).then(setFlowVersions);
-    } else if (type === 'Standards') {
-        calmService.fetchStandardVersions(namespace, resourceID).then(setStandardVersions);
-    } else if (type === 'ADRs') {
-        adrService
-            .fetchAdrRevisions(namespace, resourceID)
-            .then((revisions) => setAdrRevisions(revisions.map((rev) => rev.toString())));
+async function fetchVersionsForResource(
+    resourceID: string,
+    type: string,
+    namespace: string,
+    calmService: CalmService,
+    adrService: AdrService,
+): Promise<string[]> {
+    if (isSlug(resourceID) && type !== 'ADRs') {
+        return calmService.fetchVersionsByCustomId(namespace, resourceID);
+    }
+    switch (type) {
+        case 'Architectures':
+            return calmService.fetchArchitectureVersions(namespace, resourceID);
+        case 'Patterns':
+            return calmService.fetchPatternVersions(namespace, resourceID);
+        case 'Flows':
+            return calmService.fetchFlowVersions(namespace, resourceID);
+        case 'Standards':
+            return calmService.fetchStandardVersions(namespace, resourceID);
+        case 'ADRs':
+            return (await adrService.fetchAdrRevisions(namespace, resourceID)).map((rev) => rev.toString());
+        default:
+            return [];
     }
 }
 
@@ -550,19 +463,12 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
     const [selectedNamespace, setSelectedNamespace] = useState<string>(EMPTY_STR_VALUE);
     const [selectedType, setSelectedType] = useState<string>(EMPTY_STR_VALUE);
     const [selectedResourceID, setSelectedResourceID] = useState<string>(EMPTY_STR_VALUE);
-    const [selectedVersion, setSelectedVersion] = useState<string>(EMPTY_STR_VALUE);
 
     const [architectureSummaries, setArchitectureSummaries] = useState<ResourceSummary[]>([]);
     const [patternSummaries, setPatternSummaries] = useState<ResourceSummary[]>([]);
     const [flowSummaries, setFlowSummaries] = useState<ResourceSummary[]>([]);
     const [standardSummaries, setStandardSummaries] = useState<ResourceSummary[]>([]);
     const [adrSummaries, setAdrSummaries] = useState<AdrSummary[]>([]);
-
-    const [architectureVersions, setArchitectureVersions] = useState<string[]>([]);
-    const [patternVersions, setPatternVersions] = useState<string[]>([]);
-    const [flowVersions, setFlowVersions] = useState<string[]>([]);
-    const [standardVersions, setStandardVersions] = useState<string[]>([]);
-    const [adrRevisions, setAdrRevisions] = useState<string[]>([]);
 
     // Domain / Controls state
     const [domains, setDomains] = useState<string[]>([]);
@@ -671,25 +577,6 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
             });
             setSelectedResourceID(params.id);
             if (isSlug(params.id)) {
-                loadVersionsForId(params.id, uiType, params.namespace, calmService, {
-                    setArchitectureVersions, setPatternVersions, setFlowVersions, setStandardVersions,
-                });
-            } else {
-                loadVersions({
-                    resourceID: params.id,
-                    type: uiType,
-                    namespace: params.namespace,
-                    calmService,
-                    setArchitectureVersions,
-                    setPatternVersions,
-                    setFlowVersions,
-                    setStandardVersions,
-                    adrService,
-                    setAdrRevisions,
-                });
-            }
-            setSelectedVersion(params.version);
-            if (isSlug(params.id)) {
                 loadResourceForId(params.version, uiType, params.namespace, params.id, calmService, onDataLoad);
             } else {
                 loadResource({
@@ -714,7 +601,6 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
         }
         setSelectedType(EMPTY_STR_VALUE);
         setSelectedResourceID(EMPTY_STR_VALUE);
-        setSelectedVersion(EMPTY_STR_VALUE);
         // Clear domain selection when navigating namespaces
         setSelectedDomain('');
         setSelectedControlId(null);
@@ -735,7 +621,6 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
         setSelectedNamespace(EMPTY_STR_VALUE);
         setSelectedType(EMPTY_STR_VALUE);
         setSelectedResourceID(EMPTY_STR_VALUE);
-        setSelectedVersion(EMPTY_STR_VALUE);
         // Clear interface selection when navigating domains
         setNamespaceInterfaces([]);
         setSelectedInterfaceId(null);
@@ -788,43 +673,22 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
             }
         }
         setSelectedResourceID(EMPTY_STR_VALUE);
-        setSelectedVersion(EMPTY_STR_VALUE);
         setSelectedInterfaceId(null);
     }, [selectedNamespace, selectedType, calmService, adrService, interfaceService, enrichWithMappings]);
 
-    const handleResourceClick = useCallback((resourceID: string, type: string) => {
+    const handleResourceClick = useCallback(async (resourceID: string, type: string) => {
         setSelectedResourceID(resourceID);
-        setSelectedVersion(EMPTY_STR_VALUE);
-        if (isSlug(resourceID)) {
-            loadVersionsForId(resourceID, type, selectedNamespace, calmService, {
-                setArchitectureVersions, setPatternVersions, setFlowVersions, setStandardVersions,
-            });
-        } else {
-            loadVersions({
-                resourceID,
-                type,
-                namespace: selectedNamespace,
-                calmService,
-                setArchitectureVersions,
-                setPatternVersions,
-                setFlowVersions,
-                setStandardVersions,
-                adrService,
-                setAdrRevisions,
-            });
-        }
-    }, [selectedNamespace, calmService, adrService]);
-
-    const handleVersionClick = useCallback((version: string, type: string) => {
+        const versions = await fetchVersionsForResource(resourceID, type, selectedNamespace, calmService, adrService);
+        const latest = pickLatestVersion(versions);
+        if (!latest) return;
         const resourceIDForRoute = type === 'Architectures'
             ? architectureSummaries
-                .find((summary) => (summary.customId ?? summary.id.toString()) === selectedResourceID || summary.name === selectedResourceID)
+                .find((summary) => (summary.customId ?? summary.id.toString()) === resourceID || summary.name === resourceID)
                 ?.id
-                ?.toString() ?? selectedResourceID
-            : selectedResourceID;
-
-        navigate(`${basePath}/${selectedNamespace}/${mapTypeInUIToTypeInUrl(type as TypeInUI)}/${resourceIDForRoute}/${version}`);
-    }, [navigate, selectedNamespace, selectedResourceID, architectureSummaries]);
+                ?.toString() ?? resourceID
+            : resourceID;
+        navigate(`${basePath}/${selectedNamespace}/${mapTypeInUIToTypeInUrl(type as TypeInUI)}/${resourceIDForRoute}/${latest}`);
+    }, [navigate, selectedNamespace, calmService, adrService, architectureSummaries]);
 
     const getResourceIDs = (type: string): string[] => {
         const toId = (s: ResourceSummary) => s.customId ?? s.id.toString();
@@ -861,23 +725,6 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
                 );
             default:
                 return {};
-        }
-    };
-
-    const getVersions = (type: string): string[] => {
-        switch (type) {
-            case 'Architectures':
-                return architectureVersions;
-            case 'Patterns':
-                return patternVersions;
-            case 'Flows':
-                return flowVersions;
-            case 'Standards':
-                return standardVersions;
-            case 'ADRs':
-                return adrRevisions;
-            default:
-                return [];
         }
     };
 
@@ -931,16 +778,13 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
                                     selectedNamespace={selectedNamespace}
                                     selectedType={selectedType}
                                     selectedResourceID={selectedResourceID}
-                                    selectedVersion={selectedVersion}
                                     getResourceIDs={getResourceIDs}
                                     getResourceNames={getResourceNames}
-                                    getVersions={getVersions}
                                     namespaceInterfaces={namespaceInterfaces}
                                     selectedInterfaceId={selectedInterfaceId}
                                     onNamespaceClick={handleNamespaceClick}
                                     onTypeClick={handleTypeClick}
                                     onResourceClick={handleResourceClick}
-                                    onVersionClick={handleVersionClick}
                                     onInterfaceClick={handleInterfaceClick}
                                 />
                             ))}

--- a/calm-hub-ui/src/model/version.spec.ts
+++ b/calm-hub-ui/src/model/version.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions, sortVersionsDescending, pickLatestVersion } from './version.js';
+
+describe('compareVersions', () => {
+    it('orders dotted numeric versions numerically', () => {
+        expect(compareVersions('1.0.0', '1.0.1')).toBeLessThan(0);
+        expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0);
+        expect(compareVersions('1.10.0', '1.9.0')).toBeGreaterThan(0);
+    });
+
+    it('treats equal versions as equal', () => {
+        expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+    });
+
+    it('treats a missing trailing segment as lower', () => {
+        expect(compareVersions('1.0', '1.0.1')).toBeLessThan(0);
+        expect(compareVersions('1.0.0', '1.0')).toBe(0);
+    });
+
+    it('falls back to string compare for non-numeric labels', () => {
+        expect(compareVersions('alpha', 'beta')).toBeLessThan(0);
+        expect(compareVersions('beta', 'alpha')).toBeGreaterThan(0);
+    });
+});
+
+describe('sortVersionsDescending', () => {
+    it('returns versions newest-first without mutating the input', () => {
+        const input = ['1.0.0', '2.0.0', '1.5.0'];
+        const result = sortVersionsDescending(input);
+        expect(result).toEqual(['2.0.0', '1.5.0', '1.0.0']);
+        expect(input).toEqual(['1.0.0', '2.0.0', '1.5.0']);
+    });
+});
+
+describe('pickLatestVersion', () => {
+    it('returns the newest version', () => {
+        expect(pickLatestVersion(['1.0.0', '2.1.0', '2.0.0'])).toBe('2.1.0');
+    });
+
+    it('returns undefined for an empty list', () => {
+        expect(pickLatestVersion([])).toBeUndefined();
+    });
+
+    it('returns the only version when the list has one entry', () => {
+        expect(pickLatestVersion(['3.4.5'])).toBe('3.4.5');
+    });
+});

--- a/calm-hub-ui/src/model/version.spec.ts
+++ b/calm-hub-ui/src/model/version.spec.ts
@@ -12,7 +12,7 @@ describe('compareVersions', () => {
         expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
     });
 
-    it('treats a missing trailing segment as lower', () => {
+    it('treats a missing trailing segment as zero', () => {
         expect(compareVersions('1.0', '1.0.1')).toBeLessThan(0);
         expect(compareVersions('1.0.0', '1.0')).toBe(0);
     });

--- a/calm-hub-ui/src/model/version.ts
+++ b/calm-hub-ui/src/model/version.ts
@@ -1,0 +1,47 @@
+/**
+ * Compare two CALM version strings.
+ *
+ * Versions are usually dotted numeric strings (e.g. "1.0.0"), but may also be
+ * arbitrary labels. Numeric dotted versions are compared segment-by-segment
+ * numerically; any non-numeric segment falls back to a locale string compare so
+ * the ordering stays stable for non-semver labels.
+ *
+ * Returns a negative number when `a < b`, positive when `a > b`, and 0 when equal.
+ */
+export function compareVersions(a: string, b: string): number {
+    const segsA = a.split('.');
+    const segsB = b.split('.');
+    const len = Math.max(segsA.length, segsB.length);
+    for (let i = 0; i < len; i++) {
+        const aMissing = i >= segsA.length;
+        const bMissing = i >= segsB.length;
+        const rawA = aMissing ? '' : segsA[i];
+        const rawB = bMissing ? '' : segsB[i];
+        // A missing trailing segment counts as 0, so "1.0" and "1.0.0" compare equal.
+        const numA = aMissing ? 0 : Number(rawA);
+        const numB = bMissing ? 0 : Number(rawB);
+        const aNumeric = aMissing || (rawA !== '' && !Number.isNaN(numA));
+        const bNumeric = bMissing || (rawB !== '' && !Number.isNaN(numB));
+        if (aNumeric && bNumeric) {
+            if (numA !== numB) return numA - numB;
+        } else if (rawA !== rawB) {
+            return rawA.localeCompare(rawB);
+        }
+    }
+    return 0;
+}
+
+/**
+ * Return versions sorted newest-first.
+ */
+export function sortVersionsDescending(versions: string[]): string[] {
+    return [...versions].sort((a, b) => compareVersions(b, a));
+}
+
+/**
+ * Pick the latest (newest) version from a list, or undefined when the list is empty.
+ */
+export function pickLatestVersion(versions: string[]): string | undefined {
+    if (versions.length === 0) return undefined;
+    return sortVersionsDescending(versions)[0];
+}

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -103,6 +103,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick }: Archit
                 onEdgeClick={handleEdgeClick}
                 fitView
                 fitViewOptions={{ padding: 0.2 }}
+                minZoom={0.1}
                 attributionPosition="bottom-left"
                 style={{ background: THEME.colors.background }}
             >

--- a/calm-hub/nitrite/init-nitrite.sh
+++ b/calm-hub/nitrite/init-nitrite.sh
@@ -178,6 +178,50 @@ post_document() {
     fi
 }
 
+# Look up the numeric id of a namespace-scoped resource by its name.
+# Usage: get_resource_id_by_name <namespace> <resource> <name>
+get_resource_id_by_name() {
+    local namespace="$1"
+    local resource="$2"
+    local name="$3"
+
+    curl -s "$CALM_HUB_URL/calm/namespaces/$namespace/$resource" -H "$CONTENT_TYPE" \
+        | jq -r --arg name "$name" '.values[] | select(.name == $name) | .id' \
+        | head -n1
+}
+
+# POST an additional version of an existing architecture (mutable version store).
+# Usage: post_architecture_version <namespace> <architecture-id> <version> <name> <description> <document-json>
+post_architecture_version() {
+    local namespace="$1"
+    local architecture_id="$2"
+    local version="$3"
+    local name="$4"
+    local description="$5"
+    local doc="$6"
+
+    local payload
+    payload=$(jq -n \
+        --arg name "$name" \
+        --arg description "$description" \
+        --argjson doc "$doc" \
+        '{name: $name, description: $description, architectureJson: ($doc | tojson)}')
+
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "$CALM_HUB_URL/calm/namespaces/$namespace/architectures/$architecture_id/versions/$version" \
+        -H "$CONTENT_TYPE" \
+        -d "$payload")
+
+    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+        print_status "Created architecture '$name' version $version in namespace $namespace"
+    elif [[ "$http_code" == "409" ]]; then
+        print_warning "Architecture '$name' version $version already exists, skipping"
+    else
+        print_warning "Failed to create architecture '$name' version $version (HTTP $http_code)"
+    fi
+}
+
 # Function to create patterns
 create_patterns() {
     print_status "Creating patterns..."
@@ -1346,6 +1390,110 @@ CALMDOC
 CALMDOC
 )
     post_document "workshop" "architectures" "architectureJson" "Conference Signup Architecture" "Conference signup system architecture deployed on a Kubernetes cluster" "$doc"
+
+    # Workshop Architecture - second version (2.0.0)
+    # Provides two points-in-time so the calm-hub-ui "Compare" feature has something to diff.
+    # Versus 1.0.0 this adds an attendees cache (node + relationship), tweaks the attendees
+    # service description, and extends the Kubernetes deployment to include the cache.
+    print_status "Creating Workshop architecture version 2.0.0..."
+    local conf_arch_id
+    conf_arch_id=$(get_resource_id_by_name "workshop" "architectures" "Conference Signup Architecture")
+    local doc_v2
+    doc_v2=$(cat <<'CALMDOC'
+{
+            "nodes": [
+                {
+                    "unique-id": "conference-website",
+                    "name": "Conference Website",
+                    "description": "Website to sign up for a conference",
+                    "node-type": "webclient",
+                    "interfaces": [{ "unique-id": "conference-website-url", "url": "[[ URL ]]" }]
+                },
+                {
+                    "unique-id": "load-balancer",
+                    "name": "Load Balancer",
+                    "description": "The attendees service, or a placeholder for another application",
+                    "node-type": "network",
+                    "interfaces": [{ "unique-id": "load-balancer-host-port", "host": "[[ HOST ]]", "port": -1 }]
+                },
+                {
+                    "unique-id": "attendees",
+                    "name": "Attendees Service",
+                    "description": "The attendees service with response caching enabled",
+                    "node-type": "service",
+                    "interfaces": [
+                        { "unique-id": "attendees-image", "image": "[[ IMAGE ]]" },
+                        { "unique-id": "attendees-port", "port": -1 }
+                    ]
+                },
+                {
+                    "unique-id": "attendees-store",
+                    "name": "Attendees Store",
+                    "description": "Persistent storage for attendees",
+                    "node-type": "database",
+                    "interfaces": [
+                        { "unique-id": "database-image", "image": "[[ IMAGE ]]" },
+                        { "unique-id": "database-port", "port": -1 }
+                    ]
+                },
+                {
+                    "unique-id": "attendees-cache",
+                    "name": "Attendees Cache",
+                    "description": "In-memory cache for attendee lookups",
+                    "node-type": "database",
+                    "interfaces": [
+                        { "unique-id": "cache-image", "image": "[[ IMAGE ]]" },
+                        { "unique-id": "cache-port", "port": -1 }
+                    ]
+                },
+                {
+                    "unique-id": "k8s-cluster",
+                    "name": "Kubernetes Cluster",
+                    "description": "Kubernetes Cluster with network policy rules enabled",
+                    "node-type": "system"
+                }
+            ],
+            "relationships": [
+                {
+                    "unique-id": "conference-website-load-balancer",
+                    "description": "Request attendee details",
+                    "protocol": "HTTPS",
+                    "relationship-type": { "connects": { "source": { "node": "conference-website" }, "destination": { "node": "load-balancer" } } }
+                },
+                {
+                    "unique-id": "load-balancer-attendees-service",
+                    "description": "Forward",
+                    "protocol": "mTLS",
+                    "relationship-type": { "connects": { "source": { "node": "load-balancer" }, "destination": { "node": "attendees" } } }
+                },
+                {
+                    "unique-id": "attendees-attendees-store",
+                    "description": "Store or request attendee details",
+                    "protocol": "JDBC",
+                    "relationship-type": { "connects": { "source": { "node": "attendees" }, "destination": { "node": "attendees-store" } } }
+                },
+                {
+                    "unique-id": "attendees-attendees-cache",
+                    "description": "Cache attendee lookups",
+                    "protocol": "RESP",
+                    "relationship-type": { "connects": { "source": { "node": "attendees" }, "destination": { "node": "attendees-cache" } } }
+                },
+                {
+                    "unique-id": "deployed-in-k8s-cluster",
+                    "description": "Components deployed on the k8s cluster",
+                    "relationship-type": { "deployed-in": { "container": "k8s-cluster", "nodes": ["load-balancer", "attendees", "attendees-store", "attendees-cache"] } }
+                }
+            ],
+            "metadata": [{ "kubernetes": { "namespace": "conference" } }],
+            "$schema": "https://calm.finos.org/calm/namespaces/workshop/patterns/1/versions/1.0.0"
+        }
+CALMDOC
+)
+    if [[ -n "$conf_arch_id" ]]; then
+        post_architecture_version "workshop" "$conf_arch_id" "2.0.0" "Conference Signup Architecture" "Conference signup system architecture deployed on a Kubernetes cluster (with attendee caching)" "$doc_v2"
+    else
+        print_warning "Could not resolve Conference Signup Architecture id; skipping 2.0.0 seed"
+    fi
 
     # TraderX Architecture
     print_status "Creating TraderX architecture..."


### PR DESCRIPTION
## Description
Integrates architecture diff / timeline comparison into the main CALM Hub view, building on the diff foundations delivered in #2442. Addresses the visualiser side of #2289.

- The **Explore** panel no longer lists versions — selecting a resource loads its latest version directly (deep-links to a specific version still work for sharing).
- The version is shown as a **dropdown in the diagram header** for quick switching (preserves the active tab).
- A GitHub-style **Compare** button (architectures only) toggles a two-version diff in place of the diagram, with a from/to version picker. Defaults: baseline = previous version, comparison = current; the two selectors auto-avoid landing on the same version.
- The diff graphs **reuse the main viewer's rendering** (theme, layout, node/edge styling) with added / removed / modified / renamed highlights layered on top.
- **Pattern diff is not yet implemented**, so Compare is hidden for patterns (follow-up).
- **Test data**: the Nitrite init script now seeds a second version (`2.0.0`) of the workshop *Conference Signup Architecture*, so the Compare feature has two points-in-time to diff out of the box (run standalone mode: `../mvnw quarkus:dev -Dcalm.database.mode=standalone`, then open `workshop / Architectures / Conference Signup Architecture` and click **Compare**).

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Tested locally against a standalone (Nitrite) CALM Hub, comparing two versions of the Conference Signup architecture. `calm-hub-ui`: 685 tests pass, 0 lint errors, production Vite build clean. Init script changes validated with `bash -n` and against a running hub.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards