### PR TITLE
fix(advent): migrate website to Astro v6 content collections + PR build check

### DIFF
--- a/.github/workflows/build-advent-website.yml
+++ b/.github/workflows/build-advent-website.yml
@@ -1,0 +1,36 @@
+name: Build Advent Website
+
+permissions:
+    contents: read
+
+on:
+    pull_request:
+        branches:
+            - 'main'
+            - 'release*'
+        paths:
+            - 'advent-of-calm/**'
+
+jobs:
+    build-advent-website:
+        name: Build Advent Website
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout PR Branch
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              with:
+                  node-version: 24
+                  cache: npm
+                  cache-dependency-path: advent-of-calm/website/package-lock.json
+
+            - name: Install dependencies
+              run: npm ci
+              working-directory: advent-of-calm/website
+
+            - name: Build Advent Website
+              run: npm run build
+              working-directory: advent-of-calm/website

--- a/advent-of-calm/website/package-lock.json
+++ b/advent-of-calm/website/package-lock.json
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.7.tgz",
-      "integrity": "sha512-zIeDRrI0qNgN1lcCjNqt6/IVCVej7VwSa326cO8uP9BOk1cg4QuffhLnOn2gCgWQr32/wxpSRFfXiLKHglu1Tw==",
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.8.tgz",
+      "integrity": "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/advent-of-calm/website/src/content.config.ts
+++ b/advent-of-calm/website/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
 
 const daysCollection = defineCollection({
-  type: 'content',
+  loader: glob({ pattern: '**/*.md', base: './src/content/days' }),
 });
 
 export const collections = {

--- a/advent-of-calm/website/src/pages/day/[day].astro
+++ b/advent-of-calm/website/src/pages/day/[day].astro
@@ -1,20 +1,20 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getDayTitle } from '../../utils/calendar';
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   const allDays = await getCollection('days');
-  
+
   return allDays.map(entry => ({
-    params: { day: entry.slug.replace('day-', '') },
+    params: { day: entry.id.replace('day-', '') },
     props: { entry }
   }));
 }
 
 const { entry } = Astro.props;
-const { Content } = await entry.render();
-const dayNum = parseInt(entry.slug.replace('day-', ''));
+const { Content } = await render(entry);
+const dayNum = parseInt(entry.id.replace('day-', ''));
 
 const title = getDayTitle(dayNum);
 const prevDay = dayNum > 1 ? dayNum - 1 : null;

--- a/advent-of-calm/website/src/pages/setup.astro
+++ b/advent-of-calm/website/src/pages/setup.astro
@@ -1,12 +1,12 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { getEntry } from 'astro:content';
+import { getEntry, render } from 'astro:content';
 
 const entry = await getEntry('days', 'setup');
 if (!entry) {
   throw new Error('Setup content not found');
 }
-const { Content } = await entry.render();
+const { Content } = await render(entry);
 ---
 
 <Layout title="Setup - Keeping Your CALM Tools Up to Date" description="Learn how to keep your CALM CLI, VS Code Extension, and Copilot Agent up to date">


### PR DESCRIPTION
## Description

The Advent of CALM website (`advent-of-calm/website`) fails to build under Astro v6. The repo was bumped to Astro 6.x but the site still used the **legacy content collections API**, which Astro v6 removed:

- `src/content/config.ts` with `type: 'content'` → throws `LegacyContentConfigError`
- `entry.slug` and `entry.render()` → removed in v6

As a result the **"Build and Sync Advent"** deploy workflow has failed on every `main` run since the v6 bump (most recent 5+ runs red), and the failure was invisible at PR time because the site is only built on push-to-`main`, never on `pull_request`.

This PR:

1. **Migrates to the Astro v6 content collections API** — moves the config to `src/content.config.ts` using the `glob()` loader, and switches consumers to `entry.id` + `render(entry)`. Behaviour-neutral: the build produces the same 27 pages (`day/1`…`day/24`, `setup`, `index`) with `astro check` reporting 0 errors / 0 warnings.
2. **Adds a PR-time build check** (`build-advent-website.yml`) that installs and builds the standalone site on `pull_request` (path-filtered to `advent-of-calm/**`), so a break like this can't reach `main` silently again. Builds on `main` are already covered by the existing deploy workflow, so this check is intentionally PR-only.
3. **Folds in Renovate [#2542](https://github.com/finos/architecture-as-code/pull/2542)** (astro 6.3.7 → 6.3.8) so the migration and the patch bump land together and are verified as a unit. #2542 will be closed in favour of this PR.

### Notes for reviewers

- **`/day/setup` page** — `getCollection('days')` includes `setup.md` (it's copied into `days/` by `copy:content`), so a `/day/setup/` page is generated with `dayNum = NaN`. This is **pre-existing** behaviour (legacy `slug` did the same); preserved here unchanged rather than fixed, to keep the migration output-neutral. Happy to address separately if desired.
- The Advent website has no unit-test suite; the new CI build (`astro check` + `astro build`) is the regression guard.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components

- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [x] CI/CD

<!-- Also affects: advent-of-calm/website (Advent of CALM site), which has no dedicated checkbox above. -->

## Testing

- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified locally on Astro 6.3.8: `npm ci` clean, `npm run build` → `astro check` 0 errors / 0 warnings, 27 pages built. The new `build-advent-website.yml` check runs on this PR (it touches `advent-of-calm/**`).

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
