### PR TITLE
fix(calm-hub-ui): persist and restore visualiser node layout

### DIFF
--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -20,6 +20,7 @@ import { EmptyGraphState } from './EmptyGraphState.js';
 import { parseCALMData } from './utils/calmTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
+import { applyStoredPositions } from '../../services/node-position-service.js';
 import type { ArchitectureGraphProps } from '../../contracts/contracts.js';
 
 const edgeTypes = { custom: FloatingEdge };
@@ -58,15 +59,18 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
         onNodeClick,
         onEdgeClick,
         groupNodeTypes: GROUP_NODE_TYPES,
+        persistKey: viewportKey,
     });
 
     useEffect(() => {
         const { nodes: parsedNodes, edges: parsedEdges } = parseCALMData(jsonData, onNodeClick);
         sourceNodesRef.current = parsedNodes;
-        setNodes(parsedNodes);
+        // Restore any custom layout the user dragged for this diagram, falling
+        // back to the parsed auto-layout when none is stored.
+        setNodes(viewportKey ? applyStoredPositions(viewportKey, parsedNodes) : parsedNodes);
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
-    }, [jsonData, setNodes, setEdges, onNodeClick]);
+    }, [jsonData, setNodes, setEdges, onNodeClick, viewportKey]);
 
     // Search & filter
     const isSearchActive = searchTerm !== '' || typeFilter !== '';

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -22,6 +22,7 @@ import { EmptyGraphState } from './EmptyGraphState.js';
 import { parsePatternData } from './utils/patternTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
+import { applyStoredPositions } from '../../services/node-position-service.js';
 import { DecisionSelectorPanel } from './DecisionSelectorPanel.js';
 import {
     extractDecisionPoints,
@@ -79,17 +80,20 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
         onNodeClick,
         onEdgeClick,
         groupNodeTypes: GROUP_NODE_TYPES,
+        persistKey: viewportKey,
     });
 
     useEffect(() => {
         const { nodes: parsedNodes, edges: parsedEdges } = parsePatternData(patternData);
         sourceNodesRef.current = parsedNodes;
         sourceEdgesRef.current = parsedEdges;
-        setNodes(parsedNodes);
+        // Restore any custom layout the user dragged for this diagram, falling
+        // back to the parsed auto-layout when none is stored.
+        setNodes(viewportKey ? applyStoredPositions(viewportKey, parsedNodes) : parsedNodes);
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
         setDecisionPoints(extractDecisionPoints(parsedNodes));
-    }, [patternData, setNodes, setEdges]);
+    }, [patternData, setNodes, setEdges, viewportKey]);
 
     // Search & filter
     const isSearchActive = searchTerm !== '' || typeFilter !== '';

