### PR TITLE
fix(calm-hub): sync wrapper name/description bug 

### DIFF
--- a/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
@@ -478,4 +478,61 @@ public class MongoControlIntegration {
                 .then()
                 .statusCode(404);
     }
+
+    // --- Wrapper name/description sync from JSON body on new requirement version ---
+
+    @Test
+    @Order(40)
+    void end_to_end_list_controls_returns_wrapper_name_and_description_from_create() {
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values[0].id", equalTo(1))
+                .body("values[0].name", equalTo("Access Control"))
+                .body("values[0].description", equalTo("Ensure proper access control mechanisms"));
+    }
+
+    @Test
+    @Order(41)
+    void end_to_end_create_requirement_version_with_name_and_description_in_json() {
+        String versionBody = "{\"name\": \"Updated Access Control\", \"description\": \"Refined access control requirement\", \"type\": \"requirement-v3\"}";
+
+        given()
+                .body(versionBody)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/3.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/3.0.0"));
+    }
+
+    @Test
+    @Order(42)
+    void end_to_end_list_controls_reflects_updated_name_and_description_after_new_version() {
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == 1 }.name", equalTo("Updated Access Control"))
+                .body("values.find { it.id == 1 }.description", equalTo("Refined access control requirement"));
+    }
+
+    @Test
+    @Order(43)
+    void end_to_end_create_requirement_version_without_name_in_json_preserves_wrapper() {
+        given()
+                .body("{\"type\": \"requirement-v4\"}")
+                .header("Content-Type", "application/json")
+                .when().post("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/4.0.0")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == 1 }.name", equalTo("Updated Access Control"))
+                .body("values.find { it.id == 1 }.description", equalTo("Refined access control requirement"));
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/MongoPatternIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoPatternIntegration.java
@@ -122,4 +122,62 @@ public class MongoPatternIntegration {
                 .statusCode(200)
                 .body(equalTo(PATTERN));
     }
+
+    // --- Wrapper name/description sync from JSON body on new version ---
+
+    @Test
+    @Order(5)
+    void end_to_end_list_patterns_returns_wrapper_name_and_description_from_create() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values", hasSize(1))
+                .body("values[0].name", equalTo("name"))
+                .body("values[0].description", equalTo("description"));
+    }
+
+    @Test
+    @Order(6)
+    void end_to_end_create_pattern_version_with_name_and_description_in_json() {
+        String versionBody = "{\"name\": \"updated-pattern\", \"description\": \"updated pattern description\", \"nodes\": []}";
+
+        given()
+                .body(versionBody)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/1/versions/2.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/1/versions/2.0.0"));
+    }
+
+    @Test
+    @Order(7)
+    void end_to_end_list_patterns_reflects_updated_name_and_description_after_new_version() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values", hasSize(1))
+                .body("values[0].name", equalTo("updated-pattern"))
+                .body("values[0].description", equalTo("updated pattern description"));
+    }
+
+    @Test
+    @Order(8)
+    void end_to_end_create_pattern_version_without_name_in_json_preserves_wrapper() {
+        given()
+                .body("{\"nodes\": [], \"relationships\": []}")
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/1/versions/3.0.0")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values[0].name", equalTo("updated-pattern"))
+                .body("values[0].description", equalTo("updated pattern description"));
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/NitriteControlIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteControlIntegration.java
@@ -446,4 +446,61 @@ public class NitriteControlIntegration {
                 .then()
                 .statusCode(404);
     }
+
+    // --- Wrapper name/description sync from JSON body on new requirement version ---
+
+    @Test
+    @Order(40)
+    void end_to_end_list_controls_returns_wrapper_name_and_description_from_create() {
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values[0].id", equalTo(1))
+                .body("values[0].name", equalTo("Access Control"))
+                .body("values[0].description", equalTo("Ensure proper access control mechanisms"));
+    }
+
+    @Test
+    @Order(41)
+    void end_to_end_create_requirement_version_with_name_and_description_in_json() {
+        String versionBody = "{\"name\": \"Updated Access Control\", \"description\": \"Refined access control requirement\", \"type\": \"requirement-v3\"}";
+
+        given()
+                .body(versionBody)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/3.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/3.0.0"));
+    }
+
+    @Test
+    @Order(42)
+    void end_to_end_list_controls_reflects_updated_name_and_description_after_new_version() {
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == 1 }.name", equalTo("Updated Access Control"))
+                .body("values.find { it.id == 1 }.description", equalTo("Refined access control requirement"));
+    }
+
+    @Test
+    @Order(43)
+    void end_to_end_create_requirement_version_without_name_in_json_preserves_wrapper() {
+        given()
+                .body("{\"type\": \"requirement-v4\"}")
+                .header("Content-Type", "application/json")
+                .when().post("/calm/domains/" + VALID_DOMAIN + "/controls/1/requirement/versions/4.0.0")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == 1 }.name", equalTo("Updated Access Control"))
+                .body("values.find { it.id == 1 }.description", equalTo("Refined access control requirement"));
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/NitritePatternIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitritePatternIntegration.java
@@ -72,4 +72,63 @@ public class NitritePatternIntegration {
                 .statusCode(200)
                 .body(equalTo(PATTERN));
     }
