### PR TITLE
refactor(shared): enable TypeScript strict mode for production build

### DIFF
--- a/shared/src/commands/generate/components/options.ts
+++ b/shared/src/commands/generate/components/options.ts
@@ -1,5 +1,13 @@
 import { initLogger } from '../../../logger';
 
+/**
+ * A node within a CALM pattern's JSON schema. The pattern is unvalidated JSON
+ * that is traversed via deeply nested property chains, so values are typed as
+ * `any` to allow that traversal without a cast at every level.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SchemaNode = { [key: string]: any };
+
 export interface CalmChoice {
     description: string,
     nodes: string[],
@@ -13,19 +21,19 @@ export interface CalmOption {
     choices: CalmChoice[],
 }
 
-function isOptionsRelationship(relationship: object): boolean {
+function isOptionsRelationship(relationship: SchemaNode): boolean {
     return relationship['properties']?.['relationship-type']?.['properties']?.['options'] !== undefined;
 }
 
-function getItemsInOptionsRelationship(optionsRelationship: object): object[] {
+function getItemsInOptionsRelationship(optionsRelationship: SchemaNode): SchemaNode[] {
     return optionsRelationship['properties']['relationship-type']['properties']['options']['prefixItems'];
 }
 
-function extractOptionsFromBlock(optionsRelationship: object, blockType: 'oneOf' | 'anyOf'): CalmOption[] {
+function extractOptionsFromBlock(optionsRelationship: SchemaNode, blockType: 'oneOf' | 'anyOf'): CalmOption[] {
     return getItemsInOptionsRelationship(optionsRelationship)
-        .filter((prefixItem: object) => blockType in prefixItem)
-        .map((prefixItem: object) => prefixItem[blockType] as object[])
-        .map((choices: object[]) => ({
+        .filter((prefixItem: SchemaNode) => blockType in prefixItem)
+        .map((prefixItem: SchemaNode) => prefixItem[blockType] as SchemaNode[])
+        .map((choices: SchemaNode[]) => ({
             optionType: blockType,
             optionId: optionsRelationship['properties']['unique-id']['const'],
             prompt: optionsRelationship['properties']['description']['const'],
@@ -42,7 +50,7 @@ function extractOptionsFromBlock(optionsRelationship: object, blockType: 'oneOf'
  * @param pattern - The pattern object
  * @returns The prefixItems array from relationships, or empty array if not found
  */
