### PR TITLE
chore(deps): patch uuid <11.1.1 (GHSA-w5hq-g745-h8pq) via root override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -608,6 +608,73 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "calm-suite/calm-guard/node_modules/@mermaid-js/layout-elk": {
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.9.tgz",
+            "integrity": "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "d3": "^7.9.0",
+                "elkjs": "^0.9.3"
+            },
+            "peerDependencies": {
+                "mermaid": "^11.0.2"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@vitest/coverage-v8": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+            "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.1.7",
+                "ast-v8-to-istanbul": "^1.0.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.5.2",
+                "obug": "^2.1.1",
+                "std-env": "^4.0.0-rc.1",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.1.7",
+                "vitest": "4.1.7"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@vitest/ui": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+            "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.7",
+                "fflate": "^0.8.2",
+                "flatted": "^3.4.2",
+                "pathe": "^2.0.3",
+                "sirv": "^3.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "4.1.7"
+            }
+        },
         "calm-suite/calm-guard/node_modules/commander": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -616,6 +683,13 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "calm-suite/calm-guard/node_modules/elkjs": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+            "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+            "extraneous": true,
+            "license": "EPL-2.0"
         },
         "calm-suite/calm-guard/node_modules/estree-walker": {
             "version": "3.0.3",
@@ -1048,7 +1122,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.40.0",
+            "version": "1.41.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -1424,16 +1498,16 @@
             "license": "MIT"
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+            "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@ai-sdk/anthropic": {
-            "version": "3.0.78",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.78.tgz",
-            "integrity": "sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA==",
+            "version": "3.0.79",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.79.tgz",
+            "integrity": "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "3.0.10",
@@ -1447,9 +1521,9 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "3.0.116",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.116.tgz",
-            "integrity": "sha512-k8P17w7Eho5Y4l3tZrYxqQdffkI4xwtl8GCxkZs+JdMWZhyrLLlozqWkKLaWrCSlEYQOeIhEnQLhqQgYYU86Rw==",
+            "version": "3.0.120",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
+            "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "3.0.10",
@@ -1464,9 +1538,9 @@
             }
         },
         "node_modules/@ai-sdk/google": {
-            "version": "3.0.75",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.75.tgz",
-            "integrity": "sha512-XAm31ftiOrzlb8NjDzT7kw0xw+4lmgFdGFn1QKM73nXFFKyN1kWLESBV75UGNfjXP8X1YJ0YydnMVqO0jaPghw==",
+            "version": "3.0.79",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.79.tgz",
+            "integrity": "sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "3.0.10",
@@ -1480,9 +1554,9 @@
             }
         },
         "node_modules/@ai-sdk/openai": {
-            "version": "3.0.64",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.64.tgz",
-            "integrity": "sha512-epO4iS6QwktaY2PF6uBcPnDTJ3BxPOfsGS7/OEtBe3GtNj7C8h8gMDVtIe5K8W16HNDbn0tbR4dcQfpfs+XVFg==",
+            "version": "3.0.65",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.65.tgz",
+            "integrity": "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "3.0.10",
@@ -1496,9 +1570,9 @@
             }
         },
         "node_modules/@ai-sdk/openai-compatible": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.47.tgz",
-            "integrity": "sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg==",
+            "version": "2.0.48",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
+            "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "3.0.10",
@@ -1541,12 +1615,12 @@
             }
         },
         "node_modules/@ai-sdk/xai": {
-            "version": "3.0.91",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.91.tgz",
-            "integrity": "sha512-7zhOCe7hoLfJ5VMTLejzAjBuhaBWIakfd6ZBeQBveshP+DKAPTbl08wTVqnjRLqP1Dw2zN2oT3eyz1EtiFzyBg==",
+            "version": "3.0.92",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.92.tgz",
+            "integrity": "sha512-yqRMdEVfSkZCXs5mqeKfYOuQElo93igwz/4zWbYkhZWAW7tDh+5uqRef6MtQVYF/bTC1EsdbeO9DtsOtAZMOLA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/openai-compatible": "2.0.47",
+                "@ai-sdk/openai-compatible": "2.0.48",
                 "@ai-sdk/provider": "3.0.10",
                 "@ai-sdk/provider-utils": "4.0.27"
             },
