### PR TITLE
fix(calm-suite): declare @docusaurus/faster as dependency in calmguard-docs

### DIFF
--- a/calm-suite/calm-guard/docs/package.json
+++ b/calm-suite/calm-guard/docs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",
+    "@docusaurus/faster": "^3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.0",
     "@mdx-js/react": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -347,6 +347,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "3.10.1",
+                "@docusaurus/faster": "^3.10.1",
                 "@docusaurus/preset-classic": "3.10.1",
                 "@docusaurus/theme-mermaid": "^3.10.0",
                 "@mdx-js/react": "^3.0.0",
@@ -479,21 +480,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "calm-suite/calm-guard/node_modules/@mermaid-js/layout-elk": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.9.tgz",
-            "integrity": "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "d3": "^7.9.0",
-                "elkjs": "^0.9.3"
-            },
-            "peerDependencies": {
-                "mermaid": "^11.0.2"
-            }
-        },
         "calm-suite/calm-guard/node_modules/commander": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -502,14 +488,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "calm-suite/calm-guard/node_modules/elkjs": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
-            "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
-            "license": "EPL-2.0",
-            "optional": true,
-            "peer": true
         },
         "calm-suite/calm-guard/node_modules/https-proxy-agent": {
             "version": "7.0.6",
@@ -920,7 +898,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.45.0",
+            "version": "1.46.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -6265,6 +6243,61 @@
                 "node": ">=20.0"
             }
         },
