### PR TITLE
fix(calm-hub): fix missing validation annotations

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -294,10 +294,12 @@ void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_get_pattern
 ```
 
 Import validation constants from `ResourceValidationConstants`:
+
 ```java
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.USERNAME_MESSAGE;
 ```
 
 #### Mongo Store Tests (`@QuarkusTest` + `@InjectMock`)

--- a/calm-hub/src/main/java/org/finos/calm/domain/Domain.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/Domain.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_MESSAGE;
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_REGEX;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
 
 /**
  * Represents a domain in the CALM system.
@@ -30,7 +30,7 @@ public class  Domain {
 
     }
 
-    @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+    @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
     @NotBlank(message = "domain name must not be blank")
     @NotNull(message = "domain name must not be null")
     private String name;

--- a/calm-hub/src/main/java/org/finos/calm/domain/UserAccess.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/UserAccess.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+
+import static org.finos.calm.resources.ResourceValidationConstants.*;
 
 /**
  * Represents a CalmHub user access grant, scoped to either a namespace or a domain.
@@ -19,10 +23,10 @@ public class UserAccess {
         admin
     }
 
-    private String username;
-    private Permission permission;
-    private String namespace;
-    private String domain;
+    private @Pattern(regexp = USERNAME_REGEX, message = USERNAME_MESSAGE) @NotNull String username;
+    private @NotNull Permission permission;
+    private @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace;
+    private @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain;
     private int userAccessId;
 
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/McpValidationHelper.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_REGEX;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
 import static org.finos.calm.resources.ResourceValidationConstants.QUERY_PARAM_NO_WHITESPACE_REGEX;
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX;
@@ -108,7 +108,7 @@ final class McpValidationHelper {
         if (domain == null || domain.isBlank()) {
             return "Error: Domain must not be blank.";
         }
-        if (!domain.matches(DOMAIN_NAME_REGEX)) {
+        if (!domain.matches(DOMAIN_REGEX)) {
             return "Error: Invalid domain format '" + domain + "'. Must be alphanumeric with optional hyphens.";
         }
         return null;

--- a/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
@@ -49,7 +49,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getControlsForDomain(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain) {
         try {
             return Response.ok(new ValueWrapper<>(store.getControlsForDomain(domain))).build();
@@ -70,7 +70,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_WRITE)
     public Response createControlForDomain(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @Valid @NotNull(message = "Request must not be null") CreateControlRequirement createControlRequirement) {
         try {
@@ -92,7 +92,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getRequirementVersions(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId) {
         try {
@@ -116,7 +116,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getRequirementForVersion(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @PathParam("version")
@@ -147,7 +147,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_WRITE)
     public Response createRequirementForVersion(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @PathParam("version")
@@ -182,7 +182,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getConfigurationsForControl(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId) {
         try {
@@ -207,7 +207,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_WRITE)
     public Response createControlConfiguration(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @Valid @NotNull(message = "Request must not be null") CreateControlConfiguration createControlConfiguration) {
@@ -233,7 +233,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getConfigurationVersions(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @PathParam("configId") int configId) {
@@ -261,7 +261,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getConfigurationForVersion(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @PathParam("configId") int configId,
@@ -296,7 +296,7 @@ public class ControlResource {
     @PermissionsAllowed(CalmHubScopes.DOMAIN_WRITE)
     public Response createConfigurationForVersion(
             @PathParam("domain")
-            @Pattern(regexp = DOMAIN_NAME_REGEX, message = DOMAIN_NAME_MESSAGE)
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
             String domain,
             @PathParam("controlId") int controlId,
             @PathParam("configId") int configId,

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
@@ -1,6 +1,9 @@
 package org.finos.calm.resources;
 
 import io.quarkus.security.PermissionsAllowed;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -15,6 +18,9 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
+
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
 
 @Path("/calm/domains")
 public class DomainUserAccessResource {
@@ -35,8 +41,8 @@ public class DomainUserAccessResource {
             description = "Creates a user-access grant for a given domain"
     )
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
-    public Response createUserAccessForDomain(@PathParam("domain") String domain,
-                                              UserAccess createUserAccessRequest) {
+    public Response createUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
+                                              @Valid @NotNull UserAccess createUserAccessRequest) {
 
         createUserAccessRequest.setCreationDateTime(LocalDateTime.now());
         createUserAccessRequest.setUpdateDateTime(LocalDateTime.now());
@@ -63,7 +69,7 @@ public class DomainUserAccessResource {
             description = "Get user-access details for a given domain"
     )
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
-    public Response getUserAccessForDomain(@PathParam("domain") String domain) {
+    public Response getUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain) {
         try {
             return Response.ok(store.getUserAccessForDomain(domain)).build();
         } catch (UserAccessNotFoundException ex) {
@@ -82,8 +88,8 @@ public class DomainUserAccessResource {
             description = "Get user-access details for a given domain and Id"
     )
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
-    public Response getUserAccessForDomainAndId(@PathParam("domain") String domain,
-                                                @PathParam("userAccessId") Integer userAccessId) {
+    public Response getUserAccessForDomainAndId(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
+                                                @PathParam("userAccessId") @NotNull Integer userAccessId) {
         try {
             return Response.ok(store.getUserAccessForDomainAndId(domain, userAccessId)).build();
         } catch (UserAccessNotFoundException ex) {

--- a/calm-hub/src/main/java/org/finos/calm/resources/ResourceValidationConstants.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ResourceValidationConstants.java
@@ -6,8 +6,11 @@ import org.owasp.html.PolicyFactory;
 public class ResourceValidationConstants {
     public static final String NAMESPACE_REGEX = "^[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*$";
     public static final String NAMESPACE_MESSAGE = "namespace must match pattern '^[A-Za-z0-9-]+([.][A-Za-z0-9-]+)*$'";
-    public static final String DOMAIN_NAME_REGEX = "^[A-Za-z0-9-]+$";
-    public static final String DOMAIN_NAME_MESSAGE = "domain name must match pattern '^[A-Za-z0-9-]+$'";
+    // dashes, dots, usernames, upper/lowercase letters and numbers.
+    public static final String USERNAME_REGEX = "^[A-Za-z0-9._-]+$";
+    public static final String USERNAME_MESSAGE = "username must match pattern '^[A-Za-z0-9._-]+$'";
+    public static final String DOMAIN_REGEX = "^[A-Za-z0-9-]+$";
+    public static final String DOMAIN_MESSAGE = "domain name must match pattern '^[A-Za-z0-9-]+$'";
     public static final String VERSION_REGEX = "^(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)$";
     public static final String VERSION_MESSAGE = "version must match pattern '^(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)$'";
     // First character must be a letter so slugs are never purely numeric (avoids clash with legacy numeric IDs).

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -1,6 +1,10 @@
 package org.finos.calm.resources;
 
 import io.quarkus.security.PermissionsAllowed;
+import jakarta.annotation.Nonnull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -16,6 +20,9 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
+
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
 
 @Path("/calm/namespaces")
 public class UserAccessResource {
@@ -36,8 +43,8 @@ public class UserAccessResource {
             description = "Creates a user-access for a given namespace on a particular resource type"
     )
     @PermissionsAllowed(CalmHubScopes.ADMIN)
-    public Response createUserAccessForNamespace(@PathParam("namespace") String namespace,
-                                                 UserAccess createUserAccessRequest) {
+    public Response createUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+                                                 @Valid @NotNull UserAccess createUserAccessRequest) {
 
         createUserAccessRequest.setCreationDateTime(LocalDateTime.now());
         createUserAccessRequest.setUpdateDateTime(LocalDateTime.now());
@@ -66,7 +73,7 @@ public class UserAccessResource {
             description = "Get user-access details for a given namespace"
     )
     @PermissionsAllowed(CalmHubScopes.ADMIN)
-    public Response getUserAccessForNamespace(@PathParam("namespace") String namespace) {
+    public Response getUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace) {
 
         try {
             return Response.ok(store.getUserAccessForNamespace(namespace))
@@ -90,8 +97,8 @@ public class UserAccessResource {
             description = "Get user-access details for a given namespace and Id"
     )
     @PermissionsAllowed(CalmHubScopes.ADMIN)
-    public Response getUserAccessForNamespaceAndId(@PathParam("namespace") String namespace,
-                                                   @PathParam("userAccessId") Integer userAccessId) {
+    public Response getUserAccessForNamespaceAndId(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+                                                   @PathParam("userAccessId") @NotNull Integer userAccessId) {
 
         try {
             return Response.ok(store.getUserAccessForNamespaceAndId(namespace, userAccessId))

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +57,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     @Test    void return_a_list_of_control_details_for_a_domain() {
@@ -134,7 +134,7 @@ public class TestControlResourceShould {
                 .post("/calm/domains/invalid_domain/controls")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
     // --- Requirement Version Endpoints ---
 
@@ -145,7 +145,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls/1/requirement/versions")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     static Stream<Arguments> provideParametersForRequirementVersionTests() {
@@ -193,7 +193,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls/1/requirement/versions/1.0.0")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     @Test
@@ -251,7 +251,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls/1/configurations")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     static Stream<Arguments> provideParametersForGetConfigurationsTests() {
@@ -314,7 +314,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls/1/configurations/10/versions")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     static Stream<Arguments> provideParametersForGetConfigurationVersionsTests() {
@@ -364,7 +364,7 @@ public class TestControlResourceShould {
                 .get("/calm/domains/invalid_domain/controls/1/configurations/10/versions/1.0.0")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     @Test
@@ -425,7 +425,7 @@ public class TestControlResourceShould {
                 .post("/calm/domains/invalid_domain/controls/1/requirement/versions/2.0.0")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     @Test
@@ -537,7 +537,7 @@ public class TestControlResourceShould {
                 .post("/calm/domains/invalid_domain/controls/1/configurations")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     // --- createConfigurationForVersion ---
@@ -551,7 +551,7 @@ public class TestControlResourceShould {
                 .post("/calm/domains/invalid_domain/controls/1/configurations/10/versions/2.0.0")
                 .then()
                 .statusCode(400)
-                .body(containsString(DOMAIN_NAME_MESSAGE));
+                .body(containsString(DOMAIN_MESSAGE));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
-import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_NAME_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
@@ -82,7 +82,7 @@ public class TestDomainResourceShould {
             .when().post(CALM_DOMAINS)
             .then()
             .statusCode(400)
-            .body(containsString(DOMAIN_NAME_MESSAGE));
+            .body(containsString(DOMAIN_MESSAGE));
 
         verify(mockControlStore, never()).createDomain("invalid-domain");
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -24,6 +25,38 @@ public class TestDomainUserAccessResourceShould {
     UserAccessStore mockUserAccessStore;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void return_400_when_invalid_domain_format_provided_on_create_user_access() {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{}")
+                .when()
+                .post("/calm/domains/invalid_domain/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
+
+    @Test
+    void return_400_when_invalid_domain_format_provided_on_get_user_access() {
+        given()
+                .when()
+                .get("/calm/domains/invalid_domain/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
+
+    @Test
+    void return_400_when_invalid_domain_format_provided_on_get_user_access_by_id() {
+        given()
+                .when()
+                .get("/calm/domains/invalid_domain/user-access/1")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
 
     @Test
     void return_201_created_with_location_header_when_domain_user_access_is_created() throws Exception {

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -77,6 +77,46 @@ public class TestUserAccessResourceShould {
     }
 
     @Test
+    void return_400_when_invalid_namespace_format() throws Exception {
+        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
+                .thenThrow(new NamespaceNotFoundException());
+
+        UserAccess userAccess = new UserAccess();
+        userAccess.setNamespace("invalid &%*$% NAMESPACE");
+        userAccess.setPermission(UserAccess.Permission.read);
+        userAccess.setUsername("test_user");
+        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .when()
+                .post("/calm/namespaces/invalid/user-access")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void return_400_when_invalid_username_format() throws Exception {
+        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
+                .thenThrow(new NamespaceNotFoundException());
+
+        UserAccess userAccess = new UserAccess();
+        userAccess.setNamespace("invalid");
+        userAccess.setPermission(UserAccess.Permission.read);
+        userAccess.setUsername("INVALID USER!");
+        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .when()
+                .post("/calm/namespaces/invalid/user-access")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     void return_400_when_creating_user_access_with_invalid_namespace() throws Exception {
         when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
                 .thenThrow(new NamespaceNotFoundException());


### PR DESCRIPTION
## Description
Clean up missing annotations for namespace/control regexes 

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
