### PR TITLE
feat(cli): diff CALM patterns as well as architectures

### DIFF
--- a/calm-models/src/diff/diff.ts
+++ b/calm-models/src/diff/diff.ts
@@ -56,11 +56,25 @@ export function diffArchitectures(
     archA: CalmArchitectureSchema,
     archB: CalmArchitectureSchema,
 ): DiffResult {
-    const allNodesA = archA.nodes ?? [];
-    const allNodesB = archB.nodes ?? [];
-    const allEdgesA = archA.relationships ?? [];
-    const allEdgesB = archB.relationships ?? [];
+    return diffNodesAndRelationships(
+        archA.nodes ?? [],
+        archB.nodes ?? [],
+        archA.relationships ?? [],
+        archB.relationships ?? [],
+    );
+}
 
+/**
+ * Core diff over the node/relationship arrays that both architectures and
+ * (normalised) patterns reduce to. Matching is by `unique-id`; items missing
+ * one are surfaced via `invalidItems` rather than silently dropped.
+ */
+export function diffNodesAndRelationships(
+    allNodesA: CalmNodeSchema[],
+    allNodesB: CalmNodeSchema[],
+    allEdgesA: CalmRelationshipSchema[],
+    allEdgesB: CalmRelationshipSchema[],
+): DiffResult {
     const validNodesA = allNodesA.filter((n) => n['unique-id']);
     const validNodesB = allNodesB.filter((n) => n['unique-id']);
     const validEdgesA = allEdgesA.filter((r) => r['unique-id']);

--- a/calm-models/src/diff/fixtures/diff-test-patterns.json
+++ b/calm-models/src/diff/fixtures/diff-test-patterns.json
@@ -1,0 +1,351 @@
+{
+  "basePattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Base Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/node",
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/node",
+            "properties": {
+              "unique-id": { "const": "payment-service" },
+              "name": { "const": "Payment Service" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/node",
+            "properties": {
+              "unique-id": { "const": "user-db" },
+              "name": { "const": "User Database" },
+              "node-type": { "const": "database" }
+            }
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/relationship",
+            "properties": {
+              "unique-id": { "const": "gateway-to-payment" },
+              "description": { "const": "Gateway routes to payment service" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "api-gateway" }, "destination": { "node": "payment-service" } } }
+              }
+            }
+          },
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/relationship",
+            "properties": {
+              "unique-id": { "const": "payment-to-db" },
+              "description": { "const": "Payment persists to database" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "payment-service" }, "destination": { "node": "user-db" } } }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "additionPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Addition Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-service" },
+              "name": { "const": "Payment Service" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "user-db" },
+              "name": { "const": "User Database" },
+              "node-type": { "const": "database" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "audit-service" },
+              "name": { "const": "Audit Service" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "gateway-to-payment" },
+              "description": { "const": "Gateway routes to payment service" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "api-gateway" }, "destination": { "node": "payment-service" } } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-to-db" },
+              "description": { "const": "Payment persists to database" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "payment-service" }, "destination": { "node": "user-db" } } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-to-audit" },
+              "description": { "const": "Payment emits audit events" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "payment-service" }, "destination": { "node": "audit-service" } } }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "removalPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Removal Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-service" },
+              "name": { "const": "Payment Service" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "gateway-to-payment" },
+              "description": { "const": "Gateway routes to payment service" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "api-gateway" }, "destination": { "node": "payment-service" } } }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "modificationPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Modification Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway v2" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-service" },
+              "name": { "const": "Payment Service" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "user-db" },
+              "name": { "const": "User Database" },
+              "node-type": { "const": "database" }
+            }
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "gateway-to-payment" },
+              "description": { "const": "Gateway routes to payment service" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "api-gateway" }, "destination": { "node": "payment-service" } } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-to-db" },
+              "description": { "const": "Payment persists to database" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "payment-service" }, "destination": { "node": "user-db" } } }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "renamePattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Rename Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-processor" },
+              "name": { "const": "Payment Service" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "user-db" },
+              "name": { "const": "User Database" },
+              "node-type": { "const": "database" }
+            }
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "gateway-to-payment" },
+              "description": { "const": "Gateway routes to payment service" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "api-gateway" }, "destination": { "node": "payment-service" } } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "payment-to-db" },
+              "description": { "const": "Payment persists to database" },
+              "relationship-type": {
+                "const": { "connects": { "source": { "node": "payment-service" }, "destination": { "node": "user-db" } } }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "allOfPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "AllOf Wrapped Pattern",
+    "allOf": [
+      {
+        "properties": {
+          "nodes": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "properties": {
+                  "unique-id": { "const": "api-gateway" },
+                  "name": { "const": "API Gateway" },
+                  "node-type": { "const": "service" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "decisionPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Decision Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "unique-id": { "const": "postgres-store" },
+                  "name": { "const": "Postgres Store" },
+                  "node-type": { "const": "database" }
+                }
+              },
+              {
+                "properties": {
+                  "unique-id": { "const": "dynamo-store" },
+                  "name": { "const": "DynamoDB Store" },
+                  "node-type": { "const": "database" }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "relationships": {
+        "type": "array",
+        "prefixItems": []
+      }
+    }
+  }
+}

--- a/calm-models/src/diff/index.ts
+++ b/calm-models/src/diff/index.ts
@@ -1,8 +1,13 @@
 export {
     diffArchitectures,
+    diffNodesAndRelationships,
     nodeStructureMatches,
     relationshipStructureMatches,
 } from './diff.js';
+export {
+    diffPatterns,
+    normalisePatternToInstance,
+} from './pattern-diff.js';
 export type {
     DiffResult,
     NodeChange,

--- a/calm-models/src/diff/pattern-diff.spec.ts
+++ b/calm-models/src/diff/pattern-diff.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { diffPatterns, normalisePatternToInstance } from './pattern-diff.js';
+import testPatterns from './fixtures/diff-test-patterns.json' with { type: 'json' };
+
+describe('normalisePatternToInstance', () => {
+    it('reduces a pattern schema to instance-shaped nodes and relationships', () => {
+        const { nodes, relationships } = normalisePatternToInstance(testPatterns.basePattern);
+        expect(nodes).toHaveLength(3);
+        expect(relationships).toHaveLength(2);
+
+        const gateway = nodes.find((n) => n['unique-id'] === 'api-gateway');
+        expect(gateway).toEqual({
+            'unique-id': 'api-gateway',
+            name: 'API Gateway',
+            'node-type': 'service',
+        });
+    });
+
+    it('collapses const-wrapped relationship-type objects', () => {
+        const { relationships } = normalisePatternToInstance(testPatterns.basePattern);
+        const rel = relationships.find((r) => r['unique-id'] === 'gateway-to-payment');
+        expect(rel?.['relationship-type']).toEqual({
+            connects: { source: { node: 'api-gateway' }, destination: { node: 'payment-service' } },
+        });
+    });
+
+    it('reads nodes nested under allOf', () => {
+        const { nodes } = normalisePatternToInstance(testPatterns.allOfPattern);
+        expect(nodes.map((n) => n['unique-id'])).toEqual(['api-gateway']);
+    });
+
+    it('expands oneOf decision groups into individual nodes', () => {
+        const { nodes } = normalisePatternToInstance(testPatterns.decisionPattern);
+        expect(nodes.map((n) => n['unique-id'])).toEqual([
+            'api-gateway',
+            'postgres-store',
+            'dynamo-store',
+        ]);
+    });
+
+    it('returns empty arrays for a non-object input', () => {
+        expect(normalisePatternToInstance(null)).toEqual({ nodes: [], relationships: [] });
+        expect(normalisePatternToInstance('not a pattern')).toEqual({ nodes: [], relationships: [] });
+    });
+});
+
+describe('diffPatterns', () => {
+    it('detects added nodes and relationships', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.additionPattern);
+        expect(result.nodesAdded).toHaveLength(1);
+        expect(result.nodesAdded[0]['unique-id']).toBe('audit-service');
+        expect(result.edgesAdded).toHaveLength(1);
+        expect(result.edgesAdded[0]['unique-id']).toBe('payment-to-audit');
+    });
+
+    it('detects removed nodes and relationships', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.removalPattern);
+        expect(result.nodesRemoved).toHaveLength(1);
+        expect(result.nodesRemoved[0]['unique-id']).toBe('user-db');
+        expect(result.edgesRemoved).toHaveLength(1);
+        expect(result.edgesRemoved[0]['unique-id']).toBe('payment-to-db');
+    });
+
+    it('detects modified nodes', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.modificationPattern);
+        expect(result.nodesModified).toHaveLength(1);
+        expect(result.nodesModified[0].original['unique-id']).toBe('api-gateway');
+        expect(result.nodesModified[0].updated.name).toBe('API Gateway v2');
+    });
+
+    it('detects renamed nodes and excludes them from added/removed', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.renamePattern);
+        expect(result.nodesRenamed).toHaveLength(1);
+        expect(result.nodesRenamed[0].oldId).toBe('payment-service');
+        expect(result.nodesRenamed[0].newId).toBe('payment-processor');
+        expect(result.nodesAdded).toHaveLength(0);
+        expect(result.nodesRemoved).toHaveLength(0);
+    });
+
+    it('reports no changes for identical patterns', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.basePattern);
+        expect(result.nodesModified).toHaveLength(0);
+        expect(result.nodesRenamed).toHaveLength(0);
+        expect(result.edgesModified).toHaveLength(0);
+        expect(result.nodesSame).toHaveLength(3);
+        expect(result.edgesSame).toHaveLength(2);
+    });
+
+    it('diffs nodes inside decision groups individually', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.decisionPattern);
+        const addedIds = result.nodesAdded.map((n) => n['unique-id']);
+        expect(addedIds).toContain('postgres-store');
+        expect(addedIds).toContain('dynamo-store');
+    });
+});

