### PR TITLE
fix(calm-models): diff id-less pattern items by content instead of dropping them

### DIFF
--- a/calm-hub-ui/src/diff/components/utils/applyDiffStatus.test.ts
+++ b/calm-hub-ui/src/diff/components/utils/applyDiffStatus.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { Node, Edge } from 'reactflow';
+import type { DiffResult } from '@finos/calm-models/diff';
+import { applyDiffStatus } from './applyDiffStatus.js';
+
+const emptyDiff: DiffResult = {
+    nodesAdded: [],
+    nodesRemoved: [],
+    nodesModified: [],
+    nodesRenamed: [],
+    nodesSame: [],
+    edgesAdded: [],
+    edgesRemoved: [],
+    edgesModified: [],
+    edgesRenamed: [],
+    edgesSame: [],
+};
+
+const node = (id: string | undefined, data: Record<string, unknown>): Node =>
+    ({ id: id ?? 'idless', position: { x: 0, y: 0 }, data } as Node);
+
+describe('applyDiffStatus', () => {
+    it('highlights an added node matched by unique-id', () => {
+        const parsed = { nodes: [node('svc-a', { 'unique-id': 'svc-a' })], edges: [] as Edge[] };
+        const diff: DiffResult = {
+            ...emptyDiff,
+            nodesAdded: [{ 'unique-id': 'svc-a', name: 'A', 'node-type': 'service' }],
+        };
+        const result = applyDiffStatus(parsed, diff, false);
+        expect(result.nodes[0].data.diffStatus).toBe('added');
+    });
+
+    it('leaves id-less pattern nodes unchanged rather than matching by undefined', () => {
+        // An unconstrained pattern node has no unique-id; the diff's id-less
+        // content entry also has none. Without the guard, `undefined === undefined`
+        // would mark every id-less node 'added'.
+        const parsed = {
+            nodes: [
+                node('api-gateway', { 'unique-id': 'api-gateway' }),
+                node(undefined, { name: 'Worker', 'node-type': 'service' }),
+            ],
+            edges: [] as Edge[],
+        };
+        const diff: DiffResult = {
+            ...emptyDiff,
+            nodesAdded: [{ name: 'Worker', 'node-type': 'service' } as never],
+        };
+
+        const result = applyDiffStatus(parsed, diff, false);
+
+        expect(result.nodes.map((n) => n.data.diffStatus)).toEqual(['unchanged', 'unchanged']);
+    });
+});

