### PR TITLE
fix(calm-suite): add workspaces field to calm-studio package.json to unblock automated release

### DIFF
--- a/calm-suite/calm-studio/package.json
+++ b/calm-suite/calm-studio/package.json
@@ -6,6 +6,16 @@
   "engines": {
     "node": "^22.14.0 || >=24.10.0"
   },
+  "workspaces": [
+    "apps/studio",
+    "packages/calm-core",
+    "packages/extensions",
+    "packages/calmscript",
+    "packages/mcp-server",
+    "packages/github-action",
+    "packages/vscode-extension",
+    "packages/web-component"
+  ],
   "scripts": {
     "prepare": "husky || true",
     "build": "npm run build --workspaces --if-present",


### PR DESCRIPTION
## Problem

The `automated-release-calm-studio.yml` workflow fails at the Release stage with:

```
[multi-semantic-release]: Error: Path .../calm-ai/README.md is not in cwd .../calm-suite/calm-studio
```

`multi-semantic-release` runs from `calm-suite/calm-studio/` as cwd. Without a `workspaces` field in that directory's `package.json`, it traverses up to the repo root `package.json`, which lists `calm-ai`, `shared`, `cli`, and other packages outside the cwd — causing the path validation to fail.

## Fix

Add a `workspaces` field to `calm-suite/calm-studio/package.json` listing only the packages inside that directory. `multi-semantic-release` will now scope package discovery correctly.

## Test plan

- [ ] `automated-release-calm-studio.yml` workflow passes on next push to main touching `calm-suite/calm-studio/**`
- [ ] `multi-semantic-release` discovers only the 8 calm-studio packages
- [ ] `@calmstudio/mcp` and `@calmstudio/calm-core` published to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)