### PR TITLE
fix(calm-hub): Adding permission filtering to GET:/namespaces endpoin…

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -2,12 +2,15 @@ package org.finos.calm.resources;
 
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.finos.calm.domain.NamespaceRequest;
 import org.finos.calm.domain.ValueWrapper;
@@ -15,19 +18,35 @@ import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.security.UserAccessValidator;
 import org.finos.calm.store.NamespaceStore;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
 
 @Path("/calm/namespaces")
 public class NamespaceResource {
 
     private final NamespaceStore namespaceStore;
+    private final Instance<UserAccessValidator> userAccessValidatorInstance;
+    private final CalmHubPermissionChecker permissionChecker;
 
     @Inject
-    public NamespaceResource(NamespaceStore store) {
+    SecurityIdentity identity;
+
+    @Inject
+    @ConfigProperty(name = "calm.auth.enabled", defaultValue = "false")
+    boolean authEnabled;
+
+    @Inject
+    public NamespaceResource(NamespaceStore store,
+                             Instance<UserAccessValidator> userAccessValidatorInstance,
+                             CalmHubPermissionChecker permissionChecker) {
         this.namespaceStore = store;
+        this.userAccessValidatorInstance = userAccessValidatorInstance;
+        this.permissionChecker = permissionChecker;
     }
 
     @GET
@@ -37,7 +56,17 @@ public class NamespaceResource {
     )
     @Authenticated
     public ValueWrapper<NamespaceInfo> namespaces() {
-        return new ValueWrapper<>(namespaceStore.getNamespaces());
+        if (!authEnabled || !userAccessValidatorInstance.isResolvable()) {
+            return new ValueWrapper<>(namespaceStore.getNamespaces());
+        }
+        if (permissionChecker.hasGlobalAdmin(identity)) {
+            return new ValueWrapper<>(namespaceStore.getNamespaces());
+        }
+        Set<String> grants = userAccessValidatorInstance.get()
+                .getReadableNamespaces(identity.getPrincipal().getName());
+        return new ValueWrapper<>(namespaceStore.getNamespaces().stream()
+                .filter(ns -> grants.contains(ns.getName()))
+                .toList());
     }
 
     @POST

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
@@ -1,22 +1,32 @@
 package org.finos.calm.resources;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import jakarta.enterprise.inject.Instance;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
+import org.finos.calm.security.CalmHubPermissionChecker;
+import org.finos.calm.security.UserAccessValidator;
 import org.finos.calm.store.NamespaceStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @TestSecurity(authorizationEnabled = false)
@@ -26,6 +36,32 @@ public class TestNamespaceResourceShould {
 
     @InjectMock
     NamespaceStore namespaceStore;
+
+    // Plain Mockito mocks for direct-instantiation filtering tests
+    @Mock
+    private NamespaceStore mockNamespaceStore;
+    @Mock
+    private Instance<UserAccessValidator> mockValidatorInstance;
+    @Mock
+    private UserAccessValidator mockValidator;
+    @Mock
+    private SecurityIdentity mockIdentity;
+    @Mock
+    private Principal mockPrincipal;
+    @Mock
+    private CalmHubPermissionChecker mockPermissionChecker;
+
+    private static final List<NamespaceInfo> ALL_NAMESPACES = List.of(
+            new NamespaceInfo("finos", "FINOS namespace"),
+            new NamespaceInfo("custom", "custom namespace")
+    );
+
+    private NamespaceResource resourceWithAuth(boolean authEnabled) {
+        NamespaceResource resource = new NamespaceResource(mockNamespaceStore, mockValidatorInstance, mockPermissionChecker);
+        resource.identity = mockIdentity;
+        resource.authEnabled = authEnabled;
+        return resource;
+    }
 
     @Test
     void return_empty_wrapper_when_no_namespaces_in_store() {
@@ -225,5 +261,56 @@ public class TestNamespaceResourceShould {
                 .body(containsString("Request must not be null"));
 
         verify(namespaceStore, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void return_all_namespaces_when_auth_disabled() {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(ALL_NAMESPACES);
+
+        assertEquals(ALL_NAMESPACES, resourceWithAuth(false).namespaces().getValues());
+    }
+
+    @Test
+    void return_all_namespaces_when_validator_not_resolvable() {
+        when(mockValidatorInstance.isResolvable()).thenReturn(false);
+        when(mockNamespaceStore.getNamespaces()).thenReturn(ALL_NAMESPACES);
+
+        assertEquals(ALL_NAMESPACES, resourceWithAuth(true).namespaces().getValues());
+    }
+
+    @Test
+    void return_all_namespaces_for_global_admin() {
+        when(mockValidatorInstance.isResolvable()).thenReturn(true);
+        when(mockPermissionChecker.hasGlobalAdmin(mockIdentity)).thenReturn(true);
+        when(mockNamespaceStore.getNamespaces()).thenReturn(ALL_NAMESPACES);
+
+        assertEquals(ALL_NAMESPACES, resourceWithAuth(true).namespaces().getValues());
+    }
+
+    @Test
+    void return_only_accessible_namespaces_for_authenticated_user() {
+        when(mockValidatorInstance.isResolvable()).thenReturn(true);
+        when(mockPermissionChecker.hasGlobalAdmin(mockIdentity)).thenReturn(false);
+        when(mockIdentity.getPrincipal()).thenReturn(mockPrincipal);
+        when(mockPrincipal.getName()).thenReturn("thomas");
+        when(mockValidatorInstance.get()).thenReturn(mockValidator);
+        when(mockValidator.getReadableNamespaces("thomas")).thenReturn(Set.of("finos"));
+        when(mockNamespaceStore.getNamespaces()).thenReturn(ALL_NAMESPACES);
+
+        assertEquals(List.of(new NamespaceInfo("finos", "FINOS namespace")),
+                resourceWithAuth(true).namespaces().getValues());
+    }
+
+    @Test
+    void return_empty_list_when_user_has_no_grants() {
+        when(mockValidatorInstance.isResolvable()).thenReturn(true);
+        when(mockPermissionChecker.hasGlobalAdmin(mockIdentity)).thenReturn(false);
+        when(mockIdentity.getPrincipal()).thenReturn(mockPrincipal);
+        when(mockPrincipal.getName()).thenReturn("thomas");
+        when(mockValidatorInstance.get()).thenReturn(mockValidator);
+        when(mockValidator.getReadableNamespaces("thomas")).thenReturn(Set.of());
+        when(mockNamespaceStore.getNamespaces()).thenReturn(ALL_NAMESPACES);
+
+        assertTrue(resourceWithAuth(true).namespaces().getValues().isEmpty());
     }
 }


### PR DESCRIPTION
…t (#2609)

Adding in memory filtering of namespaces based on the users permissions following the pattern used in SearchResource.java

## Description

Updating the existing `GET:/namespaces` endpoint so that the returned namespaces are filtered based on a users permissions. This is done in memory, rather than at the DB level, following the pattern in `src/main/java/org/finos/calm/resources/SearchResource.java`. 

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