--- a/calm-hub-ui/src/diff/components/utils/applyDiffStatus.ts
+++ b/calm-hub-ui/src/diff/components/utils/applyDiffStatus.ts
@@ -25,7 +25,10 @@ export function applyDiffStatus(
         let diffStatus: DiffNodeData['diffStatus'] = 'unchanged';
         let originalId: string | undefined;
 
-        if (isFirst) {
+        // Only match by a real unique-id. Unconstrained pattern nodes have no
+        // id, and matching them by `undefined === undefined` would tar every
+        // id-less node with the same status, so leave them unchanged.
+        if (uniqueId && isFirst) {
             if (diffResult.nodesRemoved.some((n) => n['unique-id'] === uniqueId)) {
                 diffStatus = 'removed';
             } else if (diffResult.nodesModified.some((m) => m.original['unique-id'] === uniqueId)) {
@@ -34,7 +37,7 @@ export function applyDiffStatus(
                 diffStatus = 'renamed';
                 originalId = diffResult.nodesRenamed.find((r) => r.newId === uniqueId)?.oldId;
             }
-        } else {
+        } else if (uniqueId) {
             if (diffResult.nodesAdded.some((n) => n['unique-id'] === uniqueId)) {
                 diffStatus = 'added';
             } else if (diffResult.nodesModified.some((m) => m.updated['unique-id'] === uniqueId)) {
@@ -65,7 +68,9 @@ export function applyDiffStatus(
         let diffStatus: DiffEdgeData['diffStatus'] = 'unchanged';
         let originalId: string | undefined;
 
-        if (isFirst) {
+        // See the node loop above: id-less pattern edges must not match by
+        // `undefined === undefined`, so leave them unchanged.
+        if (uniqueId && isFirst) {
             if (diffResult.edgesRemoved.some((e) => e['unique-id'] === uniqueId)) {
                 diffStatus = 'removed';
             } else if (diffResult.edgesModified.some((m) => m.original['unique-id'] === uniqueId)) {
@@ -74,7 +79,7 @@ export function applyDiffStatus(
                 diffStatus = 'renamed';
                 originalId = diffResult.edgesRenamed.find((r) => r.newId === uniqueId)?.oldId;
             }
-        } else {
+        } else if (uniqueId) {
             if (diffResult.edgesAdded.some((e) => e['unique-id'] === uniqueId)) {
                 diffStatus = 'added';
             } else if (diffResult.edgesModified.some((m) => m.updated['unique-id'] === uniqueId)) {

--- a/calm-models/src/diff/diff-types.ts
+++ b/calm-models/src/diff/diff-types.ts
@@ -38,11 +38,12 @@ export interface InvalidDiffItems {
 
 /**
  * Pattern items that are legitimate but cannot be diffed: they declare a
- * node/relationship without pinning anything comparable (e.g. an unconstrained
- * `unique-id`, or a bare `$ref`). Unlike {@link InvalidDiffItems} these are not
- * invalid input — a pattern needn't pin every id — but there's no content to
- * match on, so they're surfaced (and counted toward `hasChanges`) rather than
- * silently dropped.
+ * `unique-id` that is present but not pinned with a `const`, so there's nothing
+ * concrete to match on. Unlike {@link InvalidDiffItems} these are not invalid
+ * input — a pattern needn't pin every id — but with no content to match they're
+ * surfaced (and counted toward `hasChanges`) rather than silently dropped.
+ * Items that declare no `unique-id` at all (bare `$ref`s, decision wrappers) are
+ * skipped entirely and never reported here.
  */
 export interface UndiffableDiffItems {
     nodes: unknown[];

--- a/calm-models/src/diff/diff-types.ts
+++ b/calm-models/src/diff/diff-types.ts
@@ -36,6 +36,19 @@ export interface InvalidDiffItems {
     relationships: unknown[];
 }
 
+/**
+ * Pattern items that are legitimate but cannot be diffed: they declare a
+ * node/relationship without pinning anything comparable (e.g. an unconstrained
+ * `unique-id`, or a bare `$ref`). Unlike {@link InvalidDiffItems} these are not
+ * invalid input — a pattern needn't pin every id — but there's no content to
+ * match on, so they're surfaced (and counted toward `hasChanges`) rather than
+ * silently dropped.
+ */
+export interface UndiffableDiffItems {
+    nodes: unknown[];
+    relationships: unknown[];
+}
+
 export interface DiffResult {
     nodesAdded: CalmNodeSchema[];
     nodesRemoved: CalmNodeSchema[];
@@ -50,4 +63,5 @@ export interface DiffResult {
     edgesRenamed: RelationshipRenameMapping[];
 
     invalidItems?: InvalidDiffItems;
+    undiffableItems?: UndiffableDiffItems;
 }

--- a/calm-models/src/diff/diff.ts
+++ b/calm-models/src/diff/diff.ts
@@ -29,6 +29,15 @@ function valuesEqual(a: unknown, b: unknown): boolean {
     return JSON.stringify(normalizeValue(a)) === JSON.stringify(normalizeValue(b));
 }
 
+/**
+ * A stable, order-insensitive string key for a value: object keys are sorted
+ * recursively before serialising, so two structurally-equal values produce the
+ * same key. Used by the pattern diff to match id-less items by content.
+ */
+export function canonicalKey(value: unknown): string {
+    return JSON.stringify(normalizeValue(value));
+}
+
 function omitUniqueId(item: Record<string, unknown>): Record<string, unknown> {
     const { 'unique-id': _omit, ...rest } = item;
     void _omit;

--- a/calm-models/src/diff/diff.ts
+++ b/calm-models/src/diff/diff.ts
@@ -30,9 +30,11 @@ function valuesEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
- * A stable, order-insensitive string key for a value: object keys are sorted
- * recursively before serialising, so two structurally-equal values produce the
- * same key. Used by the pattern diff to match id-less items by content.
+ * A stable content key for a value: object keys are sorted recursively before
+ * serialising, so two values differing only in object-key order produce the
+ * same key. Array element order is preserved (and therefore significant),
+ * matching {@link valuesEqual}. Used by the pattern diff to match id-less items
+ * by content.
  */
 export function canonicalKey(value: unknown): string {
     return JSON.stringify(normalizeValue(value));

--- a/calm-models/src/diff/fixtures/diff-test-patterns.json
+++ b/calm-models/src/diff/fixtures/diff-test-patterns.json
@@ -307,6 +307,149 @@
       }
     ]
   },
+  "contentBasePattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Content Base Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "type": "string" },
+              "name": { "const": "Worker" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": { "type": "array", "prefixItems": [] }
+    }
+  },
+  "contentReorderedPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Content Reordered Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "type": "string" },
+              "name": { "const": "Worker" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": { "type": "array", "prefixItems": [] }
+    }
+  },
+  "contentModifiedPattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Content Modified Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "type": "string" },
+              "name": { "const": "Worker v2" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": { "type": "array", "prefixItems": [] }
+    }
+  },
+  "contentDuplicatePattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Content Duplicate Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "type": "string" },
+              "name": { "const": "Worker" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "type": "string" },
+              "name": { "const": "Worker" },
+              "node-type": { "const": "service" }
+            }
+          }
+        ]
+      },
+      "relationships": { "type": "array", "prefixItems": [] }
+    }
+  },
+  "undiffablePattern": {
+    "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
+    "type": "object",
+    "title": "Undiffable Pattern",
+    "properties": {
+      "nodes": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "properties": {
+              "unique-id": { "const": "api-gateway" },
+              "name": { "const": "API Gateway" },
+              "node-type": { "const": "service" }
+            }
+          },
+          {
+            "properties": {
+              "unique-id": { "type": "string" }
+            }
+          },
+          {
+            "$ref": "https://calm.finos.org/release/1.0-rc2/meta/core.json#/defs/node"
+          }
+        ]
+      },
+      "relationships": { "type": "array", "prefixItems": [] }
+    }
+  },
   "decisionPattern": {
     "$schema": "https://calm.finos.org/release/1.0-rc2/meta/calm.json",
     "type": "object",

--- a/calm-models/src/diff/index.ts
+++ b/calm-models/src/diff/index.ts
@@ -27,4 +27,5 @@ export type {
     RenameMapping,
     RelationshipRenameMapping,
     InvalidDiffItems,
+    UndiffableDiffItems,
 } from './diff-types.js';

--- a/calm-models/src/diff/pattern-diff.spec.ts
+++ b/calm-models/src/diff/pattern-diff.spec.ts
@@ -42,6 +42,19 @@ describe('normalisePatternToInstance', () => {
         expect(normalisePatternToInstance(null)).toEqual({ nodes: [], relationships: [] });
         expect(normalisePatternToInstance('not a pattern')).toEqual({ nodes: [], relationships: [] });
     });
+
+    it('includes id-less but constrained nodes in the instance', () => {
+        const { nodes } = normalisePatternToInstance(testPatterns.contentBasePattern);
+        expect(nodes).toHaveLength(2);
+        expect(nodes).toContainEqual({ 'unique-id': 'api-gateway', name: 'API Gateway', 'node-type': 'service' });
+        expect(nodes).toContainEqual({ name: 'Worker', 'node-type': 'service' });
+    });
+
+    it('omits items that pin nothing comparable from the instance', () => {
+        // api-gateway is pinned; the unconstrained-id node and bare $ref are dropped.
+        const { nodes } = normalisePatternToInstance(testPatterns.undiffablePattern);
+        expect(nodes.map((n) => n['unique-id'])).toEqual(['api-gateway']);
+    });
 });
 
 describe('diffPatterns', () => {
@@ -91,5 +104,48 @@ describe('diffPatterns', () => {
         const addedIds = result.nodesAdded.map((n) => n['unique-id']);
         expect(addedIds).toContain('postgres-store');
         expect(addedIds).toContain('dynamo-store');
+    });
+
+    it('diffs id-less constrained nodes by content', () => {
+        const result = diffPatterns(testPatterns.contentBasePattern, testPatterns.contentBasePattern);
+        expect(result.nodesAdded).toHaveLength(0);
+        expect(result.nodesRemoved).toHaveLength(0);
+        // api-gateway (by id) + Worker (by content) both unchanged.
+        expect(result.nodesSame).toHaveLength(2);
+    });
+
+    it('treats reordering of identical nodes as no change', () => {
+        const result = diffPatterns(testPatterns.contentBasePattern, testPatterns.contentReorderedPattern);
+        expect(result.nodesAdded).toHaveLength(0);
+        expect(result.nodesRemoved).toHaveLength(0);
+        expect(result.nodesSame).toHaveLength(2);
+    });
+
+    it('reports a changed id-less node as remove + add, not modified', () => {
+        const result = diffPatterns(testPatterns.contentBasePattern, testPatterns.contentModifiedPattern);
+        expect(result.nodesModified).toHaveLength(0);
+        expect(result.nodesRemoved).toContainEqual({ name: 'Worker', 'node-type': 'service' });
+        expect(result.nodesAdded).toContainEqual({ name: 'Worker v2', 'node-type': 'service' });
+        // api-gateway is pinned and unchanged.
+        expect(result.nodesSame).toHaveLength(1);
+    });
+
+    it('counts identical id-less nodes as a multiset', () => {
+        const result = diffPatterns(testPatterns.contentBasePattern, testPatterns.contentDuplicatePattern);
+        // Base has one Worker, duplicate has two: exactly one Worker added.
+        expect(result.nodesAdded).toEqual([{ name: 'Worker', 'node-type': 'service' }]);
+        expect(result.nodesRemoved).toHaveLength(0);
+    });
+
+    it('surfaces items that pin nothing comparable under undiffableItems', () => {
+        const result = diffPatterns(testPatterns.undiffablePattern, testPatterns.undiffablePattern);
+        // One unconstrained-id node per side; the bare $ref is skipped silently.
+        expect(result.undiffableItems?.nodes).toHaveLength(2);
+        expect(result.undiffableItems?.relationships ?? []).toHaveLength(0);
+    });
+
+    it('leaves undiffableItems unset for fully-constrained patterns', () => {
+        const result = diffPatterns(testPatterns.basePattern, testPatterns.additionPattern);
+        expect(result.undiffableItems).toBeUndefined();
     });
 });

