### PR TITLE
Pin Netty BOM updates below 4.2.0 for Quarkus 3.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,12 @@
             ],
             "groupName": "quarkus+jacoco"
         },
+        {
+            "description": "Pin Netty to 4.1.x until Quarkus 4.x lands; Quarkus 3.x is incompatible with Netty 4.2 on Java 21",
+            "matchManagers": ["maven"],
+            "matchPackageNames": ["io.netty:netty-bom"],
+            "allowedVersions": "<4.2.0"
+        },
     {
       "description": "Group JavaScript/TypeScript dependencies by ecosystem",
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Description

Fixes #2510

This PR adds a Renovate package rule for `io.netty:netty-bom` to keep Netty updates below `4.2.0` while CALM Hub remains on Quarkus 3.x and Java 21.

This prevents Renovate from proposing Netty 4.2.x updates that are currently incompatible with the existing Quarkus 3.x setup, while still allowing future Netty 4.1.x updates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components

- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

Commit used:

```text
Pin Netty BOM updates below 4.2.0