### PR TITLE
fix(calm-hub): Cleans up Standalone mode warnings

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -24,7 +24,7 @@ This guide helps AI assistants work efficiently with the CALM Hub backend codeba
 
 # Development Mode (Hot Reload)
 ../mvnw quarkus:dev                       # Default (MongoDB)
-../mvnw quarkus:dev -Dquarkus.profile=standalone      # Standalone (NitriteDB)
+../mvnw quarkus:dev -Pstandalone                     # Standalone (NitriteDB) — use -Pstandalone, NOT -Dquarkus.profile=standalone
 ../mvnw quarkus:dev -Dquarkus.profile=secure         # Secure mode (Keycloak)
 
 # Docker
@@ -330,7 +330,10 @@ CALM Hub is largely independent - it's a standalone REST API server.
 
 1. **TestContainers Errors**: Ensure Docker is running before integration tests
 2. **Port Conflicts**: Check if port 8080 is free (or change `quarkus.http.port`)
-3. **MongoDB Connection**: Start MongoDB before dev mode (unless using `-Dquarkus.profile=standalone`)
+3. **MongoDB Connection**: Start MongoDB before dev mode (unless using `-Pstandalone` for NitriteDB)
+   - **IMPORTANT**: Use `-Pstandalone` (Maven profile), not `-Dquarkus.profile=standalone`. The Maven plugin
+     forks a separate JVM and the `-D` flag does not reliably propagate; the Maven profile injects
+     `quarkus.profile=standalone` via the plugin's own `systemProperties` configuration.
 4. **Certificate Issues**: Use exact CN in URLs when using self-signed certs
 5. **Profile Selection**: Remember to pass `-Dquarkus.profile=secure` for secure mode
 

--- a/calm-hub/README.md
+++ b/calm-hub/README.md
@@ -53,17 +53,20 @@ The storage implementation is selected based on the active Quarkus profile:
 To run the application in standalone mode:
 
 ```shell
-# Development mode with standalone storage
-../mvnw quarkus:dev -Dquarkus.profile=standalone
+# Development mode with standalone storage (uses Maven -Pstandalone profile)
+../mvnw quarkus:dev -Pstandalone
 
 # Production mode with standalone storage
 java -Dquarkus.profile=standalone -jar target/quarkus-app/quarkus-run.jar
 ```
 
-> **Note:** The `standalone` Quarkus profile automatically sets `calm.database.mode=standalone`
-> and suppresses MongoDB health-checks and dev-services. You can also pass
-> `-Dcalm.database.mode=standalone` directly, but using the profile flag is recommended as
-> it applies all standalone suppressions in one step.
+> **Note:** In dev mode use `-Pstandalone` (the Maven profile), not `-Dquarkus.profile=standalone`.
+> The `quarkus-maven-plugin` forks a separate JVM for dev mode and does not reliably propagate
+> `-D` flags from the Maven CLI into that process; the Maven profile `standalone` configures the
+> plugin's own `systemProperties` so `quarkus.profile=standalone` reaches the running app.
+> The `standalone` Quarkus profile activates `calm.database.mode=standalone` and suppresses
+> MongoDB health-checks and dev-services. For production (`java -jar …`) the JVM flag
+> `-Dquarkus.profile=standalone` is passed directly to the process and works as expected.
 
 ### Mongo Database Startup
 

--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -356,6 +356,29 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Standalone profile: activates NitriteDB dev mode via the quarkus-maven-plugin
+             systemProperties so the quarkus.profile=standalone property is reliably forwarded
+             to the Quarkus dev JVM (plain -Dquarkus.profile=standalone on the Maven CLI is
+             not propagated into the forked dev process). -->
+        <profile>
+            <id>standalone</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <quarkus.profile>standalone</quarkus.profile>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>dependency-check</id>
             <activation>

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -11,13 +11,22 @@ calm.standalone.init-script-path=mongo/init-mongo.js
 quarkus.mongodb.connection-string = mongodb://localhost:27017
 quarkus.mongodb.database = calmSchemas
 
-# Standalone profile: activates NitriteDB mode and suppresses all MongoDB activity
-# (health-check, dev-services, and connection settings) so no connection is attempted.
+# Standalone profile: activates NitriteDB mode and suppresses MongoDB health-check
+# and dev-services so Quarkus does not spin up a MongoDB container or report the
+# MongoDB health indicator as failing. The connection string and database name are
+# intentionally kept at their default values — the Quarkus MongoDB extension requires
+# a non-empty database name and creating a MongoClient config is harmless: all Mongo
+# CDI beans are gated by @LookupIfProperty(calm.database.mode=mongo) so the client is
+# never actually used in standalone mode.
 %standalone.calm.database.mode=standalone
 %standalone.quarkus.mongodb.health.enabled=false
 %standalone.quarkus.mongodb.devservices.enabled=false
-%standalone.quarkus.mongodb.connection-string=
-%standalone.quarkus.mongodb.database=
+# Suppress noisy "Connection refused" log spam from the MongoDB driver background
+# monitor threads — the MongoClient is created by the Quarkus extension but never
+# used in standalone mode (all Mongo CDI beans are @LookupIfProperty-gated).
+%standalone.quarkus.log.category."org.mongodb.driver.cluster".level=ERROR
+%standalone.quarkus.log.category."org.mongodb.driver.client".level=ERROR
+%standalone.quarkus.log.category."org.mongodb.driver.connection".level=ERROR
 
 #Disable creating the keycloak container for default profile.
 quarkus.oidc.enabled=true


### PR DESCRIPTION
Fixes #2519

The documented invocation `-Dquarkus.profile=standalone` was silently ignored in quarkus:dev because the quarkus-maven-plugin forks a separate JVM for dev mode and does not propagate Maven CLI `-D` flags into that process. As a result the application always started in Mongo mode, and the init script timed out leaving an empty NitriteDB store.

Changes:
- calm-hub/pom.xml: add Maven `standalone` profile that configures quarkus-maven-plugin <systemProperties> to forward quarkus.profile=standalone into the forked dev JVM.
- application.properties: remove empty-string MongoDB overrides (%standalone.quarkus.mongodb.connection-string= / database=) that caused startup failure ('Failed to load config value … database'); add log-level suppressions for MongoDB driver cluster/client/connection categories so the harmless 'Connection refused' background monitor noise is hidden in standalone mode.
- README.md / AGENTS.md: update dev invocation from `-Dquarkus.profile=standalone` to `-Pstandalone` with an explanation of why the Maven profile is required.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