--- a/calm-models/src/diff/pattern-diff.ts
+++ b/calm-models/src/diff/pattern-diff.ts
@@ -1,6 +1,6 @@
 import type { CalmNodeSchema, CalmRelationshipSchema } from '../types/index.js';
 import type { DiffResult } from './diff-types.js';
-import { diffNodesAndRelationships } from './diff.js';
+import { canonicalKey, diffNodesAndRelationships } from './diff.js';
 
 type SchemaObject = Record<string, unknown>;
 
@@ -91,38 +91,172 @@ function hasUniqueId(value: unknown): value is Record<string, unknown> {
     return isObject(value) && typeof value['unique-id'] === 'string';
 }
 
+function isNonEmptyObject(value: unknown): value is Record<string, unknown> {
+    return isObject(value) && Object.keys(value).length > 0;
+}
+
+/**
+ * Whether a prefix item is meant to pin a single node/relationship — i.e. it
+ * declares a `unique-id` property. Decision/options wrappers (`oneOf`/`anyOf`/
+ * `options`) and bare `$ref` placeholders don't, so when they collapse to
+ * nothing comparable they're skipped rather than reported as undiffable.
+ */
+function declaresUniqueId(item: SchemaObject): boolean {
+    return isObject(item['properties']) && 'unique-id' in (item['properties'] as SchemaObject);
+}
+
+interface PatternPartition {
+    /** Collapsed items with a `const`-pinned `unique-id`: diffable by identity. */
+    pinned: Record<string, unknown>[];
+    /** Collapsed items without a pinned `unique-id` but with comparable content. */
+    content: Record<string, unknown>[];
+    /** Items that declare a node/relationship but pin nothing comparable. */
+    undiffable: unknown[];
+}
+
+/**
+ * Collapses each (already alternative-expanded) prefix item and sorts it into:
+ * `pinned` (has a `const` `unique-id` → diff by id), `content` (no pinned id but
+ * still constrains fields → diff by content), or `undiffable` (declares a
+ * node/relationship but pins nothing comparable). Unconstrained decision/options
+ * constructs that don't declare a `unique-id` are skipped entirely.
+ */
+function partitionPrefixItems(prefixItems: SchemaObject[]): PatternPartition {
+    const pinned: Record<string, unknown>[] = [];
+    const content: Record<string, unknown>[] = [];
+    const undiffable: unknown[] = [];
+    for (const item of expandAlternatives(prefixItems)) {
+        const collapsed = collapseSchema(item);
+        if (hasUniqueId(collapsed)) {
+            pinned.push(collapsed);
+        } else if (isNonEmptyObject(collapsed)) {
+            content.push(collapsed);
+        } else if (declaresUniqueId(item)) {
+            undiffable.push(isObject(collapsed) ? collapsed : item);
+        }
+    }
+    return { pinned, content, undiffable };
+}
+
+function partitionPattern(pattern: unknown): { nodes: PatternPartition; relationships: PatternPartition } {
+    if (!isObject(pattern)) {
+        return {
+            nodes: { pinned: [], content: [], undiffable: [] },
+            relationships: { pinned: [], content: [], undiffable: [] },
+        };
+    }
+    return {
+        nodes: partitionPrefixItems(getPrefixItems(pattern, 'nodes')),
+        relationships: partitionPrefixItems(getPrefixItems(pattern, 'relationships')),
+    };
+}
+
+/**
+ * Order-insensitive multiset diff of two lists of id-less items matched by
+ * canonical content. Equal content present on both sides is `same`; surplus on
+ * one side is `added`/`removed`. There is no `modified`: with no `unique-id` to
+ * anchor identity, a content change is an add plus a remove.
+ */
+function contentMultisetDiff(
+    listA: Record<string, unknown>[],
+    listB: Record<string, unknown>[],
+): {
+    added: Record<string, unknown>[];
+    removed: Record<string, unknown>[];
+    same: Record<string, unknown>[];
+} {
+    const index = (list: Record<string, unknown>[]) => {
+        const counts = new Map<string, { item: Record<string, unknown>; count: number }>();
+        for (const item of list) {
+            const key = canonicalKey(item);
+            const entry = counts.get(key);
+            if (entry) entry.count++;
+            else counts.set(key, { item, count: 1 });
+        }
+        return counts;
+    };
+
+    const indexA = index(listA);
+    const indexB = index(listB);
+    const added: Record<string, unknown>[] = [];
+    const removed: Record<string, unknown>[] = [];
+    const same: Record<string, unknown>[] = [];
+
+    for (const key of new Set([...indexA.keys(), ...indexB.keys()])) {
+        const entryA = indexA.get(key);
+        const entryB = indexB.get(key);
+        const countA = entryA?.count ?? 0;
+        const countB = entryB?.count ?? 0;
+        const representative = (entryB ?? entryA)!.item;
+        for (let i = 0; i < Math.min(countA, countB); i++) same.push(representative);
+        for (let i = 0; i < countB - countA; i++) added.push(entryB!.item);
+        for (let i = 0; i < countA - countB; i++) removed.push(entryA!.item);
+    }
+
+    return { added, removed, same };
+}
+
 /**
  * Reduces a CALM pattern (a JSON Schema) to the instance-shaped
- * `{ nodes, relationships }` it constrains, keyed by `unique-id`. This is the
- * same reduction the Hub UI's pattern visualiser performs for rendering, so the
- * diff lines up with what users see on the graph.
+ * `{ nodes, relationships }` it constrains. Both `const`-pinned items and
+ * id-less-but-constrained items are included. Items that pin nothing comparable
+ * are omitted (see {@link diffPatterns} for how they're surfaced). Exposed as a
+ * public helper for callers that want the reduced instance; {@link diffPatterns}
+ * itself works off the lower-level partition rather than this.
  */
 export function normalisePatternToInstance(pattern: unknown): {
     nodes: CalmNodeSchema[];
     relationships: CalmRelationshipSchema[];
 } {
-    if (!isObject(pattern)) {
-        return { nodes: [], relationships: [] };
-    }
-
-    const nodes = expandAlternatives(getPrefixItems(pattern, 'nodes'))
-        .map(collapseSchema)
-        .filter(hasUniqueId) as CalmNodeSchema[];
-
-    const relationships = expandAlternatives(getPrefixItems(pattern, 'relationships'))
-        .map(collapseSchema)
-        .filter(hasUniqueId) as CalmRelationshipSchema[];
-
-    return { nodes, relationships };
+    const { nodes, relationships } = partitionPattern(pattern);
+    return {
+        nodes: [...nodes.pinned, ...nodes.content] as unknown as CalmNodeSchema[],
+        relationships: [...relationships.pinned, ...relationships.content] as unknown as CalmRelationshipSchema[],
+    };
 }
 
 /**
- * Diffs two CALM patterns by normalising each schema to its constrained
- * `{ nodes, relationships }` and delegating to the shared diff core. Returns the
- * same `DiffResult` shape as {@link diffArchitectures}.
+ * Diffs two CALM patterns. Items with a `const`-pinned `unique-id` are diffed by
+ * identity (add/remove/modify/rename) via the shared diff core. Id-less items
+ * that still constrain content are diffed by content as an order-insensitive
+ * multiset (add/remove/same — never modified). Items that pin nothing comparable
+ * are reported under `undiffableItems` and contribute to `hasChanges` so
+ * `--exit-code` doesn't pass on them silently. Returns the same `DiffResult`
+ * shape as {@link diffArchitectures}.
  */
 export function diffPatterns(patternA: unknown, patternB: unknown): DiffResult {
-    const a = normalisePatternToInstance(patternA);
-    const b = normalisePatternToInstance(patternB);
-    return diffNodesAndRelationships(a.nodes, b.nodes, a.relationships, b.relationships);
+    const a = partitionPattern(patternA);
+    const b = partitionPattern(patternB);
+
+    // Pass 1 — identity: const-pinned items, keyed by unique-id.
+    const result = diffNodesAndRelationships(
+        a.nodes.pinned as unknown as CalmNodeSchema[],
+        b.nodes.pinned as unknown as CalmNodeSchema[],
+        a.relationships.pinned as unknown as CalmRelationshipSchema[],
+        b.relationships.pinned as unknown as CalmRelationshipSchema[],
+    );
+
+    // Pass 2 — content: id-less-but-constrained items, matched by canonical
+    // content as an order-insensitive multiset. These flow into the normal
+    // add/remove/same buckets alongside the identity-matched items.
+    const nodeContent = contentMultisetDiff(a.nodes.content, b.nodes.content);
+    const relContent = contentMultisetDiff(a.relationships.content, b.relationships.content);
+    result.nodesAdded.push(...(nodeContent.added as unknown as CalmNodeSchema[]));
+    result.nodesRemoved.push(...(nodeContent.removed as unknown as CalmNodeSchema[]));
+    result.nodesSame.push(...(nodeContent.same as unknown as CalmNodeSchema[]));
+    result.edgesAdded.push(...(relContent.added as unknown as CalmRelationshipSchema[]));
+    result.edgesRemoved.push(...(relContent.removed as unknown as CalmRelationshipSchema[]));
+    result.edgesSame.push(...(relContent.same as unknown as CalmRelationshipSchema[]));
+
+    // Undiffable: legitimate pattern slots that pin nothing comparable.
+    const undiffableNodes = [...a.nodes.undiffable, ...b.nodes.undiffable];
+    const undiffableRelationships = [...a.relationships.undiffable, ...b.relationships.undiffable];
+    if (undiffableNodes.length > 0 || undiffableRelationships.length > 0) {
+        result.undiffableItems = {
+            nodes: undiffableNodes,
+            relationships: undiffableRelationships,
+        };
+    }
+
+    return result;
 }

