### PR TITLE
feat(calm-hub): read-only static Docker image with baked NitriteDB

### DIFF
--- a/.github/workflows/docker-publish-calm-hub-readonly.yml
+++ b/.github/workflows/docker-publish-calm-hub-readonly.yml
@@ -1,0 +1,94 @@
+name: Docker Publish Calm Hub (Read-Only Static)
+
+permissions:
+    contents: read
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - 'calm-hub/**'
+            - 'calm/**'
+            - '.github/workflows/docker-publish-calm-hub-readonly.yml'
+    # Manual trigger from GitHub UI (allows custom tag)
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: 'Image tag (default: latest-read-only-static)'
+                required: false
+                default: 'latest-read-only-static'
+
+concurrency:
+    group: docker-publish-calm-hub-readonly
+    cancel-in-progress: false
+
+jobs:
+    build-and-push:
+        name: Build and Push Read-Only Static Docker Image
+        runs-on: ubuntu-latest
+
+        steps:
+            # Step 1: Checkout the full repository (calm/ schemas are outside calm-hub/)
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            # Step 2: Set up JDK
+            - name: Set up JDK
+              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+              with:
+                  distribution: 'temurin'
+                  java-version: '21'
+
+            # Step 3: Cache Maven Dependencies
+            - name: Cache Maven Dependencies
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+              with:
+                  path: ~/.m2
+                  key: ${{ runner.os }}-m2-${{ hashFiles('calm-hub/pom.xml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-m2-
+
+            # Step 4: Build application and stage seed content via the shared script.
+            # --no-docker: skip the local docker build; this workflow uses buildx below
+            # for a multi-arch push.  The same script is used for local builds.
+            - name: Build and stage seed content
+              run: bash calm-hub/build-readonly-image.sh --no-docker
+
+            # Step 5: Set up Docker Buildx for multi-architecture builds
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+            # Step 6: Login to Docker Hub
+            - name: Login to Docker Hub
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            # Step 7: Extract metadata for Docker
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+              with:
+                  images: ${{ secrets.DOCKER_USERNAME }}/calm-hub
+                  tags: |
+                      type=raw,value=${{ github.event.inputs.tag || 'latest-read-only-static' }}
+                      type=sha,format=short,suffix=-read-only-static
+                      type=ref,event=tag,suffix=-read-only-static
+
+            # Step 8: Build and push the read-only static image.
+            # The seed stage (Stage 1) is pinned to linux/amd64 in the Dockerfile so it
+            # runs natively on this runner.  The final stage is built for all platforms;
+            # the .db file is architecture-neutral (H2 MVStore / pure-Java format).
+            - name: Build and push
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+              with:
+                  context: calm-hub
+                  file: calm-hub/src/main/docker/Dockerfile.readonly-static
+                  platforms: linux/amd64,linux/arm64
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/calm-hub/.dockerignore
+++ b/calm-hub/.dockerignore
@@ -12,3 +12,10 @@
 !target/*-runner.jar
 !target/lib/*
 !target/quarkus-app/*
+
+# Allow nitrite seed scripts (used by Dockerfile.readonly-static)
+!nitrite/
+!nitrite/**
+
+# Allow staged calm/ schemas and controls for the read-only static image build
+!target/readonly-seed/**

--- a/calm-hub/build-readonly-image.sh
+++ b/calm-hub/build-readonly-image.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Build script for the calm-hub read-only static Docker image.
+#
+# Encapsulates all three steps required to produce the image so the process is
+# identical locally and in CI:
+#   1. Maven package  — compiles calm-hub and runs unit tests.
+#   2. Stage content  — copies calm/ schemas and controls/ into the Docker build
+#                       context (target/readonly-seed/) which is gitignored.
+#   3. Docker build   — builds the two-stage Dockerfile.readonly-static image.
+#
+# Usage (from any directory):
+#   bash calm-hub/build-readonly-image.sh [OPTIONS] [IMAGE_TAG]
+#
+# Options:
+#   --no-docker    Run steps 1 and 2 only; skip the docker build step.
+#                  CI uses this flag and performs its own multi-arch buildx push.
+#   --no-maven     Skip the Maven build (assumes target/quarkus-app/ already exists).
+#   --help         Show this message.
+#
+# IMAGE_TAG:
+#   Optional Docker tag for the output image (default: calm-hub:read-only-static).
+#
+# Examples:
+#   bash calm-hub/build-readonly-image.sh
+#   bash calm-hub/build-readonly-image.sh calm-hub:0.7.6-read-only-static
+#   bash calm-hub/build-readonly-image.sh --no-docker
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMAGE_TAG="calm-hub:read-only-static"
+RUN_DOCKER=true
+RUN_MAVEN=true
+
+for arg in "$@"; do
+    case "${arg}" in
+        --no-docker) RUN_DOCKER=false ;;
+        --no-maven)  RUN_MAVEN=false  ;;
+        --help)
+            sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | grep '^#' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*) echo "[build] Unknown option: ${arg}" >&2; exit 1 ;;
+        *)   IMAGE_TAG="${arg}" ;;
+    esac
+done
+
+# ── Step 1: Maven build ────────────────────────────────────────────────────────
+if [[ "${RUN_MAVEN}" == true ]]; then
+    echo "[build] Building calm-hub with Maven..."
+    cd "${SCRIPT_DIR}"
+    "${REPO_ROOT}/mvnw" package -DskipITs -Ddependency-check.skip=true
+    cd "${REPO_ROOT}"
+fi
+
+# ── Step 2: Stage seed content into the Docker build context ──────────────────
+echo "[build] Staging calm/ schemas and controls into target/readonly-seed/..."
+mkdir -p "${SCRIPT_DIR}/target/readonly-seed/calm"
+mkdir -p "${SCRIPT_DIR}/target/readonly-seed/controls"
+cp -r "${REPO_ROOT}/calm/."                     "${SCRIPT_DIR}/target/readonly-seed/calm/"
+cp -r "${SCRIPT_DIR}/mongo/controls/."          "${SCRIPT_DIR}/target/readonly-seed/controls/"
+echo "[build] Staged:"
+ls "${SCRIPT_DIR}/target/readonly-seed/"
+
+# ── Step 3: Docker build ───────────────────────────────────────────────────────
+if [[ "${RUN_DOCKER}" == true ]]; then
+    echo "[build] Building Docker image: ${IMAGE_TAG}..."
+    docker build \
+        -f "${SCRIPT_DIR}/src/main/docker/Dockerfile.readonly-static" \
+        -t "${IMAGE_TAG}" \
+        "${SCRIPT_DIR}"
+    echo ""
+    echo "[build] Done. Run the image with:"
+    echo "  docker run --rm -p 8080:8080 ${IMAGE_TAG}"
+fi

--- a/calm-hub/build-readonly-image.sh
+++ b/calm-hub/build-readonly-image.sh
@@ -59,8 +59,8 @@ fi
 echo "[build] Staging calm/ schemas and controls into target/readonly-seed/..."
 mkdir -p "${SCRIPT_DIR}/target/readonly-seed/calm"
 mkdir -p "${SCRIPT_DIR}/target/readonly-seed/controls"
-cp -r "${REPO_ROOT}/calm/."                     "${SCRIPT_DIR}/target/readonly-seed/calm/"
-cp -r "${SCRIPT_DIR}/mongo/controls/."          "${SCRIPT_DIR}/target/readonly-seed/controls/"
+cp -r "${REPO_ROOT}/calm/." "${SCRIPT_DIR}/target/readonly-seed/calm/"
+cp -r "${SCRIPT_DIR}/mongo/controls/." "${SCRIPT_DIR}/target/readonly-seed/controls/"
 echo "[build] Staged:"
 ls "${SCRIPT_DIR}/target/readonly-seed/"
 

--- a/calm-hub/nitrite/seed-readonly.sh
+++ b/calm-hub/nitrite/seed-readonly.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Seeding script for the read-only static calm-hub image.
+#
+# Starts calm-hub in standalone writable mode, runs init-nitrite.sh to populate
+# the NitriteDB, then gracefully stops the app so the MVStore file is fully flushed.
+#
+# This script is executed inside the Docker seed stage (Stage 1) during the
+# Dockerfile.readonly-static build.  It is not intended for direct use outside
+# that context, but all paths and env-vars are configurable so it can be driven
+# locally if needed.
+#
+# Environment variables:
+#   DATA_DIR                - directory where the .db file will be written (default: /data)
+#   CALM_HUB_URL            - base URL for readiness checks and seeder (default: http://localhost:8080)
+#   CALM_SCHEMA_BASE_PATH   - path to the calm/ directory with release/ and draft/ (default: /calm)
+#   CALM_CONTROLS_BASE_PATH - path to the controls/ directory (default: /controls)
+#   READINESS_TIMEOUT       - seconds to wait for the app to become ready (default: 120)
+
+set -euo pipefail
+
+DATA_DIR="${DATA_DIR:-/data}"
+CALM_HUB_URL="${CALM_HUB_URL:-http://localhost:8080}"
+CALM_SCHEMA_BASE_PATH="${CALM_SCHEMA_BASE_PATH:-/calm}"
+CALM_CONTROLS_BASE_PATH="${CALM_CONTROLS_BASE_PATH:-/controls}"
+READINESS_TIMEOUT="${READINESS_TIMEOUT:-120}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_NITRITE_SCRIPT="${SCRIPT_DIR}/init-nitrite.sh"
+
+if [[ ! -f "${INIT_NITRITE_SCRIPT}" ]]; then
+    echo "[seed] ERROR: init-nitrite.sh not found at ${INIT_NITRITE_SCRIPT}" >&2
+    exit 1
+fi
+
+mkdir -p "${DATA_DIR}"
+
+echo "[seed] Starting calm-hub in standalone writable mode (data dir: ${DATA_DIR})..."
+
+QUARKUS_PROFILE=standalone \
+CALM_STANDALONE_DATA_DIRECTORY="${DATA_DIR}" \
+    java \
+        -Dquarkus.http.host=0.0.0.0 \
+        -Djava.util.logging.manager=org.jboss.logmanager.LogManager \
+        -jar /deployments/quarkus-run.jar \
+        > /var/log/calmhub-seed.log 2>&1 &
+APP_PID=$!
+echo "[seed] calm-hub started (PID ${APP_PID})"
+
+echo "[seed] Waiting for calm-hub to become ready (timeout: ${READINESS_TIMEOUT}s)..."
+elapsed=0
+interval=3
+until curl -sf "${CALM_HUB_URL}/q/swagger-ui" > /dev/null 2>&1; do
+    sleep "${interval}"
+    elapsed=$((elapsed + interval))
+    if [ "${elapsed}" -ge "${READINESS_TIMEOUT}" ]; then
+        echo "[seed] ERROR: Timed out after ${READINESS_TIMEOUT}s. Last log output:" >&2
+        tail -50 /var/log/calmhub-seed.log >&2
+        kill "${APP_PID}" 2>/dev/null || true
+        exit 1
+    fi
+    echo "[seed]   still waiting... ${elapsed}s / ${READINESS_TIMEOUT}s"
+done
+echo "[seed] calm-hub is ready."
+
+echo "[seed] Running init-nitrite.sh..."
+CALM_HUB_URL="${CALM_HUB_URL}" \
+CALM_SCHEMA_BASE_PATH="${CALM_SCHEMA_BASE_PATH}" \
+CALM_CONTROLS_BASE_PATH="${CALM_CONTROLS_BASE_PATH}" \
+    bash "${INIT_NITRITE_SCRIPT}"
+
+echo "[seed] Seeding complete. Stopping calm-hub gracefully (SIGTERM)..."
+kill -TERM "${APP_PID}"
+wait "${APP_PID}" || true
+
+echo "[seed] calm-hub stopped. Seeded database:"
+ls -lh "${DATA_DIR}/"
+echo "[seed] Done."

--- a/calm-hub/src/main/docker/Dockerfile.readonly-static
+++ b/calm-hub/src/main/docker/Dockerfile.readonly-static
@@ -1,0 +1,98 @@
+####
+# Read-only static calm-hub image.
+#
+# Produces a calm-hub container with a pre-seeded NitriteDB database baked in
+# as a read-only second layer.  No external database is required at runtime.
+# Mutating HTTP verbs (POST, PUT, DELETE, PATCH) are rejected with HTTP 405.
+#
+# Build is two stages:
+#
+#   Stage 1 (seed)  — always linux/amd64; boots the app in writable standalone
+#                     mode, runs init-nitrite.sh to populate the NitriteDB, then
+#                     shuts the app down gracefully so the MVStore file is fully
+#                     flushed.  The resulting calmSchemas.db is architecture-
+#                     neutral (pure-Java H2 MVStore format).
+#
+#   Stage 2 (final) — target platform (linux/amd64, linux/arm64, …); copies the
+#                     app artefacts and the seeded .db from Stage 1, then sets
+#                     the read-only env-vars so the app opens the file with
+#                     readOnly(true) and the HTTP filter rejects mutations.
+#
+# Prerequisites (handled by the CI workflow before `docker build` is called):
+#   • calm-hub Maven build complete: mvn package -DskipITs
+#     → target/quarkus-app/ is populated
+#   • calm/ schema content staged:  target/readonly-seed/calm/
+#   • controls content staged:      target/readonly-seed/controls/
+#
+# Build (from calm-hub/ directory):
+#   docker build -f src/main/docker/Dockerfile.readonly-static \
+#                -t calm-hub:latest-read-only-static .
+####
+
+
+# ── Stage 1: Seed ─────────────────────────────────────────────────────────────
+# Force amd64 so the JVM seeding process runs natively on GitHub Actions runners
+# (x86_64).  The resulting .db file is architecture-neutral and is safe to embed
+# in the arm64 final image.
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/openjdk-21 AS seed
+
+USER root
+
+# Install seeding tools (curl for readiness polling + REST calls; jq for JSON)
+RUN microdnf install -y curl jq && microdnf clean all
+
+# App artefacts pre-built by Maven (same layout as Dockerfile.jvm)
+COPY --chown=root target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=root target/quarkus-app/*.jar /deployments/
+COPY --chown=root target/quarkus-app/app/ /deployments/app/
+COPY --chown=root target/quarkus-app/quarkus/ /deployments/quarkus/
+
+# Seeding scripts
+COPY nitrite/seed-readonly.sh /nitrite/seed-readonly.sh
+COPY nitrite/init-nitrite.sh  /nitrite/init-nitrite.sh
+RUN chmod +x /nitrite/seed-readonly.sh /nitrite/init-nitrite.sh
+
+# CALM schema content and controls staged by the CI workflow into target/readonly-seed/
+COPY target/readonly-seed/calm/     /calm/
+COPY target/readonly-seed/controls/ /controls/
+
+# Boot calm-hub (writable standalone), seed all content, stop gracefully.
+# The resulting database file lands at /data/calmSchemas.db.
+RUN DATA_DIR=/data \
+    CALM_SCHEMA_BASE_PATH=/calm \
+    CALM_CONTROLS_BASE_PATH=/controls \
+    bash /nitrite/seed-readonly.sh
+
+
+# ── Stage 2: Final read-only image ────────────────────────────────────────────
+FROM registry.access.redhat.com/ubi8/openjdk-21
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# App artefacts (from seed stage; built once, reused across both platforms)
+COPY --chown=185 --from=seed /deployments/lib/     /deployments/lib/
+COPY --chown=185 --from=seed /deployments/*.jar    /deployments/
+COPY --chown=185 --from=seed /deployments/app/     /deployments/app/
+COPY --chown=185 --from=seed /deployments/quarkus/ /deployments/quarkus/
+
+# Bake the seeded database as a read-only file owned by the runtime user
+RUN mkdir -p /deployments/data
+COPY --chown=185 --from=seed /data/calmSchemas.db /deployments/data/calmSchemas.db
+RUN chmod 0444 /deployments/data/calmSchemas.db
+
+EXPOSE 8080
+USER 185
+
+ENV AB_JOLOKIA_OFF=""
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+# Activate the standalone profile: sets calm.database.mode=standalone and
+# suppresses MongoDB health-check / dev-services.
+ENV QUARKUS_PROFILE=standalone
+
+# Use a fixed data path (avoids ${user.home} ambiguity for UBI container UID 185)
+ENV CALM_STANDALONE_DATA_DIRECTORY=/deployments/data
+
+# Read-only mode: opens NitriteDB with readOnly(true) and rejects mutating HTTP verbs
+ENV CALM_READONLY=true


### PR DESCRIPTION
Adds a self-contained Docker image variant that bakes a pre-seeded NitriteDB database as a second read-only layer.  No external database is required at runtime; all CALM schemas, controls, patterns, architectures, and flows from the FINOS reference content are included.

How it works:
- Dockerfile.readonly-static (Stage 1, seed): boots calm-hub in writable standalone mode, runs init-nitrite.sh to populate NitriteDB via the REST API, then stops the app gracefully so the MVStore file is fully flushed.  The seed stage is pinned to linux/amd64 so it runs natively on GitHub Actions; the .db file is architecture-neutral (H2 MVStore / pure-Java format) and is safe to embed in arm64 images.
- Dockerfile.readonly-static (Stage 2, final): copies the app artefacts and seeded calmSchemas.db (chmod 0444, chown 185), sets QUARKUS_PROFILE=standalone, CALM_STANDALONE_DATA_DIRECTORY= /deployments/data, and CALM_READONLY=true.

New files:
- calm-hub/build-readonly-image.sh  convenience script (mvn package + stage content + docker build); --no-docker flag used by CI so the script is the single source of truth for both local and CI builds.
- calm-hub/nitrite/seed-readonly.sh  seeding orchestration inside the Docker seed stage (start app, poll readiness, run init-nitrite.sh, graceful SIGTERM, verify .db).
- calm-hub/src/main/docker/Dockerfile.readonly-static  two-stage build.
- .github/workflows/docker-publish-calm-hub-readonly.yml  triggers on calm-hub/** and calm/** changes; publishes with latest-read-only-static and <sha>-read-only-static tags.
- calm-hub/.dockerignore updated to expose nitrite/ scripts and target/readonly-seed/ staging area to the Docker build context.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
