### PR TITLE
fix(calm-hub): guard against null versions document in interface and standard stores

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -115,6 +115,9 @@ public class MongoInterfaceStore implements InterfaceStore {
         for (Document interfaceDoc : interfaces) {
             if (interfaceId.equals(interfaceDoc.getInteger("interfaceId"))) {
                 Document versions = (Document) interfaceDoc.get("versions");
+                if (versions == null) {
+                    throw new InterfaceNotFoundException();
+                }
                 Set<String> versionKeys = versions.keySet();
 
                 List<String> resourceVersions = new ArrayList<>();
@@ -152,6 +155,9 @@ public class MongoInterfaceStore implements InterfaceStore {
         for (Document interfaceDoc : interfaces) {
             if (interfaceId.equals(interfaceDoc.getInteger("interfaceId"))) {
                 Document versions = (Document) interfaceDoc.get("versions");
+                if (versions == null) {
+                    throw new InterfaceVersionNotFoundException();
+                }
                 Document versionDoc = (Document) versions.get(version.replace('.', '-'));
                 if (versionDoc == null) {
                     throw new InterfaceVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -113,6 +113,9 @@ public class MongoStandardStore implements StandardStore {
             if (standardId.equals(standardDoc.getInteger("standardId"))) {
                 // Extract the versions map from the matching standard
                 Document versions = (Document) standardDoc.get("versions");
+                if (versions == null) {
+                    throw new StandardNotFoundException();
+                }
                 Set<String> versionKeys = versions.keySet();
 
                 //Convert from Mongo representation
@@ -154,6 +157,9 @@ public class MongoStandardStore implements StandardStore {
         for (Document standardDoc : standards) {
             if (standardId.equals(standardDoc.getInteger("standardId"))) {
                 Document versions = (Document) standardDoc.get("versions");
+                if (versions == null) {
+                    throw new StandardVersionNotFoundException();
+                }
                 Document versionDoc = (Document) versions.get(version.replace('.', '-'));
                 if(versionDoc == null) {
                     throw new StandardVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
@@ -169,6 +169,9 @@ public class NitriteInterfaceStore implements InterfaceStore {
         }
 
         Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
+        if (versions == null) {
+            throw new InterfaceNotFoundException();
+        }
         Set<String> fieldNames = versions.getFields();
         List<String> versionList = new ArrayList<>();
         for (String fieldName : fieldNames) {
@@ -193,10 +196,14 @@ public class NitriteInterfaceStore implements InterfaceStore {
         }
 
         Document versions = interfaceDocument.get(VERSIONS_FIELD, Document.class);
-        String storedVersion = version.replace('.', '-');
-        String storedInterface = versions.get(storedVersion, String.class);
+        if (versions == null) {
+            throw new InterfaceVersionNotFoundException();
+        }
 
-        if (storedInterface == null) {
+        String storedVersion = version.replace('.', '-');
+        Object versionObj = versions.get(storedVersion);
+
+        if (!(versionObj instanceof String)) {
             LOG.warn("Version '{}' not found for interface {} in namespace '{}'",
                     storedVersion, interfaceId, namespace);
             throw new InterfaceVersionNotFoundException();
@@ -205,7 +212,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
         LOG.debug("Retrieved version '{}' for interface {} in namespace '{}'",
                 storedVersion, interfaceId, namespace);
 
-        return storedInterface;
+        return (String) versionObj;
     }
 
     @Override
@@ -233,6 +240,9 @@ public class NitriteInterfaceStore implements InterfaceStore {
             String mongoVersion = version.replace('.', '-');
 
             Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new InterfaceNotFoundException();
+            }
             if (versions.containsKey(mongoVersion)) {
                 LOG.warn("Version '{}' already exists for interface {} in namespace '{}'",
                         mongoVersion, interfaceId, namespace);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -212,9 +212,9 @@ public class NitritePatternStore implements PatternStore {
         if (versions == null) {
             throw new PatternVersionNotFoundException();
         }
-        String patternJson = versions.get(pattern.getMongoVersion(), String.class);
+        Object versionObj = versions.get(pattern.getMongoVersion());
 
-        if (patternJson == null) {
+        if (!(versionObj instanceof String)) {
             LOG.warn("Version '{}' not found for pattern {} in namespace '{}'",
                     pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
             throw new PatternVersionNotFoundException();
@@ -222,7 +222,7 @@ public class NitritePatternStore implements PatternStore {
 
         LOG.debug("Retrieved version '{}' for pattern {} in namespace '{}'",
                 pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
-        return patternJson;
+        return (String) versionObj;
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
@@ -172,6 +172,9 @@ public class NitriteStandardStore implements StandardStore {
         }
 
         Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
+        if (versions == null) {
+            throw new StandardNotFoundException();
+        }
         Set<String> fieldNames = versions.getFields();
         List<String> versionList = new ArrayList<>();
         for (String fieldName : fieldNames) {
@@ -196,10 +199,14 @@ public class NitriteStandardStore implements StandardStore {
         }
 
         Document versions = standardDocument.get(VERSIONS_FIELD, Document.class);
-        String mongoVersion = version.replace('.', '-');
-        String storedStandard = versions.get(mongoVersion, String.class);
+        if (versions == null) {
+            throw new StandardVersionNotFoundException();
+        }
 
-        if (storedStandard == null) {
+        String mongoVersion = version.replace('.', '-');
+        Object versionObj = versions.get(mongoVersion);
+
+        if (!(versionObj instanceof String)) {
             LOG.warn("Version '{}' not found for standard {} in namespace '{}'",
                     mongoVersion, standardId, namespace);
             throw new StandardVersionNotFoundException();
@@ -208,7 +215,7 @@ public class NitriteStandardStore implements StandardStore {
         LOG.debug("Retrieved version '{}' for standard {} in namespace '{}'",
                 mongoVersion, standardId, namespace);
 
-        return storedStandard;
+        return (String) versionObj;
     }
 
     @Override
@@ -236,6 +243,9 @@ public class NitriteStandardStore implements StandardStore {
             String mongoVersion = version.replace('.','-');
 
             Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new StandardNotFoundException();
+            }
             if (versions.containsKey(mongoVersion)) {
                 LOG.warn("Version '{}' already exists for standard {} in namespace '{}'",
                         mongoVersion, standardId, namespace);

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -155,6 +155,17 @@ public class TestMongoInterfaceStoreShould {
         when(findIterable.first()).thenReturn(mainDocument);
     }
 
+    private void mockSetupInterfaceDocumentWithoutVersions() {
+        Document interfaceWithNoVersions = new Document("namespace", "finos")
+                .append("interfaces", List.of(new Document("interfaceId", 42)));
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(interfaceCollection.find(any(Bson.class)))
+                .thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(interfaceWithNoVersions);
+    }
+
     @Test
     void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_interface() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
@@ -227,6 +238,22 @@ public class TestMongoInterfaceStoreShould {
         List<String> interfaceVersions = mongoInterfaceStore.getInterfaceVersions("finos", 42);
 
         assertThat(interfaceVersions, is(List.of("1.0.0")));
+    }
+
+    @Test
+    void throw_interface_not_found_when_versions_document_is_missing_on_get_versions() {
+        mockSetupInterfaceDocumentWithoutVersions();
+
+        assertThrows(InterfaceNotFoundException.class,
+                () -> mongoInterfaceStore.getInterfaceVersions("finos", 42));
+    }
+
+    @Test
+    void throw_interface_version_not_found_when_versions_document_is_missing_on_get_for_version() {
+        mockSetupInterfaceDocumentWithoutVersions();
+
+        assertThrows(InterfaceVersionNotFoundException.class,
+                () -> mongoInterfaceStore.getInterfaceForVersion("finos", 42, "1.0.0"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -152,6 +152,17 @@ public class TestMongoStandardStoreShould {
         when(findIterable.first()).thenReturn(mainDocument);
     }
 
+    private void mockSetupStandardDocumentWithoutVersions() {
+        Document standardWithNoVersions = new Document("namespace", "finos")
+                .append("standards", List.of(new Document("standardId", 42)));
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(standardCollection.find(any(Bson.class)))
+                .thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(standardWithNoVersions);
+    }
+
     @Test
     void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_standard() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
@@ -244,6 +255,22 @@ public class TestMongoStandardStoreShould {
         List<String> standardVersions = mongoStandardStore.getStandardVersions("finos", 42);
 
         assertThat(standardVersions, is(List.of("1.0.0")));
+    }
+
+    @Test
+    void throw_standard_not_found_when_versions_document_is_missing_on_get_versions() {
+        mockSetupStandardDocumentWithoutVersions();
+
+        assertThrows(StandardNotFoundException.class,
+                () -> mongoStandardStore.getStandardVersions("finos", 42));
+    }
+
+    @Test
+    void throw_standard_version_not_found_when_versions_document_is_missing_on_get_for_version() {
+        mockSetupStandardDocumentWithoutVersions();
+
+        assertThrows(StandardVersionNotFoundException.class,
+                () -> mongoStandardStore.getStandardForVersion("finos", 42, "1.0.0"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
@@ -239,7 +239,7 @@ public class TestNitriteInterfaceStoreShould {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
 
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0", String.class)).thenReturn(null);
+        when(versionsDoc.get("2-0-0")).thenReturn(null);
 
         Document interfaceDoc = mock(Document.class);
         when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
@@ -260,7 +260,7 @@ public class TestNitriteInterfaceStoreShould {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
 
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get(eq("2-0-0"), any())).thenReturn("{}");
+        when(versionsDoc.get("2-0-0")).thenReturn("{}");
 
         Document interfaceDoc = mock(Document.class);
         when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
@@ -276,6 +276,82 @@ public class TestNitriteInterfaceStoreShould {
         String result = interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "2.0.0");
 
         assertThat(result, equalTo("{}"));
+    }
+
+    @Test
+    public void testGetInterfaceVersions_whenVersionsDocumentIsNull_throwsInterfaceNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document interfaceDoc = Document.createDocument()
+                .put("interfaceId", INTERFACE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("interfaces", List.of(interfaceDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
+    }
+
+    @Test
+    public void testGetInterfaceForVersion_whenVersionsDocumentIsNull_throwsInterfaceVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document interfaceDoc = Document.createDocument()
+                .put("interfaceId", INTERFACE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("interfaces", List.of(interfaceDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(InterfaceVersionNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
+    }
+
+    @Test
+    public void testGetInterfaceForVersion_whenVersionObjIsNotAString_throwsInterfaceVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versions = Document.createDocument()
+                .put("1-0-0", 12345);
+
+        Document interfaceDoc = Document.createDocument()
+                .put("interfaceId", INTERFACE_ID)
+                .put("versions", versions);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("interfaces", List.of(interfaceDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(InterfaceVersionNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
+    }
+
+    @Test
+    public void testCreateInterfaceForVersion_whenVersionsDocumentIsNull_throwsInterfaceNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document interfaceDoc = Document.createDocument()
+                .put("interfaceId", INTERFACE_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("interfaces", List.of(interfaceDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.createInterfaceForVersion(getInterfaceToPersist(), NAMESPACE, INTERFACE_ID, "1.0.1"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -298,7 +298,7 @@ public class TestNitritePatternStoreShould {
 
         // Mock the versionsDoc with the fields we need
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get(anyString(), eq(String.class))).thenReturn(null); // Version not found
+        when(versionsDoc.get(anyString())).thenReturn(null); // Version not found
 
         // Mock the pattern document
         Document patternDoc = mock(Document.class);
@@ -355,6 +355,27 @@ public class TestNitritePatternStoreShould {
     }
 
     @Test
+    public void testGetPatternForVersion_whenVersionObjIsNotAString_throwsPatternVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versions = Document.createDocument().put("1-0-0", 12345);
+        Document patternDoc = Document.createDocument()
+                .put("patternId", PATTERN_ID)
+                .put("versions", versions);
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", List.of(patternDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE).setId(PATTERN_ID).setVersion("1.0.0").build();
+
+        assertThrows(PatternVersionNotFoundException.class, () -> patternStore.getPatternForVersion(pattern));
+    }
+
+    @Test
     public void testGetPatternForVersion_whenVersionExists_returnsPatternJson() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
         // Arrange
         Pattern pattern = new Pattern.PatternBuilder()
@@ -367,7 +388,7 @@ public class TestNitritePatternStoreShould {
 
         // Mock the versionsDoc with the fields we need
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get(eq("1-0-0"), eq(String.class))).thenReturn(PATTERN_JSON);
+        when(versionsDoc.get("1-0-0")).thenReturn(PATTERN_JSON);
 
         // Mock the pattern document
         Document patternDoc = mock(Document.class);

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
@@ -283,7 +283,7 @@ public class TestNitriteStandardStoreShould {
 
         // Mock the versionsDoc with the fields we need
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0", String.class)).thenReturn(null); // Version not found
+        when(versionsDoc.get("2-0-0")).thenReturn(null); // Version not found
 
         // Mock the standard document
         Document standardDoc = mock(Document.class);
@@ -317,7 +317,7 @@ public class TestNitriteStandardStoreShould {
         expectedStandard.setStandardJson("{}");
 
         Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get(eq("2-0-0"), any())).thenReturn("{}");
+        when(versionsDoc.get("2-0-0")).thenReturn("{}");
 
         // Mock the standard document
         Document standardDoc = mock(Document.class);
@@ -338,6 +338,82 @@ public class TestNitriteStandardStoreShould {
 
         // Assert
         assertThat(standard, equalTo("{}"));
+    }
+
+    @Test
+    public void testGetStandardVersions_whenVersionsDocumentIsNull_throwsStandardNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document standardDoc = Document.createDocument()
+                .put("standardId", STANDARD_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("standards", List.of(standardDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(StandardNotFoundException.class, () -> standardStore.getStandardVersions(NAMESPACE, STANDARD_ID));
+    }
+
+    @Test
+    public void testGetStandardForVersion_whenVersionsDocumentIsNull_throwsStandardVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document standardDoc = Document.createDocument()
+                .put("standardId", STANDARD_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("standards", List.of(standardDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(StandardVersionNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
+    }
+
+    @Test
+    public void testGetStandardForVersion_whenVersionObjIsNotAString_throwsStandardVersionNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document versions = Document.createDocument()
+                .put("1-0-0", 12345);
+
+        Document standardDoc = Document.createDocument()
+                .put("standardId", STANDARD_ID)
+                .put("versions", versions);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("standards", List.of(standardDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(StandardVersionNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
+    }
+
+    @Test
+    public void testCreateStandardForVersion_whenVersionsDocumentIsNull_throwsStandardNotFoundException() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document standardDoc = Document.createDocument()
+                .put("standardId", STANDARD_ID);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("standards", List.of(standardDoc));
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        assertThrows(StandardNotFoundException.class, () -> standardStore.createStandardForVersion(getStandardToPersist(), NAMESPACE, STANDARD_ID, "1.0.1"));
     }
 
     @Test


### PR DESCRIPTION
## Description
Closes #2564.

Same latent-corruption class as #2498 / #2561, in the two resource stores PR #2561 did not cover. When an `interface` or `standard` resource document exists **without** a `versions` sub-document (hand-edited Nitrite store, partial/aborted migration, or a future schema change), the `get*Versions` / `get*ForVersion` / Nitrite write paths dereferenced a `null` versions document and threw a `NullPointerException`, surfacing as **HTTP 500**.

This change null-guards the versions document in every affected method so the store throws a typed exception (`*NotFoundException` / `*VersionNotFoundException`) and the resource layer returns a sensible **4xx**, consistent with the architecture / pattern / timeline stores after #2561:

- `MongoInterfaceStore` — `getInterfaceVersions` → `InterfaceNotFoundException`; `getInterfaceForVersion` → `InterfaceVersionNotFoundException`.
- `MongoStandardStore` — `getStandardVersions` → `StandardNotFoundException`; `getStandardForVersion` → `StandardVersionNotFoundException`.
- `NitriteInterfaceStore` / `NitriteStandardStore` — null guards on `get*Versions`, `get*ForVersion` and the create/write path, plus an `instanceof String` guard before casting `versionObj` in `get*ForVersion` (so a non-String stored value yields a clean 4xx instead of an unchecked cast/validation 500).

### Pattern store consistency (slightly beyond the issue scope)
#2561 left `NitritePatternStore.getPatternForVersion` on the typed two-arg `get(key, String.class)` (it only added the null guard there). To avoid leaving the Nitrite stores in two different idioms, this PR also converts that method to the same `instanceof String` form. All five Nitrite resource stores now behave identically.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

New unit tests construct a resource document with no `versions` sub-document (and, for Nitrite `get*ForVersion`, a non-String version value) and assert the typed exception for each path, mirroring #2561's coverage. Verified with `./mvnw clean verify -Ddependency-check.skip=true` — **1752 tests pass, all JaCoCo coverage checks met.**

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary (no behaviour-facing docs affected)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