--- a/shared/src/commands/diff/diff.spec.ts
+++ b/shared/src/commands/diff/diff.spec.ts
@@ -147,6 +147,31 @@ describe('runDiff', () => {
         expect(result.hasChanges).toBe(true);
     });
 
+    it('warns about undiffable pattern items and treats them as changes', async () => {
+        const undiffablePattern = {
+            $schema: 'https://calm.finos.org/release/1.0-rc2/meta/calm.json',
+            type: 'object',
+            properties: {
+                nodes: {
+                    type: 'array',
+                    prefixItems: [
+                        { properties: { 'unique-id': { const: 'svc-a' }, name: { const: 'A' }, 'node-type': { const: 'service' } } },
+                        { properties: { 'unique-id': { type: 'string' } } },
+                    ],
+                },
+                relationships: { type: 'array', prefixItems: [] },
+            },
+        };
+        const a = writeArch('a.pattern.json', undiffablePattern);
+        const b = writeArch('b.pattern.json', undiffablePattern);
+
+        const result = await runDiff(a, b);
+
+        expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+        expect(loggerMock.warn.mock.calls[0][0]).toMatch(/constrain no comparable content/);
+        expect(result.hasChanges).toBe(true);
+    });
+
     it('diffs two pattern files and reports a pattern-titled summary', async () => {
         const a = writeArch('a.pattern.json', makePattern('Service A'));
         const b = writeArch('b.pattern.json', makePattern('Service A v2'));
@@ -238,6 +263,14 @@ describe('hasChanges', () => {
         };
         expect(hasChanges(r)).toBe(true);
     });
+
+    it('returns true when only undiffable items are present', () => {
+        const r: DiffResult = {
+            ...emptyResult,
+            undiffableItems: { nodes: [{ name: 'unpinned' }], relationships: [] },
+        };
+        expect(hasChanges(r)).toBe(true);
+    });
 });
 
 describe('formatDiff', () => {
@@ -259,5 +292,24 @@ describe('formatDiff', () => {
         };
         const out = formatDiff(r, 'summary');
         expect(out).toContain('Invalid items: 1 node(s) + 2 relationship(s)');
+    });
+
+    it('surfaces undiffable item counts in the summary view', () => {
+        const r: DiffResult = {
+            ...emptyResult,
+            undiffableItems: { nodes: [{ a: 1 }], relationships: [{ b: 2 }] },
+        };
+        const out = formatDiff(r, 'summary');
+        expect(out).toContain('Undiffable items: 1 node(s) + 1 relationship(s)');
+    });
+
+    it('labels id-less pattern nodes by content instead of undefined', () => {
+        const r: DiffResult = {
+            ...emptyResult,
+            nodesAdded: [{ name: 'Worker', 'node-type': 'service' } as never],
+        };
+        const out = formatDiff(r, 'summary', 'pattern');
+        expect(out).toContain('  - (unpinned service Worker)');
+        expect(out).not.toContain('undefined');
     });
 });