+        "node_modules/@docusaurus/faster": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.1.tgz",
+            "integrity": "sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.10.1",
+                "@rspack/core": "^1.7.10",
+                "@swc/core": "^1.7.39",
+                "@swc/html": "^1.13.5",
+                "browserslist": "^4.24.2",
+                "lightningcss": "^1.27.0",
+                "semver": "^7.5.4",
+                "swc-loader": "^0.2.6",
+                "tslib": "^2.6.0",
+                "webpack": "^5.95.0"
+            },
+            "engines": {
+                "node": ">=20.0"
+            },
+            "peerDependencies": {
+                "@docusaurus/types": "*"
+            }
+        },
+        "node_modules/@docusaurus/faster/node_modules/@docusaurus/types": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/faster/node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@docusaurus/logger": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
@@ -7720,7 +7753,6 @@
             "os": [
                 "aix"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7737,7 +7769,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7754,7 +7785,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7771,7 +7801,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7788,7 +7817,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7805,7 +7833,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7822,7 +7849,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7839,7 +7865,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7856,7 +7881,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7873,7 +7897,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7890,7 +7913,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7907,7 +7929,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7924,7 +7945,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7941,7 +7961,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7958,7 +7977,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7975,7 +7993,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -7992,7 +8009,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8009,7 +8025,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8026,7 +8041,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8043,7 +8057,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8060,7 +8073,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8077,7 +8089,6 @@
             "os": [
                 "openharmony"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8094,7 +8105,6 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8111,7 +8121,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8128,7 +8137,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8145,7 +8153,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -10245,6 +10252,59 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@module-federation/error-codes": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+            "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+            "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/runtime-core": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-core": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+            "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+            "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/webpack-bundler-runtime": "0.22.0"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+            "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+            "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.22.0",
+                "@module-federation/sdk": "0.22.0"
             }
         },
         "node_modules/@monaco-editor/loader": {
@@ -12411,8 +12471,7 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.62.0",
@@ -12426,8 +12485,7 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.62.0",
@@ -12441,8 +12499,7 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.62.0",
@@ -12456,8 +12513,7 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.62.0",
@@ -12471,8 +12527,7 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.62.0",
@@ -12486,8 +12541,7 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.62.0",
@@ -12501,8 +12555,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.62.0",
@@ -12516,8 +12569,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.62.0",
@@ -12531,8 +12583,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.62.0",
@@ -12546,8 +12597,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.62.0",
@@ -12561,8 +12611,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
             "version": "4.62.0",
@@ -12576,8 +12625,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.62.0",
@@ -12591,8 +12639,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
             "version": "4.62.0",
@@ -12606,8 +12653,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.62.0",
@@ -12621,8 +12667,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.62.0",
@@ -12636,8 +12681,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.62.0",
@@ -12651,8 +12695,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.62.0",
@@ -12666,8 +12709,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.62.0",
@@ -12681,8 +12723,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
             "version": "4.62.0",
@@ -12696,8 +12737,7 @@
             "optional": true,
             "os": [
                 "openbsd"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.62.0",
@@ -12711,8 +12751,7 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.62.0",
@@ -12726,8 +12765,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.62.0",
@@ -12741,8 +12779,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.62.0",
@@ -12756,8 +12793,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.62.0",
@@ -12771,8 +12807,207 @@
             "optional": true,
             "os": [
                 "win32"
+            ]
+        },
+        "node_modules/@rspack/binding": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.12.tgz",
+            "integrity": "sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.7.12",
+                "@rspack/binding-darwin-x64": "1.7.12",
+                "@rspack/binding-linux-arm64-gnu": "1.7.12",
+                "@rspack/binding-linux-arm64-musl": "1.7.12",
+                "@rspack/binding-linux-x64-gnu": "1.7.12",
+                "@rspack/binding-linux-x64-musl": "1.7.12",
+                "@rspack/binding-wasm32-wasi": "1.7.12",
+                "@rspack/binding-win32-arm64-msvc": "1.7.12",
+                "@rspack/binding-win32-ia32-msvc": "1.7.12",
+                "@rspack/binding-win32-x64-msvc": "1.7.12"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.12.tgz",
+            "integrity": "sha512-rbFprJaJiqrmfy8SHth8EsoRS0wg4bXcucwj9NiMzpGFq14Opw8c04iQ6H9BECYzgmN0PKZ9rh41LdVvhdZe4A==",
+            "cpu": [
+                "arm64"
             ],
-            "peer": true
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.12.tgz",
+            "integrity": "sha512-jnOp+/UXOJa9xqUb8KXH03sysoO2e4Ij6tw6MqDdmdj8n/A8PQENRPUbW9AwXpPtVDJPus9r4fi7b3+6e4B8Hg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.12.tgz",
+            "integrity": "sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.12.tgz",
+            "integrity": "sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.12.tgz",
+            "integrity": "sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.12.tgz",
+            "integrity": "sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-wasm32-wasi": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.12.tgz",
+            "integrity": "sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "1.0.7"
+            }
+        },
+        "node_modules/@rspack/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+            "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.5.0",
+                "@emnapi/runtime": "^1.5.0",
+                "@tybys/wasm-util": "^0.10.1"
+            }
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.12.tgz",
+            "integrity": "sha512-8+h5fYDXYdmugbdfZ+D1y8IQ3rv2EhSfyGP7vBe+bjNyaMa4jWrpucmZbtxojUL1AzaeuHbvMdj9UO/gelk/+g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.12.tgz",
+            "integrity": "sha512-cDMGwTRSa2p9fNBVe1wTRkF2AEXZ9ARWW36QeC5CkLaI0Ezz8lvhF2+CSOPnhaQ1O1qtn0L0SF+lFnrY+I7xGQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.12.tgz",
+            "integrity": "sha512-wIqFvlgFqrgUyj/6S/FJcvShnkZOmIeXTfqvheLY67MGq8qd8jb1YimQVKAIrmWB3yuJKUFACI3Ag1UBtEedEA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/core": {
+            "version": "1.7.12",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.12.tgz",
+            "integrity": "sha512-6CwFIHlhRmXfZoMj3v9MZ1SMTPBn+cHVXeMIeaGp5sufqinKsISbsqHu6ZMJu2wDSmZLdmQJX6zLxkhcAUlhkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.22.0",
+                "@rspack/binding": "1.7.12",
+                "@rspack/lite-tapable": "1.1.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/lite-tapable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+            "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+            "license": "MIT"
         },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
@@ -14996,7 +15231,6 @@
             "version": "1.15.41",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
             "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