--- a/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { Node, NodeChange } from 'reactflow';
+import { useGraphInteractions } from './useGraphInteractions.js';
+import { saveNodePositions } from '../../../services/node-position-service.js';
+
+vi.mock('../../../services/node-position-service.js', () => ({
+    saveNodePositions: vi.fn(),
+}));
+
+// reflowContainersToFitChildren returns the nodes as-is for these tests; we only
+// care about whether persistence is triggered, not the geometry.
+vi.mock('../utils/layoutUtils.js', () => ({
+    reflowContainersToFitChildren: (nodes: Node[]) => nodes,
+}));
+
+const currentNodes: Node[] = [{ id: 'a', position: { x: 10, y: 20 }, data: {} }];
+
+// A setNodes mock that immediately invokes the updater with `currentNodes`, so
+// the side effect inside the updater runs synchronously during the test.
+function makeSetNodes() {
+    return vi.fn((updater: (nodes: Node[]) => Node[]) => updater(currentNodes));
+}
+
+function setup(persistKey?: string) {
+    const setNodes = makeSetNodes();
+    const onNodesChangeBase = vi.fn();
+    const { result } = renderHook(() =>
+        useGraphInteractions({
+            setNodes,
+            onNodesChangeBase,
+            groupNodeTypes: ['group'],
+            persistKey,
+        })
+    );
+    return { result, setNodes, onNodesChangeBase };
+}
+
+const dragEnd: NodeChange = { id: 'a', type: 'position', dragging: false };
+const dragging: NodeChange = { id: 'a', type: 'position', dragging: true };
+
+describe('useGraphInteractions persistence', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('always forwards changes to the base handler', () => {
+        const { result, onNodesChangeBase } = setup('ns/id');
+        result.current.onNodesChange([dragEnd]);
+        expect(onNodesChangeBase).toHaveBeenCalledWith([dragEnd]);
+    });
+
+    it('persists positions on drag-end when a persistKey is provided', () => {
+        const { result } = setup('ns/id');
+        result.current.onNodesChange([dragEnd]);
+        expect(saveNodePositions).toHaveBeenCalledWith('ns/id', currentNodes);
+    });
+
+    it('does not persist mid-drag (dragging still true)', () => {
+        const { result } = setup('ns/id');
+        result.current.onNodesChange([dragging]);
+        expect(saveNodePositions).not.toHaveBeenCalled();
+    });
+
+    it('does not persist when no persistKey is provided', () => {
+        const { result } = setup(undefined);
+        result.current.onNodesChange([dragEnd]);
+        expect(saveNodePositions).not.toHaveBeenCalled();
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/hooks/useGraphInteractions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { Node, Edge, NodeChange } from 'reactflow';
 import { reflowContainersToFitChildren } from '../utils/layoutUtils.js';
+import { saveNodePositions } from '../../../services/node-position-service.js';
 
 interface UseGraphInteractionsOptions {
     setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
@@ -10,6 +11,9 @@ interface UseGraphInteractionsOptions {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onEdgeClick?: (data: any) => void;
     groupNodeTypes: string[];
+    // Key (namespace/id) under which to persist the layout on drag-end; when
+    // absent, layout changes are not persisted.
+    persistKey?: string;
 }
 
 export function useGraphInteractions({
@@ -18,6 +22,7 @@ export function useGraphInteractions({
     onNodeClick,
     onEdgeClick,
     groupNodeTypes,
+    persistKey,
 }: UseGraphInteractionsOptions) {
     const isGroupType = useCallback(
         (type: string | undefined) => type != null && groupNodeTypes.includes(type),
@@ -34,12 +39,25 @@ export function useGraphInteractions({
             // position each frame, so shifting a container's origin mid-drag
             // stays consistent with the pointer.
             const hasPositionChanges = changes.some((change) => change.type === 'position');
+            // A drag has finished when ReactFlow reports a position change with
+            // dragging explicitly false — the moment to persist the new layout.
+            const dragEnded = changes.some(
+                (change) => change.type === 'position' && change.dragging === false
+            );
 
             if (hasPositionChanges) {
-                setNodes((currentNodes) => reflowContainersToFitChildren(currentNodes));
+                setNodes((currentNodes) => {
+                    const reflowed = reflowContainersToFitChildren(currentNodes);
+                    // Persist the post-reflow positions so a restore needs no
+                    // further adjustment. Writing in the updater reads the
+                    // latest state; the write is idempotent so StrictMode's
+                    // double-invoke is harmless.
+                    if (dragEnded && persistKey) saveNodePositions(persistKey, reflowed);
+                    return reflowed;
+                });
             }
         },
-        [onNodesChangeBase, setNodes]
+        [onNodesChangeBase, setNodes, persistKey]
     );
 
     const handleNodeClick = useCallback(

--- a/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
@@ -58,6 +58,11 @@ describe('node-position-service', () => {
             localStorage.setItem(`${STORAGE_PREFIX}${key}`, 'this is not json');
             expect(loadStoredNodePositions(key)).toBeNull();
         });
+
+        it('returns null for valid JSON that is not an array', () => {
+            localStorage.setItem(`${STORAGE_PREFIX}${key}`, '{"id":"node-1"}');
+            expect(loadStoredNodePositions(key)).toBeNull();
+        });
     });
 
     describe('applyStoredPositions', () => {

--- a/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
@@ -1,53 +1,106 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Node } from 'reactflow';
 import {
+    applyStoredPositions,
     loadStoredNodePositions,
     saveNodePositions,
     StoredNodePosition,
 } from './node-position-service.js';
 
-const mockData: StoredNodePosition[] = [
+const STORAGE_PREFIX = 'calm-hub:node-positions:';
+const key = 'finos/conference-signup';
+
+const nodes: Node[] = [
+    { id: 'node-1', position: { x: 100, y: 200 }, data: {} },
+    { id: 'node-2', position: { x: 300, y: 400 }, data: {} },
+];
+
+const storedPositions: StoredNodePosition[] = [
     { id: 'node-1', position: { x: 100, y: 200 } },
     { id: 'node-2', position: { x: 300, y: 400 } },
 ];
-const title = 'test';
-const key = 'test';
 
-describe('PositionStorage', () => {
-    beforeEach(() => {
-        localStorage.clear();
+describe('node-position-service', () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    describe('saveNodePositions', () => {
+        it('stores positions under a namespaced key', () => {
+            saveNodePositions(key, nodes);
+            expect(localStorage.getItem(`${STORAGE_PREFIX}${key}`)).not.toBeNull();
+        });
+
+        it('serialises only id and position from each node', () => {
+            saveNodePositions(key, nodes);
+            const stored = localStorage.getItem(`${STORAGE_PREFIX}${key}`);
+            expect(JSON.parse(stored!)).toEqual(storedPositions);
+        });
+
+        it('keys distinct diagrams separately, avoiding title collisions', () => {
+            saveNodePositions('a/1', [{ id: 'n', position: { x: 1, y: 2 }, data: {} }]);
+            saveNodePositions('b/1', [{ id: 'n', position: { x: 9, y: 9 }, data: {} }]);
+            expect(loadStoredNodePositions('a/1')).toEqual([{ id: 'n', position: { x: 1, y: 2 } }]);
+            expect(loadStoredNodePositions('b/1')).toEqual([{ id: 'n', position: { x: 9, y: 9 } }]);
+        });
     });
 
-    afterEach(() => {
-        localStorage.clear();
+    describe('loadStoredNodePositions', () => {
+        it('loads previously saved positions', () => {
+            saveNodePositions(key, nodes);
+            expect(loadStoredNodePositions(key)).toEqual(storedPositions);
+        });
+
+        it('returns null when nothing is stored', () => {
+            expect(loadStoredNodePositions(key)).toBeNull();
+        });
+
+        it('returns null for malformed JSON', () => {
+            localStorage.setItem(`${STORAGE_PREFIX}${key}`, 'this is not json');
+            expect(loadStoredNodePositions(key)).toBeNull();
+        });
     });
 
-    it('creates storage key for localStrorage', () => {
-        saveNodePositions('title', mockData);
-        const stored = localStorage.getItem('title');
-        expect(stored).not.toBeNull();
-    });
+    describe('applyStoredPositions', () => {
+        it('returns the input nodes unchanged when nothing is stored', () => {
+            const parsed: Node[] = [{ id: 'node-1', position: { x: 0, y: 0 }, data: {} }];
+            expect(applyStoredPositions(key, parsed)).toBe(parsed);
+        });
 
-    it('saves node positions to localStorage', () => {
-        saveNodePositions(title, mockData);
-        const stored = localStorage.getItem(key);
-        expect(stored).not.toBeNull();
-        expect(JSON.parse(stored!)).toEqual(mockData);
-    });
+        it('restores stored positions onto parsed nodes by id', () => {
+            saveNodePositions(key, nodes);
+            const parsed: Node[] = [
+                { id: 'node-1', position: { x: 0, y: 0 }, data: {} },
+                { id: 'node-2', position: { x: 0, y: 0 }, data: {} },
+            ];
+            const result = applyStoredPositions(key, parsed);
+            expect(result.find((n) => n.id === 'node-1')!.position).toEqual({ x: 100, y: 200 });
+            expect(result.find((n) => n.id === 'node-2')!.position).toEqual({ x: 300, y: 400 });
+        });
 
-    it('loads node positions from localStorage', () => {
-        localStorage.setItem(key, JSON.stringify(mockData));
-        const loaded = loadStoredNodePositions(title);
-        expect(loaded).toEqual(mockData);
-    });
+        it('leaves nodes without a stored position untouched', () => {
+            saveNodePositions(key, [{ id: 'node-1', position: { x: 50, y: 60 }, data: {} }]);
+            const parsed: Node[] = [
+                { id: 'node-1', position: { x: 0, y: 0 }, data: {} },
+                { id: 'node-new', position: { x: 7, y: 8 }, data: {} },
+            ];
+            const result = applyStoredPositions(key, parsed);
+            expect(result.find((n) => n.id === 'node-1')!.position).toEqual({ x: 50, y: 60 });
+            expect(result.find((n) => n.id === 'node-new')!.position).toEqual({ x: 7, y: 8 });
+        });
 
-    it('returns null if nothing is stored', () => {
-        const loaded = loadStoredNodePositions(title);
-        expect(loaded).toBeNull();
-    });
-
-    it('handles malformed JSON gracefully', () => {
-        localStorage.setItem(key, 'this is not json');
-        const loaded = loadStoredNodePositions(title);
-        expect(loaded).toBeNull();
+        it('resizes containers to enclose restored children', () => {
+            // A container with one child; storing the child further out should
+            // make the reflow grow the container to keep it enclosed.
+            const child: Node = { id: 'child', parentId: 'group', position: { x: 0, y: 0 }, data: {} };
+            saveNodePositions(key, [{ ...child, position: { x: 500, y: 400 } }]);
+            const parsed: Node[] = [
+                { id: 'group', type: 'group', position: { x: 0, y: 0 }, width: 50, height: 50, data: {} },
+                child,
+            ];
+            const result = applyStoredPositions(key, parsed);
+            const container = result.find((n) => n.id === 'group')!;
+            expect(container.width).toBeGreaterThan(50);
+            expect(container.height).toBeGreaterThan(50);
+        });
     });
 });

--- a/calm-hub-ui/src/visualizer/services/node-position-service.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.tsx
@@ -38,7 +38,11 @@ export function saveNodePositions(key: string, nodes: Node[]) {
 export function loadStoredNodePositions(key: string): StoredNodePosition[] | null {
     try {
         const data = localStorage.getItem(storageKeyFor(key));
-        return data ? (JSON.parse(data) as StoredNodePosition[]) : null;
+        if (!data) return null;
+        const parsed = JSON.parse(data);
+        // Guard against valid JSON of an unexpected shape (e.g. tampered or
+        // collided storage): only an array is usable downstream.
+        return Array.isArray(parsed) ? (parsed as StoredNodePosition[]) : null;
     } catch (err) {
         console.error('Failed to load node positions:', err);
         return null;

--- a/calm-hub-ui/src/visualizer/services/node-position-service.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.tsx
@@ -1,22 +1,64 @@
+import type { Node } from 'reactflow';
+import { reflowContainersToFitChildren } from '../components/reactflow/utils/layoutUtils.js';
+
 export interface StoredNodePosition {
     id: string;
     position: { x: number; y: number };
 }
 
-export function saveNodePositions(title: string, positions: StoredNodePosition[]) {
+/**
+ * Remembers a custom node layout (positions the user dragged nodes to) so it is
+ * restored when they navigate away and back to the same diagram, instead of
+ * resetting to the auto-generated layout.
+ *
+ * Keyed by the diagram key (namespace/id, see `viewportKey`) rather than the
+ * diagram title, so distinct architectures that happen to share a title do not
+ * collide. localStorage is used so the layout survives a refresh and a new
+ * tab/session. A durable, version-aware, server-side strategy is tracked
+ * separately (#2568).
+ */
+const STORAGE_PREFIX = 'calm-hub:node-positions:';
+
+const storageKeyFor = (key: string) => `${STORAGE_PREFIX}${key}`;
+
+/** Persist the current positions of every node for the given diagram key. */
+export function saveNodePositions(key: string, nodes: Node[]) {
     try {
-        localStorage.setItem(title, JSON.stringify(positions));
+        const positions: StoredNodePosition[] = nodes.map((node) => ({
+            id: node.id,
+            position: { x: node.position.x, y: node.position.y },
+        }));
+        localStorage.setItem(storageKeyFor(key), JSON.stringify(positions));
     } catch (err) {
         console.error('Failed to save node positions:', err);
     }
 }
 
-export function loadStoredNodePositions(title: string): StoredNodePosition[] | null {
+/** The stored positions for a diagram key, or null when none/unreadable. */
+export function loadStoredNodePositions(key: string): StoredNodePosition[] | null {
     try {
-        const data = localStorage.getItem(title);
-        return data ? JSON.parse(data) : null;
+        const data = localStorage.getItem(storageKeyFor(key));
+        return data ? (JSON.parse(data) as StoredNodePosition[]) : null;
     } catch (err) {
         console.error('Failed to load node positions:', err);
         return null;
     }
+}
+
+/**
+ * Merge any stored positions onto freshly parsed nodes, matching by id, then
+ * reflow containers so they re-hug their restored children. Returns the nodes
+ * unchanged when nothing is stored, so callers fall back to the auto-layout.
+ */
+export function applyStoredPositions(key: string, nodes: Node[]): Node[] {
+    const stored = loadStoredNodePositions(key);
+    if (!stored || stored.length === 0) return nodes;
+
+    const positionsById = new Map(stored.map((p) => [p.id, p.position]));
+    const merged = nodes.map((node) => {
+        const position = positionsById.get(node.id);
+        return position ? { ...node, position: { ...position } } : node;
+    });
+
+    return reflowContainersToFitChildren(merged);
 }


### PR DESCRIPTION
## Description

Fixes #2569. The visualiser had a node-position persistence service (`node-position-service.tsx`) that was never wired in — custom layouts created by dragging nodes lived only in React state and were discarded on unmount, so they were never saved or restored (even within the same browser session).

This PR wires the service in and aligns it with the existing per-diagram persistence idiom already used for the viewport (`viewportStore.ts`):

- **Save on drag-end** — `useGraphInteractions` now persists the post-reflow node positions when a drag finishes (`change.type === 'position' && change.dragging === false`), guarded by an optional `persistKey`.
- **Restore on load** — `ArchitectureGraph` and `PatternGraph` apply any stored positions to the parsed nodes on mount, falling back to the auto-generated layout when none exist.
- **Better key** — positions are keyed by the diagram key (`namespace/id`, reusing the existing `viewportKey`) under a namespaced `calm-hub:node-positions:` localStorage prefix, instead of the bare diagram `title`. This removes the title-collision risk called out in the issue.
- `saveNodePositions` now serialises live ReactFlow nodes; a new `applyStoredPositions` merges stored positions by id and reflows containers so they re-hug their restored children.

### Deliberate design choices (vs `viewportStore`)
- **localStorage** (per-diagram entries) rather than viewport's **sessionStorage** (single tagged entry): chosen so layouts survive a new tab/session and so multiple diagrams' layouts are retained. Trade-off: entries accumulate across diagrams — acceptable for in-browser persistence.
- The save is performed inside the `setNodes` updater so it captures the *post-reflow* positions and the latest state; the write is idempotent, so React StrictMode's double-invoke is harmless.

### Scope
Durable, version-aware, server-side persistence is intentionally **out of scope** and tracked separately in #2568. This PR fixes the immediate defect: the existing in-browser persistence was non-functional.

### Verified locally
Ran the CALM Hub backend (standalone/Nitrite) + UI and confirmed the TraderX architecture loads. Drag → navigate away → return restores the custom layout; refresh preserves it. Unit tests cover the save-on-drag and restore-on-load logic.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added `useGraphInteractions.test.ts` (persists on drag-end with a key; not mid-drag; not without a key) and extended `node-position-service.test.tsx` (save/load/namespacing/collision/malformed JSON + `applyStoredPositions` merge-by-id, container reflow, and no-stored fallback). `npm test --workspace calm-hub-ui` passes (413 tests); lint and build are clean.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary <!-- no behavioural docs affected -->
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