@@ -4161,9 +4235,9 @@
             }
         },
         "node_modules/@commitlint/is-ignored/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4351,9 +4425,9 @@
             }
         },
         "node_modules/@conventional-changelog/git-client/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6362,9 +6436,9 @@
             }
         },
         "node_modules/@docusaurus/core/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -8659,6 +8733,9 @@
             "cpu": [
                 "arm"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -8674,6 +8751,9 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -8691,6 +8771,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -8706,6 +8789,9 @@
             "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -8723,6 +8809,9 @@
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -8738,6 +8827,9 @@
             "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -8755,6 +8847,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -8771,6 +8866,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -8786,6 +8884,9 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -8809,6 +8910,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -8830,6 +8934,9 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -8853,6 +8960,9 @@
             "cpu": [
                 "riscv64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -8874,6 +8984,9 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -8897,6 +9010,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -8919,6 +9035,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -8940,6 +9059,9 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -10085,9 +10207,9 @@
             }
         },
         "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -10394,6 +10516,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10409,6 +10534,9 @@
             "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -10426,6 +10554,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10441,6 +10572,9 @@
             "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -10748,9 +10882,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.130.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-            "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+            "version": "0.132.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+            "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -12239,9 +12373,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-            "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+            "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
             "cpu": [
                 "arm64"
             ],
@@ -12255,9 +12389,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-            "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+            "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
             "cpu": [
                 "arm64"
             ],
@@ -12271,9 +12405,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-            "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+            "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
             "cpu": [
                 "x64"
             ],
@@ -12287,9 +12421,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-            "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+            "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
             "cpu": [
                 "x64"
             ],
@@ -12303,9 +12437,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-            "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+            "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
             "cpu": [
                 "arm"
             ],
@@ -12319,11 +12453,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-            "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+            "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -12335,11 +12472,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-            "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+            "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -12351,11 +12491,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-            "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+            "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -12367,11 +12510,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-            "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+            "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -12383,11 +12529,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-            "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+            "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -12399,11 +12548,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-            "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+            "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -12415,9 +12567,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-            "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+            "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
             "cpu": [
                 "arm64"
             ],
@@ -12431,9 +12583,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-            "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+            "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -12449,9 +12601,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-            "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+            "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
             "cpu": [
                 "arm64"
             ],
@@ -12465,9 +12617,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-            "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+            "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
             "cpu": [
                 "x64"
             ],
@@ -12602,6 +12754,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12616,6 +12771,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12630,6 +12788,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12644,6 +12805,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12658,6 +12822,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12672,6 +12839,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12686,6 +12856,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12700,6 +12873,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12714,6 +12890,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12728,6 +12907,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12742,6 +12924,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12756,6 +12941,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12770,6 +12958,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13616,9 +13807,9 @@
             }
         },
         "node_modules/@semantic-release/npm/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -14476,9 +14667,9 @@
             }
         },
         "node_modules/@stoplight/spectral-ruleset-migrator": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.0.tgz",
