### PR TITLE
fix(calm-hub-ui): enclose nested composed-of containers and keep dragged nodes inside

### DIFF
--- a/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Node, Edge, NodeChange } from 'reactflow';
-import { calculateGroupBounds } from '../utils/layoutUtils.js';
+import { reflowContainersToFitChildren } from '../utils/layoutUtils.js';
 
 interface UseGraphInteractionsOptions {
     setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
@@ -28,35 +28,18 @@ export function useGraphInteractions({
         (changes: NodeChange[]) => {
             onNodesChangeBase(changes);
 
-            const hasPositionChanges = changes.some(
-                (change) => change.type === 'position' && change.dragging === false
-            );
+            // Reflow on every position change (during the drag, not just at the
+            // end) so containers resize live to keep their children enclosed on
+            // all sides. ReactFlow recomputes the dragged node's parent-relative
+            // position each frame, so shifting a container's origin mid-drag
+            // stays consistent with the pointer.
+            const hasPositionChanges = changes.some((change) => change.type === 'position');
 
             if (hasPositionChanges) {
-                setNodes((currentNodes) => {
-                    let updated = false;
-                    const newNodes = currentNodes.map((node) => {
-                        if (!isGroupType(node.type)) return node;
-                        const bounds = calculateGroupBounds(node.id, currentNodes);
-                        if (!bounds) return node;
-                        const currentWidth = (node.style?.width as number) || node.width || 0;
-                        const currentHeight = (node.style?.height as number) || node.height || 0;
-                        if (bounds.width !== currentWidth || bounds.height !== currentHeight) {
-                            updated = true;
-                            return {
-                                ...node,
-                                width: bounds.width,
-                                height: bounds.height,
-                                style: { ...node.style, width: bounds.width, height: bounds.height },
-                            };
-                        }
-                        return node;
-                    });
-                    return updated ? newNodes : currentNodes;
-                });
+                setNodes((currentNodes) => reflowContainersToFitChildren(currentNodes));
             }
         },
-        [onNodesChangeBase, setNodes, isGroupType]
+        [onNodesChangeBase, setNodes]
     );
 
     const handleNodeClick = useCallback(

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { parseCALMData } from './calmTransformer';
 import { CalmArchitectureSchema } from '@finos/calm-models/types';
+import { GRAPH_LAYOUT } from './constants';
 
 describe('parseCALMData', () => {
     it('returns empty arrays for null data', () => {
@@ -144,6 +145,75 @@ describe('parseCALMData', () => {
         expect(containerNode?.type).toBe('group');
         const childNode = result.nodes.find((n) => n.id === 'node-1');
         expect(childNode?.parentId).toBe('container-1');
+    });
+
+    describe('nested composed-of containers (regression: finos/architecture-as-code#2567)', () => {
+        // outer ⊃ inner ⊃ { leaf-1 → leaf-2 }. The connects edge forces the
+        // inner container to be laid out wider than a standard node, so the
+        // outer container must account for the inner container's true size.
+        const nestedData: CalmArchitectureSchema = {
+            nodes: [
+                { 'unique-id': 'outer', name: 'Outer', 'node-type': 'system' },
+                { 'unique-id': 'inner', name: 'Inner', 'node-type': 'system' },
+                { 'unique-id': 'leaf-1', name: 'Leaf 1', 'node-type': 'service' },
+                { 'unique-id': 'leaf-2', name: 'Leaf 2', 'node-type': 'service' },
+            ],
+            relationships: [
+                {
+                    'unique-id': 'rel-outer',
+                    'relationship-type': { 'composed-of': { container: 'outer', nodes: ['inner'] } },
+                },
+                {
+                    'unique-id': 'rel-inner',
+                    'relationship-type': {
+                        'composed-of': { container: 'inner', nodes: ['leaf-1', 'leaf-2'] },
+                    },
+                },
+                {
+                    'unique-id': 'rel-connects',
+                    'relationship-type': {
+                        connects: { source: { node: 'leaf-1' }, destination: { node: 'leaf-2' } },
+                    },
+                },
+            ],
+        };
+
+        it('sizes the inner container wider than a standard node', () => {
+            const { nodes } = parseCALMData(nestedData);
+            const inner = nodes.find((n) => n.id === 'inner')!;
+            expect(inner.width).toBeGreaterThan(GRAPH_LAYOUT.NODE_WIDTH);
+        });
+
+        it('fully encloses the inner container within the outer container', () => {
+            const { nodes } = parseCALMData(nestedData);
+            const outer = nodes.find((n) => n.id === 'outer')!;
+            const inner = nodes.find((n) => n.id === 'inner')!;
+
+            expect(outer.width).toBeDefined();
+            expect(outer.height).toBeDefined();
+            // The inner container (positioned relative to outer) must not
+            // overflow the outer container's right or bottom edge.
+            expect(inner.position.x).toBeGreaterThanOrEqual(0);
+            expect(inner.position.y).toBeGreaterThanOrEqual(0);
+            expect(inner.position.x + (inner.width as number)).toBeLessThanOrEqual(outer.width as number);
+            expect(inner.position.y + (inner.height as number)).toBeLessThanOrEqual(outer.height as number);
+        });
+
+        it('encloses leaf nodes within the inner container', () => {
+            const { nodes } = parseCALMData(nestedData);
+            const inner = nodes.find((n) => n.id === 'inner')!;
+            const leaves = nodes.filter((n) => n.parentId === 'inner');
+
+            expect(leaves).toHaveLength(2);
+            leaves.forEach((leaf) => {
+                expect(leaf.position.x).toBeGreaterThanOrEqual(0);
+                expect(leaf.position.y).toBeGreaterThanOrEqual(0);
+                expect(leaf.position.x + GRAPH_LAYOUT.NODE_WIDTH).toBeLessThanOrEqual(inner.width as number);
+                expect(leaf.position.y + GRAPH_LAYOUT.NODE_HEIGHT).toBeLessThanOrEqual(
+                    inner.height as number
+                );
+            });
+        });
     });
 
     it('does not create edges for deployed-in relationships', () => {

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.ts
@@ -1,6 +1,11 @@
 import { Node, Edge } from 'reactflow';
 import { CalmArchitectureSchema, CalmNodeSchema } from '@finos/calm-models/types';
-import { getLayoutedElements, createTopLevelLayout } from './layoutUtils';
+import {
+    getLayoutedElements,
+    createTopLevelLayout,
+    calculateChildBounds,
+    sortContainersDeepestFirst,
+} from './layoutUtils';
 import { identifyContainerNodes, parseNodes } from './nodeParser';
 import { extractFlowTransitions, parseRelationships } from './relationshipParser';
 import { GRAPH_LAYOUT } from './constants';
@@ -98,7 +103,10 @@ function separateNodesByParent(
  * Layouts children within each system node and calculates system dimensions
  */
 function layoutChildrenWithinSystems(systemNodes: Node[], nodesWithParents: Node[], edges: Edge[]): void {
-    systemNodes.forEach((systemNode) => {
+    // Lay out the most deeply nested containers first so that an outer
+    // container is sized once its inner container children already know their
+    // own dimensions.
+    sortContainersDeepestFirst(systemNodes).forEach((systemNode) => {
         const childNodes = nodesWithParents.filter((n) => n.parentId === systemNode.id);
 
         if (childNodes.length > 0) {
@@ -142,28 +150,6 @@ function layoutSystemWithChildren(
             };
         }
     });
-}
-
-/**
- * Calculates the bounding box of child nodes
- */
-function calculateChildBounds(children: Node[]): { minX: number; minY: number; maxX: number; maxY: number } {
-    const nodeWidth = GRAPH_LAYOUT.NODE_WIDTH;
-    const nodeHeight = GRAPH_LAYOUT.NODE_HEIGHT;
-
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-
-    children.forEach((child) => {
-        minX = Math.min(minX, child.position.x);
-        minY = Math.min(minY, child.position.y);
-        maxX = Math.max(maxX, child.position.x + nodeWidth);
-        maxY = Math.max(maxY, child.position.y + nodeHeight);
-    });
-
-    return { minX, minY, maxX, maxY };
 }
 
 /**

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
@@ -7,8 +7,13 @@ import {
     sortContainersDeepestFirst,
     getNodeWidth,
     getNodeHeight,
+    reflowContainersToFitChildren,
 } from './layoutUtils';
 import { GRAPH_LAYOUT } from './constants';
+
+const PAD = GRAPH_LAYOUT.SYSTEM_NODE_PADDING;
+const W = GRAPH_LAYOUT.NODE_WIDTH;
+const H = GRAPH_LAYOUT.NODE_HEIGHT;
 
 describe('getLayoutedElements', () => {
     it('returns empty arrays for empty input', () => {
@@ -157,6 +162,109 @@ describe('sortContainersDeepestFirst', () => {
         const before = containers.map((n) => n.id);
         sortContainersDeepestFirst(containers);
         expect(containers.map((n) => n.id)).toEqual(before);
+    });
+});
+
+describe('reflowContainersToFitChildren', () => {
+    it('hugs a child with equal padding on all sides, preserving on-screen position', () => {
+        const nodes: Node[] = [
+            { id: 'box', type: 'group', position: { x: 0, y: 0 }, data: {} },
+            { id: 'child', type: 'custom', parentId: 'box', position: { x: 300, y: 220 }, data: {} },
+        ];
+        const result = reflowContainersToFitChildren(nodes);
+        const box = result.find((n) => n.id === 'box')!;
+        const child = result.find((n) => n.id === 'child')!;
+        // Child is pulled to the padding offset; the box shifts to keep it on-screen.
+        expect(child.position).toEqual({ x: PAD, y: PAD });
+        expect(box.position.x + child.position.x).toBe(0 + 300);
+        expect(box.position.y + child.position.y).toBe(0 + 220);
+        expect(box.width).toBe(W + 2 * PAD);
+        expect(box.height).toBe(H + 2 * PAD);
+    });
+
+    it('shrinks a previously-grown box back to hug its children', () => {
+        const nodes: Node[] = [
+            {
+                id: 'box',
+                type: 'group',
+                position: { x: 0, y: 0 },
+                data: {},
+                width: 2000,
+                height: 2000,
+                style: { width: 2000, height: 2000 },
+            },
+            { id: 'a', type: 'custom', parentId: 'box', position: { x: 400, y: 300 }, data: {} },
+            { id: 'b', type: 'custom', parentId: 'box', position: { x: 700, y: 520 }, data: {} },
+        ];
+        const result = reflowContainersToFitChildren(nodes);
+        const box = result.find((n) => n.id === 'box')!;
+        const a = result.find((n) => n.id === 'a')!;
+        const b = result.find((n) => n.id === 'b')!;
+        // Leftmost/topmost child sits at the padding offset; box tightly fits both.
+        expect(Math.min(a.position.x, b.position.x)).toBe(PAD);
+        expect(Math.min(a.position.y, b.position.y)).toBe(PAD);
+        expect(box.width).toBe(Math.max(a.position.x, b.position.x) + W + PAD);
+        expect(box.height).toBe(Math.max(a.position.y, b.position.y) + H + PAD);
+        expect(box.width as number).toBeLessThan(2000);
+        expect(box.height as number).toBeLessThan(2000);
+    });
+
+    it('shifts the origin to enclose a child dragged above/left, preserving on-screen position', () => {
+        const nodes: Node[] = [
+            { id: 'box', type: 'group', position: { x: 1000, y: 1000 }, data: {} },
+            { id: 'child', type: 'custom', parentId: 'box', position: { x: -50, y: -30 }, data: {} },
+        ];
+        const absX = 1000 - 50;
+        const absY = 1000 - 30;
+        const result = reflowContainersToFitChildren(nodes);
+        const box = result.find((n) => n.id === 'box')!;
+        const child = result.find((n) => n.id === 'child')!;
+        const shiftX = PAD + 50;
+        const shiftY = PAD + 30;
+        // Child reclaims its top/left padding; container origin moves to compensate.
+        expect(child.position).toEqual({ x: PAD, y: PAD });
+        expect(box.position).toEqual({ x: 1000 - shiftX, y: 1000 - shiftY });
+        // On-screen (absolute) position is unchanged.
+        expect(box.position.x + child.position.x).toBe(absX);
+        expect(box.position.y + child.position.y).toBe(absY);
+        expect(box.width).toBe(-50 + W + shiftX + PAD);
+        expect(box.height).toBe(-30 + H + shiftY + PAD);
+    });
+
+    it('does not mutate the input nodes', () => {
+        const nodes: Node[] = [
+            { id: 'box', type: 'group', position: { x: 0, y: 0 }, data: {} },
+            { id: 'child', type: 'custom', parentId: 'box', position: { x: -10, y: -10 }, data: {} },
+        ];
+        reflowContainersToFitChildren(nodes);
+        expect(nodes[0].position).toEqual({ x: 0, y: 0 });
+        expect(nodes[1].position).toEqual({ x: -10, y: -10 });
+    });
+
+    it('cascades an inner container shift outward so nesting stays enclosed', () => {
+        const nodes: Node[] = [
+            { id: 'outer', type: 'group', position: { x: 0, y: 0 }, data: {} },
+            {
+                id: 'inner',
+                type: 'group',
+                parentId: 'outer',
+                position: { x: PAD, y: PAD },
+                data: {},
+                width: W + 2 * PAD,
+                height: H + 2 * PAD,
+                style: { width: W + 2 * PAD, height: H + 2 * PAD },
+            },
+            { id: 'leaf', type: 'custom', parentId: 'inner', position: { x: -40, y: -40 }, data: {} },
+        ];
+        const result = reflowContainersToFitChildren(nodes);
+        const outer = result.find((n) => n.id === 'outer')!;
+        const inner = result.find((n) => n.id === 'inner')!;
+        // Inner shifted up/left to enclose the leaf; outer then grew/shifted to
+        // keep the inner container fully enclosed.
+        expect(inner.position.x).toBeGreaterThanOrEqual(0);
+        expect(inner.position.y).toBeGreaterThanOrEqual(0);
+        expect(inner.position.x + (inner.width as number)).toBeLessThanOrEqual(outer.width as number);
+        expect(inner.position.y + (inner.height as number)).toBeLessThanOrEqual(outer.height as number);
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { Node, Edge } from 'reactflow';
-import { getLayoutedElements, createTopLevelLayout } from './layoutUtils';
+import {
+    getLayoutedElements,
+    createTopLevelLayout,
+    calculateChildBounds,
+    sortContainersDeepestFirst,
+    getNodeWidth,
+    getNodeHeight,
+} from './layoutUtils';
+import { GRAPH_LAYOUT } from './constants';
 
 describe('getLayoutedElements', () => {
     it('returns empty arrays for empty input', () => {
@@ -74,6 +82,81 @@ describe('getLayoutedElements', () => {
 
         expect(node1.position.x).toBeLessThan(node2.position.x);
         expect(node2.position.x).toBeLessThan(node3.position.x);
+    });
+});
+
+describe('getNodeWidth / getNodeHeight', () => {
+    it('falls back to standard dimensions when none are set', () => {
+        const node: Node = { id: 'n', position: { x: 0, y: 0 }, data: {} };
+        expect(getNodeWidth(node)).toBe(GRAPH_LAYOUT.NODE_WIDTH);
+        expect(getNodeHeight(node)).toBe(GRAPH_LAYOUT.NODE_HEIGHT);
+    });
+
+    it('prefers an explicit width/height over style', () => {
+        const node: Node = {
+            id: 'n',
+            position: { x: 0, y: 0 },
+            data: {},
+            width: 500,
+            height: 400,
+            style: { width: 999, height: 999 },
+        };
+        expect(getNodeWidth(node)).toBe(500);
+        expect(getNodeHeight(node)).toBe(400);
+    });
+
+    it('reads dimensions from style when width/height are absent', () => {
+        const node: Node = {
+            id: 'n',
+            position: { x: 0, y: 0 },
+            data: {},
+            style: { width: 320, height: 210 },
+        };
+        expect(getNodeWidth(node)).toBe(320);
+        expect(getNodeHeight(node)).toBe(210);
+    });
+});
+
+describe('calculateChildBounds', () => {
+    it('respects a child container\'s actual dimensions', () => {
+        const children: Node[] = [
+            { id: 'big', position: { x: 0, y: 0 }, data: {}, width: 600, height: 400 },
+        ];
+        const bounds = calculateChildBounds(children);
+        expect(bounds.maxX).toBe(600);
+        expect(bounds.maxY).toBe(400);
+    });
+
+    it('uses standard dimensions for plain nodes', () => {
+        const children: Node[] = [{ id: 'leaf', position: { x: 10, y: 20 }, data: {} }];
+        const bounds = calculateChildBounds(children);
+        expect(bounds.minX).toBe(10);
+        expect(bounds.minY).toBe(20);
+        expect(bounds.maxX).toBe(10 + GRAPH_LAYOUT.NODE_WIDTH);
+        expect(bounds.maxY).toBe(20 + GRAPH_LAYOUT.NODE_HEIGHT);
+    });
+});
+
+describe('sortContainersDeepestFirst', () => {
+    it('orders inner containers before their parents', () => {
+        const containers: Node[] = [
+            { id: 'outer', position: { x: 0, y: 0 }, data: {} },
+            { id: 'inner', position: { x: 0, y: 0 }, data: {}, parentId: 'outer' },
+            { id: 'innermost', position: { x: 0, y: 0 }, data: {}, parentId: 'inner' },
+        ];
+        const order = sortContainersDeepestFirst(containers).map((n) => n.id);
+        expect(order.indexOf('innermost')).toBeLessThan(order.indexOf('inner'));
+        expect(order.indexOf('inner')).toBeLessThan(order.indexOf('outer'));
+    });
+
+    it('does not mutate the input array', () => {
+        const containers: Node[] = [
+            { id: 'inner', position: { x: 0, y: 0 }, data: {}, parentId: 'outer' },
+            { id: 'outer', position: { x: 0, y: 0 }, data: {} },
+        ];
+        const before = containers.map((n) => n.id);
+        sortContainersDeepestFirst(containers);
+        expect(containers.map((n) => n.id)).toEqual(before);
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
@@ -175,15 +175,23 @@ export function reflowContainersToFitChildren(nodes: Node[]): Node[] {
         style: { ...n.style },
     }));
 
-    const parentIds = new Set<string>();
+    // Group children by parent in a single pass so the loop below stays O(n)
+    // overall rather than filtering all nodes per container (this runs on every
+    // drag frame). The arrays hold the same working-node references, so an inner
+    // container's mutations are seen when its parent is reflowed.
+    const childrenByParent = new Map<string, Node[]>();
     working.forEach((n) => {
-        if (n.parentId) parentIds.add(n.parentId);
+        if (!n.parentId) return;
+        const siblings = childrenByParent.get(n.parentId);
+        if (siblings) siblings.push(n);
+        else childrenByParent.set(n.parentId, [n]);
     });
-    const containers = working.filter((n) => parentIds.has(n.id));
+
+    const containers = working.filter((n) => childrenByParent.has(n.id));
 
     sortContainersDeepestFirst(containers).forEach((container) => {
-        const children = working.filter((n) => n.parentId === container.id);
-        if (children.length === 0) return;
+        const children = childrenByParent.get(container.id);
+        if (!children || children.length === 0) return;
 
         let minX = Infinity;
         let minY = Infinity;

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
@@ -150,30 +150,73 @@ export function createTopLevelLayout(
 }
 
 /**
- * Calculate the minimum bounds for a group node based on its children.
- * Used by both ArchitectureGraph and PatternGraph to resize groups after drag.
+ * Resizes every container node to hug its children with equal padding on all
+ * sides, growing or shrinking in any direction as the children move.
+ *
+ * A ReactFlow child's position is relative to its parent's top-left origin, and
+ * a container only changes size by adjusting width/height (its origin stays
+ * put). So to keep the top/left padding correct we also shift the container's
+ * own origin and compensate the children by the same delta, leaving their
+ * on-screen positions unchanged — a positive shift follows children dragged
+ * past the top/left edge, a negative shift reclaims slack when they move away.
+ * Containers are processed deepest-first so a shifted/resized inner container is
+ * reflected when its parent is reflowed (the shift can cascade outward).
+ *
+ * Used by both ArchitectureGraph and PatternGraph to reflow groups during and
+ * after a drag. Returns a new array; the input nodes are not mutated.
  */
-export function calculateGroupBounds(
-    groupId: string,
-    allNodes: Node[]
-): { width: number; height: number } | null {
-    const children = allNodes.filter((n) => n.parentId === groupId);
-    if (children.length === 0) return null;
-
+export function reflowContainersToFitChildren(nodes: Node[]): Node[] {
     const padding = GRAPH_LAYOUT.SYSTEM_NODE_PADDING;
 
-    let maxX = -Infinity;
-    let maxY = -Infinity;
+    // Shallow-clone nodes (and the fields we mutate) so callers' state is untouched.
+    const working = nodes.map((n) => ({
+        ...n,
+        position: { ...n.position },
+        style: { ...n.style },
+    }));
 
-    children.forEach((child) => {
-        const childRight = child.position.x + getNodeWidth(child);
-        const childBottom = child.position.y + getNodeHeight(child);
-        maxX = Math.max(maxX, childRight);
-        maxY = Math.max(maxY, childBottom);
+    const parentIds = new Set<string>();
+    working.forEach((n) => {
+        if (n.parentId) parentIds.add(n.parentId);
+    });
+    const containers = working.filter((n) => parentIds.has(n.id));
+
+    sortContainersDeepestFirst(containers).forEach((container) => {
+        const children = working.filter((n) => n.parentId === container.id);
+        if (children.length === 0) return;
+
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+        children.forEach((child) => {
+            minX = Math.min(minX, child.position.x);
+            minY = Math.min(minY, child.position.y);
+            maxX = Math.max(maxX, child.position.x + getNodeWidth(child));
+            maxY = Math.max(maxY, child.position.y + getNodeHeight(child));
+        });
+
+        // Offset that puts the top/left-most child exactly `padding` from the
+        // container origin. Positive grows up/left, negative shrinks (reclaims
+        // slack) — so the box hugs its children with equal padding on all sides.
+        const shiftX = padding - minX;
+        const shiftY = padding - minY;
+
+        if (shiftX !== 0 || shiftY !== 0) {
+            children.forEach((child) => {
+                child.position.x += shiftX;
+                child.position.y += shiftY;
+            });
+            container.position.x -= shiftX;
+            container.position.y -= shiftY;
+        }
+
+        const width = maxX + shiftX + padding;
+        const height = maxY + shiftY + padding;
+        container.width = width;
+        container.height = height;
+        container.style = { ...container.style, width, height };
     });
 
-    return {
-        width: maxX + padding,
-        height: maxY + padding,
-    };
+    return working;
 }

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
@@ -3,14 +3,77 @@ import dagre from '@dagrejs/dagre';
 import { GRAPH_LAYOUT } from './constants';
 
 /**
+ * Returns the effective width of a node, preferring an explicitly computed
+ * dimension (set when a node is a sized container) over the standard default.
+ * This lets nested container nodes be laid out at their true size rather than
+ * being treated as a standard 250x100 node.
+ */
+export function getNodeWidth(node: Node): number {
+    return (node.width as number) ?? (node.style?.width as number) ?? GRAPH_LAYOUT.NODE_WIDTH;
+}
+
+/**
+ * Returns the effective height of a node (see {@link getNodeWidth}).
+ */
+export function getNodeHeight(node: Node): number {
+    return (node.height as number) ?? (node.style?.height as number) ?? GRAPH_LAYOUT.NODE_HEIGHT;
+}
+
+/**
+ * Orders container nodes so that the most deeply nested containers come first.
+ * Containers must be laid out (and therefore sized) bottom-up: an outer
+ * container can only be sized correctly once its inner container children
+ * already know their own dimensions.
+ */
+export function sortContainersDeepestFirst(containers: Node[]): Node[] {
+    const byId = new Map(containers.map((c) => [c.id, c]));
+
+    const depth = (node: Node): number => {
+        let d = 0;
+        let current: Node | undefined = node;
+        const seen = new Set<string>();
+        while (current?.parentId && byId.has(current.parentId) && !seen.has(current.id)) {
+            seen.add(current.id);
+            d++;
+            current = byId.get(current.parentId);
+        }
+        return d;
+    };
+
+    return [...containers].sort((a, b) => depth(b) - depth(a));
+}
+
+/**
+ * Calculates the bounding box of child nodes, respecting each child's actual
+ * dimensions so that nested container children are fully enclosed.
+ */
+export function calculateChildBounds(children: Node[]): {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+} {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    children.forEach((child) => {
+        minX = Math.min(minX, child.position.x);
+        minY = Math.min(minY, child.position.y);
+        maxX = Math.max(maxX, child.position.x + getNodeWidth(child));
+        maxY = Math.max(maxY, child.position.y + getNodeHeight(child));
+    });
+
+    return { minX, minY, maxX, maxY };
+}
+
+/**
  * Applies Dagre layout to nodes and edges
  */
 export function getLayoutedElements(nodes: Node[], edges: Edge[]): { nodes: Node[]; edges: Edge[] } {
     const dagreGraph = new dagre.graphlib.Graph();
     dagreGraph.setDefaultEdgeLabel(() => ({}));
-
-    const nodeWidth = GRAPH_LAYOUT.NODE_WIDTH;
-    const nodeHeight = GRAPH_LAYOUT.NODE_HEIGHT;
 
     dagreGraph.setGraph({
         rankdir: 'LR',
@@ -23,7 +86,7 @@ export function getLayoutedElements(nodes: Node[], edges: Edge[]): { nodes: Node
     });
 
     nodes.forEach((node) => {
-        dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+        dagreGraph.setNode(node.id, { width: getNodeWidth(node), height: getNodeHeight(node) });
     });
 
     edges.forEach((edge) => {
@@ -37,8 +100,8 @@ export function getLayoutedElements(nodes: Node[], edges: Edge[]): { nodes: Node
         return {
             ...node,
             position: {
-                x: nodeWithPosition.x - nodeWidth / 2,
-                y: nodeWithPosition.y - nodeHeight / 2,
+                x: nodeWithPosition.x - getNodeWidth(node) / 2,
+                y: nodeWithPosition.y - getNodeHeight(node) / 2,
             },
         };
     });
@@ -65,9 +128,7 @@ export function createTopLevelLayout(
     });
 
     topLevelNodes.forEach((node) => {
-        const width = (node.style?.width as number) || GRAPH_LAYOUT.NODE_WIDTH;
-        const height = (node.style?.height as number) || GRAPH_LAYOUT.NODE_HEIGHT;
-        dagreGraph.setNode(node.id, { width, height });
+        dagreGraph.setNode(node.id, { width: getNodeWidth(node), height: getNodeHeight(node) });
     });
 
     topLevelEdges.forEach((edge) => {
@@ -79,11 +140,9 @@ export function createTopLevelLayout(
     const positions = new Map<string, { x: number; y: number }>();
     topLevelNodes.forEach((node) => {
         const nodeWithPosition = dagreGraph.node(node.id);
-        const width = (node.style?.width as number) || GRAPH_LAYOUT.NODE_WIDTH;
-        const height = (node.style?.height as number) || GRAPH_LAYOUT.NODE_HEIGHT;
         positions.set(node.id, {
-            x: nodeWithPosition.x - width / 2,
-            y: nodeWithPosition.y - height / 2,
+            x: nodeWithPosition.x - getNodeWidth(node) / 2,
+            y: nodeWithPosition.y - getNodeHeight(node) / 2,
         });
     });
 
@@ -102,15 +161,13 @@ export function calculateGroupBounds(
     if (children.length === 0) return null;
 
     const padding = GRAPH_LAYOUT.SYSTEM_NODE_PADDING;
-    const nodeWidth = GRAPH_LAYOUT.NODE_WIDTH;
-    const nodeHeight = GRAPH_LAYOUT.NODE_HEIGHT;
 
     let maxX = -Infinity;
     let maxY = -Infinity;
 
     children.forEach((child) => {
-        const childRight = child.position.x + nodeWidth;
-        const childBottom = child.position.y + nodeHeight;
+        const childRight = child.position.x + getNodeWidth(child);
+        const childBottom = child.position.y + getNodeHeight(child);
         maxX = Math.max(maxX, childRight);
         maxY = Math.max(maxY, childBottom);
     });

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/nodeParser.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/nodeParser.ts
@@ -63,7 +63,7 @@ function createSystemNode(
             label: node.name || id,
             ...node,
         },
-        ...(parentId && { parentId, expandParent: true }),
+        ...(parentId && { parentId }),
     };
 }
 
@@ -86,7 +86,7 @@ function createRegularNode(
             ...node,
             onShowDetails: onShowDetailsCallback,
         },
-        ...(parentId && { parentId, expandParent: true }),
+        ...(parentId && { parentId }),
     };
 }
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
@@ -432,7 +432,7 @@ function createReactFlowNodes(
                 position: { x: 0, y: 0 },
                 style: { zIndex: -1 },
                 data: buildNodeData(node),
-                ...(existingParentId && { parentId: existingParentId, expandParent: true }),
+                ...(existingParentId && { parentId: existingParentId }),
             });
         }
     });
@@ -449,7 +449,7 @@ function createReactFlowNodes(
             type: 'custom',
             position: { x: 0, y: 0 },
             data: buildNodeData(node),
-            ...(parentId && { parentId, expandParent: true }),
+            ...(parentId && { parentId }),
         });
     });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
@@ -1,5 +1,10 @@
 import { Node, Edge } from 'reactflow';
-import { getLayoutedElements, createTopLevelLayout } from './layoutUtils';
+import {
+    getLayoutedElements,
+    createTopLevelLayout,
+    calculateChildBounds,
+    sortContainersDeepestFirst,
+} from './layoutUtils';
 import { createEdge } from './edgeFactory';
 import { GRAPH_LAYOUT } from './constants';
 import { THEME } from '../theme';
@@ -539,8 +544,10 @@ function applyPatternLayout(regularNodes: Node[], groupNodes: Node[], edges: Edg
         }
     });
 
-    // Layout children within each group node
-    groupNodes.forEach((groupNode) => {
+    // Layout children within each group node, deepest-nested containers first
+    // so that an outer container is sized once its inner container children
+    // already know their own dimensions.
+    sortContainersDeepestFirst(groupNodes).forEach((groupNode) => {
         const childNodes = nodesWithParents.filter((n) => n.parentId === groupNode.id);
         if (childNodes.length > 0) {
             const groupEdges = edges.filter(
@@ -600,25 +607,6 @@ function applyPatternLayout(regularNodes: Node[], groupNodes: Node[], edges: Edg
     ];
 
     return { nodes: allNodes, edges };
-}
-
-function calculateChildBounds(children: Node[]): { minX: number; minY: number; maxX: number; maxY: number } {
-    const nodeWidth = GRAPH_LAYOUT.NODE_WIDTH;
-    const nodeHeight = GRAPH_LAYOUT.NODE_HEIGHT;
-
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-
-    children.forEach((child) => {
-        minX = Math.min(minX, child.position.x);
-        minY = Math.min(minY, child.position.y);
-        maxX = Math.max(maxX, child.position.x + nodeWidth);
-        maxY = Math.max(maxY, child.position.y + nodeHeight);
-    });
-
-    return { minX, minY, maxX, maxY };
 }
 
 // ---- Public API ----


### PR DESCRIPTION
## Description

Fixes two related container-enclosure bugs in the CALM Hub UI architecture/pattern diagrams, both surfacing with `composed-of` (and `deployed-in`) containers.

**1. Nested containers overflowed the outer box (closes #2567).** The layout sized and positioned a container's children as if every child were a standard `NODE_WIDTH`×`NODE_HEIGHT` node, ignoring the real dimensions of children that are themselves containers. So a container nested inside another (e.g. *Tools Layer* inside *Unified Agent Runtime*) was drawn too small and the inner box spilled past the outer box's right/bottom edges.
- Added `getNodeWidth`/`getNodeHeight` helpers and use each child's actual size in `getLayoutedElements`, `createTopLevelLayout`, `calculateChildBounds`.
- Centralised `calculateChildBounds` in `layoutUtils` (it was duplicated in `calmTransformer` and `patternTransformer`).
- Lay out containers deepest-first (`sortContainersDeepestFirst`) so an outer container is sized only after its inner containers are measured.

**2. Dragging a node could move it outside its container.** Nothing constrained a dragged child, and the drag-end resize only grew a container right/down (toward its fixed top-left origin) — so dragging a node up/left let it escape, and the box never shrank back on those edges.
- Replaced the old `calculateGroupBounds` drag-end resize with `reflowContainersToFitChildren`, which resizes every container to hug its children with equal padding on all sides. It recomputes the right/bottom extent and shifts the container's own origin (compensating the children, so their on-screen positions are unchanged) to keep the top/left padding correct — the box grows or shrinks in any direction. Containers reflow deepest-first so an inner container's shift cascades out and nesting stays enclosed.
- The reflow now runs on every position change, not just at drag end, so the resize is **live**. ReactFlow recomputes the dragged node's parent-relative position each frame, so shifting a container origin mid-drag stays consistent with the pointer (verified: the dragged node tracks the cursor and siblings don't drift).
- Dropped the now-unused `expandParent`/`extent` node options.

### Notes for reviewers
- The reflow runs on each drag frame and returns a fresh nodes array, i.e. a full re-render per frame. This is fine for typical CALM diagrams (tens of nodes); for very large graphs it could be optimised to skip unchanged containers — flagging in case a maintainer wants that follow-up.
- The corrected render is a taller, single-column layout for architectures whose container children have no `connects` edges between them (Dagre stacks unconnected nodes in one rank). The old render only *looked* multi-column because oversized boxes were spilling out of undersized slots; the new layout is the honest, enclosed version.
- One deliberate, improving divergence: the new dimension helpers use `??` rather than the file's previous `||`, so an explicit `0` isn't treated as "unset".

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified manually against the `ai-governance--v2` "Unified Agent Runtime" architecture (the case in #2567): nested containers are fully enclosed, and dragging child nodes in any direction keeps them inside their container with the box resizing live. Automated: `npm run lint`, `npm test`, and `npm run build` for `calm-hub-ui` all pass (717 tests). New unit tests cover nested-container sizing, the deepest-first ordering, dimension helpers, and the reflow (grow, shrink, origin-shift with preserved on-screen position, no-mutation, nested cascade).

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary (no user-facing docs affected — layout/interaction behaviour only)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
