### PR TITLE
fix(calm-hub): make the default profile secure and introduce no-auth profile

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -12,7 +12,7 @@ This guide helps AI assistants work efficiently with the CALM Hub backend codeba
   - NitriteDB (embedded, standalone mode)
 - **Testing**: JUnit 5, TestContainers
 - **API Docs**: OpenAPI/Swagger UI
-- **Security**: Per-namespace permissions enforced via Quarkus Security (`org.finos.calm.security`); three auth modes — open (default), OIDC/Keycloak (`secure`), and proxy-injected header (`proxy-auth`)
+- **Security**: Per-namespace permissions enforced via Quarkus Security (`org.finos.calm.security`); four auth modes — the default is **secure** (rejects all requests with 401), `no-auth` (open, local testing only), OIDC/Keycloak (`secure` profile), and proxy-injected header (`proxy-auth`)
 
 > **Note**: Netty is pinned to `4.1.x` (currently `4.1.132.Final` via `netty-bom` in the root `pom.xml`) to mitigate CVEs. It must stay on 4.1.x — Quarkus 3.x applies a `CleanerJava9` bytecode transformation incompatible with Netty 4.2.
 
@@ -25,8 +25,9 @@ This guide helps AI assistants work efficiently with the CALM Hub backend codeba
 ../mvnw test                              # Unit tests only
 
 # Development Mode (Hot Reload)
-../mvnw quarkus:dev                       # Default (MongoDB)
-../mvnw quarkus:dev -Pstandalone                     # Standalone (NitriteDB) — use -Pstandalone, NOT -Dquarkus.profile=standalone
+# NOTE: The default profile is secure (401 on all requests). Use no-auth for local testing.
+../mvnw quarkus:dev -Dquarkus.profile=no-auth        # No-auth (local testing, MongoDB)
+../mvnw quarkus:dev -Pstandalone                     # Standalone (NitriteDB) — no-auth is implicit
 ../mvnw quarkus:dev -Dquarkus.profile=secure         # Secure mode (Keycloak)
 
 # Docker
@@ -146,11 +147,17 @@ Security: `@PermissionsAllowed` on resource methods is resolved by
 `CalmHubPermissionChecker`, which consults `UserAccessValidator` against the
 caller's grants. See [PERMISSIONS.md](./PERMISSIONS.md) for the full model.
 
-There are **three auth modes**, each selected by a separate property file:
+There are **four auth modes**, each selected by a separate property file:
 
-**Default** (open, no auth) — `application.properties`:
-- `quarkus.oidc.tenant-enabled=false`, `calm.auth.enabled` unset (permission checks pass)
-- All endpoints open; good for development
+**Default** (secure, no mechanism configured) — `application.properties`:
+- `calm.auth.enabled=true`, `quarkus.oidc.tenant-enabled=false`
+- No auth mechanism provides an identity → all requests return 401
+- Forces explicit profile selection; nothing works until you choose an auth mode
+
+**No-auth** (open, local development only) — `application-no-auth.properties`:
+- `quarkus.oidc.tenant-enabled=false`, `calm.auth.enabled=false`
+- `NoAuthAuthenticationMechanism` supplies a non-anonymous identity so all permission checks pass
+- **Never use in production**; activate with `-Dquarkus.profile=no-auth`
 
 **Secure** (OIDC / Keycloak) — `application-secure.properties`:
 - `quarkus.oidc.tenant-enabled=true`, `calm.auth.enabled=true`
@@ -163,9 +170,6 @@ There are **three auth modes**, each selected by a separate property file:
 - The upstream proxy injects the authenticated username in a header (default
   `Remote-User`, overridable via `calm.security.proxy.username-header`), handled by
   `ProxyAuthenticationMechanism` / `ProxyIdentityProvider`
-
-In the open default, `NoAuthAuthenticationMechanism` supplies an identity so
-permission checks pass without a token.
 
 ## Key Concepts
 
@@ -377,7 +381,8 @@ private static final int PATTERN_ID = 42;
 ## Configuration Files
 
 - `pom.xml` - Maven dependencies and build config
-- `src/main/resources/application.properties` - Default (open) config
+- `src/main/resources/application.properties` - Default (secure, rejects all requests) config
+- `src/main/resources/application-no-auth.properties` - No-auth profile (local testing only, no IdP)
 - `src/main/resources/application-secure.properties` - Secure (OIDC/Keycloak) profile config
 - `src/main/resources/application-proxy-auth.properties` - Proxy-auth profile config (proxy-injected `Remote-User` header)
 - `PERMISSIONS.md` - Per-namespace permission model reference