--- a/calm-models/src/diff/pattern-diff.ts
+++ b/calm-models/src/diff/pattern-diff.ts
@@ -1,0 +1,128 @@
+import type { CalmNodeSchema, CalmRelationshipSchema } from '../types/index.js';
+import type { DiffResult } from './diff-types.js';
+import { diffNodesAndRelationships } from './diff.js';
+
+type SchemaObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is SchemaObject {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Collapses a JSON Schema fragment into the instance value it fixes, recursing
+ * through `const`, `properties` and `prefixItems`. Returns `undefined` when the
+ * fragment constrains nothing concrete, so unconstrained keys are omitted from
+ * the resulting instance (and therefore don't register as diffs).
+ */
+function collapseSchema(schema: unknown): unknown {
+    if (!isObject(schema)) return undefined;
+
+    if ('const' in schema) return schema['const'];
+
+    if (isObject(schema['properties'])) {
+        const result: Record<string, unknown> = {};
+        for (const [key, child] of Object.entries(schema['properties'])) {
+            if (key.startsWith('$')) continue;
+            const value = collapseSchema(child);
+            if (value !== undefined) result[key] = value;
+        }
+        return Object.keys(result).length > 0 ? result : undefined;
+    }
+
+    if (Array.isArray(schema['prefixItems'])) {
+        const items = schema['prefixItems']
+            .map(collapseSchema)
+            .filter((value) => value !== undefined);
+        return items.length > 0 ? items : undefined;
+    }
+
+    return undefined;
+}
+
+/**
+ * Reads the `prefixItems` for a top-level pattern field (e.g. `nodes`,
+ * `relationships`), handling both direct `properties` and `allOf` wrapping.
+ */
+function getPrefixItems(pattern: SchemaObject, key: string): SchemaObject[] {
+    const direct = isObject(pattern['properties'])
+        ? pattern['properties'][key]
+        : undefined;
+    if (isObject(direct) && Array.isArray(direct['prefixItems'])) {
+        return direct['prefixItems'] as SchemaObject[];
+    }
+
+    if (Array.isArray(pattern['allOf'])) {
+        for (const sub of pattern['allOf']) {
+            if (!isObject(sub) || !isObject(sub['properties'])) continue;
+            const field = sub['properties'][key];
+            if (isObject(field) && Array.isArray(field['prefixItems'])) {
+                return field['prefixItems'] as SchemaObject[];
+            }
+        }
+    }
+
+    return [];
+}
+
+/**
+ * Expands `oneOf`/`anyOf` decision wrappers so each alternative is diffed as an
+ * individual item by its own `unique-id`.
+ */
+function expandAlternatives(prefixItems: SchemaObject[]): SchemaObject[] {
+    const expanded: SchemaObject[] = [];
+    for (const item of prefixItems) {
+        const alternatives = Array.isArray(item['oneOf'])
+            ? item['oneOf']
+            : Array.isArray(item['anyOf'])
+                ? item['anyOf']
+                : null;
+        if (alternatives) {
+            for (const alt of alternatives) {
+                if (isObject(alt)) expanded.push(alt);
+            }
+        } else {
+            expanded.push(item);
+        }
+    }
+    return expanded;
+}
+
+function hasUniqueId(value: unknown): value is Record<string, unknown> {
+    return isObject(value) && typeof value['unique-id'] === 'string';
+}
+
+/**
+ * Reduces a CALM pattern (a JSON Schema) to the instance-shaped
+ * `{ nodes, relationships }` it constrains, keyed by `unique-id`. This is the
+ * same reduction the Hub UI's pattern visualiser performs for rendering, so the
+ * diff lines up with what users see on the graph.
+ */
+export function normalisePatternToInstance(pattern: unknown): {
+    nodes: CalmNodeSchema[];
+    relationships: CalmRelationshipSchema[];
+} {
+    if (!isObject(pattern)) {
+        return { nodes: [], relationships: [] };
+    }
+
+    const nodes = expandAlternatives(getPrefixItems(pattern, 'nodes'))
+        .map(collapseSchema)
+        .filter(hasUniqueId) as CalmNodeSchema[];
+
+    const relationships = expandAlternatives(getPrefixItems(pattern, 'relationships'))
+        .map(collapseSchema)
+        .filter(hasUniqueId) as CalmRelationshipSchema[];
+
+    return { nodes, relationships };
+}
+
+/**
+ * Diffs two CALM patterns by normalising each schema to its constrained
+ * `{ nodes, relationships }` and delegating to the shared diff core. Returns the
+ * same `DiffResult` shape as {@link diffArchitectures}.
+ */
+export function diffPatterns(patternA: unknown, patternB: unknown): DiffResult {
+    const a = normalisePatternToInstance(patternA);
+    const b = normalisePatternToInstance(patternB);
+    return diffNodesAndRelationships(a.nodes, b.nodes, a.relationships, b.relationships);
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -46,6 +46,7 @@ Options:
 Commands:
   generate [options]          Generate an architecture from a CALM pattern file.
   validate [options]          Validate that an architecture conforms to a given CALM pattern.
+  diff [options]              Compare two CALM documents (architectures or patterns) and report what changed.
   template [options]          Generate files from a CALM model using a Handlebars template bundle.
   docify [options]            Generate a documentation website off your CALM model.
   init-ai [options]           Augment a git repository with AI assistance for CALM
@@ -276,6 +277,53 @@ WARN  issues:
 
 which is just letting you know that you have left in some placeholder values which might have been generated with the generate command.
 This isn't a full break, but it implies that you've forgotten to fill out a detail in your architecture.
+
+### Diffing two CALM documents
+
+This command compares two versions of a CALM document and reports what changed between them. It works on both **architectures** and **patterns**, matching nodes and relationships by their `unique-id` and classifying each as added, removed, modified, or renamed. The document type is auto-detected; use `--type` to override detection.
+
+```shell
+% calm diff --help
+Usage: calm diff [options]
+
+Compare two CALM documents (architectures or patterns) and report what changed.
+
+Options:
+  -a, --document-a <file>   Path to the first (baseline) CALM document.
+  -b, --document-b <file>   Path to the second CALM document to compare against the baseline.
+  -f, --format <format>     Output format (choices: "json", "summary", default: "json")
+  -t, --type <type>         Force the document type instead of auto-detecting it. (choices: "architecture", "pattern")
+  -o, --output <file>       Path location at which to write the diff output. If omitted, prints to stdout.
+  --exit-code               Exit with a non-zero status code when changes are detected. Useful in CI to gate version bumps.
+  -v, --verbose             Enable verbose logging. (default: false)
+  -h, --help                display help for command
+```
+
+For a quick human-readable overview, use `--format summary`:
+
+```shell
+% calm diff -a ./baseline.arch.json -b ./updated.arch.json --format summary
+CALM architecture diff
+----------------------
+Nodes:         +1  -0  ~1  ↔0  =3
+Relationships: +1  -0  ~0  ↔0  =2
+
+Nodes added:
+  - audit-service
+...
+```
+
+The same command compares two patterns — pass the pattern files instead:
+
+```shell
+% calm diff -a ./v1.pattern.json -b ./v2.pattern.json --format summary
+```
+
+The `--exit-code` flag makes the command exit non-zero when any change (including items skipped for a missing `unique-id`) is detected, so it can gate version bumps in CI:
+
+```shell
+% calm diff -a ./baseline.arch.json -b ./updated.arch.json --exit-code
+```
 
 ## CALM init-ai
 

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -147,6 +147,19 @@ describe('CLI Commands', () => {
             }));
         });
 
