### PR TITLE
feat(calm-hub): read-only CALM Hub with Nitrite store

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
+++ b/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
@@ -42,36 +42,48 @@ public class NitriteDBConfig {
     @ConfigProperty(name = "calm.standalone.password", defaultValue = "admin")
     String password;
 
+    @ConfigProperty(name = "calm.readonly", defaultValue = "false")
+    boolean readOnly;
+
     private Nitrite db;
 
     @PostConstruct
     void initialize() {
         if ("standalone".equals(databaseMode)) {
-            LOG.info("Starting NitriteDB in standalone mode");
+            LOG.info("Starting NitriteDB in standalone mode (readOnly={})", readOnly);
             try {
-                // Ensure data directory exists
                 Path dataPath = Paths.get(dataDirectory);
-                if (!Files.exists(dataPath)) {
-                    Files.createDirectories(dataPath);
-                }
 
-                // Configure and open NitriteDB
                 Path dbFilePath = dataPath.resolve(databaseName + ".db");
 
-                // Create the database
-                // Create the MVStoreModule with the file path
-                MVStoreModule storeModule = MVStoreModule.withConfig()
-                        .filePath(dbFilePath.toString())
-                        .autoCommit(true)
-                        .build();
-
-                db = Nitrite.builder()
-                        .loadModule(storeModule)
-                        .openOrCreate(username, password);
-
-                initializeDatabase();
-
-                LOG.info("NitriteDB started successfully at {}", dbFilePath);
+                if (readOnly) {
+                    if (!Files.exists(dbFilePath)) {
+                        throw new RuntimeException(
+                                "Read-only mode requires a pre-seeded database file at " + dbFilePath +
+                                " but no such file was found.");
+                    }
+                    MVStoreModule storeModule = MVStoreModule.withConfig()
+                            .filePath(dbFilePath.toString())
+                            .readOnly(true)
+                            .build();
+                    db = Nitrite.builder()
+                            .loadModule(storeModule)
+                            .openOrCreate(username, password);
+                    LOG.info("NitriteDB opened read-only at {}", dbFilePath);
+                } else {
+                    if (!Files.exists(dataPath)) {
+                        Files.createDirectories(dataPath);
+                    }
+                    MVStoreModule storeModule = MVStoreModule.withConfig()
+                            .filePath(dbFilePath.toString())
+                            .autoCommit(true)
+                            .build();
+                    db = Nitrite.builder()
+                            .loadModule(storeModule)
+                            .openOrCreate(username, password);
+                    initializeDatabase();
+                    LOG.info("NitriteDB started successfully at {}", dbFilePath);
+                }
             } catch (IOException e) {
                 LOG.error("Failed to start NitriteDB", e);
                 throw new RuntimeException("Failed to start NitriteDB", e);
@@ -81,7 +93,7 @@ public class NitriteDBConfig {
 
 
     /**
-     * Initilise the DB.
+     * Initialise the DB collections. Only called in writable mode.
      * @throws IOException
      * @throws JsonParseException
      */

--- a/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
+++ b/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
@@ -65,6 +65,7 @@ public class NitriteDBConfig {
                     MVStoreModule storeModule = MVStoreModule.withConfig()
                             .filePath(dbFilePath.toString())
                             .readOnly(true)
+                            .autoCommit(false)
                             .build();
                     db = Nitrite.builder()
                             .loadModule(storeModule)

--- a/calm-hub/src/main/java/org/finos/calm/security/ReadOnlyRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/ReadOnlyRequestFilter.java
@@ -42,7 +42,10 @@ public class ReadOnlyRequestFilter implements ContainerRequestFilter {
             return;
         }
 
-        String path = requestContext.getUriInfo().getPath();
+        // UriInfo#getPath() in RESTEasy may or may not include a leading slash;
+        // normalise so the prefix check is reliable in all deployments.
+        String rawPath = requestContext.getUriInfo().getPath();
+        String path = rawPath.startsWith("/") ? rawPath : "/" + rawPath;
         if (!path.startsWith(CALM_PATH_PREFIX) && !path.equals("/calm")) {
             return;
         }

--- a/calm-hub/src/main/java/org/finos/calm/security/ReadOnlyRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/ReadOnlyRequestFilter.java
@@ -1,0 +1,60 @@
+package org.finos.calm.security;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * When {@code calm.readonly=true} this filter intercepts every request on the
+ * {@code /calm/*} path and rejects any mutating HTTP method (POST, PUT, DELETE,
+ * PATCH) with {@code 405 Method Not Allowed}.  Read-only methods (GET, HEAD,
+ * OPTIONS) are passed through unchanged.
+ *
+ * <p>This filter runs at priority 0 (before {@link AccessControlFilter} at
+ * priority 1) so read-only violations are rejected before auth checks.
+ */
+@ApplicationScoped
+@Provider
+@Priority(0)
+public class ReadOnlyRequestFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReadOnlyRequestFilter.class);
+
+    private static final Set<String> MUTATING_METHODS = Set.of("POST", "PUT", "DELETE", "PATCH");
+    private static final String CALM_PATH_PREFIX = "/calm/";
+    private static final String ALLOW_HEADER = "Allow";
+    private static final String ALLOWED_METHODS = "GET, HEAD, OPTIONS";
+
+    @ConfigProperty(name = "calm.readonly", defaultValue = "false")
+    boolean readOnly;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (!readOnly) {
+            return;
+        }
+
+        String path = requestContext.getUriInfo().getPath();
+        if (!path.startsWith(CALM_PATH_PREFIX) && !path.equals("/calm")) {
+            return;
+        }
+
+        String method = requestContext.getMethod();
+        if (MUTATING_METHODS.contains(method)) {
+            LOG.warn("Read-only mode: rejected {} {}", method, path);
+            requestContext.abortWith(
+                    Response.status(Response.Status.METHOD_NOT_ALLOWED)
+                            .header(ALLOW_HEADER, ALLOWED_METHODS)
+                            .entity("This CALM Hub instance is read-only.")
+                            .build());
+        }
+    }
+}

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -8,6 +8,8 @@ calm.standalone.database-name=calmSchemas
 calm.standalone.username=admin
 calm.standalone.password=admin
 calm.standalone.init-script-path=mongo/init-mongo.js
+# Read-only mode: when true, opens Nitrite with readOnly(true) and rejects mutating HTTP verbs
+calm.readonly=false
 quarkus.mongodb.connection-string = mongodb://localhost:27017
 quarkus.mongodb.database = calmSchemas
 

--- a/calm-hub/src/test/java/org/finos/calm/config/NitriteDBConfigTest.java
+++ b/calm-hub/src/test/java/org/finos/calm/config/NitriteDBConfigTest.java
@@ -139,4 +139,45 @@ public class NitriteDBConfigTest {
         assertTrue(exception.getMessage().contains("Failed to start NitriteDB"), 
                 "Exception message should indicate failure to start NitriteDB");
     }
+
+    @Test
+    public void testReadOnlyModeFailsFastWhenDbFileMissing() {
+        // Given
+        nitriteDBConfig.readOnly = true;
+        // dataDirectory exists (tempDir) but the .db file has never been seeded
+
+        // When/Then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            nitriteDBConfig.initialize();
+        });
+
+        assertTrue(exception.getMessage().contains("Read-only mode requires a pre-seeded database file"),
+                "Exception should explain that a pre-seeded .db is required");
+    }
+
+    @Test
+    public void testReadOnlyModeOpensExistingDbWithoutCreatingCollections() throws Exception {
+        // First create a writable database so the .db file exists
+        nitriteDBConfig.initialize();
+        nitriteDBConfig.shutdown();
+
+        // Re-open in read-only mode
+        NitriteDBConfig readOnlyConfig = new NitriteDBConfig();
+        readOnlyConfig.databaseMode = "standalone";
+        readOnlyConfig.dataDirectory = tempDir.toString();
+        readOnlyConfig.username = "testuser";
+        readOnlyConfig.password = "testpass";
+        readOnlyConfig.databaseName = "testdb";
+        readOnlyConfig.readOnly = true;
+
+        // When
+        readOnlyConfig.initialize();
+
+        // Then
+        Nitrite db = readOnlyConfig.getNitriteDb();
+        assertNotNull(db, "Database should be opened in read-only mode");
+        assertFalse(db.isClosed(), "Database should be open");
+
+        readOnlyConfig.shutdown();
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/security/TestReadOnlyRequestFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestReadOnlyRequestFilterShould.java
@@ -30,7 +30,8 @@ public class TestReadOnlyRequestFilterShould {
         MockitoAnnotations.openMocks(this);
         filter = new ReadOnlyRequestFilter();
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
-        when(uriInfo.getPath()).thenReturn("/calm/namespaces");
+        // RESTEasy typically returns paths without a leading slash
+        when(uriInfo.getPath()).thenReturn("calm/namespaces");
     }
 
     @ParameterizedTest
@@ -45,6 +46,21 @@ public class TestReadOnlyRequestFilterShould {
         verify(requestContext).abortWith(captor.capture());
         assertEquals(405, captor.getValue().getStatus());
         assertEquals("GET, HEAD, OPTIONS", captor.getValue().getHeaderString("Allow"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+    void reject_mutating_methods_on_calm_path_with_leading_slash_when_readonly(String method) {
+        // Covers runtimes/proxies that may include a leading slash
+        filter.readOnly = true;
+        when(requestContext.getMethod()).thenReturn(method);
+        when(uriInfo.getPath()).thenReturn("/calm/namespaces");
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(captor.capture());
+        assertEquals(405, captor.getValue().getStatus());
     }
 
     @ParameterizedTest
@@ -72,6 +88,19 @@ public class TestReadOnlyRequestFilterShould {
     @ParameterizedTest
     @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
     void allow_mutating_methods_on_non_calm_paths_when_readonly(String method) {
+        filter.readOnly = true;
+        when(requestContext.getMethod()).thenReturn(method);
+        // RESTEasy typically returns paths without a leading slash
+        when(uriInfo.getPath()).thenReturn("q/health");
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+    void allow_mutating_methods_on_non_calm_paths_with_leading_slash_when_readonly(String method) {
         filter.readOnly = true;
         when(requestContext.getMethod()).thenReturn(method);
         when(uriInfo.getPath()).thenReturn("/q/health");

--- a/calm-hub/src/test/java/org/finos/calm/security/TestReadOnlyRequestFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestReadOnlyRequestFilterShould.java
@@ -1,0 +1,83 @@
+package org.finos.calm.security;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+public class TestReadOnlyRequestFilterShould {
+
+    @Mock
+    ContainerRequestContext requestContext;
+
+    @Mock
+    UriInfo uriInfo;
+
+    private ReadOnlyRequestFilter filter;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        filter = new ReadOnlyRequestFilter();
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/calm/namespaces");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+    void reject_mutating_methods_on_calm_path_when_readonly(String method) {
+        filter.readOnly = true;
+        when(requestContext.getMethod()).thenReturn(method);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(captor.capture());
+        assertEquals(405, captor.getValue().getStatus());
+        assertEquals("GET, HEAD, OPTIONS", captor.getValue().getHeaderString("Allow"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"GET", "HEAD", "OPTIONS"})
+    void allow_read_methods_on_calm_path_when_readonly(String method) {
+        filter.readOnly = true;
+        when(requestContext.getMethod()).thenReturn(method);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+    void allow_mutating_methods_when_not_readonly(String method) {
+        filter.readOnly = false;
+        when(requestContext.getMethod()).thenReturn(method);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+    void allow_mutating_methods_on_non_calm_paths_when_readonly(String method) {
+        filter.readOnly = true;
+        when(requestContext.getMethod()).thenReturn(method);
+        when(uriInfo.getPath()).thenReturn("/q/health");
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+}


### PR DESCRIPTION
Add calm.readonly flag (default false) that opens NitriteDB with MVStore readOnly(true) and skips collection initialisation. Fails fast on startup if the .db file is absent.

Add ReadOnlyRequestFilter (priority 0, before auth) that returns 405 Method Not Allowed with Allow: GET, HEAD, OPTIONS for any mutating verb on /calm/* when the flag is set.

New unit tests cover:
- NitriteDBConfig: fail-fast missing .db, read-only open, writable regression
- ReadOnlyRequestFilter: mutating verbs rejected, read verbs allowed, writable mode passthrough, non-/calm paths passthrough

Relates to #2486

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