--- a/shared/src/commands/diff/diff.ts
+++ b/shared/src/commands/diff/diff.ts
@@ -11,7 +11,7 @@ import {
     type MomentDiff,
     type TimelineInput,
 } from '@finos/calm-models/diff';
-import type { CalmArchitectureSchema } from '@finos/calm-models/types';
+import type { CalmArchitectureSchema, CalmNodeSchema, CalmRelationshipSchema } from '@finos/calm-models/types';
 import { initLogger } from '../../logger.js';
 
 export type DiffOutputFormat = 'json' | 'summary';
@@ -43,8 +43,27 @@ export function hasChanges(diff: DiffResult): boolean {
         diff.edgesModified.length > 0 ||
         diff.edgesRenamed.length > 0 ||
         (diff.invalidItems?.nodes.length ?? 0) > 0 ||
-        (diff.invalidItems?.relationships.length ?? 0) > 0
+        (diff.invalidItems?.relationships.length ?? 0) > 0 ||
+        (diff.undiffableItems?.nodes.length ?? 0) > 0 ||
+        (diff.undiffableItems?.relationships.length ?? 0) > 0
     );
+}
+
+/**
+ * Label for a node/relationship in the summary view. Falls back to a content
+ * hint for pattern items that have no pinned `unique-id`, so they don't render
+ * as `undefined`.
+ */
+function nodeLabel(node: CalmNodeSchema): string {
+    const item = node as Record<string, unknown>;
+    if (typeof item['unique-id'] === 'string') return item['unique-id'];
+    const detail = [item['node-type'], item['name']].filter((v) => typeof v === 'string').join(' ');
+    return detail ? `(unpinned ${detail})` : '(unpinned node)';
+}
+
+function edgeLabel(edge: CalmRelationshipSchema): string {
+    const item = edge as Record<string, unknown>;
+    return typeof item['unique-id'] === 'string' ? item['unique-id'] : '(unpinned relationship)';
 }
 
 export function formatDiff(
@@ -57,6 +76,8 @@ export function formatDiff(
     }
     const invalidNodes = diff.invalidItems?.nodes.length ?? 0;
     const invalidEdges = diff.invalidItems?.relationships.length ?? 0;
+    const undiffableNodes = diff.undiffableItems?.nodes.length ?? 0;
+    const undiffableEdges = diff.undiffableItems?.relationships.length ?? 0;
     const title = `CALM ${documentType} diff`;
     const lines = [
         title,
@@ -67,6 +88,9 @@ export function formatDiff(
     if (invalidNodes + invalidEdges > 0) {
         lines.push(`Invalid items: ${invalidNodes} node(s) + ${invalidEdges} relationship(s) skipped (missing unique-id)`);
     }
+    if (undiffableNodes + undiffableEdges > 0) {
+        lines.push(`Undiffable items: ${undiffableNodes} node(s) + ${undiffableEdges} relationship(s) (no constrained unique-id to diff by)`);
+    }
     lines.push('');
     const list = (label: string, ids: string[]) => {
         if (ids.length === 0) return;
@@ -74,13 +98,13 @@ export function formatDiff(
         for (const id of ids) lines.push(`  - ${id}`);
         lines.push('');
     };
-    list('Nodes added:', diff.nodesAdded.map((n) => n['unique-id'] as string));
-    list('Nodes removed:', diff.nodesRemoved.map((n) => n['unique-id'] as string));
-    list('Nodes modified:', diff.nodesModified.map((n) => n.original['unique-id'] as string));
+    list('Nodes added:', diff.nodesAdded.map(nodeLabel));
+    list('Nodes removed:', diff.nodesRemoved.map(nodeLabel));
+    list('Nodes modified:', diff.nodesModified.map((n) => nodeLabel(n.original)));
     list('Nodes renamed:', diff.nodesRenamed.map((r) => `${r.oldId} -> ${r.newId}`));
-    list('Relationships added:', diff.edgesAdded.map((e) => e['unique-id'] as string));
-    list('Relationships removed:', diff.edgesRemoved.map((e) => e['unique-id'] as string));
-    list('Relationships modified:', diff.edgesModified.map((e) => e.original['unique-id'] as string));
+    list('Relationships added:', diff.edgesAdded.map(edgeLabel));
+    list('Relationships removed:', diff.edgesRemoved.map(edgeLabel));
+    list('Relationships modified:', diff.edgesModified.map((e) => edgeLabel(e.original)));
     list('Relationships renamed:', diff.edgesRenamed.map((r) => `${r.oldId} -> ${r.newId}`));
     return lines.join('\n');
 }
@@ -189,6 +213,17 @@ export async function runDiff(
             `Skipped ${invalidNodeCount} node(s) and ${invalidEdgeCount} relationship(s) ` +
                 'because they were missing a unique-id. These items are reported under ' +
                 'invalidItems and contribute to hasChanges so --exit-code does not pass on them silently.',
+        );
+    }
+
+    const undiffableNodeCount = diff.undiffableItems?.nodes.length ?? 0;
+    const undiffableEdgeCount = diff.undiffableItems?.relationships.length ?? 0;
+    if (undiffableNodeCount + undiffableEdgeCount > 0) {
+        logger.warn(
+            `Could not diff ${undiffableNodeCount} node(s) and ${undiffableEdgeCount} relationship(s) ` +
+                'because they constrain no comparable content (e.g. an unconstrained unique-id). ' +
+                'These items are reported under undiffableItems and contribute to hasChanges so ' +
+                '--exit-code does not pass on them silently.',
         );
     }
 


### PR DESCRIPTION
## Description

Fixes #2492.

`normalisePatternToInstance` reduced a CALM pattern (a JSON Schema) to instance-shaped `{nodes, relationships}` and **silently dropped** any item whose `unique-id` was not pinned with a `const`. Such pattern items never reached the diff core, so they never showed up in the result — producing a misleading "no changes" outcome and making `calm diff --exit-code` unreliable for patterns.

Crucially, a missing `unique-id` is **invalid in an architecture but legitimate in a pattern** (a pattern needn't pin every id), so reusing the architecture `invalidItems` channel for these would mislabel valid constructs. Patterns are now diffed in **two passes**:

- **Identity pass** — items with a `const`-pinned `unique-id` are diffed by id exactly as before (add / remove / modify / rename).
- **Content pass** — id-less-but-constrained items are diffed by canonical **content** as an order-insensitive **multiset** (add / remove / same). There is no "modified": with no `unique-id` to anchor identity, a content change is an add + a remove. Reordering identical items is therefore a non-event.

Items that declare a node/relationship but pin **nothing comparable** (an unconstrained `unique-id`, a bare `$ref`) are surfaced under a new `undiffableItems` bucket and contribute to `hasChanges`, so `--exit-code` no longer passes on them silently. Decision/`options` wrappers that don't declare a `unique-id` are skipped, as before, so valid pattern constructs aren't flagged as noise.

A follow-on found during self-review: the `calm-hub-ui` diff highlighter (`applyDiffStatus`) matched diff entries to graph nodes by `unique-id`. Now that pattern content diffs can contain id-less entries (`unique-id: undefined`) — and an unconstrained pattern node also has `unique-id: undefined` — it would match by `undefined === undefined` and tar every id-less node with one highlight. Added a falsy-id guard so unidentifiable nodes are left `unchanged`.

**Note for reviewers:** `DiffResult` node/edge arrays can now legitimately contain id-less objects (cast via `as unknown as CalmNodeSchema[]`). All in-repo consumers were audited — the summary formatter labels them by content (`(unpinned service Worker)`), JSON output serialises them fine, and the hub-ui highlighter now guards against them.

**Out of scope (possible follow-up):** a per-type *partial* identity (e.g. relationship endpoints) to reintroduce "modified" detection for id-less items. Deliberately not attempted here.

<details>
<summary><b>Worked example — before/after CLI output</b></summary>

An `Order Service Pattern` diffed across two versions where **every change lives in nodes whose `unique-id` is not pinned with a `const`**: `Order Worker` is renamed, a `Cache` node is added, and a malformed node that declares only an unconstrained `unique-id` is added. Only `api-gateway` is `const`-pinned.

**Before (on `main`)** — every id-less node is dropped before the diff, so all three changes are invisible and `--exit-code` passes:

```
CALM pattern diff
-----------------
Nodes:         +0  -0  ~0  ↔0  =1
Relationships: +0  -0  ~0  ↔0  =0

hasChanges = false   ->  calm diff --exit-code exits 0
```

**After (this PR)** — the content pass catches the rename (remove+add) and the new `Cache`; the malformed node surfaces under **Undiffable items**; id-less nodes are labelled by content; `--exit-code` fails:

```
CALM pattern diff
-----------------
Nodes:         +2  -1  ~0  ↔0  =1
Relationships: +0  -0  ~0  ↔0  =0
Undiffable items: 1 node(s) + 0 relationship(s) (no constrained unique-id to diff by)

Nodes added:
  - (unpinned service Order Worker (scaled))
  - (unpinned store Cache)

Nodes removed:
  - (unpinned service Order Worker)

hasChanges = true   ->  calm diff --exit-code exits 1
```

</details>

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

<!-- Core change is in calm-models/src/diff (no dedicated checkbox); it underpins the CLI `diff` command via shared. -->

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified locally (Node 22 baseline; run on Node 24):
- `calm-models`: build + 186 tests + lint ✅ (new content-multiset, reorder, multiset-count, undiffable, and instance-inclusion tests)
- `shared`: build + lint + 31 diff tests ✅ (undiffable `hasChanges`/formatter/`runDiff` warning, id-less label)
- `calm-hub-ui`: lint (0 errors) + 16 diff-util tests ✅ (new `applyDiffStatus` guard test)
- `cli`: 15 diff-helper tests ✅

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