-            "integrity": "sha512-KINmItys8OhdmjudgcIu7siuxQ4hDdbMsTPW/UkXhoiEosiwok1xAyaYLBfckH9zH85TZBkDDbIbsiMoDCIxBw==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.1.tgz",
+            "integrity": "sha512-IUEbDmmTro0oF6VoAtrUySRV/b6bvYmV7wV6lB99f0Ym5lF9M2DXcgPLo7VMbKTPjCOQcaBzWRnIMXAyLjIRMA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@stoplight/json": "~3.21.0",
@@ -14535,9 +14726,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@stoplight/spectral-rulesets": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.2.tgz",
-            "integrity": "sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.3.tgz",
+            "integrity": "sha512-CDkXEsrA1OOQPmF0VE92zira+eSI411s7hyIdfVeS/91BrNz3Y5HJgnwWFbh2abKVJ2rNciOzBPyGar+xfiFKA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@asyncapi/specs": "^6.8.0",
@@ -14757,16 +14948,16 @@
             }
         },
         "node_modules/@sveltejs/kit": {
-            "version": "2.60.1",
-            "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
-            "integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
+            "version": "2.61.0",
+            "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.0.tgz",
+            "integrity": "sha512-beYjgUux5ITbZeL0vn6gipZlsQiXF1/08C/3F+vlbDvthb/CTgYpZsYPdRIi9RxgTwRSkKIvnxyl+ViZlX4q5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
-                "@sveltejs/acorn-typescript": "^1.0.5",
+                "@sveltejs/acorn-typescript": "^1.0.9",
                 "@types/cookie": "^0.6.0",
-                "acorn": "^8.14.1",
+                "acorn": "^8.16.0",
                 "cookie": "^0.6.0",
                 "devalue": "^5.8.1",
                 "esm-env": "^1.2.2",
@@ -15176,9 +15367,9 @@
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
-            "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
+            "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
@@ -15194,18 +15385,18 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.15.33",
-                "@swc/core-darwin-x64": "1.15.33",
-                "@swc/core-linux-arm-gnueabihf": "1.15.33",
-                "@swc/core-linux-arm64-gnu": "1.15.33",
-                "@swc/core-linux-arm64-musl": "1.15.33",
-                "@swc/core-linux-ppc64-gnu": "1.15.33",
-                "@swc/core-linux-s390x-gnu": "1.15.33",
-                "@swc/core-linux-x64-gnu": "1.15.33",
-                "@swc/core-linux-x64-musl": "1.15.33",
-                "@swc/core-win32-arm64-msvc": "1.15.33",
-                "@swc/core-win32-ia32-msvc": "1.15.33",
-                "@swc/core-win32-x64-msvc": "1.15.33"
+                "@swc/core-darwin-arm64": "1.15.40",
+                "@swc/core-darwin-x64": "1.15.40",
+                "@swc/core-linux-arm-gnueabihf": "1.15.40",
+                "@swc/core-linux-arm64-gnu": "1.15.40",
+                "@swc/core-linux-arm64-musl": "1.15.40",
+                "@swc/core-linux-ppc64-gnu": "1.15.40",
+                "@swc/core-linux-s390x-gnu": "1.15.40",
+                "@swc/core-linux-x64-gnu": "1.15.40",
+                "@swc/core-linux-x64-musl": "1.15.40",
+                "@swc/core-win32-arm64-msvc": "1.15.40",
+                "@swc/core-win32-ia32-msvc": "1.15.40",
+                "@swc/core-win32-x64-msvc": "1.15.40"
             },
             "peerDependencies": {
                 "@swc/helpers": ">=0.5.17"
@@ -15217,9 +15408,9 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
-            "integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
+            "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
             "cpu": [
                 "arm64"
             ],
@@ -15233,9 +15424,9 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
-            "integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
+            "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
             "cpu": [
                 "x64"
             ],
@@ -15249,9 +15440,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
-            "integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
+            "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
             "cpu": [
                 "arm"
             ],
@@ -15265,11 +15456,14 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
-            "integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
+            "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15281,11 +15475,14 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
-            "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
+            "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15297,11 +15494,14 @@
             }
         },
         "node_modules/@swc/core-linux-ppc64-gnu": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
-            "integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
+            "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15313,11 +15513,14 @@
             }
         },
         "node_modules/@swc/core-linux-s390x-gnu": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
-            "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
+            "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15329,11 +15532,14 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
-            "integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
+            "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15345,11 +15551,14 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
-            "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
+            "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
@@ -15361,9 +15570,9 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
-            "integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
+            "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
             "cpu": [
                 "arm64"
             ],
@@ -15377,9 +15586,9 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
-            "integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
+            "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
             "cpu": [
                 "ia32"
             ],
@@ -15393,9 +15602,9 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.15.33",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
-            "integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
+            "version": "1.15.40",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
+            "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
             "cpu": [
                 "x64"
             ],
@@ -15416,9 +15625,10 @@
             "license": "Apache-2.0"
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.15",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+            "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+            "extraneous": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -15571,6 +15781,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15586,6 +15799,9 @@
             "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -15603,6 +15819,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -15618,6 +15837,9 @@
             "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -15828,6 +16050,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -15845,6 +16070,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -15862,6 +16090,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -15879,6 +16110,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -15896,6 +16130,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -17419,9 +17656,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -17613,6 +17850,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17627,6 +17867,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17641,6 +17884,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17655,6 +17901,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17669,6 +17918,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17683,6 +17935,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17697,6 +17952,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17711,6 +17969,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17725,6 +17986,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17739,6 +18003,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -18293,9 +18560,9 @@
             }
         },
         "node_modules/@vscode/test-electron/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -18593,9 +18860,9 @@
             }
         },
         "node_modules/@vscode/vsce/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -18967,12 +19234,12 @@
             }
         },
         "node_modules/ai": {
-            "version": "6.0.185",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.185.tgz",
-            "integrity": "sha512-oGsqscREaTlo75KHZLtwZxRyI+ZBwHV2wRX9B8smHjgOs13WwoCvUyr5aPUWpIBRz406wmIKy1RzoUEq0/WKJw==",
+            "version": "6.0.191",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
+            "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "3.0.116",
+                "@ai-sdk/gateway": "3.0.120",
                 "@ai-sdk/provider": "3.0.10",
                 "@ai-sdk/provider-utils": "4.0.27",
                 "@opentelemetry/api": "^1.9.0"
@@ -19533,6 +19800,35 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "extraneous": true,
+            "license": "MIT"
+        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -19851,9 +20147,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.31",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+            "version": "2.10.32",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -20044,9 +20340,9 @@
             }
         },
         "node_modules/bonjour-service": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+            "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -21600,9 +21896,9 @@
             }
         },
         "node_modules/conventional-changelog-writer/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -22204,9 +22500,9 @@
             }
         },
         "node_modules/css-loader/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -24086,9 +24382,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.360",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
