### PR TITLE
fix(shared): run JSON schema validation in architecture-only validate path

### DIFF
--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -27,6 +27,11 @@ const schemaDir_10 = path.join(__dirname, '../../../../calm/release/1.0/meta/');
 const schemaDir_11 = path.join(__dirname, '../../../../calm/release/1.1/meta/');
 const schemaDir_12 = path.join(__dirname, '../../../../calm/release/1.2/meta/');
 
+const invalidArchMissingRelationshipTypePath = path.join(
+    __dirname,
+    '../../../test_fixtures/command/validate/invalid-architecture-missing-relationship-type.json'
+);
+
 describe('validate E2E', () => {
     let documentLoader: FileSystemDocumentLoader;
     let schemaDirectory: SchemaDirectory;
@@ -210,6 +215,49 @@ describe('validate E2E', () => {
             expect(response.spectralSchemaValidationOutputs).toHaveLength(1);
             expect(response.spectralSchemaValidationOutputs[0].message).toContain('does not refer to the unique-id');
             expect(response.spectralSchemaValidationOutputs[0].path).toBe('/flows/0/transitions/0/relationship-unique-id');
+        });
+    });
+
+    describe('architecture-only validation (no pattern flag)', () => {
+        it('reports a schema error when relationship-type is missing from a relationship', async () => {
+            const invalidArch = JSON.parse(readFileSync(invalidArchMissingRelationshipTypePath, 'utf-8'));
+
+            const response = await validate(invalidArch, undefined, undefined, schemaDirectory, false);
+
+            expect(response.hasErrors).toBeTruthy();
+            expect(response.jsonSchemaValidationOutputs.length).toBeGreaterThan(0);
+            const relationshipError = response.jsonSchemaValidationOutputs.find(
+                o => o.message.includes('relationship-type')
+            );
+            expect(relationshipError).toBeDefined();
+        });
+
+        it('accepts a valid architecture with no $schema when all required fields are present', async () => {
+            const validArch = {
+                nodes: [
+                    {
+                        'unique-id': 'svc.payment-service',
+                        'node-type': 'service',
+                        name: 'Payment Service',
+                        description: 'Handles payment processing'
+                    }
+                ],
+                relationships: [
+                    {
+                        'unique-id': 'rel.1',
+                        'relationship-type': {
+                            interacts: {
+                                actor: 'svc.payment-service',
+                                nodes: ['svc.payment-service']
+                            }
+                        }
+                    }
+                ]
+            };
+
+            const response = await validate(validArch, undefined, undefined, schemaDirectory, false);
+
+            expect(response.jsonSchemaValidationOutputs.length).toBe(0);
         });
     });
 });

--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -257,6 +257,7 @@ describe('validate E2E', () => {
 
             const response = await validate(validArch, undefined, undefined, schemaDirectory, false);
 
+            expect(response.hasErrors).toBeFalsy();
             expect(response.jsonSchemaValidationOutputs.length).toBe(0);
         });
     });

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -723,6 +723,17 @@ describe('validate - architecture only', () => {
 
         expect(schemaDirectory.getSchema).toHaveBeenCalledWith('https://calm.finos.org/release/1.2/meta/core.json');
     });