--- a/calm-hub/README.md
+++ b/calm-hub/README.md
@@ -14,6 +14,8 @@ docker-compose up
 A version of CALM Hub will be up and running on: [http://localhost:8080](http://localhost:8080)  
 The API documentation can be found at: [http://localhost:8080/q/swagger-ui/#/](http://localhost:8080/q/swagger-ui/#/)
 
+> **Note:** The `deploy/docker-compose.yml` starts CalmHub with the `no-auth` profile for local convenience. The default profile is **secure** (see [Auth Profiles](#auth-profiles) below) and rejects all requests with 401 unless you explicitly select an auth profile.
+
 ## Working with the project
 
 There are three main locations for the Java code base:
@@ -133,12 +135,36 @@ public class AdrStoreProducer {
 From the `calm-hub` directory
 
 1. `../mvnw package`
-2. `../mvnw quarkus:dev`
+2. `../mvnw quarkus:dev -Dquarkus.profile=no-auth`
+
+> **Note:** The default profile is secure and rejects all requests with 401. Pass `-Dquarkus.profile=no-auth` for local development without an IdP, or `-Dquarkus.profile=secure` / `-Dquarkus.profile=proxy-auth` for authenticated modes.
 
 
-### Secure profile
+### Auth Profiles
 
-There are two secure profiles, `secure` and `proxy-auth`.
+The default profile is **secure by default**: no authentication mechanism is wired, so all requests are rejected with 401. You must explicitly activate one of the following profiles:
+
+| Profile | How to activate | When to use |
+|---|---|---|
+| `no-auth` | `-Dquarkus.profile=no-auth` | Local development and testing — **not for production** |
+| `secure` | `-Dquarkus.profile=secure` | Production with JWT/OIDC (Keycloak or another IdP) |
+| `proxy-auth` | `-Dquarkus.profile=proxy-auth` | Production behind an authenticating reverse proxy |
+
+#### no-auth profile
+
+For local development and testing where you do not want to configure an IdP:
+
+```bash
+# MongoDB backend
+../mvnw quarkus:dev -Dquarkus.profile=no-auth
+
+# Standalone (NitriteDB) backend — no-auth is implicit, just use -Pstandalone
+../mvnw quarkus:dev -Pstandalone
+```
+
+> **Warning:** The `no-auth` profile disables all authentication. Never use it in a production or shared environment.
+
+There are two authenticated profiles, `secure` and `proxy-auth`.
 Using either will enable entitlements driven by the database.
 
 The two modes are slightly different:

--- a/calm-hub/deploy/docker-compose.yml
+++ b/calm-hub/deploy/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - JAVA_OPTS=-Dquarkus.mongodb.connection-string=mongodb://mongodb:27017
+      # no-auth is used here for the local quick-start only — DO NOT use in production.
+      # For a production deployment select an appropriate auth profile (secure, proxy-auth).
+      - JAVA_OPTS=-Dquarkus.mongodb.connection-string=mongodb://mongodb:27017 -Dquarkus.profile=no-auth
     networks:
       - calm-net
 networks:

--- a/calm-hub/src/integration-test/java/integration/NitriteIntegrationTestProfile.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteIntegrationTestProfile.java
@@ -27,7 +27,8 @@ public class NitriteIntegrationTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "allow.put.operations", "true",
-                "calm.mcp.enabled", "true"
+                "calm.mcp.enabled", "true",
+                "calm.auth.enabled", "false"
         );
     }
 }

--- a/calm-hub/src/main/resources/application-no-auth.properties
+++ b/calm-hub/src/main/resources/application-no-auth.properties
@@ -1,0 +1,8 @@
+# No-auth profile: grants every request a non-anonymous identity so that
+# @PermissionsAllowed checks pass unconditionally. For local development and
+# testing ONLY.
+# WARNING: Do NOT use this profile in production — it disables all authentication.
+quarkus.oidc.enabled=true
+quarkus.keycloak.devservices.enabled=false
+quarkus.oidc.tenant-enabled=false
+calm.auth.enabled=false

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -23,6 +23,8 @@ quarkus.mongodb.database = calmSchemas
 %standalone.calm.database.mode=standalone
 %standalone.quarkus.mongodb.health.enabled=false
 %standalone.quarkus.mongodb.devservices.enabled=false
+# Standalone is a local-dev mode — disable auth so it works without an IdP.
+%standalone.calm.auth.enabled=false
 # Suppress noisy "Connection refused" log spam from the MongoDB driver background
 # monitor threads — the MongoClient is created by the Quarkus extension but never
 # used in standalone mode (all Mongo CDI beans are @LookupIfProperty-gated).
@@ -35,8 +37,12 @@ quarkus.oidc.enabled=true
 quarkus.keycloak.devservices.enabled=false
 quarkus.oidc.tenant-enabled=false
 
-# Default profile is open — all requests are granted a non-anonymous identity and all
-# permission checks pass. Set calm.auth.enabled=true in secure/proxy-auth profiles.
+# Default profile is secure — no authentication mechanism is wired, so all requests
+# are rejected with 401. Explicitly activate a profile to enable access:
+#   no-auth     — open access for local development/testing (no IdP needed)
+#   secure      — JWT/OIDC via Keycloak
+#   proxy-auth  — identity injected by an upstream proxy
+calm.auth.enabled=true
 
 #quarkus.http.port=8081
 

--- a/calm-hub/src/test/java/org/finos/calm/security/TestProxyIdentityProviderShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestProxyIdentityProviderShould.java
@@ -1,0 +1,45 @@
+package org.finos.calm.security;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class TestProxyIdentityProviderShould {
+
+    @Mock
+    AuthenticationRequestContext mockContext;
+
+    ProxyIdentityProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new ProxyIdentityProvider();
+    }
+
+    @Test
+    void return_trusted_authentication_request_type() {
+        assertEquals(TrustedAuthenticationRequest.class, provider.getRequestType());
+    }
+
+    @Test
+    void build_non_anonymous_identity_with_principal_from_request() {
+        TrustedAuthenticationRequest request = new TrustedAuthenticationRequest("alice");
+
+        SecurityIdentity identity = provider.authenticate(request, mockContext)
+                .await().indefinitely();
+
+        assertNotNull(identity);
+        assertFalse(identity.isAnonymous());
+        assertEquals("alice", identity.getPrincipal().getName());
+    }
+}


### PR DESCRIPTION
Currently the default profile for calm hub is a totally wide open, insecure profile. This should be opt-in rather than opt-out.
This change moves the default profile to be equivalent to the `secure` profile, using oidc. To start in no auth mode, use `-Dquarkus.profile=no-auth`.

Updated docs, agents etc for this.


## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