+        it('should accept the deprecated --architecture-a/--architecture-b aliases', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'diff',
+                '--architecture-a', 'before.json',
+                '--architecture-b', 'after.json',
+            ]);
+
+            expect(diffModule.runDiffCommand).toHaveBeenCalledWith(expect.objectContaining({
+                documentAPath: 'before.json',
+                documentBPath: 'after.json',
+            }));
+        });
+
         it('should default to json format', async () => {
             await program.parseAsync([
                 'node', 'cli.js', 'diff',

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -128,9 +128,22 @@ describe('CLI Commands', () => {
             ]);
 
             expect(diffModule.runDiffCommand).toHaveBeenCalledWith(expect.objectContaining({
-                architectureAPath: 'before.json',
-                architectureBPath: 'after.json',
+                documentAPath: 'before.json',
+                documentBPath: 'after.json',
                 outputFormat: 'summary',
+            }));
+        });
+
+        it('should pass the document type through when --type is set', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'diff',
+                '-a', 'before.pattern.json',
+                '-b', 'after.pattern.json',
+                '--type', 'pattern',
+            ]);
+
+            expect(diffModule.runDiffCommand).toHaveBeenCalledWith(expect.objectContaining({
+                documentType: 'pattern',
             }));
         });
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -253,13 +253,17 @@ Validation requires:
 
     program
         .command('diff')