-            "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+            "version": "1.5.361",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+            "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
             "license": "ISC"
         },
         "node_modules/elkjs": {
@@ -24199,9 +24495,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.5",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz",
-            "integrity": "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+            "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -24543,9 +24839,9 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -28203,9 +28499,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.21",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-            "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+            "version": "4.12.22",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+            "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -29159,9 +29455,9 @@
             }
         },
         "node_modules/is-bun-module/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -30319,22 +30615,22 @@
             }
         },
         "node_modules/jsdom/node_modules/tldts": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "version": "7.0.32",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.32.tgz",
+            "integrity": "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.30"
+                "tldts-core": "^7.0.32"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/jsdom/node_modules/tldts-core": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "version": "7.0.32",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.32.tgz",
+            "integrity": "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw==",
             "dev": true,
             "license": "MIT"
         },
@@ -30612,9 +30908,9 @@
             "license": "MIT"
         },
         "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -31204,6 +31500,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -31223,6 +31522,9 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -31244,6 +31546,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -31263,6 +31568,9 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -31352,9 +31660,19 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -32082,6 +32400,18 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/magicast": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.3",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
+            }
+        },
         "node_modules/make-asynchronous": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
@@ -32130,9 +32460,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -34037,22 +34367,22 @@
             "license": "MIT"
         },
         "node_modules/msw/node_modules/tldts": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "version": "7.0.32",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.32.tgz",
+            "integrity": "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.30"
+                "tldts-core": "^7.0.32"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/msw/node_modules/tldts-core": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "version": "7.0.32",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.32.tgz",
+            "integrity": "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw==",
             "dev": true,
             "license": "MIT"
         },
@@ -34252,6 +34582,15 @@
                 "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
             }
         },
+        "node_modules/next/node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/nimma": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
@@ -34296,9 +34635,9 @@
             }
         },
         "node_modules/node-abi/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "optional": true,
@@ -34406,10 +34745,13 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.44",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-            "license": "MIT"
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/node-sarif-builder": {
             "version": "2.0.3",
@@ -37393,9 +37735,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/package-json/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -38857,9 +39199,9 @@
             }
         },
         "node_modules/postcss-loader/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -40767,9 +41109,9 @@
             }
         },
         "node_modules/read-package-up/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -40864,9 +41206,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -41740,12 +42082,12 @@
             "license": "Unlicense"
         },
         "node_modules/rolldown": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-            "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+            "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.130.0",
+                "@oxc-project/types": "=0.132.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -41755,21 +42097,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.1",
-                "@rolldown/binding-darwin-arm64": "1.0.1",
-                "@rolldown/binding-darwin-x64": "1.0.1",
-                "@rolldown/binding-freebsd-x64": "1.0.1",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-                "@rolldown/binding-linux-arm64-musl": "1.0.1",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-                "@rolldown/binding-linux-x64-gnu": "1.0.1",
-                "@rolldown/binding-linux-x64-musl": "1.0.1",
-                "@rolldown/binding-openharmony-arm64": "1.0.1",
-                "@rolldown/binding-wasm32-wasi": "1.0.1",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-                "@rolldown/binding-win32-x64-msvc": "1.0.1"
+                "@rolldown/binding-android-arm64": "1.0.2",
+                "@rolldown/binding-darwin-arm64": "1.0.2",
+                "@rolldown/binding-darwin-x64": "1.0.2",
+                "@rolldown/binding-freebsd-x64": "1.0.2",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+                "@rolldown/binding-linux-arm64-musl": "1.0.2",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-musl": "1.0.2",
+                "@rolldown/binding-openharmony-arm64": "1.0.2",
+                "@rolldown/binding-wasm32-wasi": "1.0.2",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+                "@rolldown/binding-win32-x64-msvc": "1.0.2"
             }
         },
         "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