+
+    it('skips JSON schema validation and runs Spectral when schemaDirectory is undefined', async () => {
+        mocks.spectralRun.mockReturnValue([]);
+
+        const dummyArchitecture = { dummy: 'architecture' };
+        const response = await validate(dummyArchitecture, undefined, undefined, undefined, debugDisabled);
+
+        expect(response.hasErrors).toBeFalsy();
+        expect(response.jsonSchemaValidationOutputs.length).toBe(0);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
 });
 
 describe('validate timeline and schema', () => {

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -602,14 +602,25 @@ describe('validate pattern only', () => {
 });
 
 describe('validate - architecture only', () => {
+    const CORE_SCHEMA_URL = 'https://calm.finos.org/release/1.2/meta/core.json';
+
     beforeEach(() => {
+        mocks.jsonSchemaValidate.mockReset().mockReturnValue([]);
+        mocks.jsonSchemaValidatorConstructor.mockReset().mockImplementation(function () {
+            return {
+                validate: mocks.jsonSchemaValidate,
+                initialize: vi.fn().mockResolvedValue(undefined),
+            };
+        });
+        mocks.spectralRun.mockReset();
         schemaDirectory = {
-            getSchema: vi.fn(),
+            getSchema: vi.fn().mockResolvedValue({}),
+            getLoadedSchemas: vi.fn().mockReturnValue([CORE_SCHEMA_URL]),
             getAllSchemas: vi.fn(),
         } as unknown as SchemaDirectory;
     });
 
-    it('return errors when the architecture does not pass all the spectral validations ', async () => {
+    it('returns spectral errors when the architecture fails spectral validations', async () => {
         const expectedSpectralOutput: ISpectralDiagnostic[] = [
             {
                 code: 'example-error',
@@ -619,38 +630,79 @@ describe('validate - architecture only', () => {
                 range: { start: { line: 1, character: 1 }, end: { line: 2, character: 1 } }
             }
         ];
-
         mocks.spectralRun.mockReturnValue(expectedSpectralOutput);
 
-        // Use dummy object
-        const dummyPattern = { dummy: 'pattern' };
-        schemaDirectory.getSchema = vi.fn(function () { return Promise.resolve({}); });
+        const dummyArchitecture = { dummy: 'architecture' };
+        const response = await validate(dummyArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
 
-        const response = await validate(dummyPattern, undefined, undefined, schemaDirectory, debugDisabled);
-        expect(response).not.toBeNull();
-        expect(response).not.toBeUndefined();
         expect(response.hasErrors).toBeTruthy();
-        expect(response.allValidationOutputs()).not.toBeNull();
         expect(response.allValidationOutputs().length).toBeGreaterThan(0);
     });
 
-    it('returns no errors when the architecture passes all the spectral validations with no errors', async () => {
-        const expectedSpectralOutput: ISpectralDiagnostic[] = [];
+    it('returns no errors when the architecture passes spectral and JSON schema validations', async () => {
+        mocks.spectralRun.mockReturnValue([]);
 
-        mocks.spectralRun.mockReturnValue(expectedSpectralOutput);
+        const dummyArchitecture = { dummy: 'architecture' };
+        const response = await validate(dummyArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
 
-        // Use dummy object
-        const dummyPattern = { dummy: 'pattern' };
-        schemaDirectory.getSchema = vi.fn(function () { return Promise.resolve({}); });
-
-        const response = await validate(dummyPattern, undefined, undefined, schemaDirectory, debugDisabled);
-
-        expect(response).not.toBeNull();
-        expect(response).not.toBeUndefined();
         expect(response.hasErrors).not.toBeTruthy();
         expect(response.hasWarnings).not.toBeTruthy();
-        expect(response.allValidationOutputs()).not.toBeNull();
         expect(response.allValidationOutputs().length).toBe(0);
+    });
+
+    it('returns JSON schema errors when the architecture fails JSON schema validation', async () => {
+        mocks.spectralRun.mockReturnValue([]);
+        const jsonSchemaError = {
+            instancePath: '/relationships/0',
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: { missingProperty: 'relationship-type' },
+            message: 'must have required property \'relationship-type\''
+        };
+        mocks.jsonSchemaValidate.mockReturnValue([jsonSchemaError]);
+
+        const invalidArchitecture = {
+            nodes: [],
+            relationships: [{ 'unique-id': 'rel-1', source: 'a', target: 'b' }]
+        };
+        const response = await validate(invalidArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
+
+        expect(response.hasErrors).toBeTruthy();
+        expect(response.jsonSchemaValidationOutputs.length).toBe(1);
+        expect(response.jsonSchemaValidationOutputs[0].message).toContain('relationship-type');
+    });
+
+    it('skips JSON schema validation when no CALM core schema is loaded', async () => {
+        mocks.spectralRun.mockReturnValue([]);
+        schemaDirectory = {
+            ...schemaDirectory,
+            getLoadedSchemas: vi.fn().mockReturnValue(['https://calm.finos.org/release/1.2/meta/interface.json']),
+        } as unknown as SchemaDirectory;
+
+        const dummyArchitecture = { dummy: 'architecture' };
+        const response = await validate(dummyArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
+
+        expect(response.hasErrors).toBeFalsy();
+        expect(response.jsonSchemaValidationOutputs.length).toBe(0);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('picks the most recent CALM core schema when multiple versions are loaded', async () => {
+        mocks.spectralRun.mockReturnValue([]);
+        schemaDirectory = {
+            getSchema: vi.fn().mockResolvedValue({}),
+            getLoadedSchemas: vi.fn().mockReturnValue([
+                'https://calm.finos.org/release/1.0/meta/core.json',
+                'https://calm.finos.org/release/1.2/meta/core.json',
+                'https://calm.finos.org/release/1.1/meta/core.json',
+            ]),
+            getAllSchemas: vi.fn(),
+        } as unknown as SchemaDirectory;
+
+        const dummyArchitecture = { dummy: 'architecture' };
+        await validate(dummyArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
+
+        expect(schemaDirectory.getSchema).toHaveBeenCalledWith('https://calm.finos.org/release/1.2/meta/core.json');
     });
 });
 

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -693,8 +693,27 @@ describe('validate - architecture only', () => {
             getSchema: vi.fn().mockResolvedValue({}),
             getLoadedSchemas: vi.fn().mockReturnValue([
                 'https://calm.finos.org/release/1.0/meta/core.json',
+                'https://calm.finos.org/release/1.10/meta/core.json',
                 'https://calm.finos.org/release/1.2/meta/core.json',
                 'https://calm.finos.org/release/1.1/meta/core.json',
+            ]),
+            getAllSchemas: vi.fn(),
+        } as unknown as SchemaDirectory;
+
+        const dummyArchitecture = { dummy: 'architecture' };
+        await validate(dummyArchitecture, undefined, undefined, schemaDirectory, debugDisabled);
+
+        // 1.10 > 1.2 numerically — lexicographic sort would incorrectly pick 1.9 or 1.2
+        expect(schemaDirectory.getSchema).toHaveBeenCalledWith('https://calm.finos.org/release/1.10/meta/core.json');
+    });
+
+    it('prefers release over draft when both are loaded', async () => {
+        mocks.spectralRun.mockReturnValue([]);
+        schemaDirectory = {
+            getSchema: vi.fn().mockResolvedValue({}),
+            getLoadedSchemas: vi.fn().mockReturnValue([
+                'https://calm.finos.org/draft/2026-03/meta/core.json',
+                'https://calm.finos.org/release/1.2/meta/core.json',
             ]),
             getAllSchemas: vi.fn(),
         } as unknown as SchemaDirectory;

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -227,7 +227,7 @@ async function validatePatternOnly(pattern: object, schemaDirectory: SchemaDirec
  * @param debug - Whether to log at debug level.
  * @returns the validation outcome with the results of the spectral and JSON schema validations.
  **/
-async function validateArchitectureOnly(architecture: object, schemaDirectory: SchemaDirectory, debug: boolean): Promise<ValidationOutcome> {
+async function validateArchitectureOnly(architecture: object, schemaDirectory: SchemaDirectory | undefined, debug: boolean): Promise<ValidationOutcome> {
     logger.debug('Pattern was not provided, validating Architecture against the most recent loaded CALM core schema');
 
     const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(JSON.stringify(architecture), validationRulesForArchitecture, 'architecture');
@@ -236,7 +236,7 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
     let errors = spectralResultForArchitecture.errors;
     const warnings = spectralResultForArchitecture.warnings;
 
-    const coreSchemaUrl = findLatestCalmCoreSchemaUrl(schemaDirectory);
+    const coreSchemaUrl = schemaDirectory ? findLatestCalmCoreSchemaUrl(schemaDirectory) : undefined;
     if (!coreSchemaUrl) {
         logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
     } else {
@@ -267,17 +267,44 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
 
 /**
  * Finds the URL of the most recent CALM core schema loaded in the schema directory.
- * Schemas are sorted descending by URL, so release versions rank above draft (r > d)
- * and higher release numbers rank above lower ones (1.2 > 1.1 > 1.0).
+ *
+ * Precedence rules (highest first):
+ *   1. release > draft  (a final release outranks an in-progress draft)
+ *   2. Within release: higher version numbers win, compared numerically segment by
+ *      segment so that 1.10 > 1.9 > 1.2 (lexicographic sort would get this wrong).
+ *   3. Within draft: the same numeric segment comparison applies.
+ *
  * Returns undefined if no CALM core schema is loaded.
  */
 function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string | undefined {
     const coreSchemaPattern = /calm\.finos\.org\/.*\/meta\/core\.json$/;
     const matches = schemaDirectory.getLoadedSchemas()
-        .filter(id => coreSchemaPattern.test(id))
-        .sort()
-        .reverse();
-    return matches[0];
+        .filter(id => coreSchemaPattern.test(id));
+
+    if (matches.length === 0) return undefined;
+
+    return matches.sort((a, b) => {
+        const isRelease = (url: string) => url.includes('/release/');
+        if (isRelease(a) !== isRelease(b)) {
+            return isRelease(a) ? -1 : 1; // release first
+        }
+        return compareVersionSegments(a, b);
+    })[0];
+}
+
+function compareVersionSegments(a: string, b: string): number {
+    const versionPattern = /\/(\d+[\d.-]*)\/meta\/core\.json$/;
+    const parseSegments = (url: string) =>
+        (versionPattern.exec(url)?.[1] ?? '0').split(/[.-]/).map(Number);
+
+    const segA = parseSegments(a);
+    const segB = parseSegments(b);
+    const len = Math.max(segA.length, segB.length);
+    for (let i = 0; i < len; i++) {
+        const diff = (segB[i] ?? 0) - (segA[i] ?? 0);
+        if (diff !== 0) return diff;
+    }
+    return 0;
 }
 
 /**

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -133,7 +133,7 @@ export async function validate(
             // `patternOrSchema` should really be a CALM pattern in this case.
             return await validatePatternOnly(patternOrSchema, schemaDirectory, debug);
         } else if (architecture) {
-            return await validateArchitectureOnly(architecture);
+            return await validateArchitectureOnly(architecture, schemaDirectory, debug);
         } else {
             logger.debug('You must provide an architecture, a pattern, or a timeline');
             throw new Error('You must provide an architecture, a pattern, or a timeline');
@@ -219,24 +219,65 @@ async function validatePatternOnly(pattern: object, schemaDirectory: SchemaDirec
 }
 
 /**
- * Run the spectral validations for the case where only the architecture is provided.
- * Note that if only the architecture is provided, the CLI tool will attempt to validate the architecture against its specified CALM schema.
- * i.e. the validateArchitectureAgainstPattern method will be called instead of this method.
- * 
+ * Run the spectral and JSON schema validations for the case where only the architecture is provided.
+ * Discovers the most recent available CALM core schema from the schema directory and validates against it.
+ *
  * @param architecture - The architecture, as a JS object.
- * @returns the validation outcome with the results of the spectral validation 
+ * @param schemaDirectory - SchemaDirectory instance for schema resolution.
+ * @param debug - Whether to log at debug level.
+ * @returns the validation outcome with the results of the spectral and JSON schema validations.
  **/
-async function validateArchitectureOnly(architecture: object): Promise<ValidationOutcome> {
-    logger.debug('Pattern was not provided, validating Architecture against its specified CALM schema');
+async function validateArchitectureOnly(architecture: object, schemaDirectory: SchemaDirectory, debug: boolean): Promise<ValidationOutcome> {
+    logger.debug('Pattern was not provided, validating Architecture against the most recent loaded CALM core schema');
 
     const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(JSON.stringify(architecture), validationRulesForArchitecture, 'architecture');
 
-    const jsonSchemaValidations = [];
-    const errors = spectralResultForArchitecture.errors;
+    let jsonSchemaValidations = [];
+    let errors = spectralResultForArchitecture.errors;
     const warnings = spectralResultForArchitecture.warnings;
+
+    const coreSchemaUrl = findLatestCalmCoreSchemaUrl(schemaDirectory);
+    if (!coreSchemaUrl) {
+        logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
+    } else {
+        logger.debug(`Validating architecture against CALM core schema: ${coreSchemaUrl}`);
+        const coreSchema = await schemaDirectory.getSchema(coreSchemaUrl);
+        try {
+            const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, coreSchema, debug);
+            await jsonSchemaValidator.initialize();
+            const schemaErrors = jsonSchemaValidator.validate(architecture);
+            if (schemaErrors.length > 0) {
+                logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
+                errors = true;
+                jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'architecture');
+            }
+        } catch (error) {
+            const errorMessage = toErrorMessage(error);
+            logger.error(`JSON Schema compilation failed: ${errorMessage}`);
+            jsonSchemaValidations = [
+                new ValidationOutput('json-schema', 'error', errorMessage, '/', undefined, undefined, undefined, undefined, undefined, 'architecture')
+            ];
+            errors = true;
+        }
+    }
 
     logger.debug(`Returning validation outcome with ${jsonSchemaValidations.length} JSON schema validations, errors: ${errors}`);
     return new ValidationOutcome(jsonSchemaValidations, spectralResultForArchitecture.spectralIssues, errors, warnings);
+}
+
+/**
+ * Finds the URL of the most recent CALM core schema loaded in the schema directory.
+ * Schemas are sorted descending by URL, so release versions rank above draft (r > d)
+ * and higher release numbers rank above lower ones (1.2 > 1.1 > 1.0).
+ * Returns undefined if no CALM core schema is loaded.
+ */
+function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string | undefined {
+    const coreSchemaPattern = /calm\.finos\.org\/.*\/meta\/core\.json$/;
+    const matches = schemaDirectory.getLoadedSchemas()
+        .filter(id => coreSchemaPattern.test(id))
+        .sort()
+        .reverse();
+    return matches[0];
 }
 
 /**

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -272,6 +272,11 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
  * numeric-aware locale sort so that 1.10 > 1.9 > 1.2 (lexicographic order
  * would get this wrong).
  *
+ * Note: localeCompare with { numeric: true } treats runs of digits as numbers,
+ * which works correctly for all current CALM version formats (1.x, 2026-03).
+ * A version segment containing non-numeric characters (e.g. 1.2-beta) could
+ * sort unexpectedly — if pre-release versions are ever published, revisit this.
+ *
  * Returns undefined if no CALM core schema is loaded.
  */
 function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string | undefined {

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -268,11 +268,9 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
 /**
  * Finds the URL of the most recent CALM core schema loaded in the schema directory.
  *
- * Precedence rules (highest first):
- *   1. release > draft  (a final release outranks an in-progress draft)
- *   2. Within release: higher version numbers win, compared numerically segment by
- *      segment so that 1.10 > 1.9 > 1.2 (lexicographic sort would get this wrong).
- *   3. Within draft: the same numeric segment comparison applies.
+ * Precedence: release > draft. Within each tier, URLs are compared with a
+ * numeric-aware locale sort so that 1.10 > 1.9 > 1.2 (lexicographic order
+ * would get this wrong).
  *
  * Returns undefined if no CALM core schema is loaded.
  */
@@ -285,26 +283,9 @@ function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string |
 
     return matches.sort((a, b) => {
         const isRelease = (url: string) => url.includes('/release/');
-        if (isRelease(a) !== isRelease(b)) {
-            return isRelease(a) ? -1 : 1; // release first
-        }
-        return compareVersionSegments(a, b);
+        if (isRelease(a) !== isRelease(b)) return isRelease(a) ? -1 : 1;
+        return b.localeCompare(a, undefined, { numeric: true });
     })[0];
-}
-
-function compareVersionSegments(a: string, b: string): number {
-    const versionPattern = /\/(\d+[\d.-]*)\/meta\/core\.json$/;
-    const parseSegments = (url: string) =>
-        (versionPattern.exec(url)?.[1] ?? '0').split(/[.-]/).map(Number);
-
-    const segA = parseSegments(a);
-    const segB = parseSegments(b);
-    const len = Math.max(segA.length, segB.length);
-    for (let i = 0; i < len; i++) {
-        const diff = (segB[i] ?? 0) - (segA[i] ?? 0);
-        if (diff !== 0) return diff;
-    }
-    return 0;
 }
 
 /**

--- a/shared/test_fixtures/command/validate/invalid-architecture-missing-relationship-type.json
+++ b/shared/test_fixtures/command/validate/invalid-architecture-missing-relationship-type.json
@@ -1,7 +1,7 @@
 {
   "nodes": [
-    { "unique-id": "svc.payment-service", "node-type": "service", "name": "payment-service", "interfaces": [] },
-    { "unique-id": "topic.payment-topic", "node-type": "message-broker", "name": "payment-topic", "interfaces": [] }
+    { "unique-id": "svc.payment-service", "node-type": "service", "name": "payment-service", "description": "Handles payment processing", "interfaces": [] },
+    { "unique-id": "topic.payment-topic", "node-type": "message-broker", "name": "payment-topic", "description": "Payment events topic", "interfaces": [] }
   ],
   "relationships": [
     {

--- a/shared/test_fixtures/command/validate/invalid-architecture-missing-relationship-type.json
+++ b/shared/test_fixtures/command/validate/invalid-architecture-missing-relationship-type.json
@@ -1,0 +1,14 @@
+{
+  "nodes": [
+    { "unique-id": "svc.payment-service", "node-type": "service", "name": "payment-service", "interfaces": [] },
+    { "unique-id": "topic.payment-topic", "node-type": "message-broker", "name": "payment-topic", "interfaces": [] }
+  ],
+  "relationships": [
+    {
+      "unique-id": "rel.payment-service.publish.payment-topic",
+      "source": "svc.payment-service",
+      "target": "topic.payment-topic",
+      "interaction": "publish"
+    }
+  ]
+}


### PR DESCRIPTION
When `calm validate -a <file>` is run without a pattern flag and the architecture has no `$schema` property, validation previously only ran Spectral rules and skipped JSON schema validation entirely. This meant required fields like `relationship-type` were never checked.

The fix adds JSON schema validation to `validateArchitectureOnly` by dynamically discovering the most recent available CALM core schema from the schema directory (sorted descending by URL) and validating against it. If no CALM core schema is loaded, a warning is emitted and JSON schema validation is skipped gracefully.

Fixes #2518.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
Conformed

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
