### PR TITLE
fix(ci): repair stale CALM samples spectral validation workflow

### DIFF
--- a/.github/workflows/validate-spectral.yml
+++ b/.github/workflows/validate-spectral.yml
@@ -10,7 +10,7 @@ on:
         paths:
             - 'calm/draft/**'
             - 'calm/pattern/**'
-            - 'calm/samples/**'
+            - 'calm/architecture/**'
             - 'shared/src/spectral/**'
     push:
         branches:
@@ -18,7 +18,7 @@ on:
         paths:
             - 'calm/draft/**'
             - 'calm/pattern/**'
-            - 'calm/samples/**'
+            - 'calm/architecture/**'
             - 'shared/src/spectral/**'
 
 jobs:
@@ -37,11 +37,14 @@ jobs:
             - name: Install workspace
               run: npm ci
 
-            - name: Build workspace
-              run: npm run build
+            # Only the shared package (and its build dependencies) is needed to
+            # produce the Spectral ruleset under shared/dist/spectral. Building the
+            # whole monorepo couples this job to unrelated packages.
+            - name: Build shared Spectral ruleset
+              run: npm run build:shared
 
             - name: Install dependencies for Spectral
               run: npm install @stoplight/spectral-cli rollup
 
             - name: Run Example Spectral Linting
-              run: npx spectral lint --ruleset ./shared/dist/spectral/rules-architecture.js 'calm/samples/api-gateway-architecture(*.json|*.yaml)'
+              run: npx spectral lint --ruleset ./shared/dist/spectral/rules-architecture.js 'calm/architecture/calm-*.json'


### PR DESCRIPTION
## Description

The **Validation of CALM Samples** workflow (`validate-spectral.yml`) fails on every run. Because it's path-filtered to `shared/src/spectral/**` it rarely triggers, so the breakage went unnoticed until a PR touched the Spectral functions. It is broken for two pre-existing reasons, neither related to the Spectral rules themselves:

1. **Build step builds the whole monorepo.** `npm run build` is broken on `main` since calm-studio migrated to npm workspaces (`d4465224`). The root `workspaces` glob `calm-suite/calm-studio/packages/*` expands **alphabetically**, so `@calmstudio/github-action` builds **before** its `@calmstudio/mcp` dependency → `TS2307: Cannot find module '@calmstudio/mcp/dist/...'`. Separately, `calmguard-docs` fails because `future.v4: true` enables the Docusaurus "faster" pipeline without the `@docusaurus/faster` dependency.
2. **Lint target was deleted.** The step lints `calm/samples/api-gateway-architecture*`, but `calm/samples/` was removed in July 2025 (`bc4ad29d`, per finos/calm-schema#1). Spectral finds no files and exits non-zero.

### Fix

The job only needs the Spectral ruleset emitted at `shared/dist/spectral/`, so:

- **Build only `shared`** (and its build deps) via the existing `build:shared` script instead of the whole monorepo. This decouples the job from unrelated packages and is faster.
- **Repoint the lint** to the surviving `calm/architecture/calm-*.json` architectures, which validate with **0 errors** against `rules-architecture.js`.
- **Update the path trigger** from the removed `calm/samples/**` to `calm/architecture/**`.

Verified end-to-end locally (Node 22): `npm run build:shared` produces `shared/dist/spectral/rules-architecture.js`, and `npx spectral lint --ruleset ./shared/dist/spectral/rules-architecture.js 'calm/architecture/calm-*.json'` exits 0.

> **Out of scope (separate follow-up):** the underlying full `npm run build` break in the vendored `calm-suite` packages (calm-studio build-order + `calmguard-docs` missing `@docusaurus/faster`) is left as-is here, since this workflow does not need those packages. Worth tracking separately as it affects anyone running a full monorepo build.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Testing
- [x] I have tested my changes locally

Reproduced the failure in a clean worktree (`npm ci` + `npm run build`) and confirmed the new steps pass end-to-end.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary <!-- N/A -->
- [ ] I have added tests for my changes (if applicable) <!-- N/A: CI workflow change -->
- [x] My changes follow the project's coding standards