-            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -15040,13 +15274,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15058,13 +15290,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15076,13 +15306,11 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15094,13 +15322,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15112,13 +15338,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15130,13 +15354,11 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15148,13 +15370,11 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15166,13 +15386,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15184,13 +15402,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15202,13 +15418,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15220,13 +15434,11 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15238,13 +15450,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15253,7 +15463,6 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/helpers": {
@@ -15265,11 +15474,246 @@
                 "tslib": "^2.8.0"
             }
         },
+        "node_modules/@swc/html": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.15.41.tgz",
+            "integrity": "sha512-FHoXxI56hDKagLxpv5t8ovSPRecBufmHCAhGUuhFQqarfmxGX4g1bTfjQzwuRGRqtWm3IK14oX+TMOM10g51wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "@swc/html-darwin-arm64": "1.15.41",
+                "@swc/html-darwin-x64": "1.15.41",
+                "@swc/html-linux-arm-gnueabihf": "1.15.41",
+                "@swc/html-linux-arm64-gnu": "1.15.41",
+                "@swc/html-linux-arm64-musl": "1.15.41",
+                "@swc/html-linux-ppc64-gnu": "1.15.41",
+                "@swc/html-linux-s390x-gnu": "1.15.41",
+                "@swc/html-linux-x64-gnu": "1.15.41",
+                "@swc/html-linux-x64-musl": "1.15.41",
+                "@swc/html-win32-arm64-msvc": "1.15.41",
+                "@swc/html-win32-ia32-msvc": "1.15.41",
+                "@swc/html-win32-x64-msvc": "1.15.41"
+            }
+        },
+        "node_modules/@swc/html-darwin-arm64": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.41.tgz",
+            "integrity": "sha512-twmx/p6DjOwvuVEl7R449fTDsDy6sBGaxXBqp/+J8LWlJeonsqdy3IXNLcSPDDU90EYl4KyhVqH/bhjt6COGrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-darwin-x64": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.15.41.tgz",
+            "integrity": "sha512-VUoct8+4lz7owLlW0KSe5ljjSONZMWGpQbTAhSv++HuNPA/hZCuVoGY16PjRLF9u03zrWLDRqn2CCEdRTrUrSw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm-gnueabihf": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.41.tgz",
+            "integrity": "sha512-vDlyud/W/KhnsHD87tvHrF+WXzf4iaJBWM8XdUQ2DKpS7nlK+2qHNAphcVZqu92qZavkvWgWBBgzSNK2And+Ag==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-gnu": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.41.tgz",
+            "integrity": "sha512-dEMS/oCMk2KYrQZzRSKDj7hGSMA/UNQ28lVdI0SgWmkUXikFvBCyLBWS50FxnGvquotI3FaoIkGmm+pKJEzMeQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-musl": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.41.tgz",
+            "integrity": "sha512-1yFYeHlyP73BGHTtzaiZoiWTr/NfWkhMKXK+Fm8AH5NNQ99XfP48nDEwWAN7ubwNanDsGw1EELriRucEnxvCQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-ppc64-gnu": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.41.tgz",
+            "integrity": "sha512-XIf8fgQ5rEj1y7xjCJZHEvKDMYtAcGfsk8wWGLeUAkYvZhNGEnH2OS2BAZmgXNaaWATmaG8KDM1G2HoluhJpBA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-s390x-gnu": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.41.tgz",
+            "integrity": "sha512-mE39odiWiZcBBxMfUYgzsZ4+LpOg/eQj8aQyMkTciiKpcurokcRzcUiilMSXtUleVDcLnL1BG1YkHFyyy9rE5Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-gnu": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.41.tgz",
+            "integrity": "sha512-/etNlaoe+6KVYZ0/BVLvo5/Zcf/f69Cuw0lBSGrCQUr/GP1pKERppmxQqy+onVVT1ckMaur0KR8p9MMI2us7gA==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-musl": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.41.tgz",
+            "integrity": "sha512-Pzb5QRI0YcInNHShkGW36zypKLCNV/iC60S867PQNRiHnq7igY0z8r6UuLJUhL4EeNA0OVwF+/V5Eqtav38+4w==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-arm64-msvc": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.41.tgz",
+            "integrity": "sha512-hT0dZeNThmaU6JQ3R8LKetCyhYDjah8nDjYGNg++RYrJX9Q/iFu5GhL2GGwcTHdwR+XqpNlmpfGBA4djw1I71w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-ia32-msvc": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.41.tgz",
+            "integrity": "sha512-PBihRAO6II8L34AafDxQGea9f/Sw+l3btlrODthJF/VasxQPDIitbGKHZdWMry0qLBIzpOdX30h3p3ZD3o3/jQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-x64-msvc": {
+            "version": "1.15.41",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.41.tgz",
+            "integrity": "sha512-o+9kX1Q6EwpVrrn7uEn/CxXEJDt3n6oLChIwkJFFK2Fh0XjPfOKzlNLOUdwjx6EihRXw1lqQRu/+mE+eS5bIUw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@swc/types": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
             "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -44856,6 +45300,19 @@
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
             "license": "CC0-1.0"
         },
+        "node_modules/swc-loader": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.7.tgz",
+            "integrity": "sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==",
+            "license": "MIT",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.147",
+                "webpack": ">=2"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -45850,7 +46307,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }


### PR DESCRIPTION
## Description

The Docusaurus build for `calmguard-docs` fails on `main` with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@docusaurus/faster'
imported from .../node_modules/@docusaurus/bundler/lib/importFaster.js
```

Repro on plain `origin/main` (no local changes):

```bash
git checkout main && git pull
npm ci
npm run build --workspace calmguard-docs   # → exit code 1
```

Root cause: `@docusaurus/core@3.10.1`'s `@docusaurus/bundler` imports `@docusaurus/faster` to honour the `future.experimental_faster` / `future.v4` Faster bundler path. `calm-suite/calm-guard/docs/docusaurus.config.ts` sets `future.v4: true`, which exercises the `importFaster` code path, but `@docusaurus/faster` is not declared in `calm-suite/calm-guard/docs/package.json`.

### Fix

- Added `@docusaurus/faster: ^3.10.1` to `calm-suite/calm-guard/docs/package.json` (pinned to match the existing `@docusaurus/core` / `@docusaurus/preset-classic`).
- Regenerated root lockfile via incremental `npm install @docusaurus/faster@3.10.1 --workspace calmguard-docs --package-lock-only` — adds `@docusaurus/faster` + 4 new transitive deps (`@swc/html`, `swc-loader`, `@rspack/core`, nested `@docusaurus/types`/`commander`) without touching any other workspace's resolutions. All 19 rollup platform-specific binaries preserved (validate-lockfile guard upheld).

### Verified locally
- `npm ci` exits 0
- `npm run build --workspace calmguard-docs` exits 0 (was: `code 1` on `origin/main`)

### Out of scope / pre-existing
- `npm run build --workspace calmguard` (the Next.js app, not docs) fails on `origin/main` with `Error occurred prerendering page "/dashboard"`. Reproduces identically on plain `origin/main` with no local changes — pre-existing, unrelated to this fix.

### Context

Surfaced while preparing PR #2664 (A2 of Track A #2649 / parent epic #2600) — the calmguard-docs failure showed up on every Track A PR's CI. Fixing it here in a small standalone PR keeps the Track A queue clean rather than bundling it into A1/A2/A3.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [ ] Documentation (`docs/`)
- [x] CALMGuard docs (`calm-suite/calm-guard/docs/`) — Docusaurus build dep
- [x] Dependencies (lockfile)

## Commit Message Format ✅

Single commit, DCO-signed:
- `fix(calm-suite): declare @docusaurus/faster as dependency in calmguard-docs`

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass (`npm test` exits 0)
- [x] `npm run build --workspace calmguard-docs` exits 0

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] My changes follow the project's coding standards

Standalone — does not depend on PR #2661 or PR #2664.