@@ -42526,9 +42868,9 @@
             }
         },
         "node_modules/semantic-release/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -42661,9 +43003,9 @@
             }
         },
         "node_modules/semver-diff/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -43018,9 +43360,9 @@
             }
         },
         "node_modules/sharp/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "optional": true,
             "bin": {
@@ -43052,9 +43394,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -43455,16 +43797,6 @@
                 "faye-websocket": "^0.11.3",
                 "uuid": "^8.3.2",
                 "websocket-driver": "^0.7.4"
-            }
-        },
-        "node_modules/sockjs/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/sonner": {
@@ -45174,9 +45506,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.47.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-            "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+            "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -45476,9 +45808,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+            "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -47048,9 +47380,9 @@
             }
         },
         "node_modules/update-notifier/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -47308,16 +47640,16 @@
             }
         },
         "node_modules/uuid": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist-node/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {
@@ -47461,15 +47793,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.13",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-            "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+            "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.14",
-                "rolldown": "1.0.1",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.2",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -48089,9 +48421,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.107.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.0.tgz",
-            "integrity": "sha512-PSxeHk/dmLYZlnTU+vL1Gej6Evg5RNtl3flhxBresfznFnzxinHMzHKloHnywM/3ouQv7/AlZCswWDIkNSggUA==",
+            "version": "5.107.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.1.tgz",
+            "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.8",
@@ -48502,9 +48834,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-            "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+            "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
@@ -48994,9 +49326,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -49235,9 +49567,9 @@
             }
         },
         "node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+            "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "hono": ">=4.12.14",
         "serialize-javascript": "^7.0.5",
         "undici": "^7.25.0",
+        "uuid": "^11.1.1",
         "ws": "^8.20.1",
         "@stoplight/spectral-ruleset-bundler": "1.7.0",
         "eslint": {


### PR DESCRIPTION
## Description

Adds a root `overrides` pin of `uuid: ^11.1.1` to patch one open Dependabot alert in the npm tree.

| Advisory | Package | Severity | From → To | Method |
|---|---|---|---|---|
| [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) / CVE-2026-41907 | `uuid` | Medium (CVSS 7.5) | 8.3.2 → 11.1.1 | Centralised (root `overrides`) |

**Vulnerable path:** `docs > webpack-dev-server (devDep) > sockjs@0.3.24 > uuid@8.3.2`

`sockjs@0.3.24` is unmaintained and declares `uuid: "^8.3.2"`, so the patched version sits outside its declared range. uuid@11 still exports a CJS `require` entry, so `sockjs`'s `require('uuid').v4` call site (`node_modules/sockjs/lib/transport.js`) continues to resolve correctly — verified via clean `npm install` + full build + full test suite. In practice the project does not exercise the vulnerable code path (the advisory affects v3/v5/v6 *when a `buf` arg is provided*; sockjs calls `v4()` with no `buf`), but pinning to the patched line silences Dependabot and keeps the override centralised.

`npm audit` after the override drops total vulnerabilities from 25 → 6 (the wider drop is from organic minor bumps when the lockfile is regenerated from scratch — not separately targeted here).

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Documentation (`docs/`)  — vulnerable path is `docs` workspace devDependency tree
- [x] Dependencies

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass

Verification performed in an isolated worktree:
- `rm -rf node_modules package-lock.json && npm install` (clean regen, per repo guidance)
- `npm run build` — all workspaces succeed; `docs` (the affected workspace) builds cleanly
- `npm run lint` — 0 errors
- `npm test` — 15 workspaces, all green (no test regressions)
- `npm audit` — `uuid` advisory cleared

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary  — n/a (dependency-only change)
- [ ] I have added tests for my changes (if applicable)  — n/a (dependency-only change; existing suite verifies)
- [x] My changes follow the project's coding standards

## Not addressed

None for npm — this PR addresses the only open Dependabot alert in the npm ecosystem (alert #345).

A separate PR will follow for the open cargo alerts (rand, glib) in `calm-suite/calm-studio/apps/studio/src-tauri`.