-function getRelationshipsPrefixItems(pattern: object): object[] {
+function getRelationshipsPrefixItems(pattern: SchemaNode): SchemaNode[] {
     // Direct access for standard patterns
     if (pattern['properties']?.['relationships']?.['prefixItems']) {
         return pattern['properties']['relationships']['prefixItems'];
@@ -68,7 +76,7 @@ function getRelationshipsPrefixItems(pattern: object): object[] {
  */
 export function extractOptions(pattern: object, debug: boolean = false): CalmOption[] {
     const logger = initLogger(debug, 'calm-generate-options');
-    const calmItems: object[] = getRelationshipsPrefixItems(pattern);
+    const calmItems: SchemaNode[] = getRelationshipsPrefixItems(pattern as SchemaNode);
 
     if (calmItems.length === 0) {
         logger.debug('No relationship prefixItems found in pattern');
@@ -76,8 +84,8 @@ export function extractOptions(pattern: object, debug: boolean = false): CalmOpt
     }
 
     const options: CalmOption[] = calmItems
-        .filter((rel: object) => isOptionsRelationship(rel))
-        .flatMap((optionsRel: object) => [
+        .filter((rel: SchemaNode) => isOptionsRelationship(rel))
+        .flatMap((optionsRel: SchemaNode) => [
             ...extractOptionsFromBlock(optionsRel, 'oneOf'),
             ...extractOptionsFromBlock(optionsRel, 'anyOf')
         ]);
@@ -98,43 +106,43 @@ type Item = {
  * @param selectionPredicate - A function that takes an item and returns true if it should be included in the flattened result
  * @returns A list of items that match the selection predicate, or the item itself if it is not a oneOf or anyOf block
  */
-function flattenOneOfAndAnyOf(item: Item, selectionPredicate: (item: object) => boolean): object[] {
+function flattenOneOfAndAnyOf(item: Item, selectionPredicate: (item: SchemaNode) => boolean): object[] {
     if (!(item.oneOf || item.anyOf)) {
         // If it isn't a oneOf or anyOf block, there isn't anything to flatten so return the item
         return [item];
     }
 
-    const items: object[] = item.oneOf || item.anyOf;
+    const items: object[] = item.oneOf ?? item.anyOf ?? [];
 
     return items
         .flatMap((x: object) => x)
-        .filter((x: object) => selectionPredicate(x));
+        .filter((x: SchemaNode) => selectionPredicate(x));
 }
 
-function flattenCalmItems(pattern: object, calmType: 'nodes' | 'relationships', ids: string[]): void {
+function flattenCalmItems(pattern: SchemaNode, calmType: 'nodes' | 'relationships', ids: string[]): void {
     const calmItems = pattern['properties'][calmType]['prefixItems'];
 
-    const selectionPredicate = (x: object) => ids.includes(x['properties']['unique-id']['const']);
+    const selectionPredicate = (x: SchemaNode) => ids.includes(x['properties']['unique-id']['const']);
     pattern['properties'][calmType]['prefixItems'] = calmItems
-        .flatMap((item: object) => flattenOneOfAndAnyOf(item, selectionPredicate));
+        .flatMap((item: Item) => flattenOneOfAndAnyOf(item, selectionPredicate));
 }
 
-function flattenOptionsRelationship(relationship: object, choices: CalmChoice[]): object {
+function flattenOptionsRelationship(relationship: SchemaNode, choices: CalmChoice[]): SchemaNode {
     if (!isOptionsRelationship(relationship)) {
         return relationship;
     }
 
-    const selectionPredicate = (x: object) => choices.map(choice => choice.description).includes(x['properties']['description']['const']);
+    const selectionPredicate = (x: SchemaNode) => choices.map(choice => choice.description).includes(x['properties']['description']['const']);
     const newItems = getItemsInOptionsRelationship(relationship)
-        .flatMap((item: object) => flattenOneOfAndAnyOf(item, selectionPredicate));
+        .flatMap((item: Item) => flattenOneOfAndAnyOf(item, selectionPredicate));
 
     relationship['properties']['relationship-type']['properties']['options']['prefixItems'] = newItems;
     return relationship;
 }
 
-function flattenOptionsRelationships(pattern: object, choices: CalmChoice[]): void {
+function flattenOptionsRelationships(pattern: SchemaNode, choices: CalmChoice[]): void {
     pattern['properties']['relationships']['prefixItems'] = pattern['properties']['relationships']['prefixItems']
-        .map((rel: object) => flattenOptionsRelationship(rel, choices));
+        .map((rel: SchemaNode) => flattenOptionsRelationship(rel, choices));
 }
 
 /**
@@ -148,7 +156,7 @@ export function selectChoices(inputPattern: object, choices: CalmChoice[], debug
     const logger = initLogger(debug, 'calm-generate-options');
     logger.debug(`Selecting these choices from the pattern [${JSON.stringify(choices)}]`);
 
-    const pattern = {...inputPattern}; // make a copy so we don't mutate the input pattern
+    const pattern = {...inputPattern} as SchemaNode; // make a copy so we don't mutate the input pattern
     const nodeIds: string[] = choices.flatMap(choice => choice.nodes);
     const relationshipIds: string[] = choices.flatMap(choice => choice.relationships);
 

--- a/shared/src/commands/generate/components/property.spec.ts
+++ b/shared/src/commands/generate/components/property.spec.ts
@@ -103,6 +103,34 @@ describe('getPropertyValue', () => {
         }))
             .toBe('[[ BOOLEAN_KEY_NAME ]]');
     });
+
+    it('prefers const over type when both are present', () => {
+        expect(getPropertyValue('key-name', {
+            'const': 'fixed',
+            'type': 'string'
+        }))
+            .toBe('fixed');
+    });
+
+    it('prefers default over type when const is absent', () => {
+        expect(getPropertyValue('key-name', {
+            'default': 'fallback',
+            'type': 'string'
+        }))
+            .toBe('fallback');
+    });
+
+    it('returns an empty array for the interfaces property', () => {
+        expect(getPropertyValue('interfaces', {
+            'type': 'array'
+        }))
+            .toEqual([]);
+    });
+
+    it('returns undefined when no const, default, type or $ref is defined', () => {
+        expect(getPropertyValue('key-name', {}))
+            .toBeUndefined();
+    });
 });
 
 describe('getEnumPlaceholder', () => {

--- a/shared/src/commands/generate/components/property.ts
+++ b/shared/src/commands/generate/components/property.ts
@@ -74,7 +74,9 @@ export function getPropertyValue(keyName: string, detail: JsonSchema): string | 
 }
 
 export function getEnumPlaceholder(ref: string): string {
-    const refName = /[^/#]*$/.exec(ref)?.[0] ?? '';
+    // The pattern matches the trailing segment of any string (including the empty
+    // string), so exec never returns null here.
+    const refName = /[^/#]*$/.exec(ref)![0];
     const refPlaceholder = refName.toUpperCase().replaceAll('-', '_');
     return `[[ ENUM_${refPlaceholder} ]]`;
 }

--- a/shared/src/commands/generate/components/property.ts
+++ b/shared/src/commands/generate/components/property.ts
@@ -28,15 +28,15 @@ export function getBooleanPlaceholder(name: string): string {
  * @param detail The detail from the object to instantiate
  * @returns Either the value or the object described by the 'const' property.
  */
-export function getConstValue(detail: JsonSchema): string | object {
+export function getConstValue(detail: JsonSchema): string | object | undefined {
     return detail.const;
 }
 
-export function getDefaultValue(detail: JsonSchema): string | object {
+export function getDefaultValue(detail: JsonSchema): string | object | undefined {
     return detail.default;
 }
 
-export function getPropertyValue(keyName: string, detail: JsonSchema): string | string[] | number | object {
+export function getPropertyValue(keyName: string, detail: JsonSchema): string | string[] | number | object | undefined {
     // if const, default and type are defined, prefer const
     if (detail.const) {
         return detail.const;
@@ -74,7 +74,7 @@ export function getPropertyValue(keyName: string, detail: JsonSchema): string | 
 }
 
 export function getEnumPlaceholder(ref: string): string {
-    const refName = /[^/#]*$/.exec(ref)[0];
+    const refName = /[^/#]*$/.exec(ref)?.[0] ?? '';
     const refPlaceholder = refName.toUpperCase().replaceAll('-', '_');
     return `[[ ENUM_${refPlaceholder} ]]`;
 }

--- a/shared/src/commands/generate/generate.ts
+++ b/shared/src/commands/generate/generate.ts
@@ -32,7 +32,8 @@ export async function runGenerate(pattern: object, outputPath: string, debug: bo
         fs.writeFileSync(outputPath, output);
         logger.info(`Successfully generated architecture to [${outputPath}]`);
     } catch (err) {
-        logger.error('Error while generating architecture from pattern: ' + err.message);
-        logger.debug(err.stack);
+        const error = err instanceof Error ? err : new Error(String(err));
+        logger.error('Error while generating architecture from pattern: ' + error.message);
+        logger.debug(error.stack ?? '');
     }
 }

--- a/shared/src/commands/validate/json-schema-validator.ts
+++ b/shared/src/commands/validate/json-schema-validator.ts
@@ -21,7 +21,11 @@ export class JsonSchemaValidator {
             loadSchema: async (schemaId: string): Promise<AnySchemaObject> => {
                 this.logger.debug(`AJV is loading missing schema with ID: ${schemaId} from schema directory.`);
                 try {
-                    return await schemaDirectory.getSchema(schemaId) as AnySchemaObject;
+                    const schema = await schemaDirectory.getSchema(schemaId);
+                    if (!schema) {
+                        throw new Error(`Schema with ID '${schemaId}' could not be found in the schema directory.`);
+                    }
+                    return schema as AnySchemaObject;
                 } catch (error) {
                     this.logger.error(`Error fetching schema from schema directory: ${error}`);
                     throw error;

--- a/shared/src/commands/validate/json-schema-validator.ts
+++ b/shared/src/commands/validate/json-schema-validator.ts
@@ -1,10 +1,10 @@
-import Ajv2020, { ErrorObject, ValidateFunction } from 'ajv/dist/2020.js';
+import Ajv2020, { AnySchemaObject, ErrorObject, ValidateFunction } from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 import { SchemaDirectory } from '../../schema-directory.js';
 import { initLogger, Logger } from '../../logger.js';
 
 export class JsonSchemaValidator {
-    private validateFn: ValidateFunction<object>;
+    private validateFn?: ValidateFunction<object>;
     private ajv: Ajv2020;
     private logger: Logger;
     private pattern: object;
@@ -18,12 +18,13 @@ export class JsonSchemaValidator {
         this.ajv = new Ajv2020({
             strict: strictType,
             allErrors: true,
-            loadSchema: async (schemaId) => {
+            loadSchema: async (schemaId: string): Promise<AnySchemaObject> => {
                 this.logger.debug(`AJV is loading missing schema with ID: ${schemaId} from schema directory.`);
                 try {
-                    return await schemaDirectory.getSchema(schemaId);
+                    return await schemaDirectory.getSchema(schemaId) as AnySchemaObject;
                 } catch (error) {
                     this.logger.error(`Error fetching schema from schema directory: ${error}`);
+                    throw error;
                 }
             }
         });

--- a/shared/src/commands/validate/output-formats/junit-output.ts
+++ b/shared/src/commands/validate/output-formats/junit-output.ts
@@ -35,7 +35,7 @@ export default function createJUnitReport(
     return builder.build();
 }
 
-function createTestSuite(builder, testSuiteName: string){
+function createTestSuite(builder: ReturnType<typeof junitReportBuilder.newBuilder>, testSuiteName: string): TestSuite {
     return builder
         .testSuite()
         .name(testSuiteName);

--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -44,8 +44,9 @@ describe('validate E2E', () => {
 
     it('rejects pattern with invalid JSON Schema', async () => {
         // AJV2020 ignores references to the JSON 2020-12 draft, but will
-        // attempt to load any other JSON schema draft but not register it,
-        // leading to an infinite loop.
+        // attempt to load any other JSON schema draft. The schema directory
+        // refuses to load standard JSON Schema drafts, and that failure is
+        // now surfaced directly rather than swallowed into a later null deref.
         const badPattern = { '$schema': 'https://json-schema.org/draft/2019-09/schema' };
         const response = await validate(undefined, badPattern, undefined, schemaDirectory, false);
 
@@ -53,7 +54,7 @@ describe('validate E2E', () => {
         expect(response).not.toBeUndefined();
         expect(response.hasErrors).toBeTruthy();
         expect(response.jsonSchemaValidationOutputs).toHaveLength(1);
-        expect(response.jsonSchemaValidationOutputs[0].message).toContain('reading \'$schema\'');
+        expect(response.jsonSchemaValidationOutputs[0].message).toContain('is not supported');
     });
 
     it('accepts pattern with valid JSON Schema', async () => {

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -556,6 +556,11 @@ describe('validate pattern only', () => {
             });
     });
 
+    it('throws when no schema directory is provided for pattern validation', async () => {
+        await expect(validate(undefined, { dummy: 'pattern' }, undefined, undefined, debugDisabled))
+            .rejects.toThrow('A schema directory is required for schema validation');
+    });
+
     it('has errors when the pattern does not pass all the spectral validations ', async () => {
         const expectedSpectralOutput: ISpectralDiagnostic[] = [
             {

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -97,6 +97,17 @@ async function runSpectralValidations(
 
 
 /**
+ * Asserts that a schema directory was provided. Validating a pattern, a timeline,
+ * or an architecture against a pattern all require schema resolution, so a missing
+ * directory is a caller error rather than a recoverable condition.
+ */
+function assertSchemaDirectory(schemaDirectory: SchemaDirectory | undefined): asserts schemaDirectory is SchemaDirectory {
+    if (!schemaDirectory) {
+        throw new Error('A schema directory is required for schema validation');
+    }
+}
+
+/**
  * Validation - with simple input parameters and output validation outcomes.
  * @param architecture The architecture as a JS object, or undefined if not provided
  * @param patternOrSchema The pattern (or schema) as a JS object, or undefined if not provided
@@ -123,14 +134,17 @@ export async function validate(
                 throw new Error('You must provide a schema to validate the timeline against, or the timeline must reference it internally');
             }
             // It is acceptable, in fact desired, for `patternOrSchema` to be set, and be the CALM timeline schema.
+            assertSchemaDirectory(schemaDirectory);
             return await validateTimeline(timeline, patternOrSchema, schemaDirectory, debug);
         } else if (architecture && patternOrSchema) {
             // Note that patternOrSchema may be a CALM pattern, or might be the CALM core schema.
             // The caller is responsible for honoring the architecture's `$schema`, or using an explicitly provided pattern.
             // In either case, we validate the architecture against it.
+            assertSchemaDirectory(schemaDirectory);
             return await validateArchitectureAgainstPattern(architecture, patternOrSchema, schemaDirectory, debug);
         } else if (patternOrSchema) {
             // `patternOrSchema` should really be a CALM pattern in this case.
+            assertSchemaDirectory(schemaDirectory);
             return await validatePatternOnly(patternOrSchema, schemaDirectory, debug);
         } else if (architecture) {
             return await validateArchitectureOnly(architecture, schemaDirectory, debug);
@@ -164,7 +178,7 @@ async function validateArchitectureAgainstPattern(architecture: object, pattern:
 
     const patternResolved = applyArchitectureOptionsToPattern(architecture, pattern, debug);
 
-    let jsonSchemaValidations = [];
+    let jsonSchemaValidations: ValidationOutput[] = [];
     let jsonSchemaValidator: JsonSchemaValidator;
     try {
         jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, patternResolved, debug);
@@ -232,12 +246,12 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
 
     const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(JSON.stringify(architecture), validationRulesForArchitecture, 'architecture');
 
-    let jsonSchemaValidations = [];
+    let jsonSchemaValidations: ValidationOutput[] = [];
     let errors = spectralResultForArchitecture.errors;
     const warnings = spectralResultForArchitecture.warnings;
 
     const coreSchemaUrl = schemaDirectory ? findLatestCalmCoreSchemaUrl(schemaDirectory) : undefined;
-    if (!coreSchemaUrl) {
+    if (!schemaDirectory || !coreSchemaUrl) {
         logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
     } else {
         logger.debug(`Validating architecture against CALM core schema: ${coreSchemaUrl}`);
@@ -313,7 +327,7 @@ async function validateTimeline(timeline: object, schema: object, schemaDirector
     const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, schema, debug);
     await jsonSchemaValidator.initialize();
 
-    let jsonSchemaValidations = [];
+    let jsonSchemaValidations: ValidationOutput[] = [];
 
     const schemaErrors = jsonSchemaValidator.validate(timeline);
     if (schemaErrors.length > 0) {
@@ -349,10 +363,15 @@ export function extractChoicesFromArchitecture(architecture: object): CalmChoice
         return [];
     }
 
-    return architecture['relationships']
-        .filter((rel: object) => rel['relationship-type'] && Object.prototype.hasOwnProperty.call(rel['relationship-type'], 'options'))
-        .map((rel: object) => rel['relationship-type']['options'][0])
-        .map((rel: object) => ({
+    // architecture is unvalidated CALM JSON traversed via nested property access,
+    // so a permissive index type is used here.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const relationships = (architecture as Record<string, any>)['relationships'] as Record<string, any>[];
+
+    return relationships
+        .filter((rel) => rel['relationship-type'] && Object.prototype.hasOwnProperty.call(rel['relationship-type'], 'options'))
+        .map((rel) => rel['relationship-type']['options'][0])
+        .map((rel) => ({
             description: rel['description'],
             nodes: rel['nodes'] || [],
             relationships: rel['relationships'] || []
@@ -369,7 +388,7 @@ function getRuleNamesFromRuleset(ruleset: RulesetDefinition): string[] {
     return Object.keys((ruleset as { rules: Record<string, unknown> }).rules);
 }
 
-function prettifyJson(json) {
+function prettifyJson(json: unknown) {
     return JSON.stringify(json, null, 4);
 }
 

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -251,11 +251,11 @@ async function validateArchitectureOnly(architecture: object, schemaDirectory: S
     const warnings = spectralResultForArchitecture.warnings;
 
     const coreSchemaUrl = schemaDirectory ? findLatestCalmCoreSchemaUrl(schemaDirectory) : undefined;
-    if (!schemaDirectory || !coreSchemaUrl) {
+    const coreSchema = (schemaDirectory && coreSchemaUrl) ? await schemaDirectory.getSchema(coreSchemaUrl) : undefined;
+    if (!schemaDirectory || !coreSchema) {
         logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
     } else {
         logger.debug(`Validating architecture against CALM core schema: ${coreSchemaUrl}`);
-        const coreSchema = await schemaDirectory.getSchema(coreSchemaUrl);
         try {
             const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, coreSchema, debug);
             await jsonSchemaValidator.initialize();

--- a/shared/src/document-loader/file-system-document-loader.ts
+++ b/shared/src/document-loader/file-system-document-loader.ts
@@ -4,6 +4,7 @@ import { readdir, readFile } from 'fs/promises';
 import { join, isAbsolute } from 'path';
 import { SchemaDirectory } from '../schema-directory';
 import { existsSync } from 'fs';
+import { getErrorMessage } from '../error-utils';
 
 export class FileSystemDocumentLoader implements DocumentLoader {
     private readonly logger: Logger;
@@ -37,15 +38,15 @@ export class FileSystemDocumentLoader implements DocumentLoader {
                     // loaded schema can't be used due to having no identifier
                     continue;
                 }
-                const schemaId = schemaDef['$id'];
+                const schemaId = (schemaDef as { $id: string })['$id'];
                 schemaDirectory.storeDocument(schemaId, 'schema', schemaDef);
                 this.logger.debug(`Loaded schema with ID ${schemaId} from ${schemaPath}.`);
             }
         } catch (err) {
-            if (err.code === 'ENOENT') {
-                this.logger.error('Specified directory not found while loading documents: ' + directoryPath + ', error: ' + err.message);
+            if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+                this.logger.error('Specified directory not found while loading documents: ' + directoryPath + ', error: ' + getErrorMessage(err));
             } else {
-                this.logger.error(err);
+                this.logger.error(getErrorMessage(err));
             }
             throw err;
         }
@@ -56,17 +57,23 @@ export class FileSystemDocumentLoader implements DocumentLoader {
         const resolvedPath = this.resolvePath(documentId);
         if (resolvedPath && existsSync(resolvedPath)) {
             this.logger.debug(`Resolved relative path: ${documentId} -> ${resolvedPath}`);
-            return this.loadDocument(resolvedPath, type);
+            const doc = await this.loadDocument(resolvedPath, type);
+            if (doc) {
+                return doc;
+            }
         }
 
         // 2. Fallback to checking exact path (existing behavior)
         try {
             if (existsSync(documentId)) {
                 this.logger.info(`${documentId} exists, loading as file...`);
-                return this.loadDocument(documentId, type);
+                const doc = await this.loadDocument(documentId, type);
+                if (doc) {
+                    return doc;
+                }
             }
         } catch (err) {
-            this.logger.error(`Error checking existence of document ID ${documentId}: ${err.message}. This could be because it isn't a file path.`);
+            this.logger.error(`Error checking existence of document ID ${documentId}: ${getErrorMessage(err)}. This could be because it isn't a file path.`);
         }
 
         this.logger.debug(`Document ID ${documentId} does not exist in file system, cannot load.`);
@@ -79,7 +86,7 @@ export class FileSystemDocumentLoader implements DocumentLoader {
         });
     }
 
-    private async loadDocument(schemaPath: string, type: CalmDocumentType): Promise<object> {
+    private async loadDocument(schemaPath: string, type: CalmDocumentType): Promise<object | undefined> {
         this.logger.debug('Loading ' + schemaPath);
         const str = await readFile(schemaPath, 'utf-8');
         const parsed = JSON.parse(str);
@@ -90,7 +97,7 @@ export class FileSystemDocumentLoader implements DocumentLoader {
 
         if (!parsed || !parsed['$id']) {
             this.logger.warn('Warning: bad schema found, no $id property was defined. Path: ' + schemaPath);
-            return;
+            return undefined;
         }
 
         const schemaId = parsed['$id'];

--- a/shared/src/document-loader/loading-helpers.ts
+++ b/shared/src/document-loader/loading-helpers.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { DocumentLoader, CALM_HUB_PROTO } from './document-loader';
 import { SchemaDirectory } from '../schema-directory';
 
-export async function loadArchitectureAndPattern(architecturePath: string, patternPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ architecture: object, pattern: object }> {
+export async function loadArchitectureAndPattern(architecturePath: string, patternPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ architecture: object | undefined, pattern: object | undefined }> {
     const architecture = await loadArchitecture(architecturePath, docLoader, logger);
     if (!architecture) {
         // we have already validated that at least one of the options is provided, so pattern must be set
@@ -19,7 +19,7 @@ export async function loadArchitectureAndPattern(architecturePath: string, patte
     return { architecture, pattern: await loadPatternFromDocumentIfPresent(architecture, architecturePath, docLoader, schemaDirectory, logger) };
 }
 
-export async function loadTimeline(timelinePath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ timeline: object, pattern: object }> {
+export async function loadTimeline(timelinePath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ timeline: object, pattern: object | undefined }> {
     const timeline = await docLoader.loadMissingDocument(timelinePath, 'timeline');
     logger.debug(`Loaded timeline from ${timelinePath}`);
 
@@ -46,11 +46,12 @@ export function resolveSchemaRef(schemaRef: string, architecturePath: string, lo
     return schemaRef;
 }
 
-export async function loadPatternFromDocumentIfPresent(document: object, documentPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<object> {
-    if (!document || !document['$schema']) {
-        return;
+export async function loadPatternFromDocumentIfPresent(document: object, documentPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<object | undefined> {
+    const schemaId = document ? (document as { $schema?: string }).$schema : undefined;
+    if (!schemaId) {
+        return undefined;
     }
-    const schemaRef = resolveSchemaRef(document['$schema'], documentPath, logger);
+    const schemaRef = resolveSchemaRef(schemaId, documentPath, logger);
     try {
         const schema = await schemaDirectory.getSchema(schemaRef);
         logger.debug(`Loaded schema: ${schemaRef}`);
@@ -64,7 +65,7 @@ export async function loadPatternFromDocumentIfPresent(document: object, documen
     return pattern;
 }
 
-export async function loadPattern(patternPath: string, docLoader: DocumentLoader, logger: Logger): Promise<object> {
+export async function loadPattern(patternPath: string, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
     if (!patternPath) {
         return undefined;
     }
@@ -73,7 +74,7 @@ export async function loadPattern(patternPath: string, docLoader: DocumentLoader
     return pattern;
 }
 
-export async function loadArchitecture(architecturePath: string, docLoader: DocumentLoader, logger: Logger): Promise<object> {
+export async function loadArchitecture(architecturePath: string, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
     if (!architecturePath) {
         return undefined;
     }

--- a/shared/src/document-loader/mapped-document-loader.ts
+++ b/shared/src/document-loader/mapped-document-loader.ts
@@ -53,7 +53,7 @@ export class MappedDocumentLoader implements DocumentLoader {
                 this.logger.debug(`Pre-loaded: ${url} -> ${absolutePath}`);
                 
                 // Also store by $id if present and different from URL
-                const docId = document['$id'] as string | undefined;
+                const docId = (document as Record<string, unknown>)['$id'] as string | undefined;
                 if (docId && docId !== url) {
                     schemaDirectory.storeDocument(docId, 'schema', document);
                     this.logger.debug(`Also stored by $id: ${docId}`);
@@ -75,10 +75,10 @@ export class MappedDocumentLoader implements DocumentLoader {
         this.logger.debug(`Attempting to load: ${documentId}`);
 
         // 1. Check URL mapping
-        if (this.urlToLocalMap.has(documentId)) {
-            const localPath = this.urlToLocalMap.get(documentId);
-            const absolutePath = this.resolveLocalPath(localPath);
-            
+        const mappedPath = this.urlToLocalMap.get(documentId);
+        if (mappedPath !== undefined) {
+            const absolutePath = this.resolveLocalPath(mappedPath);
+
             this.logger.debug(`Resolved via URL mapping: ${documentId} -> ${absolutePath}`);
             return this.loadDocumentFromPath(absolutePath);
         }
@@ -124,7 +124,7 @@ export class MappedDocumentLoader implements DocumentLoader {
             throw new DocumentLoadError({
                 name: 'UNKNOWN',
                 message: `Failed to load/parse ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
-                cause: err,
+                cause: err instanceof Error ? err : undefined,
                 recoverable: false
             });
         }
@@ -135,9 +135,9 @@ export class MappedDocumentLoader implements DocumentLoader {
      */
     resolvePath(reference: string): string | undefined {
         // 1. Check URL mapping
-        if (this.urlToLocalMap.has(reference)) {
-            const localPath = this.urlToLocalMap.get(reference);
-            return this.resolveLocalPath(localPath);
+        const mappedPath = this.urlToLocalMap.get(reference);
+        if (mappedPath !== undefined) {
+            return this.resolveLocalPath(mappedPath);
         }
 
         // Relative path resolution has been moved to FileSystemDocumentLoader

--- a/shared/src/error-utils.spec.ts
+++ b/shared/src/error-utils.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage } from './error-utils';
+
+describe('getErrorMessage', () => {
+    it('returns the message of an Error instance', () => {
+        expect(getErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('returns the message of an Error subclass', () => {
+        class CustomError extends Error {}
+        expect(getErrorMessage(new CustomError('custom failure'))).toBe('custom failure');
+    });
+
+    it('coerces a non-Error string throw to a string', () => {
+        expect(getErrorMessage('just a string')).toBe('just a string');
+    });
+
+    it('coerces a non-Error object throw to a string', () => {
+        expect(getErrorMessage({ code: 42 })).toBe('[object Object]');
+    });
+
+    it('coerces null and undefined throws to a string', () => {
+        expect(getErrorMessage(null)).toBe('null');
+        expect(getErrorMessage(undefined)).toBe('undefined');
+    });
+});

--- a/shared/src/error-utils.ts
+++ b/shared/src/error-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Extracts a human-readable message from a value thrown in a catch clause.
+ *
+ * Under strict mode, `catch` bindings are typed `unknown`, so callers cannot
+ * assume an `Error`. This narrows that value to its message, falling back to a
+ * string coercion for non-Error throws.
+ */
+export function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/shared/src/hub/calm-hub-client.ts
+++ b/shared/src/hub/calm-hub-client.ts
@@ -106,9 +106,10 @@ export class CalmHubClient {
         }
         
         if (options.authPlugin) {
+            const authPlugin = options.authPlugin;
             this.ax.interceptors.request.use(async (config) => {
                 const fullUrl = (config.baseURL || '') + (config.url || '');
-                const authHeaders = await options.authPlugin.getAuthHeaders(fullUrl, config.data);
+                const authHeaders = await authPlugin.getAuthHeaders(fullUrl, config.data);
                 Object.assign(config.headers, authHeaders);
                 return config;
             });

--- a/shared/src/model-visitor/dereference-visitor.ts
+++ b/shared/src/model-visitor/dereference-visitor.ts
@@ -1,6 +1,7 @@
 import {CalmReferenceResolver} from '../resolver/calm-reference-resolver';
 import {Resolvable,ResolvableAndAdaptable} from '@finos/calm-models/model';
 import {CalmModelVisitor} from './calm-model-visitor';
+import {getErrorMessage} from '../error-utils';
 
 export class DereferencingVisitor implements CalmModelVisitor {
     private resolver: CalmReferenceResolver;
@@ -17,7 +18,7 @@ export class DereferencingVisitor implements CalmModelVisitor {
                 try {
                     await obj.dereference(this.resolver.resolve.bind(this.resolver));
                 } catch (err) {
-                    console.warn('Failed to dereference Resolvable:', obj.reference, err.message);
+                    console.warn('Failed to dereference Resolvable:', obj.reference, getErrorMessage(err));
                 }
             }
             if (obj.isResolved) {

--- a/shared/src/model-visitor/logging-visitor.ts
+++ b/shared/src/model-visitor/logging-visitor.ts
@@ -22,7 +22,7 @@ export class LoggingVisitor implements CalmModelVisitor {
         if (!obj || typeof obj !== 'object') return;
         const keys = Object.keys(obj);
         for (const key of keys) {
-            const value = (obj as unknown)[key];
+            const value = (obj as Record<string, unknown>)[key];
             const fullPath = [...path, key].join('.');
 
             if (value instanceof Resolvable) {

--- a/shared/src/resolver/network-addressable-extractor.ts
+++ b/shared/src/resolver/network-addressable-extractor.ts
@@ -1,3 +1,5 @@
+import { getErrorMessage } from '../error-utils';
+
 export interface AddressableEntry {
     path: string;
     key: string;
@@ -11,7 +13,7 @@ export function extractNetworkAddressables(jsonString: string): AddressableEntry
     try {
         data = JSON.parse(jsonString);
     } catch (err) {
-        throw new Error(`Invalid JSON string provided: ${err.message}`);
+        throw new Error(`Invalid JSON string provided: ${getErrorMessage(err)}`);
     }
     const results: AddressableEntry[] = [];
     traverse(data, 'root', results);

--- a/shared/src/resolver/network-addressable-extractor.ts
+++ b/shared/src/resolver/network-addressable-extractor.ts
@@ -1,4 +1,4 @@
-import { getErrorMessage } from '../error-utils';
+import { getErrorMessage } from '../error-utils.js';
 
 export interface AddressableEntry {
     path: string;

--- a/shared/src/resolver/network-addressable-validator.ts
+++ b/shared/src/resolver/network-addressable-validator.ts
@@ -1,5 +1,6 @@
 import { CalmReferenceResolver, HttpReferenceResolver } from './calm-reference-resolver.js';
 import { AddressableEntry } from './network-addressable-extractor.js';
+import { getErrorMessage } from '../error-utils.js';
 
 export interface ValidationResult {
     entry: AddressableEntry;
@@ -35,7 +36,7 @@ export class NetworkAddressableValidator {
                     result.isSchemaImplementation = this.isJsonSchemaImplementation(doc);
                 }
             } catch (err) {
-                result.error = err.message;
+                result.error = getErrorMessage(err);
                 result.isSchemaDefinition = false;
                 result.isSchemaImplementation = false;
             }

--- a/shared/src/schema-directory.ts
+++ b/shared/src/schema-directory.ts
@@ -63,8 +63,9 @@ export class SchemaDirectory {
         this.logger.debug(`Recursively resolving the reference, ref: ${ref}`);
         const definition = await this.lookupDefinition(newSchemaId, ref);
         if (!definition) {
-            // schema not defined
-            // schemaDirectory will return an empty schema in this case, so this code should never trigger.
+            // Unreachable in practice: lookupDefinition returns a placeholder object
+            // (getMissingSchemaPlaceholder) rather than a falsy value when a schema
+            // cannot be resolved. Kept as a defensive guard.
             throw Error('schema missing!');
         }
         const definitionRef = (definition as { $ref?: string })['$ref'];

--- a/shared/src/schema-directory.ts
+++ b/shared/src/schema-directory.ts
@@ -67,11 +67,12 @@ export class SchemaDirectory {
             // schemaDirectory will return an empty schema in this case, so this code should never trigger.
             throw Error('schema missing!');
         }
-        if (!definition['$ref']) {
+        const definitionRef = (definition as { $ref?: string })['$ref'];
+        if (!definitionRef) {
             this.logger.debug('Reached a definition with no ref, terminating recursive lookup.');
             return this.qualifyLocalReferences(definition, newSchemaId);
         }
-        const newRef: string = definition['$ref'];
+        const newRef: string = definitionRef;
         if (visitedDefinitions.includes(newRef)) {
             this.logger.warn('Circular reference detected. Terminating reference lookup. Visited definitions: ' + visitedDefinitions);
             return definition;
@@ -133,7 +134,7 @@ export class SchemaDirectory {
      * @param schemaId The ID of the schema to load.
      * @returns An entire schema as an object.
      */
-    public async getSchema(schemaId: string): Promise<object> {
+    public async getSchema(schemaId: string): Promise<object | undefined> {
         if (!this.schemas.has(schemaId)) {
             try {
                 if (/^https?:\/\/json-schema\.org/.test(schemaId)) {
@@ -149,7 +150,7 @@ export class SchemaDirectory {
                 if (err instanceof DocumentLoadError) {
                     if (err.name === 'OPERATION_NOT_IMPLEMENTED') {
                         const registered = this.getLoadedSchemas();
-                        this.logger.warn(`Schema with $id ${schemaId} not found. Returning empty object. Registered schemas: ${registered}`);
+                        this.logger.warn(`Schema with $id ${schemaId} not found. Returning undefined. Registered schemas: ${registered}`);
                         return undefined;
                     }
                 }
@@ -159,7 +160,7 @@ export class SchemaDirectory {
         return this.schemas.get(schemaId);
     }
 
-    public async getPattern(patternId: string): Promise<object> {
+    public async getPattern(patternId: string): Promise<object | undefined> {
         return await this.getSchema(patternId);
     }
 

--- a/shared/src/spectral/functions/architecture/ids-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.ts
@@ -1,21 +1,22 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 import { detectDuplicates } from '../helper-functions';
 
 /**
  * Checks that the input value exists as a node with a matching unique ID.
  */
-export function idsAreUnique(input, _, context) {
+export function idsAreUnique(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
     // get uniqueIds of all nodes
-    const nodeIdMatches = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data, resultType: 'all'});
-    const relationshipIdMatches = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data, resultType: 'all'});
-    const interfaceIdMatches = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data, resultType: 'all'});
+    const nodeIdMatches = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data as object, resultType: 'all'});
+    const relationshipIdMatches = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data as object, resultType: 'all'});
+    const interfaceIdMatches = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object, resultType: 'all'});
 
     const seenIds = new Set();
 
-    const messages = [];
+    const messages: IFunctionResult[] = [];
 
     detectDuplicates(nodeIdMatches, seenIds, messages);
     detectDuplicates(relationshipIdMatches, seenIds, messages);

--- a/shared/src/spectral/functions/architecture/interface-id-exists-on-node.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists-on-node.ts
@@ -1,10 +1,16 @@
 import { JSONPath } from 'jsonpath-plus';
 import { difference } from 'lodash';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
+
+interface ConnectsRelationship {
+    node?: string;
+    interfaces?: string[];
+}
 
 /**
  * Checks that the input value exists as an interface with matching unique ID defined under a node in the document.
  */
-export function interfaceIdExistsOnNode(input, _, context) {
+export function interfaceIdExistsOnNode(input: ConnectsRelationship | null | undefined, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input || !input.interfaces) {
         return [];
     }
@@ -17,7 +23,7 @@ export function interfaceIdExistsOnNode(input, _, context) {
     }
 
     const nodeId = input.node;
-    const nodeMatch: object[] = JSONPath({ path: `$.nodes[?(@['unique-id'] == '${nodeId}')]`, json: context.document.data });
+    const nodeMatch: object[] = JSONPath({ path: `$.nodes[?(@['unique-id'] == '${nodeId}')]`, json: context.document.data as object });
     if (!nodeMatch || nodeMatch.length === 0) {
         // other rule will report undefined node
         return [];
@@ -41,7 +47,7 @@ export function interfaceIdExistsOnNode(input, _, context) {
     if (missingInterfaces.length === 0) {
         return [];
     }
-    const results = [];
+    const results: IFunctionResult[] = [];
 
     for (const missing of missingInterfaces) {
         results.push({

--- a/shared/src/spectral/functions/architecture/interface-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists.ts
@@ -1,16 +1,17 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the input value exists as an interface with matching unique ID defined under a node in the document.
  */
-export function interfaceIdExists(input, _, context) {
+export function interfaceIdExists(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
 
-    // get uniqueIds of all interfaces 
-    const names = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data});
-    const results = [];
+    // get uniqueIds of all interfaces
+    const names = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object});
+    const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/architecture/node-has-relationship.ts
+++ b/shared/src/spectral/functions/architecture/node-has-relationship.ts
@@ -1,13 +1,14 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the given input, a unique ID, is referenced by at least one relationship.
  */
-export function nodeHasRelationship(input, _, context) {
+export function nodeHasRelationship(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     const nodeName = input;
 
-    const relationshipLabels = JSONPath({path: '$.relationships[*].relationship-type..*@string()', json: context.document.data});
-    const results = [];
+    const relationshipLabels = JSONPath({path: '$.relationships[*].relationship-type..*@string()', json: context.document.data as object});
+    const results: IFunctionResult[] = [];
     if (!relationshipLabels) {
         return [{
             message: `Node with ID '${nodeName}' is not referenced by any relationships.`,

--- a/shared/src/spectral/functions/architecture/node-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/node-id-exists.ts
@@ -1,15 +1,16 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the input value exists as a node with a matching unique ID.
  */
-export function nodeIdExists(input, _, context) {
+export function nodeIdExists(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
     // get uniqueIds of all nodes
-    const names = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data});
-    const results = [];
+    const names = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data as object});
+    const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/architecture/relationship-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/relationship-id-exists.ts
@@ -1,16 +1,17 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the input value exists as a relationship with matching unique ID defined under a node in the document.
  */
-export function relationshipIdExists(input, _, context) {
+export function relationshipIdExists(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
 
     // get uniqueIds of all relationships
-    const names = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data});
-    const results = [];
+    const names = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data as object});
+    const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
@@ -1,17 +1,18 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the sequence numbers within a flow's transitions are unique.
  */
-export function sequenceNumbersAreUnique(input, _, context) {
+export function sequenceNumbersAreUnique(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
     // get sequence-number of all transitions
-    const sequenceNumbers = JSONPath({path: '$[*].sequence-number', json: input, resultType: 'all'});
+    const sequenceNumbers = JSONPath({path: '$[*].sequence-number', json: input as object, resultType: 'all'});
 
     const seen = new Set();
-    const messages = [];
+    const messages: IFunctionResult[] = [];
     for (const match of sequenceNumbers) {
         const number = match['value'];
 

--- a/shared/src/spectral/functions/helper-functions.ts
+++ b/shared/src/spectral/functions/helper-functions.ts
@@ -1,5 +1,11 @@
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
-export function detectDuplicates(matches, seenIds, messages) {
+interface JSONPathMatch {
+    value: unknown;
+    pointer: string;
+}
+
+export function detectDuplicates(matches: JSONPathMatch[], seenIds: Set<unknown>, messages: IFunctionResult[]) {
     for (const match of matches) {
         const id = match['value'];
 
@@ -15,7 +21,7 @@ export function detectDuplicates(matches, seenIds, messages) {
     }
 }
 
-export function numericalPlaceHolder(input, _, context) {
+export function numericalPlaceHolder(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] | void {
     if (input == -1) {
         return [{
             message: 'Value was equal to -1 - placeholder property detected',

--- a/shared/src/spectral/functions/pattern/ids-are-unique.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.ts
@@ -1,20 +1,21 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 import { detectDuplicates } from '../helper-functions';
 /**
  * Checks that the input value exists as a node with a matching unique ID.
  */
-export default (input, _, context) => {
+export default (input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] => {
     if (!input) {
         return [];
     }
     // get uniqueIds of all nodes
-    const nodeIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
-    const relationshipIdMatches = JSONPath({path: '$.properties.relationships.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
-    const interfaceIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data, resultType: 'all'});
+    const nodeIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
+    const relationshipIdMatches = JSONPath({path: '$.properties.relationships.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
+    const interfaceIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
 
     const seenIds = new Set();
 
-    const messages = [];
+    const messages: IFunctionResult[] = [];
 
     detectDuplicates(nodeIdMatches, seenIds, messages);
     detectDuplicates(relationshipIdMatches, seenIds, messages);

--- a/shared/src/spectral/functions/pattern/interface-id-exists-on-node.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists-on-node.ts
@@ -1,10 +1,16 @@
 import { JSONPath } from 'jsonpath-plus';
 import { difference } from 'lodash';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
+
+interface ConnectsRelationship {
+    node?: string;
+    interfaces?: string[];
+}
 
 /**
  * Checks that the input value exists as an interface with matching unique ID defined under a node in the document.
  */
-export function interfaceIdExistsOnNode(input, _, context) {
+export function interfaceIdExistsOnNode(input: ConnectsRelationship | null | undefined, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input || !input.interfaces) {
         return [];
     }
@@ -17,7 +23,7 @@ export function interfaceIdExistsOnNode(input, _, context) {
     }
 
     const nodeId = input.node;
-    const nodes: object[] = JSONPath({ path: '$.properties.nodes.prefixItems[*]', json: context.document.data });
+    const nodes: object[] = JSONPath({ path: '$.properties.nodes.prefixItems[*]', json: context.document.data as object });
     const node = nodes.find((node) => {
         const uniqueId: string[] = JSONPath({ path: '$.properties.unique-id.const', json: node });
         uniqueId.push(...JSONPath({ path: '$.oneOf[*].properties.unique-id.const', json: node }));
@@ -47,7 +53,7 @@ export function interfaceIdExistsOnNode(input, _, context) {
     if (missingInterfaces.length === 0) {
         return [];
     }
-    const results = [];
+    const results: IFunctionResult[] = [];
 
     for (const missing of missingInterfaces) {
         results.push({

--- a/shared/src/spectral/functions/pattern/interface-id-exists.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists.ts
@@ -1,15 +1,16 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the input value exists as an interface with matching unique ID defined under a node in the document.
  */
-export function interfaceIdExists(input, _, context) {
+export function interfaceIdExists(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
-    // get uniqueIds of all interfaces 
-    const uniqueIds = JSONPath({path: '$..interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data});
-    const results = [];
+    // get uniqueIds of all interfaces
+    const uniqueIds = JSONPath({path: '$..interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object});
+    const results: IFunctionResult[] = [];
 
     if (!uniqueIds.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/pattern/is-defined-in-oneof-or-anyof.ts
+++ b/shared/src/spectral/functions/pattern/is-defined-in-oneof-or-anyof.ts
@@ -1,17 +1,18 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 /**
  * Checks that the input value should be defined in a oneOf or anyOf block.
  */
-export function isDefinedInOneOfOrAnyOf(input, { calmType }: { calmType: 'nodes' | 'relationships'}, context) {
+export function isDefinedInOneOfOrAnyOf(input: unknown, { calmType }: { calmType: 'nodes' | 'relationships'}, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input || typeof input !== 'string') {
         return [];
     }
 
-    const names = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].properties.unique-id.const`, json: context.document.data });
-    const oneofs = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].oneOf[*].properties.unique-id.const`, json: context.document.data });
-    const anyofs = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].anyOf[*].properties.unique-id.const`, json: context.document.data });
+    const names = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].properties.unique-id.const`, json: context.document.data as object });
+    const oneofs = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].oneOf[*].properties.unique-id.const`, json: context.document.data as object });
+    const anyofs = JSONPath({ path: `$.properties.${calmType}.prefixItems[*].anyOf[*].properties.unique-id.const`, json: context.document.data as object });
 
-    const results = [];
+    const results: IFunctionResult[] = [];
 
     if (names.includes(input) && !oneofs.includes(input) && !anyofs.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/pattern/node-has-relationship.ts
+++ b/shared/src/spectral/functions/pattern/node-has-relationship.ts
@@ -1,14 +1,15 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the given input, a unique ID, is referenced by at least one relationship.
  */
-export default (input, _, context) => {
+export default (input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] => {
     const nodeId = input;
 
-    const referencedNodeIds = JSONPath({path: '$..relationship-type..*@string()', json: context.document.data});
+    const referencedNodeIds = JSONPath({path: '$..relationship-type..*@string()', json: context.document.data as object});
 
-    const results = [];
+    const results: IFunctionResult[] = [];
     if (!referencedNodeIds) {
         return [{
             message: `Node with ID '${nodeId}' is not referenced by any relationships.`,

--- a/shared/src/spectral/functions/pattern/node-id-exists.ts
+++ b/shared/src/spectral/functions/pattern/node-id-exists.ts
@@ -1,18 +1,19 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 /**
  * Checks that the input value exists as a node with a matching unique ID.
  */
-export default (input, _, context) => {
+export default (input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] => {
     if (!input || typeof input !== 'string') {
         return [];
     }
 
-    const names = JSONPath({ path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data });
-    const oneofs = JSONPath({ path: '$.properties.nodes.prefixItems[*].oneOf[*].properties.unique-id.const', json: context.document.data });
-    const anyofs = JSONPath({ path: '$.properties.nodes.prefixItems[*].anyOf[*].properties.unique-id.const', json: context.document.data });
+    const names = JSONPath({ path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data as object });
+    const oneofs = JSONPath({ path: '$.properties.nodes.prefixItems[*].oneOf[*].properties.unique-id.const', json: context.document.data as object });
+    const anyofs = JSONPath({ path: '$.properties.nodes.prefixItems[*].anyOf[*].properties.unique-id.const', json: context.document.data as object });
 
     // get uniqueIds of all nodes
-    const results = [];
+    const results: IFunctionResult[] = [];
 
     if (!names.includes(input) && !oneofs.includes(input) && !anyofs.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/timeline/current-moment-must-be-last-when-no-valid-from.ts
+++ b/shared/src/spectral/functions/timeline/current-moment-must-be-last-when-no-valid-from.ts
@@ -1,7 +1,10 @@
+import { IFunctionResult } from '@stoplight/spectral-core';
+import { TimelineInput } from './timeline-types';
+
 /**
  * Checks that current-moment is the last moment when no valid-from values exist.
  */
-export function currentMomentMustBeLastWhenNoValidFrom(input) {
+export function currentMomentMustBeLastWhenNoValidFrom(input: TimelineInput | null | undefined): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/current-moment-required-when-moments-non-empty.ts
+++ b/shared/src/spectral/functions/timeline/current-moment-required-when-moments-non-empty.ts
@@ -1,7 +1,10 @@
+import { IFunctionResult } from '@stoplight/spectral-core';
+import { TimelineInput } from './timeline-types';
+
 /**
  * Checks that a current-moment is defined when the moments array is non-empty.
  */
-export function currentMomentRequiredWhenMomentsNonEmpty(input, _, _context) {
+export function currentMomentRequiredWhenMomentsNonEmpty(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/ids-are-unique.ts
+++ b/shared/src/spectral/functions/timeline/ids-are-unique.ts
@@ -1,19 +1,20 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 import { detectDuplicates } from '../helper-functions';
 
 /**
  * Checks that unique-id is unique across all moments in the timeline.
  */
-export function idsAreUnique(input, _, context) {
+export function idsAreUnique(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
     // get uniqueIds of all moments
-    const momentIdMatches = JSONPath({ path: '$.moments[*].unique-id', json: context.document.data, resultType: 'all' });
+    const momentIdMatches = JSONPath({ path: '$.moments[*].unique-id', json: context.document.data as object, resultType: 'all' });
 
     const seenIds = new Set();
 
-    const messages = [];
+    const messages: IFunctionResult[] = [];
 
     detectDuplicates(momentIdMatches, seenIds, messages);
 

--- a/shared/src/spectral/functions/timeline/moment-id-exists.ts
+++ b/shared/src/spectral/functions/timeline/moment-id-exists.ts
@@ -1,15 +1,16 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the input value exists as a moment with a matching unique ID.
  */
-export function momentIdExists(input, _, context) {
+export function momentIdExists(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
     // get uniqueIds of all moments
-    const names = JSONPath({ path: '$.moments[*].unique-id', json: context.document.data });
-    const results = [];
+    const names = JSONPath({ path: '$.moments[*].unique-id', json: context.document.data as object });
+    const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {
         results.push({

--- a/shared/src/spectral/functions/timeline/moments-must-be-non-empty.ts
+++ b/shared/src/spectral/functions/timeline/moments-must-be-non-empty.ts
@@ -1,7 +1,10 @@
+import { IFunctionResult } from '@stoplight/spectral-core';
+import { TimelineInput } from './timeline-types';
+
 /**
  * Checks that the moments array exists and is non-empty.
  */
-export function momentsMustBeNonEmpty(input, _, _context) {
+export function momentsMustBeNonEmpty(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/moments-sorted-by-valid-from.ts
+++ b/shared/src/spectral/functions/timeline/moments-sorted-by-valid-from.ts
@@ -1,7 +1,10 @@
+import { IFunctionResult } from '@stoplight/spectral-core';
+import { TimelineInput } from './timeline-types';
+
 /**
  * Checks that moments with valid-from are ordered by date.
  */
-export function momentsSortedByValidFrom(input, _, _context) {
+export function momentsSortedByValidFrom(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }
@@ -11,7 +14,7 @@ export function momentsSortedByValidFrom(input, _, _context) {
         return [];
     }
 
-    const results = [];
+    const results: IFunctionResult[] = [];
     let lastValidFromTimestamp: number | null = null;
     let lastValidFromValue: string | null = null;
 

--- a/shared/src/spectral/functions/timeline/timeline-types.ts
+++ b/shared/src/spectral/functions/timeline/timeline-types.ts
@@ -1,0 +1,9 @@
+/**
+ * Minimal shape of a timeline document as seen by the timeline Spectral functions.
+ * The properties are intentionally `unknown` because the value comes from
+ * unvalidated JSON and is narrowed at the point of use.
+ */
+export interface TimelineInput {
+    moments?: unknown;
+    'current-moment'?: unknown;
+}

--- a/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.ts
+++ b/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.ts
@@ -1,22 +1,23 @@
 import { JSONPath } from 'jsonpath-plus';
+import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
 
 /**
  * Checks that the current-moment has no moments after it with a valid-from date.
  */
-export function validFromNotAfterCurrentMoment(input, _, context) {
+export function validFromNotAfterCurrentMoment(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     if (!input) {
         return [];
     }
 
-    const moments: object[] = JSONPath({ path: '$.moments[*]', json: context.document.data, resultType: 'value' });
+    const moments: object[] = JSONPath({ path: '$.moments[*]', json: context.document.data as object, resultType: 'value' });
     if (!moments || moments.length === 0) {
         // other rule will report no moments defined
         return [];
     }
 
-    const currentMomentId: string = input;
+    const currentMomentId = input as string;
     let checkingValidFroms = false;
-    const results = [];
+    const results: IFunctionResult[] = [];
     for (const moment of moments) {
         const momentId: string = JSONPath({ path: '$.unique-id', json: moment, wrap: false }) as string;
         if (momentId && momentId === currentMomentId) {

--- a/shared/src/template/strategies/abstract-output-strategy.ts
+++ b/shared/src/template/strategies/abstract-output-strategy.ts
@@ -16,7 +16,7 @@ export abstract class AbstractOutputStrategy implements OutputStrategy {
     }
 
     protected resolvePath(data: Record<string, unknown>, dotPath: string): unknown {
-        return dotPath.split('.').reduce((obj, key) => (obj as Record<string, unknown>)?.[key], data);
+        return dotPath.split('.').reduce<unknown>((obj, key) => (obj as Record<string, unknown>)?.[key], data);
     }
 
     protected writeFile(outputPath: string, content: string, logger: Logger, logPrefix: string): void {

--- a/shared/src/template/template-bundle-file-loader.ts
+++ b/shared/src/template/template-bundle-file-loader.ts
@@ -4,6 +4,7 @@ import { IndexFile, TemplateEntry } from './types.js';
 import { initLogger, Logger } from '../logger.js';
 import { parseFrontMatterFromContent, replaceVariables } from './front-matter.js';
 import { WidgetsOptions } from '@finos/calm-widgets';
+import { getErrorMessage } from '../error-utils.js';
 
 
 export interface ITemplateBundleLoader {
@@ -188,8 +189,9 @@ export class TemplateBundleFileLoader implements ITemplateBundleLoader {
             logger.info(`✅ Successfully loaded template bundle: ${rawConfig.name}`);
             return rawConfig as IndexFile;
         } catch (error) {
-            logger.error(`❌ Error reading index.json: ${error.message}`);
-            throw new Error(`Failed to parse index.json: ${error.message}`);
+            const message = getErrorMessage(error);
+            logger.error(`❌ Error reading index.json: ${message}`);
+            throw new Error(`Failed to parse index.json: ${message}`);
         }
     }
 

--- a/shared/src/template/template-default-transformer.ts
+++ b/shared/src/template/template-default-transformer.ts
@@ -16,7 +16,10 @@ export default class TemplateDefaultTransformer implements CalmTemplateTransform
 
     }
 
-    registerTemplateHelpers(): Record<string, (...args: unknown[]) => unknown> {
+    // Matches the CalmTemplateTransformer interface: Handlebars helpers accept and
+    // return arbitrary values, so the loose signature is intentional here.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTemplateHelpers(): Record<string, (...args: any[]) => any> {
         // TODO: if this is the default transformer even used by docify then this will clash with widget helpers.
         // Move these out in subsequent PR
 

--- a/shared/src/template/template-path-extractor.ts
+++ b/shared/src/template/template-path-extractor.ts
@@ -1,6 +1,7 @@
 import { JSONPath } from 'jsonpath-plus';
 import _ from 'lodash';
 import { initLogger, Logger } from '../logger.js';
+import { getErrorMessage } from '../error-utils.js';
 
 export interface PathExtractionOptions {
     filter?: Record<string, JsonFragment>;
@@ -93,7 +94,7 @@ export class TemplatePathExtractor {
                         ? this.parseFilter(options.filter)
                         : options.filter;
 
-                    arrayContents = arrayContents.filter(item => this.matchesFilter(item, filterObj!));
+                    arrayContents = arrayContents.filter((item: JsonFragment) => this.matchesFilter(item, filterObj!));
                     logger.debug(`After filtering: ${beforeFilter} -> ${arrayContents.length} items`);
                 }
 
@@ -125,7 +126,7 @@ export class TemplatePathExtractor {
                 const filterObj = typeof options.filter === 'string'
                     ? this.parseFilter(options.filter)
                     : options.filter;
-                result = result.filter(item => this.matchesFilter(item, filterObj!));
+                result = result.filter((item: JsonFragment) => this.matchesFilter(item, filterObj!));
                 logger.debug(`After filtering: ${beforeFilter} -> ${result.length} items`);
             }
 
@@ -153,7 +154,7 @@ export class TemplatePathExtractor {
             logger.debug(`Final result: ${JSON.stringify(result[0], null, 2)}`);
             return result[0];
         } catch (err) {
-            logger.warn(`Failed to extract path "${path}": ${err.message}`);
+            logger.warn(`Failed to extract path "${path}": ${getErrorMessage(err)}`);
             return [];
         }
     }

--- a/shared/src/template/template-processor.ts
+++ b/shared/src/template/template-processor.ts
@@ -10,6 +10,7 @@ import {
     TemplateBundleFileLoader
 } from './template-bundle-file-loader.js';
 import { initLogger, Logger } from '../logger.js';
+import { getErrorMessage } from '../error-utils.js';
 import { CompositeReferenceResolver, MappedReferenceResolver } from '../resolver/calm-reference-resolver.js';
 import { pathToFileURL } from 'node:url';
 import TemplateDefaultTransformer from './template-default-transformer';
@@ -128,8 +129,9 @@ export class TemplateProcessor {
                 logger.info('\n✅ Template Generation Completed!');
             }
         } catch (error) {
-            logger.error(`❌ Error generating template: ${error.message}`);
-            throw new Error(`❌ Error generating template: ${error.message}`);
+            const message = getErrorMessage(error);
+            logger.error(`❌ Error generating template: ${message}`);
+            throw new Error(`❌ Error generating template: ${message}`);
         }
     }
 
@@ -185,7 +187,7 @@ export class TemplateProcessor {
     }
 
 
-    private async loadTransformer(transformerName: string, bundlePath: string): Promise<CalmTemplateTransformer> {
+    private async loadTransformer(transformerName: string | undefined, bundlePath: string): Promise<CalmTemplateTransformer> {
         const logger = TemplateProcessor.logger;
 
         if (!transformerName) {
@@ -229,8 +231,9 @@ export class TemplateProcessor {
             }
             return new TransformerClass();
         } catch (error) {
-            logger.error(`❌ Error loading transformer: ${error.message}`);
-            throw new Error(`❌ Error loading transformer: ${error.message}`);
+            const message = getErrorMessage(error);
+            logger.error(`❌ Error loading transformer: ${message}`);
+            throw new Error(`❌ Error loading transformer: ${message}`);
         }
     }
 }

--- a/shared/src/util.spec.ts
+++ b/shared/src/util.spec.ts
@@ -1,4 +1,4 @@
-import { updateStringValuesRecursively } from './util';
+import { mergeSchemas, updateStringValuesRecursively } from './util';
 
 describe('updateStringValuesRecursively', () => {
     it('Should update string values at top level', () => {
@@ -26,15 +26,48 @@ describe('updateStringValuesRecursively', () => {
         const object = {
             'innerObj': {
                 'modify': 'abcd'
-            }, 
+            },
             'innerObj2': {
                 'ignore': 'abcd'
-            } 
+            }
         };
-        const mapped = updateStringValuesRecursively(object, (key, value) => key === 'modify' 
+        const mapped = updateStringValuesRecursively(object, (key, value) => key === 'modify'
             ? value.toUpperCase()
             : value);
         expect(mapped['innerObj']['modify']).toEqual('ABCD');
         expect(mapped['innerObj2']['ignore']).toEqual('abcd');
+    });
+
+    it('Should recurse into objects nested within arrays', () => {
+        // Note: bare string elements of an array are not transformed; only string
+        // values held under object keys are. This exercises the array branch.
+        const object = {
+            'items': ['a', { 'nested': 'b' }, 'c']
+        };
+        const mapped = updateStringValuesRecursively(object, (_key, value) => value.toUpperCase());
+        expect(mapped['items']).toEqual(['a', { 'nested': 'B' }, 'c']);
+    });
+});
+
+describe('mergeSchemas', () => {
+    it('merges properties from both schemas, with the second taking precedence', () => {
+        const merged = mergeSchemas(
+            { properties: { a: 1, b: 2 } },
+            { properties: { b: 3, c: 4 } }
+        ) as { properties: Record<string, number> };
+        expect(merged.properties).toEqual({ a: 1, b: 3, c: 4 });
+    });
+
+    it('unions the required arrays of both schemas', () => {
+        const merged = mergeSchemas(
+            { required: ['a', 'b'] },
+            { required: ['b', 'c'] }
+        ) as { required: string[] };
+        expect(merged.required).toEqual(['a', 'b', 'c']);
+    });
+
+    it('defaults required to an empty array when neither schema declares it', () => {
+        const merged = mergeSchemas({ type: 'object' }, { title: 'x' }) as { required: string[] };
+        expect(merged.required).toEqual([]);
     });
 });

--- a/shared/src/util.ts
+++ b/shared/src/util.ts
@@ -9,10 +9,10 @@ import pointer from 'json-pointer';
  * @returns A new merged schema
  */
 export function mergeSchemas(s1: object, s2: object) {
-    const s1Required = (s1 ?? {}) ['required'] ?? [];
-    const s2Required = (s2 ?? {}) ['required'] ?? [];
+    const s1Required = (s1 as { required?: string[] })?.required ?? [];
+    const s2Required = (s2 as { required?: string[] })?.required ?? [];
     const newRequired = _.uniq([...s1Required, ...s2Required]);
-    const newSchema = _.merge({}, s1, s2);
+    const newSchema = _.merge({}, s1, s2) as Record<string, unknown>;
 
     newSchema['required'] = newRequired;
     return newSchema;
@@ -34,20 +34,21 @@ export function renderPath(path: string[]): string {
  * @returns 
  */
 export function updateStringValuesRecursively(def: object, mappingFunction: (key: string, value: string) => string): object {
-    const update = (obj) => {
+    const update = (obj: unknown) => {
         if (Array.isArray(obj)) {
             for (let i = 0; i < obj.length; i++) {
                 update(obj[i]);
             }
         }
-        else if (typeof obj == 'object') {
-            for (const key in obj) {
-                const value = obj[key];
+        else if (obj && typeof obj == 'object') {
+            const record = obj as Record<string, unknown>;
+            for (const key in record) {
+                const value = record[key];
                 if (typeof value === 'string') {
-                    obj[key] = mappingFunction(key, value);
+                    record[key] = mappingFunction(key, value);
                 }
                 else {
-                    update(obj[key]);
+                    update(record[key]);
                 }
             }
         }

--- a/shared/tsconfig.build.json
+++ b/shared/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "strict": true
   },
   "exclude": ["**/*.spec.ts", "src/docify/**/*"]
 }


### PR DESCRIPTION
## Description

Enables TypeScript **strict mode** for the production build of the `shared` package — the largest remaining blocker for #1396 (only `shared` had strict off; `calm-models` and `cli` were done in #2186).

This PR turns on `"strict": true` in `shared/tsconfig.build.json` (which excludes `*.spec.ts`) and resolves all ~170 production-code strict errors. The 22 Spectral custom functions, the generate/validate commands, the document loaders, templates, schema directory, resolver, model visitors, hub client and utils are all typed. Spec files still have strict errors and are excluded from the build; they will be addressed in a follow-up so the root `tsconfig.base.json` default can finally be flipped and #1396 closed.

Most changes are mechanical type annotations. The non-mechanical ones:

- **Spectral functions** are typed with `RulesetFunctionContext` / `IFunctionResult` from `@stoplight/spectral-core` (they were previously fully untyped).
- A shared **`getErrorMessage()`** helper replaces ~10 repeated inline `error instanceof Error ? … : String(error)` narrowings in catch clauses.
- **`JsonSchemaValidator.loadSchema`** now rethrows schema-load failures instead of swallowing them into a later `undefined` dereference. This surfaces the real cause (e.g. an unsupported standard JSON Schema draft) — the related e2e assertion was updated to match the clearer message.
- **Return types widened to `… | undefined`** on the document loaders and `SchemaDirectory.getSchema`/`getPattern` to reflect the not-found paths they already had. The `undefined` not-found signal is relied upon by callers (`calm-server`'s validation route returning 400, `lookupDefinition`'s placeholder), so the runtime behaviour is unchanged — only the types are now honest.
- A `assertSchemaDirectory` assertion throws a clear error on the pattern/timeline/architecture-against-pattern paths when no schema directory is provided (these paths cannot work without one).

### Deliberate idiom divergences (called out for reviewers)

- The deep CALM-pattern JSON traversal in `options.ts` (and a similar spot in `validate.ts`/`util.ts`) uses a documented `SchemaNode = { [key: string]: any }` index type rather than the sibling `Record<string, unknown>` convention, because these access 5-level property chains where `unknown` would require a cast at every level. Each use is documented and `eslint-disable`d locally.
- A small shared `getErrorMessage()` was added alongside the existing richer private `toErrorMessage` in `validate.ts` (the latter keeps a `JSON.stringify` fallback and stays validate-local).

## Type of Change
- [x] ♻️ Refactoring (no functional changes)
- [x] ✅ Test additions or updates

<!-- One intentional behaviour refinement: JsonSchemaValidator.loadSchema now rethrows
schema-load failures rather than swallowing them; the affected e2e assertion was updated.
Not flagged as a breaking change as the failure path was already an error path. -->

## Affected Components
- [x] Shared (`shared/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verification (Node 22):
- `tsc -p shared/tsconfig.build.json` (strict) — 0 errors
- `npm run lint --workspace shared` — clean
- `npm run build --workspace shared` — passes
- `npm run test --workspace shared` — 841 pass, branch coverage 85% (added unit tests for `getErrorMessage`, `mergeSchemas`, `getPropertyValue`, and the missing-schema-directory path to hold the gate)
- Full workspace suite green, incl. downstream consumers of `shared`: `cli`, `calm-server`, VS Code plugin

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary <!-- N/A: no user-facing behaviour change -->
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

Part of #1396.
