### PR TITLE
fix(calm-hub): pin MCP server to 1.12.1 to restore native image builds

### DIFF
--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -34,6 +34,37 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Override MCP server to a version with native-image fixes.
+                 quarkus-mcp-server-bom:3.34.7 (from root pom) resolves all MCP
+                 artifacts to 1.10.5, which predates the native-image fixes added
+                 in 1.12.0 (quarkiverse/quarkus-mcp-server#684 / #685).  All five
+                 artifacts (runtime + deployment) must be aligned to the same version
+                 to avoid mixed-version augmentation failures. -->
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-http</artifactId>
+                <version>1.12.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-http-deployment</artifactId>
+                <version>1.12.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-core</artifactId>
+                <version>1.12.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-core-deployment</artifactId>
+                <version>1.12.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.mcp</groupId>
+                <artifactId>quarkus-mcp-server-sse-client</artifactId>
+                <version>1.12.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Address first part of #2617

quarkus-mcp-server-bom:3.34.7 (added in PR #2608) resolves all MCP artifacts to 1.10.5, a downgrade from the previously pinned 1.12.0. Version 1.10.5 predates the native-image fix added in 1.12.0 (quarkiverse/quarkus-mcp-server#684/#685: fix elicitation and sampling in native image), causing both native CI workflows to fail at Quarkus augmentation.

Add explicit dependencyManagement overrides in calm-hub/pom.xml pinning all five MCP runtime and deployment artifacts to 1.12.1, overriding the 1.10.5 resolved by the platform BOM.

Verified: both build-native-image.sh --no-docker and build-readonly-native-image.sh --no-docker produce BUILD SUCCESS with a 220MB native binary.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
