### PR TITLE
fix(calm-hub-ui): render ADR detail when decisionOutcome is absent

### DIFF
--- a/calm-hub-ui/src/hub/components/adr-renderer/AdrRenderer.test.tsx
+++ b/calm-hub-ui/src/hub/components/adr-renderer/AdrRenderer.test.tsx
@@ -136,4 +136,38 @@ describe('ADR Renderer', () => {
         expect(screen.getByText('30 Apr, 2025', { exact: false })).toBeInTheDocument();
         expect(screen.getByText('12:50', { exact: false })).toBeInTheDocument();
     });
+
+    it('should render the ADR (not a blank page) when no decision outcome is recorded', () => {
+        // ADRs created via the API start in `draft` with no decisionOutcome — this
+        // must not crash the renderer (regression for the blank-page bug).
+        const draftAdr = {
+            namespace: 'finos',
+            id: 2,
+            revision: 1,
+            adr: { ...adrDetails, decisionOutcome: undefined },
+        } as Adr;
+        render(<AdrRenderer adrDetails={draftAdr} />);
+
+        expect(screen.getByText('adr title')).toBeInTheDocument();
+        expect(screen.getByText('Decision Outcome')).toBeInTheDocument();
+        expect(screen.getByText('No decision outcome recorded yet.')).toBeInTheDocument();
+        // The chosen-option content from a populated decision must be absent.
+        expect(screen.queryByText('Decision Rational:')).not.toBeInTheDocument();
+    });
+
+    it('should render safely when a decision outcome is present but has no chosen option', () => {
+        // Defensive: a malformed/partial decisionOutcome must not crash the renderer.
+        const partialAdr = {
+            namespace: 'finos',
+            id: 3,
+            revision: 1,
+            adr: { ...adrDetails, decisionOutcome: { rationale: 'tbd' } },
+        } as Adr;
+        render(<AdrRenderer adrDetails={partialAdr} />);
+
+        expect(screen.getByText('adr title')).toBeInTheDocument();
+        expect(screen.getByText('Decision Outcome')).toBeInTheDocument();
+        // DisplayChosenOption renders nothing when chosenOption is missing.
+        expect(screen.queryByText('Decision Rational:')).not.toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/adr-renderer/AdrRenderer.tsx
+++ b/calm-hub-ui/src/hub/components/adr-renderer/AdrRenderer.tsx
@@ -58,7 +58,11 @@ export function AdrRenderer({ adrDetails }: AdrRendererProps) {
                 <StyleTitle title="Decision Outcome" />
 
                 <div className="collapse-content ps-0">
-                    <DisplayChosenOption decisionOutcome={adr!.decisionOutcome} />
+                    {adr!.decisionOutcome ? (
+                        <DisplayChosenOption decisionOutcome={adr!.decisionOutcome} />
+                    ) : (
+                        <p className="italic text-xs">No decision outcome recorded yet.</p>
+                    )}
                 </div>
             </div>
 

--- a/calm-hub-ui/src/hub/helper-functions/adr/adr-helper-function.tsx
+++ b/calm-hub-ui/src/hub/helper-functions/adr/adr-helper-function.tsx
@@ -94,19 +94,24 @@ export function DisplayConsideredOptions(props: { consideredOptions: Option[] })
 }
 
 export function DisplayChosenOption(props: { decisionOutcome: Decision }) {
+    const chosenOption = props.decisionOutcome?.chosenOption;
+    if (!chosenOption) {
+        return null;
+    }
+
     return (
         <div className="pt-2">
-            <p className="font-bold pb-1">{props.decisionOutcome.chosenOption.name}</p>
+            <p className="font-bold pb-1">{chosenOption.name}</p>
 
             <div className=" pt-1 pb-1 pe-2 markdownParagraphSpacing">
-                <Markdown>{props.decisionOutcome.chosenOption.description}</Markdown>
+                <Markdown>{chosenOption.description}</Markdown>
             </div>
 
             <p className="font-bold"> Positive Consequences:</p>
-            {getListOfConsequences(props.decisionOutcome.chosenOption.positiveConsequences, true)}
+            {getListOfConsequences(chosenOption.positiveConsequences, true)}
 
             <p className="font-bold mt-4"> Negative Consequences:</p>
-            {getListOfConsequences(props.decisionOutcome.chosenOption.negativeConsequences, false)}
+            {getListOfConsequences(chosenOption.negativeConsequences, false)}
 
             <p className="font-bold mt-4"> Decision Rational:</p>
             <div className="pe-1">


### PR DESCRIPTION
## Description

The CALM Hub UI ADR detail page rendered a **completely blank page** for any ADR without a populated `decisionOutcome`. ADRs created through the REST API start in `draft` with **no** `decisionOutcome`, so in practice every freshly-created ADR blanked the page.

Root cause: `DisplayChosenOption` dereferenced `decisionOutcome.chosenOption` with no guard, and there is no error boundary around `AdrRenderer`, so the resulting `TypeError: Cannot read properties of undefined (reading 'chosenOption')` unmounted the whole view.

This is a long-standing latent bug (present since the ADR detail page was introduced in `abeaefe5`, Issue #1222), not a recent regression — it only ever rendered correctly for fully-populated ADRs.

Changes:
- **`AdrRenderer`** — render a small placeholder ("No decision outcome recorded yet.") for the Decision Outcome section when no decision has been recorded, instead of crashing.
- **`DisplayChosenOption`** — guard against a present-but-incomplete `decisionOutcome` (missing `chosenOption`) so a malformed value also degrades gracefully rather than throwing.
- Regression tests for both the **absent** and **partial** `decisionOutcome` cases.

Closes #2548

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified manually against a local CALM Hub (standalone/Nitrite): a draft ADR (no decision) that previously blanked the page now renders, and a fully-populated ADR is unchanged. `npm run lint`, `npm test` (702 passing) and `npm run build` for `calm-hub-ui` all pass.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary (n/a — no behaviour documented changes)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
