### PR TITLE
fix(shared): allow calmhub document loader to resolve standard http schemes

### DIFF
--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -32,6 +32,11 @@ describe('calmhub-document-loader', () => {
         });
     });
     
+    it('fails to load a document with invalid url scheme', async () => {
+        const calmHubUrl = 'ftp://schemas/2025-03/meta/core.json';
+        await expect(async () => await calmHubDocumentLoader.loadMissingDocument(calmHubUrl, 'schema')).rejects.toThrow();
+    });
+    
     it('calls configured auth plugin if provided', async () => {
         const authPlugin: AuthPlugin = {
             getAuthHeaders: vi.fn().mockResolvedValue({ 'Authorization': 'Bearer test-token' })

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -1,6 +1,6 @@
 import axios, { Axios } from 'axios';
 import { SchemaDirectory } from '../schema-directory';
-import { CalmDocumentType, DocumentLoader, CALM_HUB_PROTO, assertJsonObject, DocumentLoadError } from './document-loader';
+import { CalmDocumentType, DocumentLoader, assertJsonObject, DocumentLoadError, CALM_HUB_PROTOS } from './document-loader';
 import { initLogger, Logger } from '../logger';
 import { AuthPlugin } from '../auth/auth-plugin';
 
@@ -61,9 +61,9 @@ export class CalmHubDocumentLoader implements DocumentLoader {
     async loadMissingDocument(documentId: string, _: CalmDocumentType): Promise<object> {
         const url = new URL(documentId);
         const protocol = url.protocol;
-        if (protocol !== CALM_HUB_PROTO) {
+        if (!CALM_HUB_PROTOS.some(p => p === protocol)) {
             // Not a calm: reference — recoverable, let other loaders try.
-            throw new Error(`CalmHubDocumentLoader only loads documents with protocol '${CALM_HUB_PROTO}'. (Requested: ${protocol})`);
+            throw new Error(`CalmHubDocumentLoader can only load documents with protocol '${CALM_HUB_PROTOS.join(', ')}'. (Requested: ${protocol})`);
         }
 
         // From here the reference is ours: any failure is fatal and must not fall through to

--- a/shared/src/document-loader/document-loader.ts
+++ b/shared/src/document-loader/document-loader.ts
@@ -9,7 +9,7 @@ import { AuthPlugin } from '..';
 
 export type CalmDocumentType = 'architecture' | 'pattern' | 'schema' | 'timeline';
 
-export const CALM_HUB_PROTO = 'calm:';
+export const CALM_HUB_PROTOS = ['http:', 'https:', 'calm:'];
 
 export interface DocumentLoader {
     initialise(schemaDirectory: SchemaDirectory): Promise<void>;

--- a/shared/src/document-loader/loading-helpers.spec.ts
+++ b/shared/src/document-loader/loading-helpers.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resolveSchemaRef, loadArchitectureAndPattern, loadArchitecture, loadPattern, loadPatternFromDocumentIfPresent } from './loading-helpers';
-import { CALM_HUB_PROTO, DocumentLoader } from './document-loader';
+import { DocumentLoader } from './document-loader';
 import { SchemaDirectory } from '../schema-directory';
 import { Logger } from '../logger';
 
@@ -22,9 +22,9 @@ describe('resolveSchemaRef', () => {
         expect(result).toBe('https://calm.finos.org/schema.json');
     });
 
-    it(`should return ${CALM_HUB_PROTO} protocol URLs unchanged`, () => {
-        const result = resolveSchemaRef(`${CALM_HUB_PROTO}//namespace/schema`, '/path/to/arch.json', mockLogger);
-        expect(result).toBe(`${CALM_HUB_PROTO}//namespace/schema`);
+    it('should return calm:// protocol URLs unchanged', () => {
+        const result = resolveSchemaRef('calm://namespace/schema', '/path/to/arch.json', mockLogger);
+        expect(result).toBe('calm://namespace/schema');
     });
 
     it('should return file:// URLs unchanged', () => {

--- a/shared/src/document-loader/loading-helpers.ts
+++ b/shared/src/document-loader/loading-helpers.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { Logger } from '../logger';
-import { DocumentLoader, CALM_HUB_PROTO } from './document-loader';
+import { DocumentLoader, CALM_HUB_PROTOS } from './document-loader';
 import { SchemaDirectory } from '../schema-directory';
 
 export async function loadArchitectureAndPattern(architecturePath: string, patternPath: string | undefined, docLoader: DocumentLoader, schemaDirectory: SchemaDirectory, logger: Logger): Promise<{ architecture: object | undefined, pattern: object | undefined }> {
@@ -28,7 +28,7 @@ export async function loadTimeline(timelinePath: string, docLoader: DocumentLoad
 
 export function resolveSchemaRef(schemaRef: string, architecturePath: string, logger: Logger): string {
     // If it's an absolute URL (http, https, file) or calm: protocol, use as-is
-    if (schemaRef.startsWith('http://') || schemaRef.startsWith('https://') || schemaRef.startsWith('file://') || schemaRef.startsWith(CALM_HUB_PROTO)) {
+    if (schemaRef.startsWith('file://') || CALM_HUB_PROTOS.some(p => schemaRef.startsWith(p))) {
         return schemaRef;
     }
     // If it's an absolute file path, use as-is


### PR DESCRIPTION

## Description
Currently CalmHubDocumentLoader can exclusively load calm:// urls.
This is nice in principle but blocking https and http URLs causes problems with existing schemas, requiring them to be converted, and also breaks all other JSON schema tooling.

This pr allows https, http and calm:// as allowed schemes.

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [x] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
