### PR TITLE
fix(calm-hub): guard against null versions document in resource stores

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -136,6 +136,9 @@ public class MongoArchitectureStore implements ArchitectureStore {
             if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
                 // Extract the versions map from the matching pattern
                 Document versions = (Document) architectureDoc.get("versions");
+                if (versions == null) {
+                    throw new ArchitectureNotFoundException();
+                }
                 Set<String> versionKeys = versions.keySet();
 
                 //Convert from Mongo representation
@@ -176,6 +179,9 @@ public class MongoArchitectureStore implements ArchitectureStore {
             if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
                 // Retrieve the versions map from the matching pattern
                 Document versions = (Document) architectureDoc.get("versions");
+                if (versions == null) {
+                    throw new ArchitectureVersionNotFoundException();
+                }
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(architecture.getMongoVersion());

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -125,6 +125,9 @@ public class MongoPatternStore implements PatternStore {
             if (pattern.getId() == patternDoc.getInteger("patternId")) {
                 // Extract the versions map from the matching pattern
                 Document versions = (Document) patternDoc.get("versions");
+                if (versions == null) {
+                    throw new PatternNotFoundException();
+                }
                 Set<String> versionKeys = versions.keySet();
 
                 //Convert from Mongo representation
@@ -165,6 +168,9 @@ public class MongoPatternStore implements PatternStore {
             if (pattern.getId() == patternDoc.getInteger("patternId")) {
                 // Retrieve the versions map from the matching pattern
                 Document versions = (Document) patternDoc.get("versions");
+                if (versions == null) {
+                    throw new PatternVersionNotFoundException();
+                }
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(pattern.getMongoVersion());

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -117,6 +117,9 @@ public class MongoTimelineStore implements TimelineStore {
             if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
                 // Extract the versions map from the matching timeline
                 Document versions = (Document) timelineDoc.get("versions");
+                if (versions == null) {
+                    throw new TimelineNotFoundException();
+                }
                 Set<String> versionKeys = versions.keySet();
 
                 // Convert from Mongo representation
@@ -157,6 +160,9 @@ public class MongoTimelineStore implements TimelineStore {
             if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
                 // Retrieve the versions map from the matching timeline
                 Document versions = (Document) timelineDoc.get("versions");
+                if (versions == null) {
+                    throw new TimelineVersionNotFoundException();
+                }
 
                 // Return the timeline JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(timeline.getMongoVersion());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -162,6 +162,9 @@ public class NitriteArchitectureStore implements ArchitectureStore {
             if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
                 // Extract the versions map from the matching architecture
                 Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                if (versions == null) {
+                    throw new ArchitectureNotFoundException();
+                }
                 Set<String> versionKeys = versions.getFields();
 
                 // Convert from Nitrite representation
@@ -205,20 +208,21 @@ public class NitriteArchitectureStore implements ArchitectureStore {
             if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
                 // Retrieve the versions map from the matching architecture
                 Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                if (versions == null) {
+                    throw new ArchitectureVersionNotFoundException();
+                }
 
                 // Return the architecture JSON blob for the specified version
                 String mongoVersion = architecture.getMongoVersion();
                 Object versionObj = versions.get(mongoVersion);
                 LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
 
-                if (versionObj == null) {
+                if (!(versionObj instanceof String)) {
                     LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",
                             architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
                     throw new ArchitectureVersionNotFoundException();
                 }
 
-                // In NitriteDB, we're storing the JSON as a string directly
-                // No need to convert to JSON string
                 return (String) versionObj;
             }
         }
@@ -285,6 +289,9 @@ public class NitriteArchitectureStore implements ArchitectureStore {
                         if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architecture.getId()) {
                             // Found the architecture, update its version
                             Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                            if (versions == null) {
+                                throw new ArchitectureNotFoundException();
+                            }
                             versions.put(architecture.getMongoVersion(), architecture.getArchitectureJson());
                             architectureDoc.put(NAME_FIELD, architecture.getName());
                             architectureDoc.put(DESCRIPTION_FIELD, architecture.getDescription());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -181,6 +181,9 @@ public class NitritePatternStore implements PatternStore {
         }
 
         Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+        if (versions == null) {
+            throw new PatternNotFoundException();
+        }
         Set<String> fieldNames = versions.getFields();
         List<String> versionList = new ArrayList<>();
         for (String fieldName : fieldNames) {
@@ -206,6 +209,9 @@ public class NitritePatternStore implements PatternStore {
         }
 
         Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+        if (versions == null) {
+            throw new PatternVersionNotFoundException();
+        }
         String patternJson = versions.get(pattern.getMongoVersion(), String.class);
 
         if (patternJson == null) {
@@ -243,6 +249,9 @@ public class NitritePatternStore implements PatternStore {
             }
 
             Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new PatternNotFoundException();
+            }
             if (versions.containsKey(pattern.getMongoVersion())) {
                 LOG.warn("Version '{}' already exists for pattern {} in namespace '{}'",
                         pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
@@ -307,6 +316,9 @@ public class NitritePatternStore implements PatternStore {
         }
 
         Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+        if (versions == null) {
+            throw new PatternNotFoundException();
+        }
         versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
         patternDoc.put(VERSIONS_FIELD, versions);
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -162,14 +162,15 @@ public class NitriteTimelineStore implements TimelineStore {
             if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
                 // Extract the versions map from the matching timeline
                 Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
+                if (versions == null) {
+                    throw new TimelineNotFoundException();
+                }
 
                 // Convert from Nitrite representation
                 List<String> resourceVersions = new ArrayList<>();
-                if (versions != null) {
-                    Set<String> versionKeys = versions.getFields();
-                    for (String versionKey : versionKeys) {
-                        resourceVersions.add(versionKey.replace('-', '.'));
-                    }
+                Set<String> versionKeys = versions.getFields();
+                for (String versionKey : versionKeys) {
+                    resourceVersions.add(versionKey.replace('-', '.'));
                 }
                 return resourceVersions;
             }
@@ -204,19 +205,21 @@ public class NitriteTimelineStore implements TimelineStore {
             if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
                 // Retrieve the versions map from the matching timeline
                 Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
+                if (versions == null) {
+                    throw new TimelineVersionNotFoundException();
+                }
 
                 // Return the timeline JSON blob for the specified version
                 String mongoVersion = timeline.getMongoVersion();
                 Object versionObj = versions.get(mongoVersion);
                 LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
 
-                if (versionObj == null) {
+                if (!(versionObj instanceof String)) {
                     LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",
                             timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
                     throw new TimelineVersionNotFoundException();
                 }
 
-                // In NitriteDB, we're storing the JSON as a string directly
                 return (String) versionObj;
             }
         }
@@ -280,6 +283,9 @@ public class NitriteTimelineStore implements TimelineStore {
                     if (timelineDoc.get(TIMELINE_ID_FIELD, Integer.class) == timeline.getId()) {
                         // Found the timeline, update its version
                         Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
+                        if (versions == null) {
+                            throw new TimelineNotFoundException();
+                        }
                         versions.put(timeline.getMongoVersion(), timeline.getTimelineJson());
                         timelineDoc.put(VERSIONS_FIELD, versions);
                         // Defensive: the REST layer enforces @NotBlank on name/description via CreateTimelineRequest,

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -274,6 +274,38 @@ public class TestMongoArchitectureStoreShould {
     }
 
     @Test
+    void throw_architecture_not_found_when_versions_document_is_missing_on_get_versions() {
+        Document architectureWithNoVersions = new Document("namespace", NAMESPACE)
+                .append("architectures", List.of(new Document("architectureId", 42)));
+        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(architectureCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(architectureWithNoVersions);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).setId(42).build();
+
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> mongoArchitectureStore.getArchitectureVersions(architecture));
+    }
+
+    @Test
+    void throw_architecture_version_not_found_when_versions_document_is_missing_on_get_for_version() {
+        Document architectureWithNoVersions = new Document("namespace", NAMESPACE)
+                .append("architectures", List.of(new Document("architectureId", 42)));
+        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(architectureCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(architectureWithNoVersions);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).setId(42).setVersion("1.0.0").build();
+
+        assertThrows(ArchitectureVersionNotFoundException.class,
+                () -> mongoArchitectureStore.getArchitectureForVersion(architecture));
+    }
+
+    @Test
     void get_architecture_versions_for_valid_architecture_returns_list_of_versions() throws ArchitectureNotFoundException, NamespaceNotFoundException {
         mockSetupArchitectureDocumentWithVersions();
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -254,6 +254,38 @@ public class TestMongoPatternStoreShould {
     }
 
     @Test
+    void throw_pattern_not_found_when_versions_document_is_missing_on_get_versions() {
+        Document patternWithNoVersions = new Document("namespace", "finos")
+                .append("patterns", List.of(new Document("patternId", 42)));
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(patternCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(patternWithNoVersions);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos").setId(42).build();
+
+        assertThrows(PatternNotFoundException.class,
+                () -> mongoPatternStore.getPatternVersions(pattern));
+    }
+
+    @Test
+    void throw_pattern_version_not_found_when_versions_document_is_missing_on_get_for_version() {
+        Document patternWithNoVersions = new Document("namespace", "finos")
+                .append("patterns", List.of(new Document("patternId", 42)));
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(patternCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(patternWithNoVersions);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos").setId(42).setVersion("1.0.0").build();
+
+        assertThrows(PatternVersionNotFoundException.class,
+                () -> mongoPatternStore.getPatternForVersion(pattern));
+    }
+
+    @Test
     void get_pattern_versions_for_valid_pattern_returns_list_of_versions() throws PatternNotFoundException, NamespaceNotFoundException {
         mockSetupPatternDocumentWithVersions();
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -250,6 +250,38 @@ public class TestMongoTimelineStoreShould {
     }
 
     @Test
+    void throw_timeline_not_found_when_versions_document_is_missing_on_get_versions() {
+        Document timelineWithNoVersions = new Document("namespace", NAMESPACE)
+                .append("timelines", List.of(new Document("timelineId", 42)));
+        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(timelineCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(timelineWithNoVersions);
+
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(42).build();
+
+        assertThrows(TimelineNotFoundException.class,
+                () -> mongoTimelineStore.getTimelineVersions(timeline));
+    }
+
+    @Test
+    void throw_timeline_version_not_found_when_versions_document_is_missing_on_get_for_version() {
+        Document timelineWithNoVersions = new Document("namespace", NAMESPACE)
+                .append("timelines", List.of(new Document("timelineId", 42)));
+        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(timelineCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(timelineWithNoVersions);
+
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(42).setVersion("1.0.0").build();
+
+        assertThrows(TimelineVersionNotFoundException.class,
+                () -> mongoTimelineStore.getTimelineForVersion(timeline));
+    }
+
+    @Test
     void get_timeline_versions_for_valid_timeline_returns_list_of_versions() throws TimelineNotFoundException, NamespaceNotFoundException {
         mockSetupTimelineDocumentWithVersions();
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -362,6 +362,29 @@ public class TestNitriteArchitectureStoreShould {
     }
 
     @Test
+    public void testGetArchitectureVersions_whenVersionsDocumentIsNull_throwsArchitectureNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document architectureDoc = Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("architectures", List.of(architectureDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .build();
+
+        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.getArchitectureVersions(architecture));
+    }
+
+    @Test
     public void testGetArchitectureForVersion_whenNamespaceDoesNotExist_throwsException() {
         // Arrange
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
@@ -428,6 +451,58 @@ public class TestNitriteArchitectureStoreShould {
         // Act & Assert
         assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
         verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    }
+
+    @Test
+    public void testGetArchitectureForVersion_whenVersionsDocumentIsNull_throwsArchitectureVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document architectureDoc = Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("architectures", List.of(architectureDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .build();
+
+        assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
+    }
+
+    @Test
+    public void testGetArchitectureForVersion_whenVersionObjIsNotAString_throwsArchitectureVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versions = Document.createDocument()
+                .put("1-0-0", 12345);
+
+        Document architectureDoc = Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID)
+                .put("versions", versions);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("architectures", List.of(architectureDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .build();
+
+        assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
     }
 
     @Test
@@ -626,6 +701,31 @@ public class TestNitriteArchitectureStoreShould {
         // Act & Assert
         assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
         verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    }
+
+    @Test
+    public void testUpdateArchitectureForVersion_whenVersionsDocumentIsNull_throwsArchitectureNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document architectureDoc = Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("architectures", List.of(architectureDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .setArchitecture(VALID_JSON)
+                .build();
+
+        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -319,6 +319,42 @@ public class TestNitritePatternStoreShould {
     }
 
     @Test
+    public void testGetPatternVersions_whenVersionsDocumentIsNull_throwsPatternNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document patternDoc = Document.createDocument().put("patternId", PATTERN_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", List.of(patternDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE).setId(PATTERN_ID).build();
+
+        assertThrows(PatternNotFoundException.class, () -> patternStore.getPatternVersions(pattern));
+    }
+
+    @Test
+    public void testGetPatternForVersion_whenVersionsDocumentIsNull_throwsPatternVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document patternDoc = Document.createDocument().put("patternId", PATTERN_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", List.of(patternDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE).setId(PATTERN_ID).setVersion("1.0.0").build();
+
+        assertThrows(PatternVersionNotFoundException.class, () -> patternStore.getPatternForVersion(pattern));
+    }
+
+    @Test
     public void testGetPatternForVersion_whenVersionExists_returnsPatternJson() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
         // Arrange
         Pattern pattern = new Pattern.PatternBuilder()

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -495,6 +495,29 @@ public class TestNitritePatternStoreShould {
     }
 
     @Test
+    public void testCreatePatternForVersion_whenVersionsDocumentIsNull_throwsPatternNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document patternDoc = Document.createDocument().put("patternId", PATTERN_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", List.of(patternDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1.0.0")
+                .setPattern(PATTERN_JSON)
+                .build();
+
+        assertThrows(PatternNotFoundException.class, () -> patternStore.createPatternForVersion(pattern));
+    }
+
+    @Test
     public void testCreatePatternForVersion_whenSuccess_returnsPattern() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionExistsException {
         // Arrange
         Pattern pattern = new Pattern.PatternBuilder()
@@ -572,6 +595,29 @@ public class TestNitritePatternStoreShould {
         when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
 
         // Act & Assert
+        assertThrows(PatternNotFoundException.class, () -> patternStore.updatePatternForVersion(pattern));
+    }
+
+    @Test
+    public void testUpdatePatternForVersion_whenVersionsDocumentIsNull_throwsPatternNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document patternDoc = Document.createDocument().put("patternId", PATTERN_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", List.of(patternDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1.0.0")
+                .setPattern(PATTERN_JSON)
+                .build();
+
         assertThrows(PatternNotFoundException.class, () -> patternStore.updatePatternForVersion(pattern));
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
@@ -354,6 +354,63 @@ public class TestNitriteTimelineStoreShould {
     }
 
     @Test
+    public void testGetTimelineVersions_whenVersionsDocumentIsNull_throwsTimelineNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("timelines", List.of(timelineDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).build();
+
+        assertThrows(TimelineNotFoundException.class, () -> timelineStore.getTimelineVersions(timeline));
+    }
+
+    @Test
+    public void testGetTimelineForVersion_whenVersionsDocumentIsNull_throwsTimelineVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("timelines", List.of(timelineDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).setVersion(VERSION).build();
+
+        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
+    }
+
+    @Test
+    public void testGetTimelineForVersion_whenVersionObjIsNotAString_throwsTimelineVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versions = Document.createDocument().put("1-0-0", 12345);
+        Document timelineDoc = Document.createDocument()
+                .put("timelineId", TIMELINE_ID)
+                .put("versions", versions);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("timelines", List.of(timelineDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).setVersion(VERSION).build();
+
+        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
+    }
+
+    @Test
     public void testGetTimelineForVersion_whenVersionExists_returnsTimelineJson() throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
@@ -567,6 +567,29 @@ public class TestNitriteTimelineStoreShould {
     }
 
     @Test
+    public void testUpdateTimelineForVersion_whenVersionsDocumentIsNull_throwsTimelineNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("timelines", List.of(timelineDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Timeline timeline = new Timeline.TimelineBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(TIMELINE_ID)
+                .setVersion(VERSION)
+                .setTimeline(VALID_JSON)
+                .build();
+
+        assertThrows(TimelineNotFoundException.class, () -> timelineStore.updateTimelineForVersion(timeline));
+    }
+
+    @Test
     public void testUpdateTimelineForVersion_whenValidParameters_returnsUpdatedTimeline() throws NamespaceNotFoundException, TimelineNotFoundException {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
 


### PR DESCRIPTION
## Description
When a resource document exists without a versions sub-document (e.g. hand-edited store, partial migration), all get* and write* methods in the Mongo and Nitrite architecture/pattern/timeline stores would NPE.

Add null checks on the versions document in every affected method, throwing the appropriate *NotFoundException or *VersionNotFoundException rather than propagating a NullPointerException as HTTP 500.

Also add instanceof String guards in the Nitrite stores before casting versionObj, covering the case where the stored value is not a String.

All store implementations now behave consistently: a null versions document throws *NotFoundException from getVersions and *VersionNotFoundException from getForVersion across both Mongo and Nitrite backends.

Inline null checks were preferred over a helper method because each method throws a different checked exception type, and Java checked exceptions do not compose cleanly with functional interfaces — a helper would require an awkward multi-throws signature or an unchecked wrapper that hides intent. The three-line pattern is idiomatic Java here.

NitriteTimelineStore.getTimelineVersions previously returned an empty list (200) when the versions sub-document was absent; it now throws TimelineNotFoundException (404) for consistency with all other store implementations. This is an intentional behavior change.

Fixes #2498.

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