+
+    // --- Wrapper name/description sync from JSON body on new version ---
+
+    @Test
+    @Order(4)
+    void end_to_end_list_patterns_returns_wrapper_name_and_description_from_create() {
+        int id = Integer.parseInt(createdPatternId);
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == " + id + " }.name", equalTo("name"))
+                .body("values.find { it.id == " + id + " }.description", equalTo("description"));
+    }
+
+    @Test
+    @Order(5)
+    void end_to_end_create_pattern_version_with_name_and_description_in_json() {
+        String versionBody = "{\"name\": \"updated-pattern\", \"description\": \"updated pattern description\", \"nodes\": []}";
+
+        given()
+                .body(versionBody)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/" + createdPatternId + "/versions/2.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/" + createdPatternId + "/versions/2.0.0"));
+    }
+
+    @Test
+    @Order(6)
+    void end_to_end_list_patterns_reflects_updated_name_and_description_after_new_version() {
+        int id = Integer.parseInt(createdPatternId);
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == " + id + " }.name", equalTo("updated-pattern"))
+                .body("values.find { it.id == " + id + " }.description", equalTo("updated pattern description"));
+    }
+
+    @Test
+    @Order(7)
+    void end_to_end_create_pattern_version_without_name_in_json_preserves_wrapper() {
+        int id = Integer.parseInt(createdPatternId);
+        given()
+                .body("{\"nodes\": [], \"relationships\": []}")
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/" + createdPatternId + "/versions/3.0.0")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == " + id + " }.name", equalTo("updated-pattern"))
+                .body("values.find { it.id == " + id + " }.description", equalTo("updated pattern description"));
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/CalmJsonMetadata.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/CalmJsonMetadata.java
@@ -1,0 +1,73 @@
+package org.finos.calm.domain;
+
+import org.bson.Document;
+
+/**
+ * Extracts the {@code name} and {@code description} fields from CALM JSON content
+ * (patterns and control requirements). Used by stores to keep the wrapper-level
+ * {@code name}/{@code description} in sync with the latest version's JSON body, so
+ * list endpoints reflect the most recently posted content.
+ *
+ * <p>Both pattern and control-requirement schemas declare {@code name} and
+ * {@code description} as required top-level string fields. When the JSON cannot be
+ * parsed, or the fields are missing/non-string, the corresponding accessor returns
+ * {@code null} and callers should fall back to their existing wrapper values.
+ */
+public final class CalmJsonMetadata {
+
+    private final String name;
+    private final String description;
+
+    private CalmJsonMetadata(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean hasName() {
+        return name != null && !name.isBlank();
+    }
+
+    public boolean hasDescription() {
+        return description != null && !description.isBlank();
+    }
+
+    /**
+     * Parses {@code json} and returns the top-level {@code name} / {@code description}
+     * string fields if present. Returns an empty instance (both {@code null}) if the
+     * input is blank, fails to parse, or the fields are absent/non-string.
+     */
+    public static CalmJsonMetadata extract(String json) {
+        if (json == null || json.isBlank()) {
+            return new CalmJsonMetadata(null, null);
+        }
+        try {
+            return extract(Document.parse(json));
+        } catch (RuntimeException e) {
+            return new CalmJsonMetadata(null, null);
+        }
+    }
+
+    /**
+     * Reads the top-level {@code name} / {@code description} string fields from an
+     * already-parsed {@link Document}. Returns an empty instance if {@code parsed} is
+     * {@code null} or the fields are missing/non-string.
+     */
+    public static CalmJsonMetadata extract(Document parsed) {
+        if (parsed == null) {
+            return new CalmJsonMetadata(null, null);
+        }
+        Object name = parsed.get("name");
+        Object description = parsed.get("description");
+        return new CalmJsonMetadata(
+                name instanceof String s ? s : null,
+                description instanceof String s ? s : null);
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
@@ -153,7 +153,7 @@ public class ControlResource {
     @Path("{domain}/controls/{controlId}/requirement/versions/{version}")
     @Operation(
             summary = "Create a new requirement version for a control",
-            description = "Creates a new version of the requirement for an existing control"
+            description = "Creates a new version of the requirement for an existing control. The wrapper-level name and description used by the control listing endpoint are refreshed from the top-level `name` and `description` fields of the supplied JSON body when present, so listings reflect the latest version's metadata."
     )
     @PermittedScopes({CalmHubScopes.ARCHITECTURES_ALL})
     public Response createRequirementForVersion(

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -154,6 +154,10 @@ public class PatternResource {
     @Path("{namespace}/patterns/{patternId}/versions/{version}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Create a new version of an existing pattern",
+            description = "Stores a new version of the pattern under the supplied {version}. The wrapper-level name and description used by the pattern listing endpoint are refreshed from the top-level `name` and `description` fields of the supplied JSON body when present, so listings reflect the latest version's metadata."
+    )
     @PermittedScopes({CalmHubScopes.ARCHITECTURES_ALL})
     public Response createVersionedPattern(
             @PathParam("namespace") @jakarta.validation.constraints.Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
@@ -189,7 +193,7 @@ public class PatternResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Updates a Pattern (if available)",
-            description = "In mutable version stores pattern updates are supported by this endpoint, operation unavailable returned in repositories without configuration specified"
+            description = "In mutable version stores pattern updates are supported by this endpoint, operation unavailable returned in repositories without configuration specified. The wrapper-level name and description used by the pattern listing endpoint are refreshed from the top-level `name` and `description` fields of the supplied JSON body when present."
     )
     @PermittedScopes({CalmHubScopes.ARCHITECTURES_ALL})
     public Response updateVersionedPattern(

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -104,9 +104,8 @@ public class MongoControlStore implements ControlStore {
         int controlId = counterStore.getNextControlSequenceValue();
 
         Document parsedRequirement = Document.parse(request.getRequirementJson());
-        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedRequirement);
-        String name = metadata.hasName() ? metadata.getName() : request.getName();
-        String description = metadata.hasDescription() ? metadata.getDescription() : request.getDescription();
+        String name = request.getName();
+        String description = request.getDescription();
 
         Document requirementVersions = new Document("1-0-0", parsedRequirement);
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.finos.calm.domain.CalmJsonMetadata;
 import org.finos.calm.domain.controls.ControlDetail;
 import org.finos.calm.domain.controls.CreateControlConfiguration;
 import org.finos.calm.domain.controls.CreateControlRequirement;
@@ -102,11 +103,16 @@ public class MongoControlStore implements ControlStore {
 
         int controlId = counterStore.getNextControlSequenceValue();
 
-        Document requirementVersions = new Document("1-0-0", Document.parse(request.getRequirementJson()));
+        Document parsedRequirement = Document.parse(request.getRequirementJson());
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedRequirement);
+        String name = metadata.hasName() ? metadata.getName() : request.getName();
+        String description = metadata.hasDescription() ? metadata.getDescription() : request.getDescription();
+
+        Document requirementVersions = new Document("1-0-0", parsedRequirement);
 
         Document controlDoc = new Document("controlId", controlId)
-                .append("name", request.getName())
-                .append("description", request.getDescription())
+                .append("name", name)
+                .append("description", description)
                 .append("requirement", requirementVersions)
                 .append("configurations", new ArrayList<>());
 
@@ -116,7 +122,7 @@ public class MongoControlStore implements ControlStore {
                 new UpdateOptions().upsert(true)
         );
 
-        return new ControlDetail(controlId, request.getName(), request.getDescription());
+        return new ControlDetail(controlId, name, description);
     }
 
     @Override
@@ -208,14 +214,23 @@ public class MongoControlStore implements ControlStore {
 
         String mongoVersion = version.replace('.', '-');
 
+        Document parsedRequirement = Document.parse(requirementJson);
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedRequirement);
+
         // Atomic conditional update: only succeeds if the requirement version doesn't already exist
         Document filter = new Document("domain", domain)
                 .append("controls", new Document("$elemMatch",
                         new Document("controlId", controlId)
                                 .append("requirement." + mongoVersion, new Document("$exists", false))));
 
-        Document update = new Document("$set",
-                new Document("controls.$.requirement." + mongoVersion, Document.parse(requirementJson)));
+        Document setFields = new Document("controls.$.requirement." + mongoVersion, parsedRequirement);
+        if (metadata.hasName()) {
+            setFields.append("controls.$.name", metadata.getName());
+        }
+        if (metadata.hasDescription()) {
+            setFields.append("controls.$.description", metadata.getDescription());
+        }
+        Document update = new Document("$set", setFields);
 
         if (controlCollection.updateOne(filter, update).getMatchedCount() == 0) {
             throw new ControlRequirementVersionExistsException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.finos.calm.domain.CalmJsonMetadata;
 import org.finos.calm.domain.Pattern;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
@@ -89,11 +90,16 @@ public class MongoPatternStore implements PatternStore {
         }
 
         int id = counterStore.getNextPatternSequenceValue();
+        Document parsedPattern = Document.parse(patternRequest.getPatternJson());
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedPattern);
+        String name = metadata.hasName() ? metadata.getName() : patternRequest.getName();
+        String description = metadata.hasDescription() ? metadata.getDescription() : patternRequest.getDescription();
+
         Document patternDocument = new Document("patternId", id)
-                .append("name", patternRequest.getName())
-                .append("description", patternRequest.getDescription())
+                .append("name", name)
+                .append("description", description)
                 .append("versions",
-                new Document("1-0-0", Document.parse(patternRequest.getPatternJson())));
+                new Document("1-0-0", parsedPattern));
 
         patternCollection.updateOne(
                 Filters.eq("namespace", namespace),
@@ -178,14 +184,23 @@ public class MongoPatternStore implements PatternStore {
         // Validates namespace and pattern existence
         getPatternVersions(pattern);
 
+        Document parsedPattern = Document.parse(pattern.getPatternJson());
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedPattern);
+
         // Atomic conditional update: only succeeds if the version doesn't already exist
         Document filter = new Document("namespace", pattern.getNamespace())
                 .append("patterns", new Document("$elemMatch",
                         new Document("patternId", pattern.getId())
                                 .append("versions." + pattern.getMongoVersion(), new Document("$exists", false))));
 
-        Document update = new Document("$set",
-                new Document("patterns.$.versions." + pattern.getMongoVersion(), Document.parse(pattern.getPatternJson())));
+        Document setFields = new Document("patterns.$.versions." + pattern.getMongoVersion(), parsedPattern);
+        if (metadata.hasName()) {
+            setFields.append("patterns.$.name", metadata.getName());
+        }
+        if (metadata.hasDescription()) {
+            setFields.append("patterns.$.description", metadata.getDescription());
+        }
+        Document update = new Document("$set", setFields);
 
         if (patternCollection.updateOne(filter, update).getMatchedCount() == 0) {
             throw new PatternVersionExistsException();
@@ -207,10 +222,17 @@ public class MongoPatternStore implements PatternStore {
         retrievePatternVersions(pattern);
 
         Document patternDocument = Document.parse(pattern.getPatternJson());
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(patternDocument);
         Document filter = new Document("namespace", pattern.getNamespace())
                 .append("patterns.patternId", pattern.getId());
-        Document update = new Document("$set",
-                new Document("patterns.$.versions." + pattern.getMongoVersion(), patternDocument));
+        Document setFields = new Document("patterns.$.versions." + pattern.getMongoVersion(), patternDocument);
+        if (metadata.hasName()) {
+            setFields.append("patterns.$.name", metadata.getName());
+        }
+        if (metadata.hasDescription()) {
+            setFields.append("patterns.$.description", metadata.getDescription());
+        }
+        Document update = new Document("$set", setFields);
 
         try {
             patternCollection.updateOne(filter, update, new UpdateOptions().upsert(true));

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -91,9 +91,8 @@ public class MongoPatternStore implements PatternStore {
 
         int id = counterStore.getNextPatternSequenceValue();
         Document parsedPattern = Document.parse(patternRequest.getPatternJson());
-        CalmJsonMetadata metadata = CalmJsonMetadata.extract(parsedPattern);
-        String name = metadata.hasName() ? metadata.getName() : patternRequest.getName();
-        String description = metadata.hasDescription() ? metadata.getDescription() : patternRequest.getDescription();
+        String name = patternRequest.getName();
+        String description = patternRequest.getDescription();
 
         Document patternDocument = new Document("patternId", id)
                 .append("name", name)

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -90,9 +90,8 @@ public class NitriteControlStore implements ControlStore {
         try {
             int controlId = counterStore.getNextControlSequenceValue();
 
-            CalmJsonMetadata metadata = CalmJsonMetadata.extract(request.getRequirementJson());
-            String name = metadata.hasName() ? metadata.getName() : request.getName();
-            String description = metadata.hasDescription() ? metadata.getDescription() : request.getDescription();
+            String name = request.getName();
+            String description = request.getDescription();
 
         Document requirementVersions = Document.createDocument()
                 .put("1-0-0", request.getRequirementJson());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -7,6 +7,7 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.domain.CalmJsonMetadata;
 import org.finos.calm.domain.controls.ControlDetail;
 import org.finos.calm.domain.controls.CreateControlConfiguration;
 import org.finos.calm.domain.controls.CreateControlRequirement;
@@ -89,13 +90,17 @@ public class NitriteControlStore implements ControlStore {
         try {
             int controlId = counterStore.getNextControlSequenceValue();
 
+            CalmJsonMetadata metadata = CalmJsonMetadata.extract(request.getRequirementJson());
+            String name = metadata.hasName() ? metadata.getName() : request.getName();
+            String description = metadata.hasDescription() ? metadata.getDescription() : request.getDescription();
+
         Document requirementVersions = Document.createDocument()
                 .put("1-0-0", request.getRequirementJson());
 
         Document controlDoc = Document.createDocument()
                 .put(CONTROL_ID_FIELD, controlId)
-                .put("name", request.getName())
-                .put("description", request.getDescription())
+                .put("name", name)
+                .put("description", description)
                 .put(REQUIREMENT_FIELD, requirementVersions)
                 .put(CONFIGURATIONS_FIELD, new ArrayList<>());
 
@@ -121,7 +126,7 @@ public class NitriteControlStore implements ControlStore {
             controlCollection.update(where(DOMAIN_FIELD).eq(domain), existingDoc);
         }
 
-            return new ControlDetail(controlId, request.getName(), request.getDescription());
+            return new ControlDetail(controlId, name, description);
         } finally {
             lock.unlock();
         }
@@ -231,6 +236,14 @@ public class NitriteControlStore implements ControlStore {
                 controlDoc.put(REQUIREMENT_FIELD, requirement);
             }
             requirement.put(nitriteVersion, requirementJson);
+
+            CalmJsonMetadata metadata = CalmJsonMetadata.extract(requirementJson);
+            if (metadata.hasName()) {
+                controlDoc.put("name", metadata.getName());
+            }
+            if (metadata.hasDescription()) {
+                controlDoc.put("description", metadata.getDescription());
+            }
 
             controlCollection.update(where(DOMAIN_FIELD).eq(domain), domainDoc);
         } finally {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -93,37 +93,37 @@ public class NitriteControlStore implements ControlStore {
             String name = request.getName();
             String description = request.getDescription();
 
-        Document requirementVersions = Document.createDocument()
-                .put("1-0-0", request.getRequirementJson());
+            Document requirementVersions = Document.createDocument()
+                    .put("1-0-0", request.getRequirementJson());
 
-        Document controlDoc = Document.createDocument()
-                .put(CONTROL_ID_FIELD, controlId)
-                .put("name", name)
-                .put("description", description)
-                .put(REQUIREMENT_FIELD, requirementVersions)
-                .put(CONFIGURATIONS_FIELD, new ArrayList<>());
+            Document controlDoc = Document.createDocument()
+                    .put(CONTROL_ID_FIELD, controlId)
+                    .put("name", name)
+                    .put("description", description)
+                    .put(REQUIREMENT_FIELD, requirementVersions)
+                    .put(CONFIGURATIONS_FIELD, new ArrayList<>());
 
-        Document existingDoc = controlCollection.find(where(DOMAIN_FIELD).eq(domain)).firstOrNull();
+            Document existingDoc = controlCollection.find(where(DOMAIN_FIELD).eq(domain)).firstOrNull();
 
-        if (existingDoc == null) {
-            List<Document> controls = new ArrayList<>();
-            controls.add(controlDoc);
-            Document newDoc = Document.createDocument()
-                    .put(DOMAIN_FIELD, domain)
-                    .put(CONTROLS_FIELD, controls);
-            controlCollection.insert(newDoc);
-        } else {
-            @SuppressWarnings("unchecked")
-            List<Document> controls = (List<Document>) existingDoc.get(CONTROLS_FIELD);
-            if (controls == null) {
-                controls = new ArrayList<>();
+            if (existingDoc == null) {
+                List<Document> controls = new ArrayList<>();
+                controls.add(controlDoc);
+                Document newDoc = Document.createDocument()
+                        .put(DOMAIN_FIELD, domain)
+                        .put(CONTROLS_FIELD, controls);
+                controlCollection.insert(newDoc);
             } else {
-                controls = new ArrayList<>(controls);
+                @SuppressWarnings("unchecked")
+                List<Document> controls = (List<Document>) existingDoc.get(CONTROLS_FIELD);
+                if (controls == null) {
+                    controls = new ArrayList<>();
+                } else {
+                    controls = new ArrayList<>(controls);
+                }
+                controls.add(controlDoc);
+                existingDoc.put(CONTROLS_FIELD, controls);
+                controlCollection.update(where(DOMAIN_FIELD).eq(domain), existingDoc);
             }
-            controls.add(controlDoc);
-            existingDoc.put(CONTROLS_FIELD, controls);
-            controlCollection.update(where(DOMAIN_FIELD).eq(domain), existingDoc);
-        }
 
             return new ControlDetail(controlId, name, description);
         } finally {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -9,6 +9,7 @@ import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.domain.CalmJsonMetadata;
 import org.finos.calm.domain.Pattern;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
@@ -120,10 +121,14 @@ public class NitritePatternStore implements PatternStore {
             Filter filter = where(NAMESPACE_FIELD).eq(namespace);
             Document namespaceDocument = patternCollection.find(filter).firstOrNull();
 
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(patternRequest.getPatternJson());
+        String name = metadata.hasName() ? metadata.getName() : patternRequest.getName();
+        String description = metadata.hasDescription() ? metadata.getDescription() : patternRequest.getDescription();
+
         Document patternDocument = Document.createDocument()
                 .put(PATTERN_ID_FIELD, id)
-                .put(NAME_FIELD, patternRequest.getName())
-                .put(DESCRIPTION_FIELD, patternRequest.getDescription())
+                .put(NAME_FIELD, name)
+                .put(DESCRIPTION_FIELD, description)
                 .put(VERSIONS_FIELD, Document.createDocument().put("1-0-0", patternRequest.getPatternJson()));
 
         if (namespaceDocument == null) {
@@ -248,6 +253,14 @@ public class NitritePatternStore implements PatternStore {
             versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
             patternDoc.put(VERSIONS_FIELD, versions);
 
+            CalmJsonMetadata metadata = CalmJsonMetadata.extract(pattern.getPatternJson());
+            if (metadata.hasName()) {
+                patternDoc.put(NAME_FIELD, metadata.getName());
+            }
+            if (metadata.hasDescription()) {
+                patternDoc.put(DESCRIPTION_FIELD, metadata.getDescription());
+            }
+
             // Update the pattern in the namespace document
             List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
             // Create a mutable copy of the list
@@ -295,6 +308,14 @@ public class NitritePatternStore implements PatternStore {
         Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
         versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
         patternDoc.put(VERSIONS_FIELD, versions);
+
+        CalmJsonMetadata metadata = CalmJsonMetadata.extract(pattern.getPatternJson());
+        if (metadata.hasName()) {
+            patternDoc.put(NAME_FIELD, metadata.getName());
+        }
+        if (metadata.hasDescription()) {
+            patternDoc.put(DESCRIPTION_FIELD, metadata.getDescription());
+        }
 
         // Update the pattern in the namespace document
         List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -121,43 +121,43 @@ public class NitritePatternStore implements PatternStore {
             Filter filter = where(NAMESPACE_FIELD).eq(namespace);
             Document namespaceDocument = patternCollection.find(filter).firstOrNull();
 
-        String name = patternRequest.getName();
-        String description = patternRequest.getDescription();
+            String name = patternRequest.getName();
+            String description = patternRequest.getDescription();
 
-        Document patternDocument = Document.createDocument()
-                .put(PATTERN_ID_FIELD, id)
-                .put(NAME_FIELD, name)
-                .put(DESCRIPTION_FIELD, description)
-                .put(VERSIONS_FIELD, Document.createDocument().put("1-0-0", patternRequest.getPatternJson()));
+            Document patternDocument = Document.createDocument()
+                    .put(PATTERN_ID_FIELD, id)
+                    .put(NAME_FIELD, name)
+                    .put(DESCRIPTION_FIELD, description)
+                    .put(VERSIONS_FIELD, Document.createDocument().put("1-0-0", patternRequest.getPatternJson()));
 
-        if (namespaceDocument == null) {
-            // Create new namespace document with pattern
-            Document newNamespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, namespace)
-                    .put(PATTERNS_FIELD, List.of(patternDocument));
+            if (namespaceDocument == null) {
+                // Create new namespace document with pattern
+                Document newNamespaceDoc = Document.createDocument()
+                        .put(NAMESPACE_FIELD, namespace)
+                        .put(PATTERNS_FIELD, List.of(patternDocument));
 
-            patternCollection.insert(newNamespaceDoc);
-        } else {
-            // Update existing namespace document
-            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class)
-                    .getList(PATTERNS_FIELD);
-            if (patterns == null) {
-                patterns = new ArrayList<>();
+                patternCollection.insert(newNamespaceDoc);
             } else {
-                patterns = new ArrayList<>(patterns); // Make a mutable copy
+                // Update existing namespace document
+                List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class)
+                        .getList(PATTERNS_FIELD);
+                if (patterns == null) {
+                    patterns = new ArrayList<>();
+                } else {
+                    patterns = new ArrayList<>(patterns); // Make a mutable copy
+                }
+                patterns.add(patternDocument);
+
+                namespaceDocument.put(PATTERNS_FIELD, patterns);
+                patternCollection.update(filter, namespaceDocument);
             }
-            patterns.add(patternDocument);
 
-            namespaceDocument.put(PATTERNS_FIELD, patterns);
-            patternCollection.update(filter, namespaceDocument);
-        }
-
-        Pattern persistedPattern = new Pattern.PatternBuilder()
-                .setId(id)
-                .setNamespace(namespace)
-                .setPattern(patternRequest.getPatternJson())
-                .setVersion("1-0-0")
-                .build();
+            Pattern persistedPattern = new Pattern.PatternBuilder()
+                    .setId(id)
+                    .setNamespace(namespace)
+                    .setPattern(patternRequest.getPatternJson())
+                    .setVersion("1-0-0")
+                    .build();
 
             LOG.info("Created pattern with ID {} for namespace '{}'", id, namespace);
             return persistedPattern;

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -121,9 +121,8 @@ public class NitritePatternStore implements PatternStore {
             Filter filter = where(NAMESPACE_FIELD).eq(namespace);
             Document namespaceDocument = patternCollection.find(filter).firstOrNull();
 
-        CalmJsonMetadata metadata = CalmJsonMetadata.extract(patternRequest.getPatternJson());
-        String name = metadata.hasName() ? metadata.getName() : patternRequest.getName();
-        String description = metadata.hasDescription() ? metadata.getDescription() : patternRequest.getDescription();
+        String name = patternRequest.getName();
+        String description = patternRequest.getDescription();
 
         Document patternDocument = Document.createDocument()
                 .put(PATTERN_ID_FIELD, id)

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
@@ -683,7 +683,7 @@ public class TestMongoControlStoreShould {
     // --- JSON-derived name/description (bug-fix coverage) ---
 
     @Test
-    void create_control_requirement_prefers_name_and_description_from_json_body() throws DomainNotFoundException {
+    void create_control_requirement_uses_dto_name_and_description_on_initial_create() throws DomainNotFoundException {
         when(domainStore.getDomains()).thenReturn(List.of("security"));
         when(counterStore.getNextControlSequenceValue()).thenReturn(7);
 
@@ -692,8 +692,8 @@ public class TestMongoControlStoreShould {
 
         ControlDetail result = mongoControlStore.createControlRequirement(createRequest, "security");
 
-        assertThat(result.getName(), is("From JSON"));
-        assertThat(result.getDescription(), is("From JSON Desc"));
+        assertThat(result.getName(), is("Wrapper Name"));
+        assertThat(result.getDescription(), is("Wrapper Desc"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
@@ -21,6 +21,7 @@ import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundExceptio
 import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -677,5 +678,82 @@ public class TestMongoControlStoreShould {
 
         assertThrows(ControlNotFoundException.class, () ->
                 mongoControlStore.createConfigurationForVersion("security", 999, 10, "2.0.0", "{}"));
+    }
+
+    // --- JSON-derived name/description (bug-fix coverage) ---
+
+    @Test
+    void create_control_requirement_prefers_name_and_description_from_json_body() throws DomainNotFoundException {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+        when(counterStore.getNextControlSequenceValue()).thenReturn(7);
+
+        String json = "{\"control-id\":\"c1\",\"name\":\"From JSON\",\"description\":\"From JSON Desc\"}";
+        CreateControlRequirement createRequest = new CreateControlRequirement("Wrapper Name", "Wrapper Desc", json);
+
+        ControlDetail result = mongoControlStore.createControlRequirement(createRequest, "security");
+
+        assertThat(result.getName(), is("From JSON"));
+        assertThat(result.getDescription(), is("From JSON Desc"));
+    }
+
+    @Test
+    void create_requirement_for_version_updates_wrapper_name_and_description_from_json() throws Exception {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+
+        Document requirement = new Document("1-0-0", new Document("type", "req"));
+        Document controlDoc = new Document("controlId", 1)
+                .append("name", "Old Name")
+                .append("description", "Old Desc")
+                .append("requirement", requirement)
+                .append("configurations", new ArrayList<>());
+        Document domainDoc = new Document("domain", "security")
+                .append("controls", List.of(controlDoc));
+
+        FindIterable<Document> findIterable = mockFindIterable();
+        when(controlCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(domainDoc);
+        when(controlCollection.updateOne(any(Document.class), any(Document.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        String json = "{\"control-id\":\"c1\",\"name\":\"New Name\",\"description\":\"New Desc\"}";
+        mongoControlStore.createRequirementForVersion("security", 1, "2.0.0", json);
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(controlCollection).updateOne(any(Document.class), updateCaptor.capture());
+
+        Document set = (Document) updateCaptor.getValue().get("$set");
+        assertThat(set.getString("controls.$.name"), is("New Name"));
+        assertThat(set.getString("controls.$.description"), is("New Desc"));
+        assertThat(set, hasKey("controls.$.requirement.2-0-0"));
+    }
+
+    @Test
+    void create_requirement_for_version_leaves_wrapper_untouched_when_json_lacks_metadata() throws Exception {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+
+        Document requirement = new Document("1-0-0", new Document("type", "req"));
+        Document controlDoc = new Document("controlId", 1)
+                .append("name", "Old Name")
+                .append("description", "Old Desc")
+                .append("requirement", requirement)
+                .append("configurations", new ArrayList<>());
+        Document domainDoc = new Document("domain", "security")
+                .append("controls", List.of(controlDoc));
+
+        FindIterable<Document> findIterable = mockFindIterable();
+        when(controlCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(domainDoc);
+        when(controlCollection.updateOne(any(Document.class), any(Document.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        mongoControlStore.createRequirementForVersion("security", 1, "2.0.0", "{\"type\":\"req-v2\"}");
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(controlCollection).updateOne(any(Document.class), updateCaptor.capture());
+
+        Document set = (Document) updateCaptor.getValue().get("$set");
+        assertThat(set, not(hasKey("controls.$.name")));
+        assertThat(set, not(hasKey("controls.$.description")));
+        assertThat(set, hasKey("controls.$.requirement.2-0-0"));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -26,13 +26,16 @@ import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.domain.pattern.NamespacePatternSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -386,5 +389,84 @@ public class TestMongoPatternStoreShould {
 
         verify(patternCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
         verify(patternCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- JSON-derived name/description (bug-fix coverage) ---
+
+    @Test
+    void create_pattern_for_namespace_prefers_name_and_description_from_json_body() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextPatternSequenceValue()).thenReturn(7);
+
+        String json = "{\"name\":\"JSON Pattern\",\"description\":\"JSON Desc\"}";
+        CreatePatternRequest request = new CreatePatternRequest("Wrapper Name", "Wrapper Desc", json);
+
+        mongoPatternStore.createPatternForNamespace(request, "finos");
+
+        Document expectedDoc = new Document("patternId", 7)
+                .append("name", "JSON Pattern")
+                .append("description", "JSON Desc")
+                .append("versions", new Document("1-0-0", Document.parse(json)));
+
+        verify(patternCollection).updateOne(
+                eq(Filters.eq("namespace", "finos")),
+                eq(Updates.push("patterns", expectedDoc)),
+                any(UpdateOptions.class));
+    }
+
+    @Test
+    void create_pattern_for_version_updates_wrapper_name_and_description_from_json() throws Exception {
+        mockSetupPatternDocumentWithVersions();
+        when(patternCollection.updateOne(any(Document.class), any(Document.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        String json = "{\"name\":\"v2 name\",\"description\":\"v2 desc\"}";
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
+                .setId(42).setVersion("2.0.0").setPattern(json).build();
+
+        mongoPatternStore.createPatternForVersion(pattern);
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(patternCollection).updateOne(any(Document.class), updateCaptor.capture());
+        Document set = (Document) updateCaptor.getValue().get("$set");
+        assertThat(set.getString("patterns.$.name"), is("v2 name"));
+        assertThat(set.getString("patterns.$.description"), is("v2 desc"));
+        assertThat(set, hasKey("patterns.$.versions.2-0-0"));
+    }
+
+    @Test
+    void create_pattern_for_version_leaves_wrapper_untouched_when_json_lacks_metadata() throws Exception {
+        mockSetupPatternDocumentWithVersions();
+        when(patternCollection.updateOne(any(Document.class), any(Document.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
+                .setId(42).setVersion("2.0.0").setPattern(validJson).build();
+
+        mongoPatternStore.createPatternForVersion(pattern);
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(patternCollection).updateOne(any(Document.class), updateCaptor.capture());
+        Document set = (Document) updateCaptor.getValue().get("$set");
+        assertThat(set, not(hasKey("patterns.$.name")));
+        assertThat(set, not(hasKey("patterns.$.description")));
+        assertThat(set, hasKey("patterns.$.versions.2-0-0"));
+    }
+
+    @Test
+    void update_pattern_for_version_updates_wrapper_name_and_description_from_json() throws Exception {
+        mockSetupPatternDocumentWithVersions();
+
+        String json = "{\"name\":\"updated\",\"description\":\"updated desc\"}";
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
+                .setId(42).setVersion("1.0.0").setPattern(json).build();
+
+        mongoPatternStore.updatePatternForVersion(pattern);
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(patternCollection).updateOne(any(Document.class), updateCaptor.capture(), any(UpdateOptions.class));
+        Document set = (Document) updateCaptor.getValue().get("$set");
+        assertThat(set.getString("patterns.$.name"), is("updated"));
+        assertThat(set.getString("patterns.$.description"), is("updated desc"));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -394,7 +394,7 @@ public class TestMongoPatternStoreShould {
     // --- JSON-derived name/description (bug-fix coverage) ---
 
     @Test
-    void create_pattern_for_namespace_prefers_name_and_description_from_json_body() throws NamespaceNotFoundException {
+    void create_pattern_for_namespace_uses_dto_name_and_description_on_initial_create() throws NamespaceNotFoundException {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
         when(counterStore.getNextPatternSequenceValue()).thenReturn(7);
 
@@ -404,8 +404,8 @@ public class TestMongoPatternStoreShould {
         mongoPatternStore.createPatternForNamespace(request, "finos");
 
         Document expectedDoc = new Document("patternId", 7)
-                .append("name", "JSON Pattern")
-                .append("description", "JSON Desc")
+                .append("name", "Wrapper Name")
+                .append("description", "Wrapper Desc")
                 .append("versions", new Document("1-0-0", Document.parse(json)));
 
         verify(patternCollection).updateOne(

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
@@ -727,4 +727,73 @@ public class TestNitriteControlStoreShould {
 
         verify(mockCollection).update(any(Filter.class), any(Document.class));
     }
+
+    // --- JSON-derived name/description (bug-fix coverage) ---
+
+    @Test
+    public void testCreateControlRequirement_prefersNameAndDescriptionFromJsonBody() throws DomainNotFoundException {
+        when(mockDomainStore.getDomains()).thenReturn(List.of(TEST_DOMAIN));
+        when(mockCounterStore.getNextControlSequenceValue()).thenReturn(7);
+
+        DocumentCursor mockCursor = mock(DocumentCursor.class);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+
+        String json = "{\"control-id\":\"c1\",\"name\":\"From JSON\",\"description\":\"From JSON Desc\"}";
+        CreateControlRequirement createRequest = new CreateControlRequirement("Wrapper Name", "Wrapper Desc", json);
+
+        ControlDetail result = controlStore.createControlRequirement(createRequest, TEST_DOMAIN);
+
+        assertThat(result.getName(), is("From JSON"));
+        assertThat(result.getDescription(), is("From JSON Desc"));
+    }
+
+    @Test
+    public void testCreateRequirementForVersion_updatesWrapperNameAndDescriptionFromJson() throws Exception {
+        when(mockDomainStore.getDomains()).thenReturn(List.of(TEST_DOMAIN));
+
+        Document requirement = Document.createDocument().put("1-0-0", "{}");
+        Document controlDoc = Document.createDocument()
+                .put("controlId", 1)
+                .put("name", "Old Name")
+                .put("description", "Old Desc")
+                .put("requirement", requirement)
+                .put("configurations", new ArrayList<>());
+        Document domainDoc = Document.createDocument()
+                .put("domain", TEST_DOMAIN)
+                .put("controls", Arrays.asList(controlDoc));
+
+        setupDomainDocReturn(domainDoc);
+
+        String json = "{\"control-id\":\"c1\",\"name\":\"New Name\",\"description\":\"New Desc\"}";
+        controlStore.createRequirementForVersion(TEST_DOMAIN, 1, "2.0.0", json);
+
+        assertThat(controlDoc.get("name", String.class), is("New Name"));
+        assertThat(controlDoc.get("description", String.class), is("New Desc"));
+        verify(mockCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void testCreateRequirementForVersion_leavesWrapperUntouchedWhenJsonLacksMetadata() throws Exception {
+        when(mockDomainStore.getDomains()).thenReturn(List.of(TEST_DOMAIN));
+
+        Document requirement = Document.createDocument().put("1-0-0", "{}");
+        Document controlDoc = Document.createDocument()
+                .put("controlId", 1)
+                .put("name", "Old Name")
+                .put("description", "Old Desc")
+                .put("requirement", requirement)
+                .put("configurations", new ArrayList<>());
+        Document domainDoc = Document.createDocument()
+                .put("domain", TEST_DOMAIN)
+                .put("controls", Arrays.asList(controlDoc));
+
+        setupDomainDocReturn(domainDoc);
+
+        controlStore.createRequirementForVersion(TEST_DOMAIN, 1, "2.0.0", "{\"type\":\"req-v2\"}");
+
+        assertThat(controlDoc.get("name", String.class), is("Old Name"));
+        assertThat(controlDoc.get("description", String.class), is("Old Desc"));
+        verify(mockCollection).update(any(Filter.class), any(Document.class));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
@@ -731,7 +731,7 @@ public class TestNitriteControlStoreShould {
     // --- JSON-derived name/description (bug-fix coverage) ---
 
     @Test
-    public void testCreateControlRequirement_prefersNameAndDescriptionFromJsonBody() throws DomainNotFoundException {
+    public void testCreateControlRequirement_usesDtoNameAndDescriptionOnInitialCreate() throws DomainNotFoundException {
         when(mockDomainStore.getDomains()).thenReturn(List.of(TEST_DOMAIN));
         when(mockCounterStore.getNextControlSequenceValue()).thenReturn(7);
 
@@ -744,8 +744,8 @@ public class TestNitriteControlStoreShould {
 
         ControlDetail result = controlStore.createControlRequirement(createRequest, TEST_DOMAIN);
 
-        assertThat(result.getName(), is("From JSON"));
-        assertThat(result.getDescription(), is("From JSON Desc"));
+        assertThat(result.getName(), is("Wrapper Name"));
+        assertThat(result.getDescription(), is("Wrapper Desc"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -633,7 +633,7 @@ public class TestNitritePatternStoreShould {
     // --- JSON-derived name/description (bug-fix coverage) ---
 
     @Test
-    public void testCreatePatternForNamespace_prefersNameAndDescriptionFromJsonBody() throws NamespaceNotFoundException {
+    public void testCreatePatternForNamespace_usesDtoNameAndDescriptionOnInitialCreate() throws NamespaceNotFoundException {
         String json = "{\"name\":\"JSON Name\",\"description\":\"JSON Desc\"}";
         CreatePatternRequest request = new CreatePatternRequest("Wrapper", "Wrapper Desc", json);
 
@@ -652,8 +652,8 @@ public class TestNitritePatternStoreShould {
         @SuppressWarnings("unchecked")
         List<Document> patterns = (List<Document>) inserted.getValue().get("patterns");
         Document patternDoc = patterns.get(0);
-        assertThat(patternDoc.get("name", String.class), is("JSON Name"));
-        assertThat(patternDoc.get("description", String.class), is("JSON Desc"));
+        assertThat(patternDoc.get("name", String.class), is("Wrapper"));
+        assertThat(patternDoc.get("description", String.class), is("Wrapper Desc"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -629,4 +629,99 @@ public class TestNitritePatternStoreShould {
         assertThat(result.getMongoVersion(), is("1-0-0"));
         assertThat(result.getPatternJson(), is(PATTERN_JSON));
     }
+
+    // --- JSON-derived name/description (bug-fix coverage) ---
+
+    @Test
+    public void testCreatePatternForNamespace_prefersNameAndDescriptionFromJsonBody() throws NamespaceNotFoundException {
+        String json = "{\"name\":\"JSON Name\",\"description\":\"JSON Desc\"}";
+        CreatePatternRequest request = new CreatePatternRequest("Wrapper", "Wrapper Desc", json);
+
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+        when(mockCounterStore.getNextPatternSequenceValue()).thenReturn(PATTERN_ID);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        patternStore.createPatternForNamespace(request, NAMESPACE);
+
+        org.mockito.ArgumentCaptor<Document> inserted = org.mockito.ArgumentCaptor.forClass(Document.class);
+        verify(mockCollection).insert(inserted.capture());
+
+        @SuppressWarnings("unchecked")
+        List<Document> patterns = (List<Document>) inserted.getValue().get("patterns");
+        Document patternDoc = patterns.get(0);
+        assertThat(patternDoc.get("name", String.class), is("JSON Name"));
+        assertThat(patternDoc.get("description", String.class), is("JSON Desc"));
+    }
+
+    @Test
+    public void testCreatePatternForVersion_updatesWrapperNameAndDescriptionFromJson() throws Exception {
+        String json = "{\"name\":\"v2 name\",\"description\":\"v2 desc\"}";
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("2-0-0")
+                .setPattern(json)
+                .build();
+
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versionsDoc = mock(Document.class);
+        when(versionsDoc.containsKey(anyString())).thenReturn(false);
+
+        Document patternDoc = mock(Document.class);
+        when(patternDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
+        when(patternDoc.get("patternId", Integer.class)).thenReturn(PATTERN_ID);
+
+        List<Document> patterns = new ArrayList<>();
+        patterns.add(patternDoc);
+
+        Document namespaceDoc = mock(Document.class);
+        when(namespaceDoc.get(eq("patterns"), any())).thenReturn(patterns);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        patternStore.createPatternForVersion(pattern);
+
+        verify(patternDoc).put(eq("name"), eq("v2 name"));
+        verify(patternDoc).put(eq("description"), eq("v2 desc"));
+    }
+
+    @Test
+    public void testUpdatePatternForVersion_updatesWrapperNameAndDescriptionFromJson() throws Exception {
+        String json = "{\"name\":\"updated\",\"description\":\"updated desc\"}";
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1-0-0")
+                .setPattern(json)
+                .build();
+
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versionsDoc = mock(Document.class);
+
+        Document patternDoc = mock(Document.class);
+        when(patternDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
+        when(patternDoc.get("patternId", Integer.class)).thenReturn(PATTERN_ID);
+
+        List<Document> patterns = new ArrayList<>();
+        patterns.add(patternDoc);
+
+        Document namespaceDoc = mock(Document.class);
+        when(namespaceDoc.get(eq("patterns"), any())).thenReturn(patterns);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        patternStore.updatePatternForVersion(pattern);
+
+        verify(patternDoc).put(eq("name"), eq("updated"));
+        verify(patternDoc).put(eq("description"), eq("updated desc"));
+    }
 }


### PR DESCRIPTION
Fixes #2484 

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
