### PR TITLE
test(shared): enable strict mode repo-wide by typing the test suite

### DIFF
--- a/shared/src/commands/generate/components/instantiate.spec.ts
+++ b/shared/src/commands/generate/components/instantiate.spec.ts
@@ -2,11 +2,13 @@ import {describe, it, expect, vi, beforeEach, Mock} from 'vitest';
 import * as fs from 'fs';
 import { instantiate } from './instantiate'; // replace with actual relative path
 import { SchemaDirectory } from '../../../schema-directory';
+import { DocumentLoader } from '../../../document-loader/document-loader';
 
 interface TestInstantiatedPattern {
-    $schema?: string;
-    nodes?: Array<Record<string, unknown>>;
-    relationships?: Array<Record<string, unknown>>;
+    $schema: string;
+    nodes: Array<Record<string, unknown>>;
+    relationships: Array<Record<string, unknown>>;
+    [key: string]: unknown;
 }
 
 
@@ -161,7 +163,7 @@ describe('instantiate', () => {
     it('instantiates architecture with correct schema', async () => {
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result: TestInstantiatedPattern = await instantiate(pattern, true,  new SchemaDirectory({} as any));
+        const result = await instantiate(pattern, true,  new SchemaDirectory({} as any)) as TestInstantiatedPattern;
 
         expect(result.$schema).toEqual('test-pattern');
     });
@@ -169,7 +171,7 @@ describe('instantiate', () => {
     it('instantiates nodes with schema-required and const fields', async () => {
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result: TestInstantiatedPattern = await instantiate(pattern, true,  new SchemaDirectory({} as any));
+        const result = await instantiate(pattern, true,  new SchemaDirectory({} as any)) as TestInstantiatedPattern;
 
         expect(result.nodes[0]).toEqual({
             'unique-id': 'my-node',
@@ -184,7 +186,7 @@ describe('instantiate', () => {
     it('instantiates nested controls with patternProperties and consts', async () => {
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result: TestInstantiatedPattern = await instantiate(pattern, true,  new SchemaDirectory({} as any));
+        const result = await instantiate(pattern, true,  new SchemaDirectory({} as any)) as TestInstantiatedPattern;
 
         expect(result.relationships[0]).toEqual({
             'unique-id': 'rel-1',
@@ -205,10 +207,10 @@ describe('instantiate', () => {
     it('handles missing required schema fields by generating placeholders', async () => {
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result: TestInstantiatedPattern = await instantiate(pattern, true, new SchemaDirectory({} as any));
+        const result = await instantiate(pattern, true, new SchemaDirectory({} as any)) as TestInstantiatedPattern;
 
         expect(result.nodes[0]['node-type']).toBe('[[ NODE_TYPE ]]');
-        expect(result.nodes[0]['details']['arch']).toBe('[[ ARCH ]]');
+        expect((result.nodes[0]['details'] as Record<string, unknown>)['arch']).toBe('[[ ARCH ]]');
     });
 
     it('uses const values directly for array items', async () => {
@@ -241,7 +243,7 @@ describe('instantiate', () => {
         (fs.readFileSync as Mock).mockImplementation(function () { return JSON.stringify(patternWithConstArrayItems); });
 
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
-        const result = await instantiate(pattern, true, new SchemaDirectory(null));
+        const result = await instantiate(pattern, true, new SchemaDirectory(null as unknown as DocumentLoader)) as TestInstantiatedPattern;
 
         expect(result['simpleArray']).toEqual([
             'string-value',
@@ -279,7 +281,7 @@ describe('instantiate', () => {
         (fs.readFileSync as Mock).mockImplementation(function () { return JSON.stringify(patternWithTopLevelConst); });
 
         const pattern = JSON.parse(fs.readFileSync(patternPath, { encoding: 'utf-8' }));
-        const result = await instantiate(pattern, true, new SchemaDirectory(null));
+        const result = await instantiate(pattern, true, new SchemaDirectory(null as unknown as DocumentLoader)) as TestInstantiatedPattern;
 
         expect(result['simple-const']).toBe('simple-value');
         expect(result['object-const']).toEqual({ nested: 'object-value' });

--- a/shared/src/commands/generate/components/options.spec.ts
+++ b/shared/src/commands/generate/components/options.spec.ts
@@ -43,7 +43,7 @@ function buildPatternChoice({description, nodes, relationships}: CalmChoice) {
 }
 
 function buildPatternOption(optionType: 'oneOf' | 'anyOf', ...choices: object[]) {
-    const option = {};
+    const option: Record<string, object[]> = {};
     option[optionType] = choices;
     return option;
 }

--- a/shared/src/commands/generate/generate.e2e.spec.ts
+++ b/shared/src/commands/generate/generate.e2e.spec.ts
@@ -26,7 +26,7 @@ const expectedPlainPath = join(expectedDir, 'conference-signup.arch.json');
 const expectedSecurePath = join(expectedDir, 'conference-secure-signup.arch.json');
 
 describe('runGenerate E2E', () => {
-    let schemaDirectory;
+    let schemaDirectory: SchemaDirectory;
     beforeEach(() => {
         if (existsSync(outputDir)) {
             rmSync(outputDir, { recursive: true, force: true });

--- a/shared/src/commands/generate/generate.spec.ts
+++ b/shared/src/commands/generate/generate.spec.ts
@@ -1,4 +1,5 @@
 import { runGenerate } from './generate';
+import { SchemaDirectory } from '../../schema-directory';
 import { tmpdir } from 'node:os';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
@@ -31,16 +32,16 @@ vi.mock('./components/flatten-allof', () => ({
 
 
 describe('runGenerate', () => {
-    let tempDirectoryPath;
+    let tempDirectoryPath: string;
     const testPath: string = 'test_fixtures/api-gateway.json';
     const testPattern: object = JSON.parse(readFileSync(testPath, { encoding: 'utf8' }));
-    let schemaDirectory;
+    let schemaDirectory: SchemaDirectory;
 
     beforeEach(() => {
         tempDirectoryPath = mkdtempSync(path.join(tmpdir(), 'calm-test-'));
         schemaDirectory = {
             loadSchemas: vi.fn().mockResolvedValue(undefined)
-        };
+        } as unknown as SchemaDirectory;
     });
 
     afterEach(() => {

--- a/shared/src/commands/validate/validate.spec.ts
+++ b/shared/src/commands/validate/validate.spec.ts
@@ -56,7 +56,7 @@ const debugDisabled = false;
 
 describe('validation support functions', () => {
     describe('exitBasedOffOfValidationOutcome', () => {
-        let mockExit;
+        let mockExit: ReturnType<typeof vi.spyOn>;
 
         beforeEach(() => {
             mockExit = vi.spyOn(process, 'exit')

--- a/shared/src/docify/docifier.spec.ts
+++ b/shared/src/docify/docifier.spec.ts
@@ -1,12 +1,11 @@
 import { Docifier } from './docifier';
 import { TemplateProcessor } from '../template/template-processor';
-import { Mock } from 'vitest';
 import * as urlMapping from '../template/url-mapping';
 
 vi.mock('../template/template-processor');
 vi.mock('../template/url-mapping');
 
-const MockedTemplateProcessor: Mock = vi.mocked(TemplateProcessor);
+const MockedTemplateProcessor = vi.mocked(TemplateProcessor);
 
 describe('Docifier', () => {
     const inputPath = 'some/input/path';

--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -17,9 +17,9 @@ mock.onGet('/schemas/2025-03/meta/core.json').reply(200, {
 
 describe('calmhub-document-loader', () => {
     let calmHubDocumentLoader: CalmHubDocumentLoader;
-    let schemaDirectory: SchemaDirectory;
+    const schemaDirectory: SchemaDirectory = {} as unknown as SchemaDirectory;
     beforeEach(() => {
-        calmHubDocumentLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, null, ax);
+        calmHubDocumentLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, undefined, ax);
         calmHubDocumentLoader.initialise(schemaDirectory);
     });
 

--- a/shared/src/document-loader/file-system-document-loader.spec.ts
+++ b/shared/src/document-loader/file-system-document-loader.spec.ts
@@ -1,3 +1,4 @@
+import { SchemaDirectory } from '../schema-directory';
 import { fs, vol } from 'memfs';
 import { FileSystemDocumentLoader } from './file-system-document-loader';
 import { DocumentLoadError } from './document-loader';
@@ -30,7 +31,7 @@ const exampleSchema = {
 };
 
 describe('file-system-document-loader', () => {
-    let fileSystemDocumentLoader;
+    let fileSystemDocumentLoader: FileSystemDocumentLoader;
     beforeEach(() => {
         process.chdir('/');
         vol.fromJSON({
@@ -45,7 +46,7 @@ describe('file-system-document-loader', () => {
 
 
     it('loads a single schema into schema directory', async () => {
-        await fileSystemDocumentLoader.initialise(mocks.schemaDirectory);
+        await fileSystemDocumentLoader.initialise(mocks.schemaDirectory as unknown as SchemaDirectory);
         expect(mocks.schemaDirectory.storeDocument).toHaveBeenCalledWith(exampleSchema['$id'], 'schema', exampleSchema);
     });
 

--- a/shared/src/document-loader/loading-helpers.spec.ts
+++ b/shared/src/document-loader/loading-helpers.spec.ts
@@ -82,7 +82,7 @@ describe('loading helpers', () => {
 
     describe('loadArchitecture', () => {
         it('should return undefined if architecturePath is not provided', async () => {
-            const result = await loadArchitecture(undefined, mockDocLoader, mockLogger);
+            const result = await loadArchitecture(undefined as unknown as string, mockDocLoader, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -97,7 +97,7 @@ describe('loading helpers', () => {
 
     describe('loadPattern', () => {
         it('should return undefined if patternPath is not provided', async () => {
-            const result = await loadPattern(undefined, mockDocLoader, mockLogger);
+            const result = await loadPattern(undefined as unknown as string, mockDocLoader, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -112,7 +112,7 @@ describe('loading helpers', () => {
 
     describe('loadPatternFromDocumentIfPresent', () => {
         it('should return undefined if architecture is missing', async () => {
-            const result = await loadPatternFromDocumentIfPresent(undefined, 'arch.json', mockDocLoader, mockSchemaDirectory, mockLogger);
+            const result = await loadPatternFromDocumentIfPresent(undefined as unknown as object, 'arch.json', mockDocLoader, mockSchemaDirectory, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -161,7 +161,7 @@ describe('loading helpers', () => {
         it('should load pattern only if architecture fails to load', async () => {
             const pattern = { kind: 'pattern' };
             vi.mocked(mockDocLoader.loadMissingDocument)
-                .mockResolvedValueOnce(undefined) // architecture
+                .mockResolvedValueOnce(undefined as unknown as object) // architecture
                 .mockResolvedValueOnce(pattern);  // pattern
 
             const result = await loadArchitectureAndPattern('arch.json', 'pattern.json', mockDocLoader, mockSchemaDirectory, mockLogger);
@@ -175,7 +175,7 @@ describe('loading helpers', () => {
             vi.mocked(mockDocLoader.loadMissingDocument).mockResolvedValueOnce(arch);
             vi.mocked(mockSchemaDirectory.getSchema).mockResolvedValue(pattern);
 
-            const result = await loadArchitectureAndPattern('arch.json', undefined, mockDocLoader, mockSchemaDirectory, mockLogger);
+            const result = await loadArchitectureAndPattern('arch.json', undefined as unknown as string, mockDocLoader, mockSchemaDirectory, mockLogger);
 
             expect(result).toEqual({ architecture: arch, pattern });
         });

--- a/shared/src/document-loader/loading-helpers.spec.ts
+++ b/shared/src/document-loader/loading-helpers.spec.ts
@@ -82,7 +82,7 @@ describe('loading helpers', () => {
 
     describe('loadArchitecture', () => {
         it('should return undefined if architecturePath is not provided', async () => {
-            const result = await loadArchitecture(undefined as unknown as string, mockDocLoader, mockLogger);
+            const result = await loadArchitecture(undefined, mockDocLoader, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -97,7 +97,7 @@ describe('loading helpers', () => {
 
     describe('loadPattern', () => {
         it('should return undefined if patternPath is not provided', async () => {
-            const result = await loadPattern(undefined as unknown as string, mockDocLoader, mockLogger);
+            const result = await loadPattern(undefined, mockDocLoader, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -112,7 +112,7 @@ describe('loading helpers', () => {
 
     describe('loadPatternFromDocumentIfPresent', () => {
         it('should return undefined if architecture is missing', async () => {
-            const result = await loadPatternFromDocumentIfPresent(undefined as unknown as object, 'arch.json', mockDocLoader, mockSchemaDirectory, mockLogger);
+            const result = await loadPatternFromDocumentIfPresent(undefined, 'arch.json', mockDocLoader, mockSchemaDirectory, mockLogger);
             expect(result).toBeUndefined();
         });
 
@@ -175,7 +175,7 @@ describe('loading helpers', () => {
             vi.mocked(mockDocLoader.loadMissingDocument).mockResolvedValueOnce(arch);
             vi.mocked(mockSchemaDirectory.getSchema).mockResolvedValue(pattern);
 
-            const result = await loadArchitectureAndPattern('arch.json', undefined as unknown as string, mockDocLoader, mockSchemaDirectory, mockLogger);
+            const result = await loadArchitectureAndPattern('arch.json', undefined, mockDocLoader, mockSchemaDirectory, mockLogger);
 
             expect(result).toEqual({ architecture: arch, pattern });
         });

--- a/shared/src/document-loader/loading-helpers.ts
+++ b/shared/src/document-loader/loading-helpers.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { DocumentLoader, CALM_HUB_PROTO } from './document-loader';
 import { SchemaDirectory } from '../schema-directory';
 
-export async function loadArchitectureAndPattern(architecturePath: string, patternPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ architecture: object | undefined, pattern: object | undefined }> {
+export async function loadArchitectureAndPattern(architecturePath: string, patternPath: string | undefined, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ architecture: object | undefined, pattern: object | undefined }> {
     const architecture = await loadArchitecture(architecturePath, docLoader, logger);
     if (!architecture) {
         // we have already validated that at least one of the options is provided, so pattern must be set
@@ -46,7 +46,7 @@ export function resolveSchemaRef(schemaRef: string, architecturePath: string, lo
     return schemaRef;
 }
 
-export async function loadPatternFromDocumentIfPresent(document: object, documentPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<object | undefined> {
+export async function loadPatternFromDocumentIfPresent(document: object | undefined, documentPath: string, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<object | undefined> {
     const schemaId = document ? (document as { $schema?: string }).$schema : undefined;
     if (!schemaId) {
         return undefined;
@@ -65,7 +65,7 @@ export async function loadPatternFromDocumentIfPresent(document: object, documen
     return pattern;
 }
 
-export async function loadPattern(patternPath: string, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
+export async function loadPattern(patternPath: string | undefined, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
     if (!patternPath) {
         return undefined;
     }
@@ -74,7 +74,7 @@ export async function loadPattern(patternPath: string, docLoader: DocumentLoader
     return pattern;
 }
 
-export async function loadArchitecture(architecturePath: string, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
+export async function loadArchitecture(architecturePath: string | undefined, docLoader: DocumentLoader, logger: Logger): Promise<object | undefined> {
     if (!architecturePath) {
         return undefined;
     }

--- a/shared/src/document-loader/mapped-document-loader.spec.ts
+++ b/shared/src/document-loader/mapped-document-loader.spec.ts
@@ -1,3 +1,4 @@
+import { SchemaDirectory } from '../schema-directory';
 import { fs, vol } from 'memfs';
 import { MappedDocumentLoader } from './mapped-document-loader';
 import { DocumentLoadError } from './document-loader';
@@ -54,7 +55,7 @@ describe('MappedDocumentLoader', () => {
             ]);
 
             const loader = new MappedDocumentLoader(urlMap, '/project', false);
-            await loader.initialise(mocks.schemaDirectory);
+            await loader.initialise(mocks.schemaDirectory as unknown as SchemaDirectory);
 
             // Should store by mapped URL
             expect(mocks.schemaDirectory.storeDocument).toHaveBeenCalledWith(
@@ -91,7 +92,7 @@ describe('MappedDocumentLoader', () => {
             const loader = new MappedDocumentLoader(urlMap, '/project', false);
             
             // Should not throw
-            await expect(loader.initialise(mocks.schemaDirectory)).resolves.not.toThrow();
+            await expect(loader.initialise(mocks.schemaDirectory as unknown as SchemaDirectory)).resolves.not.toThrow();
             
             // Should not store anything
             expect(mocks.schemaDirectory.storeDocument).not.toHaveBeenCalled();
@@ -107,7 +108,7 @@ describe('MappedDocumentLoader', () => {
             ]);
 
             const loader = new MappedDocumentLoader(urlMap, '/other/path', false);
-            await loader.initialise(mocks.schemaDirectory);
+            await loader.initialise(mocks.schemaDirectory as unknown as SchemaDirectory);
 
             expect(mocks.schemaDirectory.storeDocument).toHaveBeenCalledWith(
                 'https://mapped.example.com/abs.json',

--- a/shared/src/document-loader/multi-strategy-document-loader.spec.ts
+++ b/shared/src/document-loader/multi-strategy-document-loader.spec.ts
@@ -11,11 +11,13 @@ describe('MultiStrategyDocumentLoader', () => {
     it('calls initialise on each loader', async () => {
         const mockLoader1: DocumentLoader = {
             initialise: vi.fn().mockResolvedValue(undefined),
-            loadMissingDocument: vi.fn()
+            loadMissingDocument: vi.fn(),
+            resolvePath: vi.fn()
         };
         const mockLoader2: DocumentLoader = {
             initialise: vi.fn().mockResolvedValue(undefined),
-            loadMissingDocument: vi.fn()
+            loadMissingDocument: vi.fn(),
+            resolvePath: vi.fn()
         };
         const multi = new MultiStrategyDocumentLoader([mockLoader1, mockLoader2]);
         const schemaDir = {} as SchemaDirectory;
@@ -28,11 +30,13 @@ describe('MultiStrategyDocumentLoader', () => {
         const error = new Error('fail');
         const mockLoader1: DocumentLoader = {
             initialise: vi.fn(),
-            loadMissingDocument: vi.fn().mockRejectedValue(error)
+            loadMissingDocument: vi.fn().mockRejectedValue(error),
+            resolvePath: vi.fn()
         };
         const mockLoader2: DocumentLoader = {
             initialise: vi.fn(),
-            loadMissingDocument: vi.fn().mockResolvedValue({ foo: 'bar' })
+            loadMissingDocument: vi.fn().mockResolvedValue({ foo: 'bar' }),
+            resolvePath: vi.fn()
         };
         const multi = new MultiStrategyDocumentLoader([mockLoader1, mockLoader2]);
         const result = await multi.loadMissingDocument('id', 'schema');
@@ -104,11 +108,13 @@ describe('MultiStrategyDocumentLoader', () => {
         const error2 = new Error('fail2');
         const mockLoader1: DocumentLoader = {
             initialise: vi.fn(),
-            loadMissingDocument: vi.fn().mockRejectedValue(error1)
+            loadMissingDocument: vi.fn().mockRejectedValue(error1),
+            resolvePath: vi.fn()
         };
         const mockLoader2: DocumentLoader = {
             initialise: vi.fn(),
-            loadMissingDocument: vi.fn().mockRejectedValue(error2)
+            loadMissingDocument: vi.fn().mockRejectedValue(error2),
+            resolvePath: vi.fn()
         };
         const multi = new MultiStrategyDocumentLoader([mockLoader1, mockLoader2]);
         await expect(multi.loadMissingDocument('id', 'schema')).rejects.toThrow();

--- a/shared/src/hub/calm-hub-client.spec.ts
+++ b/shared/src/hub/calm-hub-client.spec.ts
@@ -1,3 +1,4 @@
+import { AuthPlugin } from '../auth/auth-plugin';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
@@ -214,7 +215,7 @@ describe('CalmHubClient', () => {
             const ax = axios.create({ baseURL: 'http://localhost:8080' });
             authMock = new AxiosMockAdapter(ax);
             authClient = new CalmHubClient(
-                { calmHubUrl: 'http://localhost:8080', authPlugin: { getAuthHeaders } },
+                { calmHubUrl: 'http://localhost:8080', authPlugin: { getAuthHeaders } as unknown as AuthPlugin },
                 ax
             );
         });
@@ -957,7 +958,7 @@ describe('CalmHubClient', () => {
 
         beforeEach(() => {
             getAuthHeaders = vi.fn().mockResolvedValue({ Authorization: 'Bearer test-token' });
-            const authPlugin = { getAuthHeaders };
+            const authPlugin = { getAuthHeaders } as unknown as AuthPlugin;
             const ax = axios.create({ baseURL: 'http://localhost:8080' });
             authMock = new AxiosMockAdapter(ax);
             authClient = new CalmHubClient({ calmHubUrl: 'http://localhost:8080', authPlugin }, ax);

--- a/shared/src/model-visitor/dereference-visitor.spec.ts
+++ b/shared/src/model-visitor/dereference-visitor.spec.ts
@@ -155,7 +155,7 @@ describe('DereferencingVisitor', () => {
         const canonical: CalmCoreCanonicalModel = core.toCanonicalSchema();
         expect(canonical.nodes.length).toBe(2);
         expect(canonical.nodes[0]['unique-id']).toBe('web-tier');
-        expect(canonical.nodes[0].details.nodes).toEqual([  {
+        expect(canonical.nodes[0].details!.nodes).toEqual([  {
             'unique-id': 'db-tier',
             'node-type': 'database',
             'name': 'Database Tier',
@@ -171,7 +171,7 @@ describe('DereferencingVisitor', () => {
             'metadata': undefined,
             'details': undefined
         }]);
-        expect(canonical.controls['user-auth'].requirements[0]).toEqual({
+        expect(canonical.controls!['user-auth'].requirements[0]).toEqual({
             'requirement-url': 'https://calm.finos.org/release/1.0-rc2/prototype/user-auth-requirement.json',
             'token-endpoint': 'https://auth.example.com/token',
         });

--- a/shared/src/model-visitor/logging-visitor.spec.ts
+++ b/shared/src/model-visitor/logging-visitor.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LoggingVisitor } from './logging-visitor';
+import { Logger } from '../logger';
 import { CalmCore } from '@finos/calm-models/model';
 import { CalmCoreSchema } from '@finos/calm-models/types';
 
@@ -84,7 +85,7 @@ describe('LoggingVisitor', () => {
         const json = JSON.stringify(testArch, null, 2);
         const architecture: CalmCoreSchema = JSON.parse(json);
         const core = CalmCore.fromSchema(architecture);
-        const visitor = new LoggingVisitor((logger as Logger));
+        const visitor = new LoggingVisitor((logger as unknown as Logger));
         await visitor.visit(core);
 
         const logLines = logger.info.mock.calls.map(args => args[0]);

--- a/shared/src/schema-directory.spec.ts
+++ b/shared/src/schema-directory.spec.ts
@@ -1,5 +1,4 @@
 import { SchemaDirectory } from '.';
-import { DocumentLoader } from './document-loader/document-loader';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { TEST_ALL_SCHEMA } from './test/test-utils';
@@ -17,15 +16,16 @@ vi.mock('./logger', () => {
     };
 });
 
-function getMockDocumentLoader(): DocumentLoader {
+function getMockDocumentLoader() {
     return {
         initialise: vi.fn(),
-        loadMissingDocument: vi.fn()
+        loadMissingDocument: vi.fn(),
+        resolvePath: vi.fn()
     };
 }
 
 describe('SchemaDirectory', () => {
-    let mockDocLoader;
+    let mockDocLoader: ReturnType<typeof getMockDocumentLoader>;
 
     beforeEach(() => {
         mockDocLoader = getMockDocumentLoader();
@@ -60,7 +60,7 @@ describe('SchemaDirectory', () => {
 
         mockDocLoader.loadMissingDocument.mockReturnValueOnce(new Promise(resolve => resolve(nodeJson)));
 
-        const nodeDef = await schemaDir.getDefinition(nodeRef);
+        const nodeDef = await schemaDir.getDefinition(nodeRef) as Record<string, unknown>;
 
         // node should have a required property of node-type
         expect(nodeDef['required']).toContain('node-type');
@@ -74,7 +74,7 @@ describe('SchemaDirectory', () => {
         );
 
         const ref = 'https://calm.com/references.json#/defs/top-level';
-        const definition = await schemaDir.getDefinition(ref);
+        const definition = await schemaDir.getDefinition(ref) as Record<string, unknown>;
 
         // this should include top-level, but also recursively pull in inner-prop
         expect(definition['properties']).toHaveProperty('top-level');
@@ -87,7 +87,7 @@ describe('SchemaDirectory', () => {
         mockDocLoader.loadMissingDocument.mockResolvedValueOnce(loadSchema('test_fixtures/schema-directory/relative-ref.json'));
 
         const ref = 'https://calm.com/relative.json#/defs/top-level';
-        const definition = await schemaDir.getDefinition(ref);
+        const definition = await schemaDir.getDefinition(ref) as Record<string, unknown>;
 
         expect(definition['$ref']).toEqual('https://calm.com/relative.json#/defs/inner');
     });
@@ -111,10 +111,10 @@ describe('SchemaDirectory', () => {
 
         const ref = 'https://calm.com/missing-inner-ref.json#/defs/top-level';
         const missingRef = '/defs/not-found'; // see missing-inner-ref.json
-        const definition = await schemaDir.getDefinition(ref);
+        const definition = await schemaDir.getDefinition(ref) as Record<string, unknown>;
 
         expect(definition['properties']).toHaveProperty('missing-value');
-        expect(definition['properties']['missing-value']).toEqual('MISSING OBJECT, ref: ' + missingRef + ' could not be resolved');
+        expect((definition['properties'] as Record<string, unknown>)['missing-value']).toEqual('MISSING OBJECT, ref: ' + missingRef + ' could not be resolved');
     });
 
     it('terminate early in the case of a circular reference', async () => {
@@ -125,7 +125,7 @@ describe('SchemaDirectory', () => {
         );
 
         const ref = 'https://calm.com/recursive.json#/defs/top-level';
-        const definition = await schemaDir.getDefinition(ref);
+        const definition = await schemaDir.getDefinition(ref) as Record<string, unknown>;
 
         // this should include top-level and port. If circular refs are not handled properly this will crash the whole test by stack overflow
         expect(definition['properties']).toHaveProperty('top-level');
@@ -140,7 +140,7 @@ describe('SchemaDirectory', () => {
         );
 
         const ref = 'https://calm.com/relative.json#/defs/top-level';
-        const definition = await schemaDir.getDefinition(ref);
+        const definition = await schemaDir.getDefinition(ref) as Record<string, unknown>;
 
         // this should include top-level, but also recursively pull in inner-prop
         expect(definition['properties']).toHaveProperty('top-level');

--- a/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { idsAreUnique } from './ids-are-unique';
 
 describe('idsAreUnique', () => {
@@ -10,7 +11,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -36,7 +37,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -53,7 +54,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /nodes/1/unique-id');
     });
@@ -71,7 +72,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /relationships/1/unique-id');
     });
@@ -96,7 +97,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: intf1, path: /nodes/1/interfaces/0/unique-id');
     });
@@ -120,7 +121,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /relationships/0/unique-id');
     });

--- a/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { interfaceIdExistsOnNode } from './interface-id-exists-on-node';
 
 describe('interfaceIdExistsOnNode', () => {
@@ -9,7 +10,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -21,7 +22,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -34,7 +35,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe('Invalid connects relationship - no node defined.');
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
@@ -57,7 +58,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -72,7 +73,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Node with unique-id ${input.node} has no interfaces defined, expected interfaces [${input.interfaces}].`);
     });
@@ -95,7 +96,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[0]}' was not defined on the node with ID '${input.node}'.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
@@ -119,7 +120,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[1]}' was not defined on the node with ID '${input.node}'.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);

--- a/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { interfaceIdExists } from './interface-id-exists';
 
 describe('interfaceIdExists', () => {
@@ -9,7 +10,7 @@ describe('interfaceIdExists', () => {
             }
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -30,7 +31,7 @@ describe('interfaceIdExists', () => {
             }
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -52,7 +53,7 @@ describe('interfaceIdExists', () => {
             path: ['/relationships/0/connects/destination/interface']
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing interface.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination/interface']);

--- a/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { nodeIdExists } from './node-id-exists';
 
 describe('nodeIdExists', () => {
@@ -9,7 +10,7 @@ describe('nodeIdExists', () => {
             }
         };
 
-        const result = nodeIdExists(input, null, context);
+        const result = nodeIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -25,7 +26,7 @@ describe('nodeIdExists', () => {
             }
         };
 
-        const result = nodeIdExists(input, null, context);
+        const result = nodeIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -42,7 +43,7 @@ describe('nodeIdExists', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = nodeIdExists(input, null, context);
+        const result = nodeIdExists(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing node.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);

--- a/shared/src/spectral/functions/architecture/relationship-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/relationship-id-exists.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { relationshipIdExists } from './relationship-id-exists';
 
 describe('relationshipIdExists', () => {
@@ -9,7 +10,7 @@ describe('relationshipIdExists', () => {
             }
         };
 
-        const result = relationshipIdExists(input, null, context);
+        const result = relationshipIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -25,7 +26,7 @@ describe('relationshipIdExists', () => {
             }
         };
 
-        const result = relationshipIdExists(input, null, context);
+        const result = relationshipIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -42,7 +43,7 @@ describe('relationshipIdExists', () => {
             path: ['/relationships/0']
         };
 
-        const result = relationshipIdExists(input, null, context);
+        const result = relationshipIdExists(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing relationship.`);
         expect(result[0].path).toEqual(['/relationships/0']);

--- a/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.spec.ts
+++ b/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { sequenceNumbersAreUnique } from './sequence-numbers-are-unique';
 
 describe('sequenceNumbersAreUnique', () => {
@@ -10,7 +11,7 @@ describe('sequenceNumbersAreUnique', () => {
             path: ['flows', 0, 'transitions']
         };
 
-        const result = sequenceNumbersAreUnique(input, null, context);
+        const result = sequenceNumbersAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -26,7 +27,7 @@ describe('sequenceNumbersAreUnique', () => {
             path: ['flows', 0, 'transitions']
         };
 
-        const result = sequenceNumbersAreUnique(input, null, context);
+        const result = sequenceNumbersAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -42,7 +43,7 @@ describe('sequenceNumbersAreUnique', () => {
             path: ['flows', 0, 'transitions']
         };
 
-        const result = sequenceNumbersAreUnique(input, null, context);
+        const result = sequenceNumbersAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate sequence-number 1 detected. path: /1/sequence-number');
     });

--- a/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import idsAreUnique from './ids-are-unique';
 
 describe('idsAreUnique', () => {
@@ -10,7 +11,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -40,7 +41,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -61,7 +62,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/nodes/prefixItems/1/properties/unique-id/const');
     });
@@ -83,7 +84,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: rel1, path: /properties/relationships/prefixItems/1/properties/unique-id/const');
     });
@@ -112,7 +113,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: intf1, path: /properties/nodes/prefixItems/1/properties/interfaces/prefixItems/0/properties/unique-id/const');
     });
@@ -142,7 +143,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /properties/relationships/prefixItems/0/properties/unique-id/const');
     });

--- a/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { interfaceIdExistsOnNode } from './interface-id-exists-on-node';
 
 describe('interfaceIdExistsOnNode', () => {
@@ -9,7 +10,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -21,7 +22,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -34,7 +35,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe('Invalid connects relationship - no node defined.');
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
@@ -65,7 +66,7 @@ describe('interfaceIdExistsOnNode', () => {
             }
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -90,7 +91,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Node with unique-id ${input.node} has no interfaces defined, expected interfaces [${input.interfaces}]`);
     });
@@ -121,7 +122,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[0]}' was not defined on the node with ID '${input.node}'.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);
@@ -153,7 +154,7 @@ describe('interfaceIdExistsOnNode', () => {
             path: ['/relationships/0/connects/destination']
         };
 
-        const result = interfaceIdExistsOnNode(input, null, context);
+        const result = interfaceIdExistsOnNode(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`Referenced interface with ID '${input.interfaces[1]}' was not defined on the node with ID '${input.node}'.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination']);

--- a/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { interfaceIdExists } from './interface-id-exists';
 
 describe('interfaceIdExists', () => {
@@ -9,7 +10,7 @@ describe('interfaceIdExists', () => {
             }
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -27,7 +28,7 @@ describe('interfaceIdExists', () => {
             }
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -46,7 +47,7 @@ describe('interfaceIdExists', () => {
             path: ['/relationships/0/connects/destination/interface']
         };
 
-        const result = interfaceIdExists(input, null, context);
+        const result = interfaceIdExists(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing interface.`);
         expect(result[0].path).toEqual(['/relationships/0/connects/destination/interface']);

--- a/shared/src/spectral/functions/spectral-test-helpers.ts
+++ b/shared/src/spectral/functions/spectral-test-helpers.ts
@@ -1,0 +1,12 @@
+import { RulesetFunctionContext } from '@stoplight/spectral-core';
+
+/**
+ * Casts a minimal mock object to a {@link RulesetFunctionContext} for unit tests.
+ *
+ * The custom Spectral functions only read `context.document.data` and
+ * `context.path`, so tests construct a partial context and use this helper to
+ * satisfy the full type without restating every field.
+ */
+export function asContext(partial: unknown): RulesetFunctionContext {
+    return partial as RulesetFunctionContext;
+}

--- a/shared/src/spectral/functions/timeline/current-moment-required-when-moments-non-empty.ts
+++ b/shared/src/spectral/functions/timeline/current-moment-required-when-moments-non-empty.ts
@@ -4,7 +4,7 @@ import { TimelineInput } from './timeline-types';
 /**
  * Checks that a current-moment is defined when the moments array is non-empty.
  */
-export function currentMomentRequiredWhenMomentsNonEmpty(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
+export function currentMomentRequiredWhenMomentsNonEmpty(input: TimelineInput | null | undefined, _?: unknown, _context?: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/timeline/ids-are-unique.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { idsAreUnique } from './ids-are-unique';
 
 describe('idsAreUnique', () => {
@@ -10,7 +11,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -27,7 +28,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -45,7 +46,7 @@ describe('idsAreUnique', () => {
             }
         };
 
-        const result = idsAreUnique(input, null, context);
+        const result = idsAreUnique(input, null, asContext(context));
         expect(result.length).toBeGreaterThan(0);
         expect(result[0].message).toContain('Duplicate unique-id detected. ID: node1, path: /moments/2/unique-id');
     });

--- a/shared/src/spectral/functions/timeline/moment-id-exists.spec.ts
+++ b/shared/src/spectral/functions/timeline/moment-id-exists.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { momentIdExists } from './moment-id-exists';
 
 describe('momentIdExists', () => {
@@ -9,7 +10,7 @@ describe('momentIdExists', () => {
             }
         };
 
-        const result = momentIdExists(input, null, context);
+        const result = momentIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -26,7 +27,7 @@ describe('momentIdExists', () => {
             }
         };
 
-        const result = momentIdExists(input, null, context);
+        const result = momentIdExists(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -44,7 +45,7 @@ describe('momentIdExists', () => {
             path: ['/current-moment']
         };
 
-        const result = momentIdExists(input, null, context);
+        const result = momentIdExists(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe(`'${input}' does not refer to the unique-id of an existing moment.`);
         expect(result[0].path).toEqual(['/current-moment']);

--- a/shared/src/spectral/functions/timeline/moments-must-be-non-empty.ts
+++ b/shared/src/spectral/functions/timeline/moments-must-be-non-empty.ts
@@ -4,7 +4,7 @@ import { TimelineInput } from './timeline-types';
 /**
  * Checks that the moments array exists and is non-empty.
  */
-export function momentsMustBeNonEmpty(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
+export function momentsMustBeNonEmpty(input: TimelineInput | null | undefined, _?: unknown, _context?: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/moments-sorted-by-valid-from.ts
+++ b/shared/src/spectral/functions/timeline/moments-sorted-by-valid-from.ts
@@ -4,7 +4,7 @@ import { TimelineInput } from './timeline-types';
 /**
  * Checks that moments with valid-from are ordered by date.
  */
-export function momentsSortedByValidFrom(input: TimelineInput | null | undefined, _: unknown, _context: unknown): IFunctionResult[] {
+export function momentsSortedByValidFrom(input: TimelineInput | null | undefined, _?: unknown, _context?: unknown): IFunctionResult[] {
     if (!input) {
         return [];
     }

--- a/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.spec.ts
+++ b/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.spec.ts
@@ -1,3 +1,4 @@
+import { asContext } from '../spectral-test-helpers';
 import { validFromNotAfterCurrentMoment } from './valid-from-not-after-current-moment';
 
 describe('validFromNotAfterCurrentMoment', () => {
@@ -9,7 +10,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -23,7 +24,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -40,7 +41,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -58,7 +59,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -76,7 +77,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -94,7 +95,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result).toEqual([]);
     });
 
@@ -112,7 +113,7 @@ describe('validFromNotAfterCurrentMoment', () => {
             }
         };
 
-        const result = validFromNotAfterCurrentMoment(input, null, context);
+        const result = validFromNotAfterCurrentMoment(input, null, asContext(context));
         expect(result.length).toBe(1);
         expect(result[0].message).toBe('Moment with unique-id "moment3" is after current-moment "moment2" but has a valid-from.');
     });

--- a/shared/src/template/front-matter.spec.ts
+++ b/shared/src/template/front-matter.spec.ts
@@ -1,3 +1,4 @@
+import { WidgetsOptions } from '@finos/calm-widgets';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -339,7 +340,7 @@ Content`;
 
         it('should handle no widget options', () => {
             const content = 'Template content';
-            const widgetOptions = undefined;
+            const widgetOptions = undefined as unknown as WidgetsOptions;
 
             const result = injectWidgetOptionsIntoContent(content, widgetOptions);
 

--- a/shared/src/template/front-matter.spec.ts
+++ b/shared/src/template/front-matter.spec.ts
@@ -1,4 +1,3 @@
-import { WidgetsOptions } from '@finos/calm-widgets';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -340,7 +339,7 @@ Content`;
 
         it('should handle no widget options', () => {
             const content = 'Template content';
-            const widgetOptions = undefined as unknown as WidgetsOptions;
+            const widgetOptions = undefined;
 
             const result = injectWidgetOptionsIntoContent(content, widgetOptions);
 

--- a/shared/src/template/front-matter.ts
+++ b/shared/src/template/front-matter.ts
@@ -122,7 +122,7 @@ export function replaceVariables(content: string, frontMatter: Record<string, un
     return result;
 }
 
-export function injectWidgetOptionsIntoContent(content: string, widgetOptions: WidgetsOptions): string {
+export function injectWidgetOptionsIntoContent(content: string, widgetOptions: WidgetsOptions | undefined): string {
     if (widgetOptions === undefined) {
         return content;
     }

--- a/shared/src/template/strategies/repeated-strategy.spec.ts
+++ b/shared/src/template/strategies/repeated-strategy.spec.ts
@@ -183,7 +183,7 @@ describe('RepeatedStrategy', () => {
             expect(mockCompiledTemplate).toHaveBeenCalledWith(
                 expect.objectContaining({
                     _root: context.data,
-                    _architecture: context.data.document,
+                    _architecture: (context.data as Record<string, unknown>).document,
                     'node-id': 'node-1'
                 })
             );

--- a/shared/src/template/template-bundle-file-loader.spec.ts
+++ b/shared/src/template/template-bundle-file-loader.spec.ts
@@ -9,7 +9,7 @@ vi.mock('fs');
 describe('TemplateBundleFileLoader', () => {
     const mockBundlePath = '/mock/template-bundle';
     const mockIndexJsonPath = path.join(mockBundlePath, 'index.json');
-    const mockTemplateFiles = {
+    const mockTemplateFiles: Record<string, string> = {
         'template1.hbs': '{{name}} template',
         'template2.hbs': '{{name}} another template',
     };
@@ -215,7 +215,7 @@ widget-options:
 describe('SelfProvidedDirectoryTemplateLoader', () => {
     const templateDir = '/mock/templates';
     const files = ['doc1.md', 'doc2.hbs', 'doc3.md', 'readme.txt'];
-    const fileContents = {
+    const fileContents: Record<string, string> = {
         'doc1.md': `---
 name: Sample Document
 widget-options:

--- a/shared/src/template/template-engine.spec.ts
+++ b/shared/src/template/template-engine.spec.ts
@@ -226,11 +226,12 @@ describe('TemplateEngine', () => {
     });
 
     it('should log a warning for an unknown output type', () => {
-        const templateConfig: IndexFile = {
+        // Deliberately invalid output-type to exercise the unknown-type warning path.
+        const templateConfig = {
             name: 'Test Template',
             transformer: 'mock-transformer',
             templates: [{ template: 'main.hbs', from: 'data', output: 'output.txt', 'output-type': 'invalid-type' }],
-        };
+        } as unknown as IndexFile;
 
         const templateFiles = {
             'main.hbs': 'User: {{name}}',

--- a/shared/src/template/template-path-extractor.spec.ts
+++ b/shared/src/template/template-path-extractor.spec.ts
@@ -161,7 +161,7 @@ describe('TemplatePathExtractor', () => {
     it('filters nodes by node-type', () => {
         const result = TemplatePathExtractor.convertFromDotNotation(architectureDocument, "architecture.nodes[node-type=='system']");
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray.length).toBe(1);
         expect(resultArray[0]['unique-id']).toBe('account-system');
     });
@@ -178,7 +178,7 @@ describe('TemplatePathExtractor', () => {
             "architecture.nodes['account-system'].details.nodes[node-type=='service']"
         );
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray.length).toBe(1);
         expect(resultArray[0]['name']).toBe('Account Service');
     });
@@ -189,7 +189,7 @@ describe('TemplatePathExtractor', () => {
             "architecture.nodes['user-interface'].interfaces"
         );
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray[0]['url']).toBe('https://account.example.com');
     });
 
@@ -199,7 +199,7 @@ describe('TemplatePathExtractor', () => {
             "architecture.nodes['account-system'].details.nodes['account-db'].interfaces[definition-url=='https://calm.finos.org/interface/container-port.json']"
         );
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray[0]['port']).toBe(5432);
     });
 
@@ -237,7 +237,7 @@ describe('TemplatePathExtractor', () => {
             { sort: 'name' }
         );
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray[0]['name']).toBe('Account Database');
         expect(resultArray[1]['name']).toBe('Account Service');
     });
@@ -259,7 +259,7 @@ describe('TemplatePathExtractor', () => {
             { filter: { name: 'Account Database' } }
         );
         expect(Array.isArray(result)).toBe(true);
-        const resultArray = result as JsonFragment[];
+        const resultArray = result as Record<string, unknown>[];
         expect(resultArray.length).toBe(1);
         expect(resultArray[0]['unique-id']).toBe('account-db');
     });

--- a/shared/src/template/template-processor.e2e.spec.ts
+++ b/shared/src/template/template-processor.e2e.spec.ts
@@ -255,10 +255,10 @@ describe('TemplateProcessor E2E', () => {
         expect(actualContent).toEqual(expectedContent);
     }, 20_000);
 
-    function simulateAmendmentsPostGenerate(archPath, amendedPath) {
+    function simulateAmendmentsPostGenerate(archPath: string, amendedPath: string) {
         const original = fs.readFileSync(archPath, 'utf-8');
 
-        const AMENDMENTS = {
+        const AMENDMENTS: Record<string, Record<string, Record<string, unknown>>> = {
             'load-balancer': {
                 'load-balancer-host-port': { port: 80, host: 'localhost' },
             },
@@ -278,7 +278,7 @@ describe('TemplateProcessor E2E', () => {
             const updates = AMENDMENTS[node['unique-id']];
             if (!updates) return;
 
-            node.interfaces = node.interfaces.map(
+            node.interfaces = (node.interfaces ?? []).map(
                 (iface: CalmInterfaceTypeSchema) => {
                     const patch = updates[iface['unique-id']];
                     return patch ? { ...iface, ...patch } : iface;

--- a/shared/src/util.spec.ts
+++ b/shared/src/util.spec.ts
@@ -5,7 +5,7 @@ describe('updateStringValuesRecursively', () => {
         const object = {
             'stringKey': 'abcd'
         };
-        const mapped = updateStringValuesRecursively(object, (key, value) => value.toUpperCase());
+        const mapped = updateStringValuesRecursively(object, (key, value) => value.toUpperCase()) as Record<string, unknown>;
         expect(mapped['stringKey']).toEqual('ABCD');
     });
 
@@ -33,9 +33,9 @@ describe('updateStringValuesRecursively', () => {
         };
         const mapped = updateStringValuesRecursively(object, (key, value) => key === 'modify'
             ? value.toUpperCase()
-            : value);
-        expect(mapped['innerObj']['modify']).toEqual('ABCD');
-        expect(mapped['innerObj2']['ignore']).toEqual('abcd');
+            : value) as Record<string, unknown>;
+        expect((mapped['innerObj'] as Record<string, unknown>)['modify']).toEqual('ABCD');
+        expect((mapped['innerObj2'] as Record<string, unknown>)['ignore']).toEqual('abcd');
     });
 
     it('Should recurse into objects nested within arrays', () => {
@@ -44,7 +44,7 @@ describe('updateStringValuesRecursively', () => {
         const object = {
             'items': ['a', { 'nested': 'b' }, 'c']
         };
-        const mapped = updateStringValuesRecursively(object, (_key, value) => value.toUpperCase());
+        const mapped = updateStringValuesRecursively(object, (_key, value) => value.toUpperCase()) as Record<string, unknown>;
         expect(mapped['items']).toEqual(['a', { 'nested': 'B' }, 'c']);
     });
 });

--- a/shared/src/view-model/adr.spec.ts
+++ b/shared/src/view-model/adr.spec.ts
@@ -12,7 +12,7 @@ import {
     CalmAdrOptionSchema,
     CalmAdrDecisionSchema,
     CalmAdrLinkSchema,
-} from '../types/adr-types';
+} from '@finos/calm-models/types';
 
 describe('CalmAdrMeta', () => {
     it('should create a CalmAdrMeta instance from JSON data', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
         "declaration": true,
         "sourceMap": true,
         "outDir": "dist",
-        "strict": false,
+        "strict": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,


### PR DESCRIPTION
## Description

Completes #1396 by making **TypeScript strict mode the repo-wide default**.

PR #2583 (which this stacks on) enabled strict for `shared`'s *production* build (specs excluded). This PR resolves the ~190 remaining strict-mode type errors in `shared`'s **spec files**, then flips the root `tsconfig.base.json` default from `"strict": false` to `"strict": true`. `shared/tsconfig.json` was the last config inheriting the non-strict default — every other module already sets `strict: true` explicitly — so this makes strict mode the baseline for the whole repo and closes the issue.

### Notable changes beyond mechanical test typing

- **Spectral function tests:** added a small `asContext()` test helper so unit tests can pass partial mock contexts to the now-typed custom functions, instead of restating the full `RulesetFunctionContext`.
- **Three timeline functions** (`momentsMustBeNonEmpty`, `momentsSortedByValidFrom`, `currentMomentRequiredWhenMomentsNonEmpty`): made the unused trailing `_`/`_context` params optional, so their tests can call them with just the input under test. Spectral still invokes them with all three args at runtime.
- **`adr.spec.ts`** imported ADR schema types from a deleted local `../types/adr-types` module — repointed to `@finos/calm-models/types`, where those types now live (the spec was effectively dead).
- Typed previously-untyped mock loaders/spies and cast JSON-shaped test results at the point of use.

No production behaviour changes beyond the optional spectral params.

## Type of Change
- [x] ♻️ Refactoring (no functional changes)
- [x] ✅ Test additions or updates

## Affected Components
- [x] Shared (`shared/`)
- [x] CI/CD <!-- root tsconfig.base.json default -->

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass

Verification (Node 22):
- `tsc -p shared/tsconfig.json` (strict via base) — 0 errors
- `npm run lint --workspace shared` — clean
- `npm run build:cli`, `build:calm-server`, and the VS Code plugin build — all pass (builds use the `*.build.json` configs, which already set strict)
- Full workspace test suite green — shared 841 tests pass; all other workspaces pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary <!-- N/A -->
- [x] I have added tests for my changes (if applicable) <!-- N/A: this typed the existing tests -->
- [x] My changes follow the project's coding standards

Closes #1396.
