### PR TITLE
fix(ci): use issue type Bug instead of non-existent bug label

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -2,7 +2,6 @@
 name: 🐛 Bug Report
 about: If something isn't working as expected 🤔
 type: Bug
-labels: bug
 assignees: ''
 ---
 


### PR DESCRIPTION
## Description
The 🐛 Bug Report issue template set both `type: Bug` and `labels: bug` in its front matter, but this repo has no `bug` label — it classifies issues by GitHub **issue type**. As a result, creating a bug report via the GitHub API/CLI with that label fails (`could not add label: 'bug' not found`). This drops the redundant `labels: bug` line and relies on `type: Bug`, which is already present.

```diff
 type: Bug
-labels: bug
 assignees: ''
```

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [x] CI/CD <!-- .github/ISSUE_TEMPLATE -->

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Front-matter-only change to an issue template. Verified the `bug` label does not exist in the repo (`gh label list` has no `bug`), confirming the label assignment was a no-op-that-errors. `type: Bug` remains, so new bug reports are still classified correctly.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable) <!-- N/A — issue-template metadata -->
- [x] My changes follow the project's coding standards

---

### Note
`Meeting.md` and `Office_Hours.md` similarly set `labels: meeting` / `labels: meeting, office-hours`. I left those untouched (out of scope); if those labels don't exist either, they'd warrant the same treatment in a follow-up.
