### PR TITLE
docs: sync all AGENTS.md guides with current monorepo (root + per-package)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,23 +30,38 @@ architecture-as-code/
 ├── calm/                      # CALM specification (JSON schemas)
 ├── cli/                       # TypeScript CLI (@finos/calm-cli)
 ├── calm-hub/                  # Java/Quarkus REST API backend
+├── calm-hub-ui/               # React frontend for CALM Hub
+├── calm-server/               # TypeScript server (@finos/calm-server)
 ├── calm-plugins/vscode/       # VSCode extension
 ├── calm-models/               # TypeScript data models
 ├── calm-widgets/              # React visualization components
 ├── calm-ai/                   # AI agent tools & prompts
+├── calm-suite/                # Sub-monorepos (see below)
+│   ├── calm-studio/           #   SvelteKit visual CALM editor — nested npm-workspace monorepo
+│   └── calm-guard/            #   Next.js continuous-compliance platform (CALMGuard)
 ├── shared/                    # Shared TypeScript utilities
 ├── docs/                      # Docusaurus documentation site
 ├── advent-of-calm/            # Educational content (24-day challenge)
-├── calm-hub-ui/               # React frontend for CALM Hub
-└── experimental/              # Experimental features
+├── experimental/              # Experimental features
+├── template-bundles/          # Reusable Handlebars template bundles
+├── conferences/               # Conference/workshop material
+├── brand/                     # Logo and brand assets
+└── scripts/                   # Repo maintenance scripts (e.g. lockfile validation)
 ```
+
+### `calm-suite/` — nested workspaces
+
+`calm-suite/` holds two products whose packages are wired directly into the **root** npm workspaces (run all npm commands from the repo root, never from inside these folders):
+
+- **`calm-studio/`** (`calmstudio-workspace`) — a SvelteKit (Svelte 5) visual CALM editor, itself an npm-workspace monorepo. Sub-packages and the app are root workspaces via `calm-suite/calm-studio/packages/*` and `calm-suite/calm-studio/apps/*`: `@calmstudio/calm-core`, `@calmstudio/calmscript`, `@calmstudio/extensions`, `@calmstudio/github-action`, `@calmstudio/mcp`, `@calmstudio/diagram` (web-component), `calmstudio` (vscode-extension), and `@calmstudio/studio` (app).
+- **`calm-guard/`** (`calmguard`) — a Next.js 14 (App Router) continuous-compliance platform, plus its Docusaurus docs (`calmguard-docs`). Both are root workspaces.
 
 ## Technology Stack
 
 **TypeScript/Node.js** (npm workspaces):
-- CLI, models, widgets, shared, VSCode plugin, Hub UI
+- CLI, models, widgets, shared, VSCode plugin, Hub UI, calm-server, calm-ai, and the `calm-suite/` products (CalmStudio's 8 packages/app + CALMGuard)
 - Build: tsup (esbuild), vitest for testing
-- Package manager: npm workspaces
+- Package manager: npm workspaces (single root lockfile; see [Lockfile Regeneration](#lockfile-regeneration))
 
 **Java/Maven** (Maven reactor build):
 - Root pom.xml defines multi-module reactor
@@ -57,7 +72,7 @@ architecture-as-code/
 - Maven reactor allows building all modules from root: `./mvnw clean install`
 
 **Documentation**:
-- Docusaurus for main docs
+- Docusaurus for main docs (and for CalmStudio's `docs-site` / CALMGuard's `calmguard-docs`)
 - Astro for advent-of-calm website
 
 ## Node Version Requirements
@@ -78,7 +93,7 @@ brew install node@22
 export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
 
 # If using nvm:
-nvm use   # reads .nvmrc → 22.14.0
+nvm use   # reads .nvmrc → 22.22.2
 ```
 
 ### Known Node 25 Bug — localStorage
@@ -87,9 +102,9 @@ Node 25 introduces a built-in `localStorage` global that is an **incomplete stub
 
 ### Configuration Details
 
-- **`.nvmrc`** pins `22.14.0` — run `nvm use` to switch automatically
+- **`.nvmrc`** pins `22.22.2` — run `nvm use` to switch automatically
 - **`.npmrc`** has `engine-strict=true` — `npm install` will refuse to run on Node versions outside the `engines` range (e.g. Node 18, 20, or 23)
-- **`@types/node`** is overridden to `^22.0.0` in root `package.json` to prevent transitive dependencies from pulling in a different major version
+- **`@types/node`** is overridden to `^22.19.15` in root `package.json` to prevent transitive dependencies from pulling in a different major version
 - **Renovate** is configured with `allowedVersions: "<23.0.0"` for `@types/node`
 
 ### Lockfile Regeneration
@@ -120,8 +135,12 @@ For detailed guidance on specific packages, see:
 - **[cli/AGENTS.md](cli/AGENTS.md)** - CLI commands, build pipeline, Commander.js patterns
 - **[calm-hub/AGENTS.md](calm-hub/AGENTS.md)** - Java/Quarkus backend, storage modes, security
 - **[calm-hub-ui/AGENTS.md](calm-hub-ui/AGENTS.md)** - React frontend, service patterns, component conventions
+- **[calm-server/AGENTS.md](calm-server/AGENTS.md)** - TypeScript CALM server
 - **[calm-plugins/vscode/AGENTS.md](calm-plugins/vscode/AGENTS.md)** - VSCode extension, MVVM architecture
 - **[calm-widgets/AGENTS.md](calm-widgets/AGENTS.md)** - Widget system, Handlebars templates, common pitfalls
+- **[shared/AGENTS.md](shared/AGENTS.md)** - Shared TypeScript utilities consumed across packages
+- **[calm-suite/calm-studio/AGENTS.md](calm-suite/calm-studio/AGENTS.md)** - CalmStudio visual editor, CALM 1.2 rules, nested workspaces
+- **[calm-suite/calm-guard/AGENTS.md](calm-suite/calm-guard/AGENTS.md)** - CALMGuard compliance platform, agents/skills
 - **[advent-of-calm/AGENTS.md](advent-of-calm/AGENTS.md)** - Educational content, day format, testing
 
 ### When to Use Package-Specific Guides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ architecture-as-code/
 `calm-suite/` holds two products whose packages are wired directly into the **root** npm workspaces (run all npm commands from the repo root, never from inside these folders):
 
 - **`calm-studio/`** (`calmstudio-workspace`) — a SvelteKit (Svelte 5) visual CALM editor, itself an npm-workspace monorepo. Sub-packages and the app are root workspaces via `calm-suite/calm-studio/packages/*` and `calm-suite/calm-studio/apps/*`: `@calmstudio/calm-core`, `@calmstudio/calmscript`, `@calmstudio/extensions`, `@calmstudio/github-action`, `@calmstudio/mcp`, `@calmstudio/diagram` (web-component), `calmstudio` (vscode-extension), and `@calmstudio/studio` (app).
-- **`calm-guard/`** (`calmguard`) — a Next.js 14 (App Router) continuous-compliance platform, plus its Docusaurus docs (`calmguard-docs`). Both are root workspaces.
+- **`calm-guard/`** (`calmguard`) — a Next.js (App Router) continuous-compliance platform, plus its Docusaurus docs (`calmguard-docs`). Both are root workspaces.
 
 ## Technology Stack
 
@@ -72,7 +72,7 @@ architecture-as-code/
 - Maven reactor allows building all modules from root: `./mvnw clean install`
 
 **Documentation**:
-- Docusaurus for main docs (and for CalmStudio's `docs-site` / CALMGuard's `calmguard-docs`)
+- Docusaurus for main docs (and for CALMGuard's `calmguard-docs`)
 - Astro for advent-of-calm website
 
 ## Node Version Requirements

--- a/advent-of-calm/AGENTS.md
+++ b/advent-of-calm/AGENTS.md
@@ -14,23 +14,33 @@ This guide helps AI assistants work efficiently with the Advent of CALM educatio
 
 ```
 advent-of-calm/
-├── home.md              # Landing page content
+├── home.md              # Landing page content (copied into website/src/)
 ├── setup.md             # Tool installation and update instructions
 ├── day-1.md             # Day 1: Install CLI and setup
 ├── day-2.md             # Day 2: Create first architecture
 ├── ...
-├── day-24.md            # Day 24: (to be created)
-└── website/             # Astro static site
+├── day-24.md            # Day 24: Capstone "Congratulations" page
+└── website/             # Astro static site (own npm project, see below)
     ├── src/
     │   ├── content/days/     # Copied from parent (day-*.md, setup.md)
+    │   ├── content.config.ts # Defines the `days` content collection (glob loader)
+    │   ├── home.md           # Copied from parent (lands in src/, not content/days/)
     │   ├── pages/            # Astro pages
+    │   │   ├── index.astro   # Landing page
+    │   │   ├── setup.astro   # Setup page
+    │   │   └── day/[day].astro  # Dynamic day route (param = bare day number)
     │   ├── components/       # UI components
     │   ├── layouts/          # Page layouts
+    │   ├── utils/calendar.ts # Day titles + unlock logic (getDayTitle, etc.)
     │   └── styles/           # CSS
     ├── public/               # Static assets
+    ├── package-lock.json     # Website has its OWN lockfile (not a root workspace)
     ├── astro.config.mjs      # Astro configuration
     └── package.json          # Website dependencies
 ```
+
+**All 24 day files (Days 1-24) exist** — `day-N.md` is non-zero-padded, and
+`day-24.md` is the completed capstone page.
 
 ## Content Structure
 
@@ -56,7 +66,7 @@ advent-of-calm/
 
 ### Day Content Format
 
-Each `day-N.md` follows this structure:
+Most `day-N.md` files share this structure (these headings appear in the large majority of the 24 days):
 
 ```markdown
 # Day N: [Clear Task Title]
@@ -76,21 +86,24 @@ Detailed instructions with code examples
 ### 2. [Next Requirement]
 Step-by-step guidance
 
-## Testing Your Solution
-How to validate the work
+## Deliverables
+What the learner should produce. Many days title this
+`## Deliverables / Validation Criteria` and fold the "done" checklist in here.
 
-## Success Criteria
-Clear checklist of what "done" looks like
+## Tips
+Practical hints and gotchas
 
-## Troubleshooting
-Common issues and solutions
+## Resources
+Links to CALM docs and related material
 
-## Going Further (Optional)
-Advanced extensions for learners who want more
-
-## Reflection
-Questions to consolidate learning
+## Next Steps
+What the next day builds toward
 ```
+
+Individual days add their own topic-specific sections as needed (e.g. ADR
+sub-headings on Day 10, scenario sections in Week 4, occasional `## Reflection`
+or `## Common Pitfalls`). Treat the list above as the common spine, not a rigid
+template.
 
 ## Key Concepts
 
@@ -122,22 +135,29 @@ The curriculum uses a **running e-commerce example**:
 ## Website (Astro Static Site)
 
 ### Tech Stack
-- **Framework**: Astro 5+ (static site generator)
+- **Framework**: Astro 6+ (static site generator)
 - **Language**: TypeScript
 - **Content**: Markdown files copied from parent directory
 - **Styling**: CSS (custom)
+
+> **CRITICAL: `advent-of-calm/website` is NOT a root npm workspace.** It has its
+> own `package-lock.json` and is installed and built independently. You must run
+> `npm install` *inside* `website/` before any `npm run` command there — the
+> root `npm install` does not cover it.
 
 ### Key Commands
 
 ```bash
 cd website
+npm install              # Required first time (separate from root install)
 
 # Development
 npm run dev              # Start dev server (copies content first)
 npm start                # Alternative: start dev server
 
 # Build
-npm run build            # Copy content + Astro build
+npm run build            # copy:content + astro check + astro build
+                         # NOTE: `astro check` is a type-check gate and can fail the build
 npm run preview          # Preview production build
 
 # Content sync
@@ -147,7 +167,9 @@ npm run copy:content     # Manually copy markdown files
 ### Content Pipeline
 
 1. **Source**: Markdown files in `advent-of-calm/` (day-*.md, setup.md, home.md)
-2. **Copy**: `npm run copy:content` syncs to `website/src/content/days/`
+2. **Copy**: `npm run copy:content` syncs `day-*.md` and `setup.md` to
+   `website/src/content/days/`, but copies `home.md` to `website/src/` (NOT
+   `content/days/`)
 3. **Build**: Astro processes and generates static HTML
 4. **Deploy**: Static files in `website/dist/`
 
@@ -173,9 +195,8 @@ npm run copy:content     # Manually copy markdown files
 **Content Guidelines:**
 - Use conversational, encouraging tone
 - Provide clear "why" explanations (rationale)
-- Include both basic and "Going Further" content
-- Add troubleshooting for common issues
-- Link to CALM docs for deeper reading
+- Add Tips for common gotchas
+- Link to CALM docs for deeper reading (Resources)
 - Use realistic examples (the e-commerce architecture)
 
 ### Testing Content Changes
@@ -188,7 +209,7 @@ vim day-10.md
 cd website
 npm run dev
 
-# 3. Check http://localhost:4321/advent/days/day-10/
+# 3. Check http://localhost:4321/advent/day/10/  (route is /advent/day/<bare-number>/)
 
 # 4. When satisfied, commit
 cd ..
@@ -200,13 +221,12 @@ git commit -m "docs(advent): update day 10 ADR linking"
 
 **Checklist for new day content:**
 
-- [ ] Create `day-N.md` following standard format
-- [ ] Include Overview, Objectives, Requirements
+- [ ] Create `day-N.md` following the common structure
+- [ ] Include Overview, Objective and Rationale, Requirements
 - [ ] Add code examples with proper syntax highlighting
-- [ ] Write Testing and Success Criteria sections
-- [ ] Add Troubleshooting section
-- [ ] Include "Going Further" optional extensions
-- [ ] Add Reflection questions
+- [ ] Write Deliverables (and validation criteria) for what "done" looks like
+- [ ] Add Tips for common gotchas
+- [ ] Add Resources / Next Steps sections
 - [ ] Test in website (`npm run dev`)
 - [ ] Ensure builds without errors (`npm run build`)
 - [ ] Update `home.md` if week structure changes

--- a/calm-hub-ui/AGENTS.md
+++ b/calm-hub-ui/AGENTS.md
@@ -10,64 +10,94 @@ This guide helps AI assistants work efficiently with the CALM Hub UI frontend co
 - **Testing**: Vitest, React Testing Library, Cypress (E2E)
 - **Styling**: TailwindCSS + DaisyUI
 - **HTTP Client**: Axios
-- **Auth**: OIDC via `oidc-client-ts` / `react-oidc-context`
+- **Auth**: OIDC via `oidc-client-ts` (see `src/authService.tsx`)
 
 ## Key Commands
 
 ```bash
 # All commands from repository root using workspaces
-npm run build --workspace calm-hub-ui     # Production build
+npm run build --workspace calm-hub-ui     # Production build (vite build → build/)
 npm test --workspace calm-hub-ui          # Run unit tests (vitest run)
-npm run lint --workspace calm-hub-ui      # Lint
-npm run dev --workspace calm-hub-ui       # Dev server with hot reload
+npm run lint --workspace calm-hub-ui      # Lint (eslint + stylelint on src/**/*.css)
+npm run start --workspace calm-hub-ui     # Dev server with hot reload
+
+# Root-level aliases
+npm run calm-hub-ui:run                    # Alias for `start`
+npm run build:calm-hub-ui                  # Build calm-models + calm-hub-ui
+npm run calm-hub-ui:prod                   # Build, then rsync build/ into calm-hub resources
 ```
+
+The build output goes to `build/` (Vite `outDir`). `npm run prod` (via the
+`calm-hub-ui:prod` alias) copies that output into
+`../calm-hub/src/main/resources/META-INF/resources` — the UI ships **embedded
+in the Quarkus backend**. A `copy-public` prebuild step copies brand assets from
+`../brand` into `public/` before both `start` and `build`.
 
 ## Directory Structure
 
 ```
 src/
+├── authService.tsx       # OIDC auth (oidc-client-ts) + getAuthHeaders helper
+├── ProtectedRoute.tsx    # Route guard for authenticated routes
 ├── service/              # API service classes (axios-based)
 ├── model/                # TypeScript interfaces and types
 ├── hub/
 │   └── components/       # Feature components
 │       ├── tree-navigation/
 │       ├── control-detail-section/
+│       ├── interface-detail-section/
 │       ├── document-detail-section/
 │       ├── diagram-section/
 │       ├── json-renderer/
 │       ├── adr-renderer/
 │       ├── section-header/
 │       └── value-table/
+├── visualizer/           # Architecture visualiser (largest subtree)
+│   ├── components/       # UI: reactflow/, sidebar/, drawer/
+│   ├── contracts/        # Typed *-contracts.ts interface definitions
+│   ├── helpers/          # Pure helpers (e.g. set-functions)
+│   └── services/         # e.g. node-position-service
+├── diff/                 # Architecture diff view (components, model, fixtures)
 ├── components/           # Shared/common components
-├── visualizer/           # Architecture visualiser
 ├── fixtures/             # Test fixtures
 └── theme/                # Theme configuration
 ```
+
+The `visualizer/contracts/*-contracts.ts` files hold the typed interfaces shared
+across the visualiser (nodes, edges, decorators, panels, etc.); add new
+visualiser-facing types there rather than inline.
 
 ## Conventions
 
 ### Service Pattern
 
-All API services follow a **class-based pattern with injectable Axios instances**, matching `CalmService` as the reference implementation:
+All API services follow a **class-based pattern with injectable Axios instances**. `ControlService` (`src/service/control-service.ts`) is the clearest reference; `InterfaceService` and `SearchService` follow the same shape:
 
 ```typescript
 import axios, { AxiosInstance } from 'axios';
+import { getAuthHeaders } from '../authService.js';
 
-class MyService {
-    private ax: AxiosInstance;
+export class MyService {
+    private readonly ax: AxiosInstance;
 
-    constructor(ax: AxiosInstance = axios.create()) {
-        this.ax = ax;
+    constructor(axiosInstance?: AxiosInstance) {
+        if (axiosInstance) {
+            this.ax = axiosInstance;
+        } else {
+            this.ax = axios.create();
+        }
     }
 
-    async fetchItems(): Promise<Item[]> {
-        try {
-            const response = await this.ax.get<Item[]>('/api/items');
-            return response.data;
-        } catch (error) {
-            console.error('%s', error);
-            return Promise.reject(new Error('Failed to fetch items'));
-        }
+    public async fetchItems(domain: string): Promise<Item[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get(`/calm/domains/${encodeURIComponent(domain)}/items`, { headers })
+            .then((res) => (Array.isArray(res.data?.values) ? res.data.values : []))
+            .catch((error) => {
+                const errorMessage = `Error fetching items for domain ${domain}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
     }
 }
 ```
@@ -75,9 +105,13 @@ class MyService {
 Key rules:
 - Constructor accepts an optional `AxiosInstance` (defaults to `axios.create()`)
 - Methods return promises directly — **no setter callbacks**
-- Errors use `Promise.reject(new Error(...))`, not thrown exceptions
-- Log errors with `console.error('%s', error)` (format-string style)
+- Resolve auth via `await getAuthHeaders()` and pass `{ headers }` to each request
+- Use `.then(...).catch(...)` chaining; on error log then `Promise.reject(new Error(...))`
+- Log errors in the format-string style: `console.error('%s', errorMessage, error)`
 - Encode user-supplied path segments with `encodeURIComponent`
+
+> Note: the older `CalmService` (`src/service/calm-service.tsx`) predates these
+> conventions and is not a clean template — prefer the services above.
 
 ### Service Testing Pattern
 

--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -5,14 +5,16 @@ This guide helps AI assistants work efficiently with the CALM Hub backend codeba
 ## Tech Stack
 
 - **Language**: Java 21
-- **Framework**: Quarkus 3.29+ (Reactive REST, CDI)
+- **Framework**: Quarkus 3.34+ (Reactive REST, CDI) — `quarkus.platform.version` is pinned to `3.34.2` in the root `pom.xml`
 - **Build Tool**: Maven (via parent POM)
 - **Databases**: 
   - MongoDB (production default)
   - NitriteDB (embedded, standalone mode)
 - **Testing**: JUnit 5, TestContainers
 - **API Docs**: OpenAPI/Swagger UI
-- **Security**: Keycloak integration (secure profile)
+- **Security**: Per-namespace permissions enforced via Quarkus Security (`org.finos.calm.security`); three auth modes — open (default), OIDC/Keycloak (`secure`), and proxy-injected header (`proxy-auth`)
+
+> **Note**: Netty is pinned to `4.1.x` (currently `4.1.132.Final` via `netty-bom` in the root `pom.xml`) to mitigate CVEs. It must stay on 4.1.x — Quarkus 3.x applies a `CleanerJava9` bytecode transformation incompatible with Netty 4.2.
 
 ## Key Commands
 
@@ -46,8 +48,12 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 ```
 src/
 ├── main/java/org/finos/calm/
-│   ├── resources/            # REST API endpoints
+│   ├── resources/            # REST API endpoints (namespace-scoped under /calm/...)
 │   ├── services/             # Business logic
+│   ├── security/             # Auth: CalmHubPermissionChecker, CalmHubScopes,
+│   │                         #   UserAccessValidator, NoAuthAuthenticationMechanism,
+│   │                         #   ProxyAuthenticationMechanism, ReadOnlyRequestFilter
+│   ├── mcp/                  # MCP server (@Tool classes under mcp/tools/)
 │   ├── store/                # Data access layer
 │   │   ├── interfaces        # Store abstractions
 │   │   ├── mongo/           # MongoDB implementations
@@ -60,21 +66,35 @@ src/
 ```
 
 ### REST API Pattern (Quarkus JAX-RS)
+
+Resources are **namespace-scoped** under `/calm/...`. `ArchitectureResource` and
+`NamespaceResource` both use `@Path("/calm/namespaces")` with sub-paths such as
+`{namespace}/architectures`. Endpoints are guarded with `@PermissionsAllowed`
+(e.g. `CalmHubScopes.READ` / `WRITE`).
+
 ```java
-@Path("/api/v1/architectures")
+@Path("/calm/namespaces")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ArchitectureResource {
-    
+
     @Inject
-    ArchitectureService service;
-    
+    ArchitectureStore store;
+
     @GET
-    public List<Architecture> listArchitectures() {
-        return service.findAll();
+    @Path("{namespace}/architectures")
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getArchitecturesForNamespace(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace
+    ) {
+        return Response.ok(new ValueWrapper<>(store.getArchitecturesForNamespace(namespace))).build();
     }
 }
 ```
+
+Resource types are not limited to architectures/patterns/controls — the `resources/`
+package also covers ADR, Decorator, Domain, Flow, Interface, Standard, Timeline,
+Search, and UserAccess (per-namespace and domain-level access grants).
 
 ### Storage Mode Selection
 
@@ -114,16 +134,38 @@ public class ArchitectureStoreProducer {
 }
 ```
 
-### Security Profiles
+### Security & Authorization
 
-**Default Profile** (no auth):
-- All endpoints open
-- Good for development
+Authorization is **per-namespace**, not role-flat. Entitlements are stored as
+`UserAccess` records (in the active store), each granting a user `read`, `write`,
+or `admin` action on a single namespace, plus a `global_admin` scope that applies
+across all namespaces. Scope constants live in
+`org.finos.calm.security.CalmHubScopes` (`READ`, `WRITE`, `ADMIN`,
+`DOMAIN_READ`, `DOMAIN_WRITE`, `GLOBAL_ADMIN`). Enforcement runs through Quarkus
+Security: `@PermissionsAllowed` on resource methods is resolved by
+`CalmHubPermissionChecker`, which consults `UserAccessValidator` against the
+caller's grants. See [PERMISSIONS.md](./PERMISSIONS.md) for the full model.
 
-**Secure Profile** (Keycloak):
-- OAuth2/OIDC authentication
-- Requires Keycloak running on https://localhost:9443
-- Self-signed certificates for local dev
+There are **three auth modes**, each selected by a separate property file:
+
+**Default** (open, no auth) — `application.properties`:
+- `quarkus.oidc.tenant-enabled=false`, `calm.auth.enabled` unset (permission checks pass)
+- All endpoints open; good for development
+
+**Secure** (OIDC / Keycloak) — `application-secure.properties`:
+- `quarkus.oidc.tenant-enabled=true`, `calm.auth.enabled=true`
+- `quarkus.oidc.auth-server-url=https://calm-hub.finos.org:9443/realms/calm-hub-realm`
+  (requires an `/etc/hosts` entry mapping `calm-hub.finos.org`; uses self-signed certs)
+- App serves SSL on port **8443** (`quarkus.http.ssl-port=8443`)
+
+**Proxy-auth** (proxy-injected header) — `application-proxy-auth.properties`:
+- `quarkus.oidc.enabled=false`, `calm.auth.enabled=true`
+- The upstream proxy injects the authenticated username in a header (default
+  `Remote-User`, overridable via `calm.security.proxy.username-header`), handled by
+  `ProxyAuthenticationMechanism` / `ProxyIdentityProvider`
+
+In the open default, `NoAuthAuthenticationMechanism` supplies an identity so
+permission checks pass without a token.
 
 ## Key Concepts
 
@@ -138,6 +180,25 @@ public class ArchitectureStoreProducer {
 2. Implement store interfaces
 3. Update Producer classes to inject and conditionally return new implementation
 4. Add mode to configuration documentation
+
+### MCP Server
+- An MCP server exposes CALM Hub operations as tools to AI clients
+- Tool classes live in `mcp/tools/` (~13 classes; the `*Tools` ones carry `@Tool` methods)
+- **Gated by `calm.mcp.enabled`** (default `false`): when disabled, every `@Tool`
+  method returns a disabled error, though the `/mcp` HTTP endpoint stays reachable
+- Enable with `-Dcalm.mcp.enabled=true` or `CALM_MCP_ENABLED=true`
+
+### Read-Only Deployment Mode
+- `calm.readonly=true` opens Nitrite with `readOnly(true)` and installs
+  `ReadOnlyRequestFilter`, which rejects mutating verbs (POST/PUT/PATCH/DELETE)
+  on `/calm/*` with `405 Method Not Allowed`
+- `build-readonly-image.sh` packages a static, pre-seeded read-only Docker image
+  (Maven package + stage `calm/` schemas and controls + build `Dockerfile.readonly-static`)
+
+### Local-Dev Nitrite Seeding
+- `nitrite/init-nitrite.sh` is the standard script for seeding a local Nitrite
+  database for standalone development; `nitrite/seed-readonly.sh` seeds the
+  read-only variant
 
 ### Integration Tests
 - Located in `src/integration-test/java/`
@@ -161,7 +222,7 @@ public class ArchitectureStoreProducer {
 ../mvnw clean verify -Ddependency-check.skip=true
 ```
 
-**Exclusions**: Classes in `**/domain/**/*`, `**/*Constants.*`, `**/CalmHubScopes.*`, and `**/LogSanitizationPolicy.*` are excluded from the coverage check.
+**Exclusions** (from `pom.xml`): `**/*Builder.*`, `**/*CalmResourceErrorResponses.*`, `**/*Constants.*`, `**/*NamespaceStandardSummary.*`, `**/*ArchitectureRequest.*`, `**/config/**/*`, and `**/domain/**/*` are excluded from the coverage check.
 
 If coverage drops below 90% for a class you've modified, add tests for uncovered error paths (catch blocks, edge cases) until the threshold is met. Check the JaCoCo report at `target/site/jacoco/` for details on uncovered lines.
 
@@ -305,17 +366,21 @@ private static final int PATTERN_ID = 42;
 
 ### Secure Mode Development
 1. Generate certificates (see README.md)
-2. Start Keycloak: `cd keycloak-dev && docker-compose up`
-3. Login to Keycloak: https://localhost:9443 (admin/password)
-4. Switch to `calm-hub-realm`
-5. Use `demo` user for testing
-6. Run app: `../mvnw quarkus:dev -Dquarkus.profile=secure`
+2. Add an `/etc/hosts` entry mapping `calm-hub.finos.org` to localhost (the OIDC
+   `auth-server-url` uses this hostname, not `localhost`)
+3. Start Keycloak: `cd keycloak-dev && docker-compose up`
+4. Login to Keycloak: https://calm-hub.finos.org:9443 (admin/password)
+5. Switch to `calm-hub-realm`
+6. Use `demo` user for testing
+7. Run app: `../mvnw quarkus:dev -Dquarkus.profile=secure` (serves SSL on port 8443)
 
 ## Configuration Files
 
 - `pom.xml` - Maven dependencies and build config
-- `src/main/resources/application.properties` - Default config
-- `src/main/resources/application-secure.properties` - Secure profile config
+- `src/main/resources/application.properties` - Default (open) config
+- `src/main/resources/application-secure.properties` - Secure (OIDC/Keycloak) profile config
+- `src/main/resources/application-proxy-auth.properties` - Proxy-auth profile config (proxy-injected `Remote-User` header)
+- `PERMISSIONS.md` - Per-namespace permission model reference
 
 ## Dependencies on Other Packages
 

--- a/calm-plugins/vscode/AGENTS.md
+++ b/calm-plugins/vscode/AGENTS.md
@@ -25,6 +25,10 @@ npm run lint --workspace calm-plugins/vscode           # ESLint check
 npm run lint-fix --workspace calm-plugins/vscode       # Auto-fix linting issues
 npm run package --workspace calm-plugins/vscode        # Create .vsix package for distribution
 
+# Convenience scripts (run the build:shared prerequisite for you)
+npm run test:vscode                                    # build:shared + test the extension
+npm run package:vscode                                 # build:shared + package the extension
+
 # Testing Extension in VSCode
 # 1. Open the repository root in VSCode (File → Open Folder)
 # 2. Use the "calm-plugin: watch" task or run: npm run watch --workspace calm-plugins/vscode
@@ -63,15 +67,19 @@ src/
 │
 ├── core/                           # Framework-free business logic
 │   ├── ports/                      # Interfaces for dependency inversion
-│   ├── services/                   # Core services (refresh, selection, watch, navigation)
-│   ├── mediators/                  # Cross-cutting coordinators
+│   ├── services/                   # Core services (model, config, navigation, diagnostics, calm-schema-registry, logging)
+│   ├── mediators/                  # Cross-cutting coordinators (refresh, selection, watch, store-reaction)
 │   └── emitter.ts                 # Event system (framework-free)
 │
 ├── features/                       # Feature modules
 │   ├── tree-view/                 # Sidebar tree navigation
-│   │   └── view-model/           # MVVM presentation logic
+│   │   ├── tree-view-factory.ts  # Wires view + view-model
+│   │   ├── view/                 # VSCode-specific view (tree-view.ts, tree-item.ts)
+│   │   └── view-model/           # MVVM presentation logic (framework-free)
 │   ├── editor/                    # Editor integration (hover, CodeLens)
 │   └── preview/                   # Webview preview panel
+│       ├── webview/              # Webview internals (mermaid-renderer, pan-zoom-manager,
+│       │                         #   diagram-controls, panel.view)
 │       ├── docify-tab/           # Documentation generation
 │       ├── model-tab/            # Model data display
 │       └── template-tab/         # Template processing & live mode
@@ -94,6 +102,10 @@ src/
 
 **Store Location**: `src/application-store.ts`
 
+The store is created via the `createApplicationStore()` factory (using Zustand's
+`subscribeWithSelector` middleware), not a module-level `create()` singleton. The
+extension controller owns the instance and injects it where needed.
+
 ```typescript
 interface ApplicationStore {
     calmModel: CalmModel | null;
@@ -108,13 +120,17 @@ interface ApplicationStore {
 }
 ```
 
-**Usage**:
+**Usage** (illustrative — the real store is a per-instance object created by the factory):
 ```typescript
-import { useApplicationStore } from './application-store';
+import { createApplicationStore } from './application-store';
 
-// In ViewModels or components
-const model = useApplicationStore(state => state.calmModel);
-const setModel = useApplicationStore(state => state.setCalmModel);
+const store = createApplicationStore();
+
+// Read with a selector
+const model = store.getState().calmModel;
+
+// React to changes (subscribeWithSelector)
+store.subscribe(state => state.calmModel, model => { /* ... */ });
 ```
 
 ### MVVM Pattern
@@ -180,7 +196,9 @@ export class StoreReactionMediator {
 - **Purpose**: Sidebar navigation of CALM model structure
 - **Location**: `src/features/tree-view/`
 - **Key Files**:
-  - `tree-data-provider.ts` - VSCode TreeDataProvider
+  - `view/tree-view.ts` - VSCode TreeDataProvider implementation
+  - `view/tree-item.ts` - VSCode TreeItem wrapper
+  - `tree-view-factory.ts` - Wires the view and view-model together
   - `view-model/tree-view-model.ts` - Business logic (framework-free)
 
 #### Validation Service
@@ -213,7 +231,7 @@ export class StoreReactionMediator {
 
 ### Test Structure
 - `*.spec.ts` - Unit tests alongside source
-- `test-architectures/` - Sample CALM files for testing
+- `test_fixtures/` - Sample CALM files for testing (`architecture/`, `navigable-architecture/`)
 
 ### Running Tests
 ```bash
@@ -278,17 +296,21 @@ export function activate(context: vscode.ExtensionContext) {
 
 ### Adding State to Store
 
-1. Update `src/application-store.ts`:
+1. Update `src/application-store.ts` (add to the interface and the `createApplicationStore` factory):
 ```typescript
 interface ApplicationStore {
     myNewState: string;
     setMyNewState: (value: string) => void;
 }
 
-export const useApplicationStore = create<ApplicationStore>((set) => ({
-    myNewState: '',
-    setMyNewState: (value) => set({ myNewState: value }),
-}));
+export function createApplicationStore(): ApplicationStoreApi {
+    return createStore<ApplicationStore>()(
+        subscribeWithSelector((set) => ({
+            myNewState: '',
+            setMyNewState: (value) => set({ myNewState: value }),
+        }))
+    );
+}
 ```
 
 ### Creating a New ViewModel
@@ -344,14 +366,21 @@ npm run build --workspace calm-widgets
 npm run build --workspace shared
 ```
 
-## Bundled CALM Schemas
+## Bundled Assets
 
-The extension bundles CALM schemas from the `calm/` directory at the repository root. This allows validation to work without network access.
+The extension bundles CALM schemas, widgets, and template bundles into `dist/` at build
+time so validation, rendering, and templating work without network access or reaching into
+sibling workspaces at runtime.
 
 ### Build Process
-The `postbuild` script (`scripts/copy-calm-schemas.js`) copies schemas from:
-- `calm/release/*/meta/*.json` → `dist/calm/release/*/meta/`
-- `calm/draft/*/meta/*.json` → `dist/calm/draft/*/meta/`
+The `postbuild` step does two things:
+
+1. **`copyfiles`** copies CALM schemas from the repo root:
+   - `calm/release/**/meta/*` → `dist/calm/release/...`
+   - `calm/draft/**/meta/*` → `dist/calm/draft/...`
+2. **`scripts/copy-calm-assets.js`** copies the remaining runtime assets:
+   - widgets from `calm-widgets/dist/cli/widgets` (falls back to `calm-widgets/src/widgets`) → `dist/widgets/`
+   - template bundles from `shared/dist/template-bundles` → `dist/template-bundles/`
 
 Schemas are indexed by their `$id` field for lookup when validating documents.
 
@@ -402,7 +431,8 @@ When new CALM schema versions are released:
 
 ```bash
 # From repository root
-npm run package --workspace calm-plugins/vscode        # Creates .vsix file
+npm run package:vscode                                 # build:shared + creates .vsix file
+# (or, if dependencies are already built: npm run package --workspace calm-plugins/vscode)
 # Then publish to VS Code Marketplace via GitHub Actions
 ```
 

--- a/calm-plugins/vscode/screenshots/AGENTS.md
+++ b/calm-plugins/vscode/screenshots/AGENTS.md
@@ -27,6 +27,7 @@ npm --prefix calm-plugins/vscode/screenshots run test
 # Static checks (run in CI)
 npm --prefix calm-plugins/vscode/screenshots run typecheck
 npm --prefix calm-plugins/vscode/screenshots run lint
+npm --prefix calm-plugins/vscode/screenshots run lint-fix   # Auto-fix lint issues
 ```
 
 The extension must be built first. The orchestrator will fail with a helpful message if `calm-plugins/vscode/dist/extension.js` is missing.

--- a/calm-server/AGENTS.md
+++ b/calm-server/AGENTS.md
@@ -18,13 +18,13 @@ calm-server/
 ├── src/
 │   ├── index.ts                    # Entry point, CLI argument parsing
 │   ├── server/
-│   │   ├── cli-server.ts           # Express server startup
+│   │   ├── server.ts               # Express server startup
 │   │   └── routes/
 │   │       ├── routes.ts           # Router setup
 │   │       ├── health-route.ts     # Health check endpoint
 │   │       └── validation-route.ts # Architecture validation endpoint
 │   └── *.spec.ts                   # Unit tests
-├── dist/
+├── dist/                           # (generated) build output
 │   ├── index.js                    # Compiled executable
 │   └── calm/                       # Bundled CALM schemas
 │       ├── release/                # Released schema versions
@@ -44,7 +44,7 @@ calm-server/
 npm run build:calm-server
 ```
 
-This builds the TypeScript code and copies all CALM schemas from `calm/release` and `calm/draft` into `dist/calm/`.
+This builds the TypeScript code and copies the CALM meta schemas (the `**/meta/*` files) from `calm/release` and `calm/draft` into `dist/calm/`.
 
 ### Run the server locally
 ```bash
@@ -137,7 +137,7 @@ curl -X POST http://localhost:3000/calm/validate \
 
 The calm-server implementation mirrors the server functionality from the CLI package (`cli/src/server/`):
 
-- `src/server/cli-server.ts` - Express server setup
+- `src/server/server.ts` - Express server setup
 - `src/server/routes/routes.ts` - Route configuration
 - `src/server/routes/health-route.ts` - Health check
 - `src/server/routes/validation-route.ts` - Architecture validation

--- a/calm-suite/calm-guard/AGENTS.md
+++ b/calm-suite/calm-guard/AGENTS.md
@@ -10,13 +10,13 @@ Built for the DTCC/FINOS Innovate.DTCC AI Hackathon (Feb 23-27, 2026).
 
 | Layer | Choice | Notes |
 |-------|--------|-------|
-| Framework | Next.js 14+ (App Router) | `src/app/` routing, API routes for SSE |
+| Framework | Next.js 15 (App Router, Turbopack) | `src/app/` routing, API routes for SSE |
 | Package Manager | npm (workspaces) | CalmGuard is a workspace of the monorepo root. Run `npm` commands from the repo root or use `--workspace=calmguard`. The docs sub-package is `calmguard-docs`. |
 | Language | TypeScript (strict mode) | No `any` types. Use Zod for runtime validation |
 | LLM SDK | Vercel AI SDK (`ai`) | `generateObject` with Zod schemas for all agent outputs |
-| Default LLM | Google Gemini | `@ai-sdk/google`. Multi-provider: also supports Anthropic, OpenAI, Ollama, Grok |
+| Default LLM | Google Gemini | `@ai-sdk/google`. Multi-provider: also supports Anthropic, OpenAI, xAI/Grok |
 | UI | shadcn/ui + Tailwind CSS | Dark theme (slate palette). Components in `src/components/ui/` |
-| Visualization | React Flow | Architecture graphs. Custom nodes per CALM node-type |
+| Visualization | React Flow (`@xyflow/react`) | Architecture graphs. Custom nodes per CALM node-type |
 | Charts | Recharts | Compliance gauges, heat maps |
 | State | Zustand | Single store in `src/store/analysis-store.ts` |
 | Validation | Zod | Schema validation for CALM parsing AND agent outputs |
@@ -24,9 +24,9 @@ Built for the DTCC/FINOS Innovate.DTCC AI Hackathon (Feb 23-27, 2026).
 | Skills | Markdown files in `skills/` | Compliance knowledge injected into agent prompts |
 | Deployment | Vercel | Zero-config Next.js deployment |
 
-## CALM Schema Reference (v1.1)
+## CALM Schema Reference (v1.2)
 
-Source: `https://github.com/finos/architecture-as-code` (CALM release 1.1)
+Source: `https://github.com/finos/architecture-as-code` (CALM release 1.2)
 
 ### Core Entities
 
@@ -59,7 +59,7 @@ Source: `https://github.com/finos/architecture-as-code` (CALM release 1.1)
 ### Agent Pattern
 Each agent in `src/lib/agents/` follows this pattern:
 1. Loads config from YAML definition in `agents/`
-2. Loads skills from `skills/*.md` via skill loader
+2. Loads skills from the skills markdown files (`skills/*.md`) via the skill loader (`src/lib/skills/loader.ts`)
 3. Calls Vercel AI SDK `generateObject` with Zod output schema
 4. Emits typed `AgentEvent`s via SSE event emitter
 5. Returns structured result matching its Zod schema
@@ -70,10 +70,34 @@ Each agent in `src/lib/agents/` follows this pattern:
 - Client connects via `EventSource` hook in `src/hooks/use-agent-stream.ts`
 - Events flow: Agent → EventEmitter → SSE Route → EventSource → Zustand Store → React Components
 
+### Agents
+Seven agents (YAML in `agents/`, implementations in `src/lib/agents/`):
+- **orchestrator** — coordinates the run and aggregates results
+- **architecture-analyzer** — parses and analyzes the CALM model
+- **compliance-mapper** — maps controls to frameworks (SOX, PCI-DSS, NIST-CSF, ...)
+- **pipeline-generator** — generates CI/CD pipeline configs
+- **cloud-infra-generator** — generates IaC / cloud infrastructure config
+- **risk-scorer** — produces aggregate risk assessment
+- **calm-remediator** — proposes CALM model remediations (merged via `remediation-merge.ts`)
+
 ### Orchestration
-- Phase 1: Architecture Analyzer + Compliance Mapper + Pipeline Generator run in parallel (`Promise.all`)
-- Phase 2: Risk Scorer runs sequentially on aggregated Phase 1 results
+- Phase 1 (parallel, `Promise.allSettled` for graceful degradation): Architecture Analyzer + Compliance Mapper + Pipeline Generator + Cloud Infra Generator
+- Phase 2 (sequential): Risk Scorer runs on aggregated Phase 1 results
+- The CALM Remediator runs as a separate remediation flow
 - All events stream to dashboard in real-time
+
+### GitHub / GitOps Integration
+- `src/lib/github/` plus API routes under `src/app/api/github/` (`fetch-calm`, `create-pr`, `status`)
+- Fetches CALM models directly from GitHub repos, and opens pull requests with remediated CALM
+- Surfaced in the UI via `gitops-card.tsx`
+
+### Learning Subsystem
+- `src/lib/learning/` stores and replays learned compliance patterns/insights, injected into agent runs (the orchestrator pre-checks the learning store)
+- Exposed via the `dashboard/learning` and `dashboard/squad` routes
+
+### CALM CLI Validation
+- Uses the `@finos/calm-cli` dependency via `src/lib/calm/cli-validator.ts`
+- Exposed through the `src/app/api/calm/validate` route to validate CALM input against the official schema
 
 ## File Organization
 
@@ -83,12 +107,14 @@ src/
     api/                        # Backend API routes (SSE streaming, CALM parsing)
     dashboard/                  # Dashboard pages
   lib/                          # Core business logic (framework-agnostic)
-    calm/                       # CALM parsing, types, validation
     agents/                     # Agent implementations, orchestrator, registry
     ai/                         # AI SDK provider setup, streaming utilities
-    skills/                     # SKILL.md loader
-    compliance/                 # Framework definitions, control mapping, scoring
-    pipeline/                   # GitHub Actions, security scanning, IaC generation
+    api/                        # Shared API helpers
+    calm/                       # CALM parsing, types, validation, CLI validator
+    github/                     # GitHub/GitOps integration (fetch CALM, create PR, status)
+    learning/                   # Learning subsystem (compliance pattern store)
+    report/                     # Report generation
+    skills/                     # Skill loader (markdown files live in top-level skills/)
   components/
     ui/                         # shadcn/ui base components (do not modify)
     dashboard/                  # Dashboard-specific components
@@ -96,7 +122,7 @@ src/
   hooks/                        # React hooks (SSE, CALM parser, compliance)
   store/                        # Zustand store
 agents/                         # YAML agent definitions (AOF-inspired)
-skills/                         # SKILL.md compliance knowledge files
+skills/                         # Compliance knowledge markdown files (e.g. SOX.md, PCI-DSS.md, NIST-CSF.md)
 examples/                       # Demo CALM architecture JSON files
 ```
 
@@ -161,11 +187,11 @@ OPENAI_API_KEY=                 # OpenAI (optional)
 
 ## Important References
 
-- CALM Schema 1.1: https://github.com/finos/architecture-as-code/tree/main/calm/release/1.1
+- CALM Schema 1.2: https://github.com/finos/architecture-as-code/tree/main/calm/release/1.2
 - CALM CLI: https://github.com/finos/architecture-as-code/tree/main/cli
 - CALM AI module: https://github.com/finos/architecture-as-code/tree/main/calm-ai
 - Vercel AI SDK: https://sdk.vercel.ai/docs
-- React Flow: https://reactflow.dev
+- React Flow (`@xyflow/react`): https://reactflow.dev
 - shadcn/ui: https://ui.shadcn.com
 
 ## Git Workflow

--- a/calm-suite/calm-studio/AGENTS.md
+++ b/calm-suite/calm-studio/AGENTS.md
@@ -39,7 +39,7 @@ All output must conform to CALM 1.2. These are non-negotiable:
 { "unique-id": "...", "relationship-type": { "options": [ ... ] } }
 ```
 
-The legacy flat shape (`'relationship-type': 'connects'` + sibling `source`/`destination` strings) is **not valid CALM 1.2** and was removed in #2550. Use the variant accessors `getRelationshipVariant`, `getConnectsEndpoints`, `getContainerAndNodes`, `getActorAndNodes`, `getReferencedNodeIds` from `@calmstudio/calm-core` to traverse relationships generically.
+The flat shape (`'relationship-type': 'connects'` + sibling `source`/`destination` strings) was a **local CalmStudio divergence** — it has **never** been valid in any published CALM release. The nested `relationship-type` object above is canonical across CALM 1.0/1.1/1.2 (identical in `calm/release/1.1/meta/core.json` and `calm/release/1.2/meta/core.json`); CalmStudio was brought onto it in #2550/#2553. Use the variant accessors `getRelationshipVariant`, `getConnectsEndpoints`, `getContainerAndNodes`, `getActorAndNodes`, `getReferencedNodeIds` from `@calmstudio/calm-core` to traverse relationships generically.
 
 **Protocols:** `HTTP`, `HTTPS`, `FTP`, `SFTP`, `JDBC`, `WebSocket`, `SocketIO`, `LDAP`, `AMQP`, `TLS`, `mTLS`, `TCP`
 

--- a/calm-suite/calm-studio/AGENTS.md
+++ b/calm-suite/calm-studio/AGENTS.md
@@ -4,10 +4,13 @@ Visual CALM architecture editor. SvelteKit (Svelte 5), TypeScript strict, npm wo
 
 ## Structure
 - `packages/calm-core/` — CALM types, validation
-- `packages/extensions/` — Node type packs (core, fluxnova, ai, aws, gcp, azure, k8s)
+- `packages/extensions/` — Node type packs (core, fluxnova, ai, aws, gcp, azure, k8s, messaging, identity, opengris)
 - `packages/calmscript/` — DSL compiler
-- `packages/mcp-server/` — MCP server (21 tools)
-- `apps/studio/src/lib/` — canvas, editor, io, layout, palette, properties, stores, validation, governance, templates
+- `packages/mcp-server/` — MCP server (20 tools)
+- `packages/github-action/` — GitHub Action build target
+- `packages/vscode-extension/` — VSCode extension build target
+- `packages/web-component/` — embeddable web component build target
+- `apps/studio/src/lib/` — canvas, editor, io, layout, palette, properties, stores, validation, governance, templates (also c4, desktop, search, toolbar; list illustrative)
 
 ## Commands
 `npm run dev --workspace=@calmstudio/studio` | `npm run build --workspace=@calmstudio/studio` | `npm run test --workspace=@calmstudio/studio` | `npm run typecheck --workspace=@calmstudio/studio` (from repo root)

--- a/calm-widgets/AGENTS.md
+++ b/calm-widgets/AGENTS.md
@@ -8,7 +8,7 @@ CALM Widgets is a TypeScript widget system built on Handlebars that provides reu
 
 ## Tech Stack
 
-- **Language**: TypeScript 5.x
+- **Language**: TypeScript (compiler provided by the monorepo root, not pinned in this package)
 - **Template Engine**: Handlebars
 - **Build Tool**: tsup (esbuild-based)
 - **Test Framework**: Vitest
@@ -37,11 +37,12 @@ calm-widgets/
 │   ├── widget-logger.ts            # Configurable logging for debugging
 │   ├── widgets/                    # Widget implementations
 │   │   ├── table/                  # Table widget
-│   │   │   ├── index.ts            # Logic & transformToViewModel
-│   │   │   ├── index.spec.ts       # Unit tests
-│   │   │   ├── table-template.html # Horizontal table template
-│   │   │   ├── table-vertical.html # Vertical table template
-│   │   │   └── row-template.html   # Row rendering (recursive)
+│   │   │   ├── index.ts             # Logic & transformToViewModel
+│   │   │   ├── index.spec.ts        # Unit tests
+│   │   │   ├── table-template.html  # Dispatcher (branches on isNested/isVertical)
+│   │   │   ├── table-horizontal.html # Horizontal table template
+│   │   │   ├── table-vertical.html  # Vertical table template
+│   │   │   └── row-template.html    # Row rendering (recursive)
 │   │   ├── list/                   # List widget
 │   │   ├── json-viewer/            # JSON display widget
 │   │   ├── flow-sequence/          # Mermaid sequence diagrams
@@ -63,26 +64,49 @@ calm-widgets/
 
 ### Widget Structure
 
-Each widget follows a consistent pattern:
+Each widget implements the `CalmWidget<TContext, TOptions, TViewModel>` interface
+(see `src/types.ts`):
 
 ```typescript
-export const MyWidget: WidgetDefinition = {
-    name: 'my-widget',
-    templatePath: path.join(__dirname, 'template.html'),
-    
-    // Transform raw data into view model
-    transformToViewModel(context: unknown, options: WidgetOptions): ViewModel {
+export const MyWidget: CalmWidget<MyContext, MyOptions, MyViewModel> = {
+    id: 'my-widget',                 // helper name used in templates
+    templatePartial: 'template.html', // main template file (relative to widget folder)
+    partials: ['row-template.html'], // optional extra partials to register
+
+    // Optional: register widget-scoped Handlebars helpers
+    registerHelpers: () => ({
+        myHelper: (value: unknown) => String(value),
+    }),
+
+    // Optional: transform raw context into the view model the template consumes
+    transformToViewModel: (context, options) => {
         // Process context, apply options, return structured data
-    }
+        return { /* view model */ };
+    },
+
+    // REQUIRED: type-guard validating the incoming context
+    validateContext: (context): context is MyContext => {
+        return typeof context === 'object' && context !== null;
+    },
 };
 ```
 
+Key points:
+- `id` is the Handlebars helper name (e.g. `{{my-widget ...}}`), not `name`.
+- `templatePartial` names the main template file (resolved against the widget
+  folder), not a `templatePath`.
+- `partials` lists any additional partial templates to register.
+- `validateContext` is **required** — it is a type-guard that gates rendering.
+- `registerHelpers` and `transformToViewModel` are optional. Widgets such as
+  `related-nodes` and `block-architecture` use `registerHelpers`/`partials`.
+
 ### Template System
 
-Widgets use Handlebars templates with HTML output:
-- Templates are HTML files in the widget directory
-- Templates can call other widgets via Handlebars helpers
-- Output is rendered into Markdown-compatible HTML
+Widgets use Handlebars templates rendered to HTML/Markdown:
+- Each widget folder holds its template(s) plus any partials.
+- Templates can call other widgets via Handlebars helpers.
+- Template extensions are mixed: `flow-sequence`, `related-nodes`, and
+  `block-architecture` use `.hbs`; `table`, `list`, and `json-viewer` use `.html`.
 
 ## Key Concepts
 
@@ -246,12 +270,15 @@ npm run build --workspace calm-widgets
 ## Adding a New Widget
 
 1. Create directory: `src/widgets/my-widget/`
-2. Create `index.ts` with `WidgetDefinition`
-3. Create template file(s): `template.html`
+2. Create `index.ts` exporting a `CalmWidget` (include the required `validateContext`)
+3. Create template file(s), e.g. `template.html` (or `.hbs`), plus any partials
 4. Create tests: `index.spec.ts`
 5. Export from `src/index.ts`
-6. Add test fixtures in `test-fixtures/my-widget/`
-7. Document in `README.md`
+6. **Register the widget** in `widget-engine.ts` `registerDefaultWidgets()` —
+   add `{ widget: MyWidget, folder: __dirname + '/widgets/my-widget' }`.
+   A widget is not usable until it is registered here.
+7. Add test fixtures in `test-fixtures/my-widget/`
+8. Document in `README.md`
 
 ## Useful Links
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -43,37 +43,57 @@ npm run copy-ai-tools         # Copy AI agent files from ../calm-ai/
 ## Architecture Overview
 
 ### Entry Point & Command Structure
-- **Entry**: `src/index.ts` - Sets up Commander.js and registers commands
-- **Commands**: `src/cli.ts` - Main command implementations
-- **Pattern**: Each command is a separate function (generateArchitecture, validateArchitecture, etc.)
+- **Entry**: `src/index.ts` - Thin (~13-line) bin bootstrap. Imports Commander's `program`, calls `setupCLI(program)`, then `program.parseAsync(...)`. No command definitions live here.
+- **Commands**: `src/cli.ts` - Exports `setupCLI(program)`, which registers every command and its options/actions. This is where all command wiring lives.
+- **Pattern**: Each command is registered inline in `setupCLI`; the heavier action logic is dynamically imported from `src/command-helpers/` (see below).
 
 ### Key Commands
 1. **generate** - Generate architecture from CALM pattern
-2. **validate** - Validate architecture against pattern
+2. **validate** - Validate a CALM document (architecture, pattern, and/or timeline) against schemas
 3. **init-ai** - Install AI Assistant support for CALM
 4. **template** - Generate files from Handlebars templates
 5. **docify** - Generate documentation websites (supports `--scaffold` for two-stage workflow)
+6. **diff** - Compare two CALM documents (architectures or patterns), or adjacent/explicit moments of a CALM timeline, and report what changed. Supports `--exit-code` to gate CI on detected changes.
+7. **timeline** - Synthesise an implied CALM timeline from a set of local versioned architecture files (one moment per input).
+8. **init-config** - Create or update the CLI configuration file (`~/.calm.json`), e.g. allowed remote hosts and CALM Hub URL.
+9. **hub** - Command **group** for interacting with CALM Hub. Subcommands:
+   - `hub push <resource> <file>` / `hub pull <resource>` / `hub list <resources>` / `hub create <resource>`
+   - Resources span architectures, patterns, standards, control-requirements, control-configurations, namespaces, and domains (which subcommands exist varies per verb).
 
 ### Important Directories
 ```
 src/
-├── cli.ts                    # Main command implementations
-├── cli-config.ts             # Configuration helpers
-├── index.ts                  # Entry point
-├── command-helpers/          # Shared utilities for commands
+├── cli.ts                    # setupCLI: registers all commands, options, and actions
+├── cli-config.ts             # Configuration helpers (~/.calm.json loading/saving)
+├── index.ts                  # Thin bin bootstrap (calls setupCLI + parseAsync)
+├── command-helpers/          # Action logic for commands (see below)
 └── test_helpers/             # Test utilities
 ```
+
+The `command-helpers/` directory now holds the substantial per-command logic that
+`cli.ts` dynamically imports:
+- `diff.ts` - document and timeline diffing
+- `timeline.ts` - timeline synthesis
+- `hub-commands.ts` - CALM Hub push/pull/list/create implementations
+- `hub-output.ts` - formatting of Hub command output
+- `template.ts` - template processing helpers (e.g. URL-to-local-file mapping)
+- `validate.ts` - validation option checks and execution
+- `generate-options.ts` - interactive/option-choice handling for `generate`
+- `ai-tools.ts` - `init-ai` provider setup
 
 ### Build Artifacts
 After `npm run build`, the `dist/` directory contains:
 ```
 dist/
 ├── index.js              # Compiled CLI entry point (bin)
-├── calm/release/         # Copied CALM schemas
+├── calm/                 # Copied CALM meta schemas only (release + draft **/meta/* files)
 ├── calm-ai/              # Copied AI agent files
 ├── template-bundles/     # Copied docify templates
-└── cli/widgets/          # Copied widget files
+└── widgets/              # Copied widget files (copy-widgets uses --up 4)
 ```
+
+Note: `copy-calm-schema` only bundles `**/meta/*` files (not every CALM schema)
+into `dist/calm/`.
 
 ## Key Concepts
 
@@ -88,7 +108,7 @@ dist/
 - Supports both file paths and URLs for pattern/architecture files
 
 ### Verbose Mode
-- All commands support `-v, --verbose` flag
+- Most top-level commands support `-v, --verbose` (generate, validate, template, docify, init-ai, diff, timeline). `init-config` and the `hub` subcommands do not.
 - Use for debugging command execution
 
 ### Configuration

--- a/shared/AGENTS.md
+++ b/shared/AGENTS.md
@@ -10,7 +10,7 @@ The `shared` package contains common utilities, helpers, and core logic used acr
 
 ## Critical Development Rules
 
-Also include all rules from [../AGENTS.md](the root level AGENTS.md.)
+Also include all rules from [the root level AGENTS.md](../AGENTS.md).
 
 ### 1. Impact Analysis
 **WARNING**: Changes in this package affect multiple downstream projects.
@@ -26,6 +26,9 @@ Because this is a shared library, rigorous testing is mandatory.
 # Run tests for this package only (from repository root)
 npm test --workspace shared
 
+# Build shared (+ deps) then run its tests in one step
+npm run test:shared
+
 # Run tests for ALL packages (REQUIRED before PR)
 npm test
 
@@ -35,14 +38,19 @@ npx vitest run ${TEST FILE}
 
 ## Key Components
 
-- **Document Loader**: Strategies for loading CALM documents (FileSystem, MultiStrategy).
-- **Template Processor**: Handlebars-based template generation logic.
-- **Model Visitors**: Visitor pattern implementations for traversing CALM models.
-- **Validation**: Core validation logic (Spectral integration) and output enrichment.
-  - `runValidation()` - Main validation function used by CLI and VSCode
+- **Document Loader** (`document-loader/`): Strategies for loading CALM documents — FileSystem, MultiStrategy, plus CalmHub, direct-URL, and mapped loaders.
+- **Template Processor** (`template/`): Handlebars-based template generation logic.
+- **Model Visitors** (`model-visitor/`): Visitor pattern implementations for traversing CALM models.
+- **Validation** (`commands/validate/`, `spectral/`): Core validation logic (Spectral integration) and output enrichment.
+  - `validate()` - Main validation function (`commands/validate/validate.ts`) used by CLI and VSCode
   - `enrichWithDocumentPositions()` - Adds precise line/character positions to validation output using `@stoplight/json`
   - `parseDocumentWithPositions()` - Parses JSON/YAML with position tracking for error location
-- **Schema Directory**: Registry of bundled CALM schemas, used for lookup by schema URL.
+- **Schema Directory** (`schema-directory.ts`): Registry of bundled CALM schemas, used for lookup by schema URL (`getSchema`).
+- **Docify** (`docify/`): Documentation generator (`docifier`) with C4/relationship graphing (`docify/graphing`) and template bundles (`docify/template-bundles`, e.g. `ants`, `docusaurus`).
+- **Resolver** (`resolver/`): CALM reference resolver plus the network-addressable extractor and validator.
+- **Hub Client** (`hub/`): `calm-hub-client` for talking to CALM Hub.
+- **View Model** (`view-model/`): ADR (Architecture Decision Record) view-model logic.
+- **Auth** (`auth/`): Auth plugin abstraction (`auth-plugin`, `no-auth-plugin`).
 
 ## Common Workflows
 
@@ -52,7 +60,19 @@ npx vitest run ${TEST FILE}
 ```bash
 # Build this package (from repository root)
 npm run build --workspace shared
+
+# Build shared and its TypeScript dependencies (calm-models + calm-widgets + shared)
+npm run build:shared
 ```
+
+This package builds with `tsc` (not tsup/esbuild): `tsc -p ./tsconfig.build.json` followed by the
+`copy:docify-template-bundle` post-build step (`scripts/copy-templates.mjs`), which copies the docify
+template bundles into `dist`.
+
+#### Build configuration
+`tsconfig.build.json` is the production build config. It enables `"strict": true` and **excludes** spec
+files (`**/*.spec.ts`) and `src/docify/**`. This means specs and the `docify/` module are not strictly
+type-checked, but **all other new code must compile under strict mode**.
 
 ### Testing Changes
 1. Make changes in `shared/src/...`


### PR DESCRIPTION
## Description
Refreshes the CALM monorepo's AI-assistant guides (`AGENTS.md`, aliased by `CLAUDE.md`) so they match the current codebase. Two parts:

**1. Root `AGENTS.md`** — documents the previously-missing `calm-suite/` products (CalmStudio + CALMGuard) and `calm-server`; adds a `calm-suite/` nested-workspaces section; updates the tech-stack and package-guide links; and corrects stale config facts (`.nvmrc` → `22.22.2`, `@types/node` override → `^22.19.15`).

**2. Every per-package `AGENTS.md`** — audited against the live code and corrected. Highlights:

| File | Key corrections |
|---|---|
| `cli/` | entry-point description; add `diff`/`timeline`/`init-config`/`hub` commands; widgets dist path; verbose claim |
| `calm-hub/` | rewrite security for per-namespace `UserAccess` + Quarkus Security (default/secure/proxy-auth); REST path; JaCoCo excludes; Quarkus 3.34; MCP server + read-only mode |
| `calm-hub-ui/` | drop non-existent `react-oidc-context`; `start` script; real reference service; visualizer/diff/embedded-build |
| `calm-server/` | `cli-server.ts` → `server.ts`; meta-schema copy wording |
| `calm-widgets/` | `WidgetDefinition` → `CalmWidget` (`id`/`templatePartial`/`validateContext`); `table-horizontal.html`; registration step |
| `shared/` | `tsc` (not tsup) + strict `tsconfig.build.json`; `runValidation` → `validate`; docify/resolver/hub/view-model |
| `advent-of-calm/` | real day template; `day-24` exists; preview URL; Astro 6; website not a root workspace |
| `calm-plugins/vscode/` | `copy-calm-assets.js`; mediators vs services; `test_fixtures/` |
| `calm-suite/calm-studio/` | 20 MCP tools; 10 extension packs; add omitted workspaces |
| `calm-suite/calm-guard/` | Next.js 15; real lib dirs; drop Ollama; align to CALM 1.2; github/learning/remediation features |

`calm-plugins/vscode/screenshots/AGENTS.md` was already accurate (one trivial addition).

Closes #2587

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] CLI (`cli/`)
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)
- [x] CALM Server (`calm-server/`)
- [x] CALM Widgets (`calm-widgets/`)
- [x] Documentation (`docs/` — and root + every package `AGENTS.md`)
- [x] Shared (`shared/`)
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [x] Other: `calm-suite/` (CalmStudio + CALMGuard), `advent-of-calm/`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Documentation-only change. Each claim was verified against the live code (package.json scripts, source files, config, directory listings via `git ls-files`); only git-tracked state was trusted (untracked local build artefacts ignored). Confirmed every cross-linked `AGENTS.md` target exists and no internal anchors broke. No code paths affected; no markdown linter in CI.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable) <!-- N/A — documentation only -->
- [x] My changes follow the project's coding standards

---

### Notes for reviewers
- Scope grew from the original root-file fix to a full per-package audit (requested). All in this single PR, tracked by #2587.
- `calm-suite/calm-studio` and `calm-suite/calm-guard` are recently-contributed and not yet fully aligned with the monorepo; these doc fixes correct what's there but further alignment work remains.
- Some packages have larger undocumented surfaces (e.g. calm-hub MCP tools, calm-guard learning subsystem) — covered at a summary level rather than exhaustively.