-        .description('Compare two CALM architecture JSON files and report what changed.')
-        .requiredOption('-a, --architecture-a <file>', 'Path to the first (baseline) architecture file.')
-        .requiredOption('-b, --architecture-b <file>', 'Path to the second architecture file to compare against the baseline.')
+        .description('Compare two CALM documents (architectures or patterns) and report what changed.')
+        .requiredOption('-a, --document-a <file>', 'Path to the first (baseline) CALM document.')
+        .requiredOption('-b, --document-b <file>', 'Path to the second CALM document to compare against the baseline.')
         .addOption(
             new Option('-f, --format <format>', 'Output format')
                 .choices(['json', 'summary'])
                 .default('json')
+        )
+        .addOption(
+            new Option('-t, --type <type>', 'Force the document type instead of auto-detecting it.')
+                .choices(['architecture', 'pattern'])
         )
         .option(OUTPUT_OPTION, 'Path location at which to write the diff output. If omitted, prints to stdout.')
         .option('--exit-code', 'Exit with a non-zero status code when changes are detected. Useful in CI to gate version bumps.', false)
@@ -267,10 +271,11 @@ Validation requires:
         .action(async (options) => {
             const { runDiffCommand } = await import('./command-helpers/diff');
             const hasChanges = await runDiffCommand({
-                architectureAPath: options.architectureA,
-                architectureBPath: options.architectureB,
+                documentAPath: options.documentA,
+                documentBPath: options.documentB,
                 outputFormat: options.format,
                 outputPath: options.output,
+                documentType: options.type,
                 verbose: !!options.verbose,
             });
             if (options.exitCode && hasChanges) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -254,8 +254,12 @@ Validation requires:
     program
         .command('diff')
         .description('Compare two CALM documents (architectures or patterns) and report what changed.')
-        .requiredOption('-a, --document-a <file>', 'Path to the first (baseline) CALM document.')
-        .requiredOption('-b, --document-b <file>', 'Path to the second CALM document to compare against the baseline.')
+        .option('-a, --document-a <file>', 'Path to the first (baseline) CALM document.')
+        .option('-b, --document-b <file>', 'Path to the second CALM document to compare against the baseline.')
+        // Deprecated aliases retained for backwards compatibility with cli-v1.41.0,
+        // which shipped the diff command with architecture-only long flags.
+        .addOption(new Option('--architecture-a <file>', 'Deprecated alias for --document-a.').hideHelp())
+        .addOption(new Option('--architecture-b <file>', 'Deprecated alias for --document-b.').hideHelp())
         .addOption(
             new Option('-f, --format <format>', 'Output format')
                 .choices(['json', 'summary'])
@@ -268,11 +272,19 @@ Validation requires:
         .option(OUTPUT_OPTION, 'Path location at which to write the diff output. If omitted, prints to stdout.')
         .option('--exit-code', 'Exit with a non-zero status code when changes are detected. Useful in CI to gate version bumps.', false)
         .option(VERBOSE_OPTION, 'Enable verbose logging.', false)
-        .action(async (options) => {
+        .action(async (options, command) => {
+            const documentAPath = options.documentA ?? options.architectureA;
+            const documentBPath = options.documentB ?? options.architectureB;
+            if (!documentAPath || !documentBPath) {
+                command.error('error: both -a/--document-a <file> and -b/--document-b <file> are required');
+            }
+            if (options.architectureA || options.architectureB) {
+                process.stderr.write('warning: --architecture-a/--architecture-b are deprecated; use --document-a/--document-b.\n');
+            }
             const { runDiffCommand } = await import('./command-helpers/diff');
             const hasChanges = await runDiffCommand({
-                documentAPath: options.documentA,
-                documentBPath: options.documentB,
+                documentAPath,
+                documentBPath,
                 outputFormat: options.format,
                 outputPath: options.output,
                 documentType: options.type,

--- a/cli/src/command-helpers/diff.spec.ts
+++ b/cli/src/command-helpers/diff.spec.ts
@@ -28,8 +28,8 @@ beforeEach(() => {
 });
 
 const baseOptions = {
-    architectureAPath: 'a.json',
-    architectureBPath: 'b.json',
+    documentAPath: 'a.json',
+    documentBPath: 'b.json',
     outputFormat: 'json' as const,
     outputPath: undefined,
     verbose: false,

--- a/cli/src/command-helpers/diff.ts
+++ b/cli/src/command-helpers/diff.ts
@@ -1,19 +1,21 @@
-import { runDiff, type DiffOutputFormat, initLogger } from '@finos/calm-shared';
+import { runDiff, type DiffOutputFormat, type DiffDocumentType, initLogger } from '@finos/calm-shared';
 
 export interface DiffCommandOptions {
-    architectureAPath: string;
-    architectureBPath: string;
+    documentAPath: string;
+    documentBPath: string;
     outputFormat: DiffOutputFormat;
     outputPath?: string;
+    documentType?: DiffDocumentType;
     verbose: boolean;
 }
 
 export async function runDiffCommand(options: DiffCommandOptions): Promise<boolean> {
     const logger = initLogger(options.verbose, 'calm-diff');
     try {
-        const result = await runDiff(options.architectureAPath, options.architectureBPath, {
+        const result = await runDiff(options.documentAPath, options.documentBPath, {
             format: options.outputFormat,
             outputPath: options.outputPath,
+            documentType: options.documentType,
             verbose: options.verbose,
         });
 
@@ -25,7 +27,7 @@ export async function runDiffCommand(options: DiffCommandOptions): Promise<boole
         return result.hasChanges;
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        logger.error('An error occurred while diffing architectures: ' + message);
+        logger.error('An error occurred while diffing CALM documents: ' + message);
         if (err instanceof Error && err.stack) logger.debug(err.stack);
         process.exit(1);
     }

--- a/docs/docs/working-with-calm/using-the-cli.md
+++ b/docs/docs/working-with-calm/using-the-cli.md
@@ -30,6 +30,7 @@ Options:
 Commands:
   generate [options]          Generate an architecture from a CALM pattern file.
   validate [options]          Validate that an architecture conforms to a given CALM pattern.
+  diff [options]              Compare two CALM documents (architectures or patterns) and report what changed.
   template [options]          Generate files from a CALM model using a template bundle, a single file, or a directory of templates
   docify [options]            Generate a documentation website from your CALM model using a template or template directory
   init-ai [options]           Augment a git repository with AI assistance for CALM

--- a/shared/src/commands/diff/diff.spec.ts
+++ b/shared/src/commands/diff/diff.spec.ts
@@ -170,6 +170,14 @@ describe('runDiff', () => {
         const { hasChanges: changed } = await runDiff(a, b, { documentType: 'pattern' });
         expect(changed).toBe(false);
     });
+
+    it('throws when a forced documentType conflicts with the document content', async () => {
+        const a = writeArch('a.json', archA);
+        const b = writeArch('b.json', archB);
+        await expect(runDiff(a, b, { documentType: 'pattern' })).rejects.toThrow(
+            /matches 'architecture'/,
+        );
+    });
 });
 
 describe('detectDocumentType', () => {

--- a/shared/src/commands/diff/diff.spec.ts
+++ b/shared/src/commands/diff/diff.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { tmpdir } from 'node:os';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { runDiff, formatDiff, hasChanges } from './diff.js';
+import { runDiff, formatDiff, hasChanges, detectDocumentType } from './diff.js';
 import type { DiffResult } from '@finos/calm-models/diff';
 
 const loggerMock = {
@@ -45,6 +45,26 @@ const archB = {
         },
     ],
 };
+
+const makePattern = (nodeName: string) => ({
+    $schema: 'https://calm.finos.org/release/1.0-rc2/meta/calm.json',
+    type: 'object',
+    properties: {
+        nodes: {
+            type: 'array',
+            prefixItems: [
+                {
+                    properties: {
+                        'unique-id': { const: 'svc-a' },
+                        name: { const: nodeName },
+                        'node-type': { const: 'service' },
+                    },
+                },
+            ],
+        },
+        relationships: { type: 'array', prefixItems: [] },
+    },
+});
 
 const emptyResult: DiffResult = {
     nodesAdded: [],
@@ -125,6 +145,54 @@ describe('runDiff', () => {
         expect(loggerMock.warn).toHaveBeenCalledTimes(1);
         expect(loggerMock.warn.mock.calls[0][0]).toMatch(/missing a unique-id/);
         expect(result.hasChanges).toBe(true);
+    });
+
+    it('diffs two pattern files and reports a pattern-titled summary', async () => {
+        const a = writeArch('a.pattern.json', makePattern('Service A'));
+        const b = writeArch('b.pattern.json', makePattern('Service A v2'));
+
+        const { diff, hasChanges: changed, formatted } = await runDiff(a, b, { format: 'summary' });
+
+        expect(changed).toBe(true);
+        expect(diff.nodesModified.map((n) => n.original['unique-id'])).toEqual(['svc-a']);
+        expect(formatted).toContain('CALM pattern diff');
+    });
+
+    it('throws when the two inputs are different document types', async () => {
+        const a = writeArch('a.json', archA);
+        const b = writeArch('b.pattern.json', makePattern('Service A'));
+        await expect(runDiff(a, b)).rejects.toThrow(/mismatched document types: architecture vs pattern/);
+    });
+
+    it('honours an explicit documentType override', async () => {
+        const a = writeArch('a.pattern.json', makePattern('Service A'));
+        const b = writeArch('b.pattern.json', makePattern('Service A'));
+        const { hasChanges: changed } = await runDiff(a, b, { documentType: 'pattern' });
+        expect(changed).toBe(false);
+    });
+});
+
+describe('detectDocumentType', () => {
+    it('classifies a document with top-level node/relationship arrays as an architecture', () => {
+        expect(detectDocumentType(archA)).toBe('architecture');
+    });
+
+    it('classifies a JSON Schema document as a pattern', () => {
+        expect(detectDocumentType(makePattern('Service A'))).toBe('pattern');
+    });
+
+    it('classifies a pattern wrapped in allOf as a pattern', () => {
+        const allOfPattern = {
+            $schema: 'https://calm.finos.org/release/1.0-rc2/meta/calm.json',
+            allOf: [{ properties: { nodes: { type: 'array', prefixItems: [] } } }],
+        };
+        expect(detectDocumentType(allOfPattern)).toBe('pattern');
+    });
+
+    it('throws when the document matches neither an architecture nor a pattern', () => {
+        expect(() => detectDocumentType({ $schema: 'something', title: 'mystery' })).toThrow(
+            /Could not determine the CALM document type/,
+        );
     });
 });
 

--- a/shared/src/commands/diff/diff.ts
+++ b/shared/src/commands/diff/diff.ts
@@ -101,17 +101,30 @@ function looksLikePattern(doc: Record<string, unknown>): boolean {
 }
 
 /**
- * Distinguishes a CALM architecture instance (top-level `nodes`/`relationships`
- * arrays) from a CALM pattern (a JSON Schema describing those arrays under
- * `properties`/`allOf`). Throws when the input matches neither shape, so
- * malformed input is surfaced rather than silently diffed to an empty result.
+ * Classifies a document as an architecture instance (top-level
+ * `nodes`/`relationships` arrays) or a pattern (a JSON Schema describing those
+ * arrays under `properties`/`allOf`). Returns `null` when the input clearly
+ * matches neither shape, leaving the decision to the caller.
  */
-export function detectDocumentType(doc: Record<string, unknown>): DiffDocumentType {
+export function tryDetectDocumentType(doc: Record<string, unknown>): DiffDocumentType | null {
     if (Array.isArray(doc['nodes']) || Array.isArray(doc['relationships'])) {
         return 'architecture';
     }
     if (looksLikePattern(doc)) {
         return 'pattern';
+    }
+    return null;
+}
+
+/**
+ * Like {@link tryDetectDocumentType} but throws when the input matches neither
+ * shape, so malformed input is surfaced rather than silently diffed to an empty
+ * result.
+ */
+export function detectDocumentType(doc: Record<string, unknown>): DiffDocumentType {
+    const detected = tryDetectDocumentType(doc);
+    if (detected) {
+        return detected;
     }
     throw new Error(
         'Could not determine the CALM document type: expected an architecture ' +
@@ -132,15 +145,33 @@ export async function runDiff(
     const docA = readDocument(docAPath);
     const docB = readDocument(docBPath);
 
-    const typeA = options.documentType ?? detectDocumentType(docA);
-    const typeB = options.documentType ?? detectDocumentType(docB);
-    if (typeA !== typeB) {
-        throw new Error(
-            `Cannot diff mismatched document types: ${typeA} vs ${typeB}. Both inputs must be the ` +
-                'same CALM document type; pass --type to override detection.',
-        );
+    let documentType: DiffDocumentType;
+    if (options.documentType) {
+        // An explicit --type overrides auto-detection (and rescues genuinely
+        // ambiguous inputs), but if a document's content confidently matches the
+        // opposite type the override is almost certainly a mistake — fail loudly
+        // rather than emit a misleading empty diff.
+        documentType = options.documentType;
+        for (const [docPath, doc] of [[docAPath, docA], [docBPath, docB]] as const) {
+            const detected = tryDetectDocumentType(doc);
+            if (detected && detected !== documentType) {
+                throw new Error(
+                    `--type was set to '${documentType}', but ${docPath} matches '${detected}'. ` +
+                        'Remove --type to auto-detect, or pass inputs of the forced type.',
+                );
+            }
+        }
+    } else {
+        const typeA = detectDocumentType(docA);
+        const typeB = detectDocumentType(docB);
+        if (typeA !== typeB) {
+            throw new Error(
+                `Cannot diff mismatched document types: ${typeA} vs ${typeB}. Both inputs must be the ` +
+                    'same CALM document type; pass --type to override detection.',
+            );
+        }
+        documentType = typeA;
     }
-    const documentType = typeA;
 
     const diff = documentType === 'pattern'
         ? diffPatterns(docA, docB)

--- a/shared/src/commands/diff/diff.ts
+++ b/shared/src/commands/diff/diff.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { mkdirp } from 'mkdirp';
 import {
     diffArchitectures,
+    diffPatterns,
     type DiffResult,
 } from '@finos/calm-models/diff';
 import type { CalmArchitectureSchema } from '@finos/calm-models/types';
@@ -10,10 +11,14 @@ import { initLogger } from '../../logger.js';
 
 export type DiffOutputFormat = 'json' | 'summary';
 
+export type DiffDocumentType = 'architecture' | 'pattern';
+
 export interface DiffRunOptions {
     format?: DiffOutputFormat;
     outputPath?: string;
     verbose?: boolean;
+    /** Override automatic architecture/pattern detection. */
+    documentType?: DiffDocumentType;
 }
 
 export interface DiffRunResult {
@@ -37,15 +42,20 @@ export function hasChanges(diff: DiffResult): boolean {
     );
 }
 
-export function formatDiff(diff: DiffResult, format: DiffOutputFormat): string {
+export function formatDiff(
+    diff: DiffResult,
+    format: DiffOutputFormat,
+    documentType: DiffDocumentType = 'architecture',
+): string {
     if (format === 'json') {
         return JSON.stringify(diff, null, 2);
     }
     const invalidNodes = diff.invalidItems?.nodes.length ?? 0;
     const invalidEdges = diff.invalidItems?.relationships.length ?? 0;
+    const title = `CALM ${documentType} diff`;
     const lines = [
-        'CALM architecture diff',
-        '----------------------',
+        title,
+        '-'.repeat(title.length),
         `Nodes:         +${diff.nodesAdded.length}  -${diff.nodesRemoved.length}  ~${diff.nodesModified.length}  ↔${diff.nodesRenamed.length}  =${diff.nodesSame.length}`,
         `Relationships: +${diff.edgesAdded.length}  -${diff.edgesRemoved.length}  ~${diff.edgesModified.length}  ↔${diff.edgesRenamed.length}  =${diff.edgesSame.length}`,
     ];
@@ -70,25 +80,71 @@ export function formatDiff(diff: DiffResult, format: DiffOutputFormat): string {
     return lines.join('\n');
 }
 
-function readArchitecture(filePath: string): CalmArchitectureSchema {
+function readDocument(filePath: string): Record<string, unknown> {
     const resolved = path.resolve(filePath);
     const raw = fs.readFileSync(resolved, 'utf-8');
-    return JSON.parse(raw) as CalmArchitectureSchema;
+    return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function looksLikePattern(doc: Record<string, unknown>): boolean {
+    const hasNodeOrRelProps = (schema: Record<string, unknown>): boolean => {
+        const props = isObject(schema['properties']) ? schema['properties'] : undefined;
+        return !!props && (isObject(props['nodes']) || isObject(props['relationships']));
+    };
+    if (hasNodeOrRelProps(doc)) return true;
+    return Array.isArray(doc['allOf'])
+        && doc['allOf'].some((sub) => isObject(sub) && hasNodeOrRelProps(sub));
+}
+
+/**
+ * Distinguishes a CALM architecture instance (top-level `nodes`/`relationships`
+ * arrays) from a CALM pattern (a JSON Schema describing those arrays under
+ * `properties`/`allOf`). Throws when the input matches neither shape, so
+ * malformed input is surfaced rather than silently diffed to an empty result.
+ */
+export function detectDocumentType(doc: Record<string, unknown>): DiffDocumentType {
+    if (Array.isArray(doc['nodes']) || Array.isArray(doc['relationships'])) {
+        return 'architecture';
+    }
+    if (looksLikePattern(doc)) {
+        return 'pattern';
+    }
+    throw new Error(
+        'Could not determine the CALM document type: expected an architecture ' +
+            '(top-level nodes/relationships arrays) or a pattern (a JSON Schema ' +
+            'describing them). Pass --type architecture|pattern to specify it explicitly.',
+    );
 }
 
 export async function runDiff(
-    archAPath: string,
-    archBPath: string,
+    docAPath: string,
+    docBPath: string,
     options: DiffRunOptions = {},
 ): Promise<DiffRunResult> {
     const logger = initLogger(!!options.verbose, 'calm-diff');
     const format = options.format ?? 'json';
 
-    logger.info(`Comparing ${archAPath} -> ${archBPath}`);
-    const archA = readArchitecture(archAPath);
-    const archB = readArchitecture(archBPath);
+    logger.info(`Comparing ${docAPath} -> ${docBPath}`);
+    const docA = readDocument(docAPath);
+    const docB = readDocument(docBPath);
 
-    const diff = diffArchitectures(archA, archB);
+    const typeA = options.documentType ?? detectDocumentType(docA);
+    const typeB = options.documentType ?? detectDocumentType(docB);
+    if (typeA !== typeB) {
+        throw new Error(
+            `Cannot diff mismatched document types: ${typeA} vs ${typeB}. Both inputs must be the ` +
+                'same CALM document type; pass --type to override detection.',
+        );
+    }
+    const documentType = typeA;
+
+    const diff = documentType === 'pattern'
+        ? diffPatterns(docA, docB)
+        : diffArchitectures(docA as CalmArchitectureSchema, docB as CalmArchitectureSchema);
 
     const invalidNodeCount = diff.invalidItems?.nodes.length ?? 0;
     const invalidEdgeCount = diff.invalidItems?.relationships.length ?? 0;
@@ -100,7 +156,7 @@ export async function runDiff(
         );
     }
 
-    const formatted = formatDiff(diff, format);
+    const formatted = formatDiff(diff, format, documentType);
 
     if (options.outputPath) {
         const dir = path.dirname(path.resolve(options.outputPath));

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -10,8 +10,10 @@ export { runGenerate } from './commands/generate/generate.js';
 export {
     runDiff,
     formatDiff,
+    detectDocumentType,
     hasChanges as diffHasChanges,
     type DiffOutputFormat,
+    type DiffDocumentType,
     type DiffRunOptions,
     type DiffRunResult,
 } from './commands/diff/diff.js';


### PR DESCRIPTION
## Description
Adds version/diff support for **CALM patterns** to the model core and the CLI, so patterns can be compared the same way architectures already can. This is the shared-core + CLI half of the pattern-diff work; a follow-up PR wires the visual compare into the CALM Hub UI (the visualiser side of the pattern-diff follow-up noted in #2482).

- **`calm-models`**: new `diffPatterns(patternA, patternB)`. A pattern is a JSON Schema, so it's first normalised to the instance-shaped `{ nodes, relationships }` it constrains — collapsing `const`/`prefixItems`/`properties` and expanding `oneOf`/`anyOf` decision groups — which is the same reduction the Hub pattern visualiser performs for rendering. The normalised result is then fed to the existing `unique-id`-based diff core (extracted as `diffNodesAndRelationships`), so pattern and architecture diffs share identical matching/rename/modify semantics.
- **`shared`**: `runDiff` now auto-detects whether each input is an architecture (top-level `nodes`/`relationships` arrays) or a pattern (a JSON Schema describing them), dispatches accordingly, and reports the detected type in the summary header. Detection throws on input that matches neither shape rather than silently producing an empty diff. A `documentType` option overrides detection.
- **`cli`**: the `diff` command is generalised from "two architecture files" to "two CALM documents". `-a/-b` are now `--document-a/--document-b`, with a new `-t/--type architecture|pattern` override. `--format`, `--output`, `--exit-code` are unchanged.
- **Docs**: documented the `diff` command in the CLI README (it was previously undocumented) and added it to the command list on the Docusaurus "Using the CLI" page.

### Out of scope (v1)
Granular highlighting of changes *inside* `oneOf`/`anyOf` decision groups and `options` relationships: their member nodes/relationships are diffed individually by `unique-id`, but the group's structural change is not itself flagged. This matches how the pattern visualiser treats them as containers.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Affected Components
- [x] CLI (`cli/`)
- [x] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] CALM Hub UI (`calm-hub-ui/`) — follow-up PR

> Note: `calm-models` (the TypeScript model package) is the primary code change but isn't a checkbox option above.

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verification on Node 22: `calm-models` (146 tests), `shared` (693), `cli` (223, incl. the pack/install e2e) all pass; `npm run lint` clean for the three workspaces; production builds succeed. New tests cover pattern normalisation (const collapsing, allOf wrapping, oneOf expansion), pattern node/relationship add/remove/modify/rename diffs, document-type detection (architecture, pattern, allOf-pattern, ambiguous-throws), and the CLI `--type` wiring.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards