### PR TITLE
feat(calm-hub): implement RESTful user access management API (#2676)

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/domain/UserAccessRequest.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/UserAccessRequest.java
@@ -1,0 +1,36 @@
+package org.finos.calm.domain;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import static org.finos.calm.resources.ResourceValidationConstants.USERNAME_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.USERNAME_REGEX;
+
+public class UserAccessRequest {
+
+    @Pattern(regexp = USERNAME_REGEX, message = USERNAME_MESSAGE)
+    @NotNull
+    private String username;
+
+    @NotNull
+    private UserAccess.Permission permission;
+
+    public UserAccessRequest() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public UserAccess.Permission getPermission() {
+        return permission;
+    }
+
+    public void setPermission(UserAccess.Permission permission) {
+        this.permission = permission;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/CurrentUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CurrentUserAccessResource.java
@@ -1,0 +1,47 @@
+package org.finos.calm.resources;
+
+import java.util.List;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.finos.calm.domain.UserAccess;
+import org.finos.calm.store.UserAccessStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
+@Path("/api/calm/user-access")
+public class CurrentUserAccessResource {
+
+    private final UserAccessStore store;
+    private final Logger logger = LoggerFactory.getLogger(CurrentUserAccessResource.class);
+
+    @Inject
+    SecurityIdentity identity;
+
+    public CurrentUserAccessResource(UserAccessStore store) {
+        this.store = store;
+    }
+
+    @GET
+    @Path("current")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Authenticated
+    @Operation(
+            summary = "Get grants for the authenticated user",
+            description = "Returns all user-access grants for the calling user, including wildcard grants that grant implicit access. Used by UIs to determine which namespaces the user can access."
+    )
+    public Response getCurrentUserAccess() {
+        String username = identity.getPrincipal().getName();
+        logger.debug("Fetching grants for user [{}]", username);
+        List<UserAccess> grants = store.getGrantsForUser(username);
+        return Response.ok(grants).build();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
@@ -10,8 +10,10 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.UserAccess;
+import org.finos.calm.domain.UserAccessRequest;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.store.DomainStore;
 import org.finos.calm.store.UserAccessStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,10 +30,12 @@ import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
 public class DomainUserAccessResource {
 
     private final UserAccessStore store;
+    private final DomainStore domainStore;
     private final Logger logger = LoggerFactory.getLogger(DomainUserAccessResource.class);
 
-    public DomainUserAccessResource(UserAccessStore userAccessStore) {
+    public DomainUserAccessResource(UserAccessStore userAccessStore, DomainStore domainStore) {
         this.store = userAccessStore;
+        this.domainStore = domainStore;
     }
 
     @POST
@@ -44,18 +48,20 @@ public class DomainUserAccessResource {
     )
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
     public Response createUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
-                                              @Valid @NotNull UserAccess createUserAccessRequest) {
+                                              @Valid @NotNull UserAccessRequest request) {
 
-        createUserAccessRequest.setCreationDateTime(LocalDateTime.now());
-        createUserAccessRequest.setUpdateDateTime(LocalDateTime.now());
-
-        if (!domain.equals(createUserAccessRequest.getDomain())) {
-            logger.error("Request contains an invalid domain [{}]", createUserAccessRequest.getDomain());
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Bad Request").build();
+        if (!domainStore.domainExists(domain)) {
+            return invalidDomainResponse(domain);
         }
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setDomain(domain)
+                .setUsername(request.getUsername())
+                .setPermission(request.getPermission())
+                .build();
+        userAccess.setCreationDateTime(LocalDateTime.now());
+        userAccess.setUpdateDateTime(LocalDateTime.now());
         try {
-            return locationResponse(store.createUserAccessForDomain(createUserAccessRequest));
+            return locationResponse(store.createUserAccessForDomain(userAccess));
         } catch (URISyntaxException ex) {
             logger.error("Failed to create user-access for domain: [{}]", domain, ex);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -72,14 +78,10 @@ public class DomainUserAccessResource {
     )
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
     public Response getUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain) {
-        try {
-            return Response.ok(store.getUserAccessForDomain(domain)).build();
-        } catch (UserAccessNotFoundException ex) {
-            logger.error("User-access details not found for domain [{}]", domain, ex);
-            return Response.status(Response.Status.NOT_FOUND)
-                    .entity("No access permissions found")
-                    .build();
+        if (!domainStore.domainExists(domain)) {
+            return invalidDomainResponse(domain);
         }
+        return Response.ok(store.getUserAccessForDomain(domain)).build();
     }
 
     @GET
@@ -92,6 +94,9 @@ public class DomainUserAccessResource {
     @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
     public Response getUserAccessForDomainAndId(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
                                                 @PathParam("userAccessId") @NotNull Integer userAccessId) {
+        if (!domainStore.domainExists(domain)) {
+            return invalidDomainResponse(domain);
+        }
         try {
             return Response.ok(store.getUserAccessForDomainAndId(domain, userAccessId)).build();
         } catch (UserAccessNotFoundException ex) {
@@ -99,6 +104,34 @@ public class DomainUserAccessResource {
             return Response.status(Response.Status.NOT_FOUND)
                     .entity("No access permissions found").build();
         }
+    }
+
+    @DELETE
+    @Path("{domain}/user-access/{userAccessId}")
+    @Operation(
+            summary = "Revoke a domain user-access grant",
+            description = "Deletes the user-access record for the given domain and id"
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
+                                              @PathParam("userAccessId") @NotNull Integer userAccessId) {
+        if (!domainStore.domainExists(domain)) {
+            return invalidDomainResponse(domain);
+        }
+        try {
+            store.deleteUserAccessForDomain(domain, userAccessId);
+            return Response.noContent().build();
+        } catch (UserAccessNotFoundException ex) {
+            logger.error("User-access record [{}] not found in domain [{}]", userAccessId, domain, ex);
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No access permissions found").build();
+        }
+    }
+
+    private Response invalidDomainResponse(String domain) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity("Invalid domain provided: " + domain)
+                .build();
     }
 
     private Response locationResponse(UserAccess userAccess) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -1,7 +1,6 @@
 package org.finos.calm.resources;
 
 import io.quarkus.security.PermissionsAllowed;
-import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -11,6 +10,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.UserAccess;
+import org.finos.calm.domain.UserAccessRequest;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
@@ -46,17 +46,17 @@ public class UserAccessResource {
     )
     @PermissionsAllowed(CalmHubScopes.ADMIN)
     public Response createUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
-                                                 @Valid @NotNull UserAccess createUserAccessRequest) {
+                                                 @Valid @NotNull UserAccessRequest request) {
 
-        createUserAccessRequest.setCreationDateTime(LocalDateTime.now());
-        createUserAccessRequest.setUpdateDateTime(LocalDateTime.now());
-        if (!namespace.equals(createUserAccessRequest.getNamespace())) {
-            logger.error("Request contains an invalid namespace [{}]", createUserAccessRequest.getNamespace());
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Bad Request").build();
-        }
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace(namespace)
+                .setUsername(request.getUsername())
+                .setPermission(request.getPermission())
+                .build();
+        userAccess.setCreationDateTime(LocalDateTime.now());
+        userAccess.setUpdateDateTime(LocalDateTime.now());
         try {
-            return locationResponse(store.createUserAccessForNamespace(createUserAccessRequest));
+            return locationResponse(store.createUserAccessForNamespace(userAccess));
         } catch (NamespaceNotFoundException exception) {
             logger.error("Invalid namespace [{}] when creating user access", namespace, exception);
             return invalidNamespaceResponse(namespace);
@@ -78,16 +78,10 @@ public class UserAccessResource {
     public Response getUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace) {
 
         try {
-            return Response.ok(store.getUserAccessForNamespace(namespace))
-                    .build();
+            return Response.ok(store.getUserAccessForNamespace(namespace)).build();
         } catch (NamespaceNotFoundException exception) {
             logger.error("Invalid namespace [{}] when getting user-access details", namespace, exception);
             return invalidNamespaceResponse(namespace);
-        } catch (UserAccessNotFoundException ex) {
-            logger.error("Use-access details are not found [{}]", namespace, ex);
-            return Response.status(Response.Status.NOT_FOUND)
-                    .entity("No access permissions found")
-                    .build();
         }
     }
 
@@ -110,6 +104,28 @@ public class UserAccessResource {
             return invalidNamespaceResponse(namespace);
         } catch (UserAccessNotFoundException ex) {
             logger.error("Use-access details are not found [{}]", namespace, ex);
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No access permissions found").build();
+        }
+    }
+
+    @DELETE
+    @Path("{namespace}/user-access/{userAccessId}")
+    @Operation(
+            summary = "Revoke a user-access grant",
+            description = "Deletes the user-access record for the given namespace and id"
+    )
+    @PermissionsAllowed(CalmHubScopes.ADMIN)
+    public Response deleteUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+                                                 @PathParam("userAccessId") @NotNull Integer userAccessId) {
+        try {
+            store.deleteUserAccessForNamespace(namespace, userAccessId);
+            return Response.noContent().build();
+        } catch (NamespaceNotFoundException exception) {
+            logger.error("Invalid namespace [{}] when deleting user access", namespace, exception);
+            return invalidNamespaceResponse(namespace);
+        } catch (UserAccessNotFoundException ex) {
+            logger.error("User-access record [{}] not found in namespace [{}]", userAccessId, namespace, ex);
             return Response.status(Response.Status.NOT_FOUND)
                     .entity("No access permissions found").build();
         }

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
@@ -121,8 +121,13 @@ public class CalmHubPermissionChecker {
         logger.debug("Checking namespace access for user [{}] on namespace [{}] action=[{}]", username, namespace, action);
 
         List<UserAccess> grants = userAccessStore.getGrantsForUser(username);
-        List<String> ancestors = ancestorChain(namespace);
 
+        if (action == UserAction.ADMIN && isGlobalAdminFromGrants(username, grants)) {
+            logger.debug("User [{}] AUTHORIZED for [{}] in namespace [{}] via GLOBAL admin grant", username, action, namespace);
+            return true;
+        }
+
+        List<String> ancestors = ancestorChain(namespace);
         boolean result = action == UserAction.READ
                 ? allAncestorsHaveGrant(ancestors, grants, action)
                 : anyAncestorHasGrant(ancestors, grants, action);
@@ -133,6 +138,13 @@ public class CalmHubPermissionChecker {
             logger.debug("User [{}] DENIED for [{}] in namespace [{}]", username, action, namespace);
         }
         return result;
+    }
+
+    private boolean isGlobalAdminFromGrants(String username, List<UserAccess> grants) {
+        return grants.stream()
+                .anyMatch(g -> username.equals(g.getUsername())
+                        && GLOBAL_ACCESS.equals(g.getNamespace())
+                        && permissionSufficient(g, UserAction.ADMIN));
     }
 
     private boolean allAncestorsHaveGrant(List<String> ancestors, List<UserAccess> grants, UserAction action) {

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceMigrationService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceMigrationService.java
@@ -7,7 +7,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
@@ -61,11 +60,11 @@ public class NamespaceMigrationService {
     boolean backfillIfNeeded(String namespace) {
         try {
             List<UserAccess> existing = userAccessStore.getUserAccessForNamespace(namespace);
-            // Namespace has explicit grants — admin configured access intentionally, do not add * read
-            LOG.debug("Namespace [{}] has {} existing grant(s) — skipping", namespace, existing.size());
-            return false;
-        } catch (UserAccessNotFoundException e) {
-            // no grants at all — safe to insert the default public read
+            if (!existing.isEmpty()) {
+                // Namespace has explicit grants — admin configured access intentionally, do not add * read
+                LOG.debug("Namespace [{}] has {} existing grant(s) — skipping", namespace, existing.size());
+                return false;
+            }
         } catch (NamespaceNotFoundException e) {
             LOG.warn("Namespace [{}] not found during migration — skipping", namespace);
             return false;

--- a/calm-hub/src/main/java/org/finos/calm/store/DomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/DomainStore.java
@@ -25,4 +25,12 @@ public interface DomainStore {
      * @throws DomainAlreadyExistsException if a domain with the same name already exists
      */
     Domain createDomain(String name) throws DomainAlreadyExistsException;
+
+    /**
+     * Checks whether a domain with the given name exists.
+     *
+     * @param name the domain name to check
+     * @return true if the domain exists, false otherwise
+     */
+    boolean domainExists(String name);
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/UserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/UserAccessStore.java
@@ -43,9 +43,9 @@ public interface UserAccessStore {
      * Retrieves a list of all UserAccess details associated to a namespace.
      *
      * @param namespace the name of the namespace to fetch associated UserAccess records.
-     * @return a list of UserAccess details
+     * @return a list of UserAccess details (empty if none exist)
      */
-    List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException, UserAccessNotFoundException;
+    List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException;
 
     /**
      * Retrieve a UserAccess object that is mapped to a namespace and userAccessId.
@@ -68,9 +68,9 @@ public interface UserAccessStore {
      * Retrieves all UserAccess grants for a given domain.
      *
      * @param domain the domain name to fetch associated UserAccess records.
-     * @return a list of UserAccess details
+     * @return a list of UserAccess details (empty if none exist)
      */
-    List<UserAccess> getUserAccessForDomain(String domain) throws UserAccessNotFoundException;
+    List<UserAccess> getUserAccessForDomain(String domain);
 
     /**
      * Retrieve a specific domain-scoped UserAccess record by domain and id.
@@ -80,4 +80,23 @@ public interface UserAccessStore {
      * @return the UserAccess record
      */
     UserAccess getUserAccessForDomainAndId(String domain, Integer userAccessId) throws UserAccessNotFoundException;
+
+    /**
+     * Delete a namespace-scoped UserAccess grant by namespace and id.
+     *
+     * @param namespace    the namespace the grant belongs to.
+     * @param userAccessId the sequence number of the UserAccess record to delete.
+     * @throws NamespaceNotFoundException  if the namespace does not exist.
+     * @throws UserAccessNotFoundException if no grant exists for that id in the namespace.
+     */
+    void deleteUserAccessForNamespace(String namespace, Integer userAccessId) throws NamespaceNotFoundException, UserAccessNotFoundException;
+
+    /**
+     * Delete a domain-scoped UserAccess grant by domain and id.
+     *
+     * @param domain       the domain the grant belongs to.
+     * @param userAccessId the sequence number of the UserAccess record to delete.
+     * @throws UserAccessNotFoundException if no grant exists for that id in the domain.
+     */
+    void deleteUserAccessForDomain(String domain, Integer userAccessId) throws UserAccessNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
@@ -4,6 +4,7 @@ import com.mongodb.ErrorCategory;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
@@ -46,6 +47,11 @@ public class MongoDomainStore implements DomainStore {
             domains.add(doc.getString("name"));
         }
         return domains;
+    }
+
+    @Override
+    public boolean domainExists(String name) {
+        return domainsCollection.countDocuments(Filters.eq("name", name)) > 0;
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -3,6 +3,7 @@ package org.finos.calm.store.mongo;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.result.DeleteResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
@@ -110,19 +111,13 @@ public class MongoUserAccessStore implements UserAccessStore {
     }
 
     @Override
-    public List<UserAccess> getUserAccessForNamespace(String namespace)
-            throws NamespaceNotFoundException, UserAccessNotFoundException {
-
+    public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
         List<UserAccess> userAccessList = new ArrayList<>();
         for (Document doc : userAccessCollection.find(Filters.eq("namespace", namespace))) {
             userAccessList.add(buildFromDocument(doc));
-        }
-
-        if (userAccessList.isEmpty()) {
-            throw new UserAccessNotFoundException();
         }
         return userAccessList;
     }
@@ -147,16 +142,10 @@ public class MongoUserAccessStore implements UserAccessStore {
     }
 
     @Override
-    public List<UserAccess> getUserAccessForDomain(String domain)
-            throws UserAccessNotFoundException {
-
+    public List<UserAccess> getUserAccessForDomain(String domain) {
         List<UserAccess> userAccessList = new ArrayList<>();
         for (Document doc : userAccessCollection.find(Filters.eq("domain", domain))) {
             userAccessList.add(buildFromDocument(doc));
-        }
-
-        if (userAccessList.isEmpty()) {
-            throw new UserAccessNotFoundException();
         }
         return userAccessList;
     }
@@ -174,6 +163,33 @@ public class MongoUserAccessStore implements UserAccessStore {
             throw new UserAccessNotFoundException();
         }
         return buildFromDocument(document);
+    }
+
+    @Override
+    public void deleteUserAccessForDomain(String domain, Integer userAccessId) throws UserAccessNotFoundException {
+        DeleteResult result = userAccessCollection.deleteOne(Filters.and(
+                Filters.eq("domain", domain),
+                Filters.eq("userAccessId", userAccessId)));
+        if (result.getDeletedCount() == 0) {
+            throw new UserAccessNotFoundException();
+        }
+    }
+
+    @Override
+    public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
+            throws NamespaceNotFoundException, UserAccessNotFoundException {
+
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+
+        DeleteResult result = userAccessCollection.deleteOne(Filters.and(
+                Filters.eq("namespace", namespace),
+                Filters.eq("userAccessId", userAccessId)));
+
+        if (result.getDeletedCount() == 0) {
+            throw new UserAccessNotFoundException();
+        }
     }
 
     private UserAccess buildFromDocument(Document doc) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDomainStore.java
@@ -88,13 +88,8 @@ public class NitriteDomainStore implements DomainStore {
         }
     }
 
-    /**
-     * Checks if a domain with the given name already exists.
-     *
-     * @param name the domain name to check
-     * @return true if the domain exists, false otherwise
-     */
-    private boolean domainExists(String name) {
+    @Override
+    public boolean domainExists(String name) {
         Filter filter = where(NAME_FIELD).eq(name);
         return domainCollection.find(filter).firstOrNull() != null;
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -120,23 +120,14 @@ public class NitriteUserAccessStore implements UserAccessStore {
     }
 
     @Override
-    public List<UserAccess> getUserAccessForNamespace(String namespace)
-            throws NamespaceNotFoundException, UserAccessNotFoundException {
-        
+    public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
-        
         Filter filter = where(NAMESPACE_FIELD).eq(namespace);
         List<UserAccess> userAccessList = new ArrayList<>();
-        
         for (Document doc : userAccessCollection.find(filter)) {
-            UserAccess userAccess = buildUserAccessFromDocument(doc);
-            userAccessList.add(userAccess);
-        }
-
-        if (userAccessList.isEmpty()) {
-            throw new UserAccessNotFoundException();
+            userAccessList.add(buildUserAccessFromDocument(doc));
         }
         return userAccessList;
     }
@@ -192,16 +183,11 @@ public class NitriteUserAccessStore implements UserAccessStore {
     }
 
     @Override
-    public List<UserAccess> getUserAccessForDomain(String domain) throws UserAccessNotFoundException {
+    public List<UserAccess> getUserAccessForDomain(String domain) {
         Filter filter = where(DOMAIN_FIELD).eq(domain);
         List<UserAccess> userAccessList = new ArrayList<>();
-
         for (Document doc : userAccessCollection.find(filter)) {
             userAccessList.add(buildUserAccessFromDocument(doc));
-        }
-
-        if (userAccessList.isEmpty()) {
-            throw new UserAccessNotFoundException();
         }
         return userAccessList;
     }
@@ -216,6 +202,42 @@ public class NitriteUserAccessStore implements UserAccessStore {
         }
 
         return buildUserAccessFromDocument(document);
+    }
+
+    @Override
+    public void deleteUserAccessForDomain(String domain, Integer userAccessId) throws UserAccessNotFoundException {
+        lock.lock();
+        try {
+            Filter filter = where(DOMAIN_FIELD).eq(domain).and(where(USER_ACCESS_ID_FIELD).eq(userAccessId));
+            Document existing = userAccessCollection.find(filter).firstOrNull();
+            if (existing == null) {
+                throw new UserAccessNotFoundException();
+            }
+            userAccessCollection.remove(existing);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
+            throws NamespaceNotFoundException, UserAccessNotFoundException {
+
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+
+        lock.lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(USER_ACCESS_ID_FIELD).eq(userAccessId));
+            Document existing = userAccessCollection.find(filter).firstOrNull();
+            if (existing == null) {
+                throw new UserAccessNotFoundException();
+            }
+            userAccessCollection.remove(existing);
+        } finally {
+            lock.unlock();
+        }
     }
 
     private UserAccess buildUserAccessFromDocument(Document doc) {

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceShould.java
@@ -1,0 +1,99 @@
+package org.finos.calm.resources;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.finos.calm.domain.UserAccess;
+import org.finos.calm.store.UserAccessStore;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+public class TestCurrentUserAccessResourceShould {
+
+    @InjectMock
+    UserAccessStore mockUserAccessStore;
+
+    @Test
+    @TestSecurity(user = "alice")
+    void return_200_with_grants_for_authenticated_user() {
+        UserAccess grant = new UserAccess();
+        grant.setUsername("alice");
+        grant.setNamespace("finos");
+        grant.setPermission(UserAccess.Permission.admin);
+        grant.setUserAccessId(1);
+
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
+
+        given()
+                .when()
+                .get("/api/calm/user-access/current")
+                .then()
+                .statusCode(200)
+                .body(containsString("alice"))
+                .body(containsString("finos"));
+
+        verify(mockUserAccessStore, times(1)).getGrantsForUser("alice");
+    }
+
+    @Test
+    @TestSecurity(user = "bob")
+    void return_200_with_empty_list_when_user_has_no_grants() {
+        when(mockUserAccessStore.getGrantsForUser("bob")).thenReturn(Collections.emptyList());
+
+        given()
+                .when()
+                .get("/api/calm/user-access/current")
+                .then()
+                .statusCode(200)
+                .body(containsString("[]"));
+
+        verify(mockUserAccessStore, times(1)).getGrantsForUser("bob");
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    void return_200_including_wildcard_grants_for_implicit_access() {
+        UserAccess personalGrant = new UserAccess();
+        personalGrant.setUsername("alice");
+        personalGrant.setNamespace("finos");
+        personalGrant.setPermission(UserAccess.Permission.admin);
+        personalGrant.setUserAccessId(1);
+
+        UserAccess wildcardGrant = new UserAccess();
+        wildcardGrant.setUsername("*");
+        wildcardGrant.setNamespace("finos.open");
+        wildcardGrant.setPermission(UserAccess.Permission.read);
+        wildcardGrant.setUserAccessId(2);
+
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(personalGrant, wildcardGrant));
+
+        given()
+                .when()
+                .get("/api/calm/user-access/current")
+                .then()
+                .statusCode(200)
+                .body(containsString("alice"))
+                .body(containsString("\"*\""))
+                .body(containsString("finos.open"));
+
+        verify(mockUserAccessStore, times(1)).getGrantsForUser("alice");
+    }
+
+    @Test
+    void return_401_when_not_authenticated() {
+        given()
+                .when()
+                .get("/api/calm/user-access/current")
+                .then()
+                .statusCode(401);
+
+        verify(mockUserAccessStore, never()).getGrantsForUser(any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
@@ -1,20 +1,23 @@
 package org.finos.calm.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
+import org.finos.calm.store.DomainStore;
 import org.finos.calm.store.UserAccessStore;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @TestSecurity(authorizationEnabled = false)
@@ -24,7 +27,13 @@ public class TestDomainUserAccessResourceShould {
     @InjectMock
     UserAccessStore mockUserAccessStore;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    @InjectMock
+    DomainStore mockDomainStore;
+
+    @BeforeEach
+    void defaultDomainExists() {
+        lenient().when(mockDomainStore.domainExists(anyString())).thenReturn(true);
+    }
 
     @Test
     void return_400_when_invalid_domain_format_provided_on_create_user_access() {
@@ -59,13 +68,7 @@ public class TestDomainUserAccessResourceShould {
     }
 
     @Test
-    void return_201_created_with_location_header_when_domain_user_access_is_created() throws Exception {
-        UserAccess userAccess = new UserAccess();
-        userAccess.setDomain("payments");
-        userAccess.setPermission(UserAccess.Permission.write);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
+    void return_201_created_with_location_header_when_domain_user_access_is_created() {
         UserAccess created = new UserAccess();
         created.setDomain("payments");
         created.setPermission(UserAccess.Permission.write);
@@ -75,7 +78,7 @@ public class TestDomainUserAccessResourceShould {
 
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"test_user\",\"permission\":\"write\"}")
                 .when()
                 .post("/api/calm/domains/payments/user-access")
                 .then()
@@ -86,40 +89,15 @@ public class TestDomainUserAccessResourceShould {
     }
 
     @Test
-    void return_400_when_creating_user_access_with_mismatched_domain() throws Exception {
-        UserAccess userAccess = new UserAccess();
-        userAccess.setDomain("other");
-        userAccess.setPermission(UserAccess.Permission.write);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
-        given()
-                .header("Content-Type", "application/json")
-                .body(requestBody)
-                .when()
-                .post("/api/calm/domains/payments/user-access")
-                .then()
-                .statusCode(400)
-                .body(containsString("Bad Request"));
-
-        verify(mockUserAccessStore, times(0)).createUserAccessForDomain(any(UserAccess.class));
-    }
-
-    @Test
-    void return_500_when_store_returns_domain_that_causes_uri_syntax_error() throws Exception {
+    void return_500_when_store_returns_domain_that_causes_uri_syntax_error() {
         UserAccess invalid = new UserAccess();
         invalid.setDomain("payments invalid");
         invalid.setUserAccessId(1);
         when(mockUserAccessStore.createUserAccessForDomain(any(UserAccess.class))).thenReturn(invalid);
 
-        UserAccess userAccess = new UserAccess();
-        userAccess.setDomain("payments");
-        userAccess.setPermission(UserAccess.Permission.write);
-        userAccess.setUsername("test_user");
-
         given()
                 .header("Content-Type", "application/json")
-                .body(OBJECT_MAPPER.writeValueAsString(userAccess))
+                .body("{\"username\":\"test_user\",\"permission\":\"write\"}")
                 .when()
                 .post("/api/calm/domains/payments/user-access")
                 .then()
@@ -130,19 +108,13 @@ public class TestDomainUserAccessResourceShould {
     }
 
     @Test
-    void return_500_when_internal_error_occurs_during_domain_user_access_creation() throws Exception {
+    void return_500_when_internal_error_occurs_during_domain_user_access_creation() {
         when(mockUserAccessStore.createUserAccessForDomain(any(UserAccess.class)))
                 .thenThrow(new RuntimeException("Unexpected error"));
 
-        UserAccess userAccess = new UserAccess();
-        userAccess.setDomain("payments");
-        userAccess.setPermission(UserAccess.Permission.write);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"test_user\",\"permission\":\"write\"}")
                 .when()
                 .post("/api/calm/domains/payments/user-access")
                 .then()
@@ -177,16 +149,15 @@ public class TestDomainUserAccessResourceShould {
     }
 
     @Test
-    void return_404_when_no_user_access_found_for_domain() throws Exception {
-        when(mockUserAccessStore.getUserAccessForDomain("payments"))
-                .thenThrow(new UserAccessNotFoundException());
+    void return_200_with_empty_list_when_domain_has_no_grants() {
+        when(mockUserAccessStore.getUserAccessForDomain("payments")).thenReturn(Collections.emptyList());
 
         given()
                 .when()
                 .get("/api/calm/domains/payments/user-access")
                 .then()
-                .statusCode(404)
-                .body(containsString("No access permissions found"));
+                .statusCode(200)
+                .body(containsString("[]"));
 
         verify(mockUserAccessStore, times(1)).getUserAccessForDomain("payments");
     }
@@ -236,5 +207,101 @@ public class TestDomainUserAccessResourceShould {
                 .body(containsString("No access permissions found"));
 
         verify(mockUserAccessStore, times(1)).getUserAccessForDomainAndId("payments", 999);
+    }
+
+    @Test
+    void return_204_when_domain_user_access_is_deleted() throws Exception {
+        doNothing().when(mockUserAccessStore).deleteUserAccessForDomain("payments", 201);
+
+        given()
+                .when()
+                .delete("/api/calm/domains/payments/user-access/201")
+                .then()
+                .statusCode(204);
+
+        verify(mockUserAccessStore, times(1)).deleteUserAccessForDomain("payments", 201);
+    }
+
+    @Test
+    void return_404_when_deleting_domain_user_access_that_does_not_exist() throws Exception {
+        doThrow(new UserAccessNotFoundException())
+                .when(mockUserAccessStore).deleteUserAccessForDomain("payments", 999);
+
+        given()
+                .when()
+                .delete("/api/calm/domains/payments/user-access/999")
+                .then()
+                .statusCode(404)
+                .body(containsString("No access permissions found"));
+
+        verify(mockUserAccessStore, times(1)).deleteUserAccessForDomain("payments", 999);
+    }
+
+    @Test
+    void return_400_when_invalid_domain_format_provided_on_delete_user_access() {
+        given()
+                .when()
+                .delete("/api/calm/domains/invalid_domain/user-access/1")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
+
+    @Test
+    void return_404_when_domain_does_not_exist_on_create_user_access() {
+        when(mockDomainStore.domainExists("unknown")).thenReturn(false);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"test_user\",\"permission\":\"write\"}")
+                .when()
+                .post("/api/calm/domains/unknown/user-access")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid domain provided: unknown"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForDomain(any());
+    }
+
+    @Test
+    void return_404_when_domain_does_not_exist_on_get_user_access() {
+        when(mockDomainStore.domainExists("unknown")).thenReturn(false);
+
+        given()
+                .when()
+                .get("/api/calm/domains/unknown/user-access")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid domain provided: unknown"));
+
+        verify(mockUserAccessStore, never()).getUserAccessForDomain(any());
+    }
+
+    @Test
+    void return_404_when_domain_does_not_exist_on_get_user_access_by_id() throws Exception {
+        when(mockDomainStore.domainExists("unknown")).thenReturn(false);
+
+        given()
+                .when()
+                .get("/api/calm/domains/unknown/user-access/1")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid domain provided: unknown"));
+
+        verify(mockUserAccessStore, never()).getUserAccessForDomainAndId(any(), any());
+    }
+
+    @Test
+    void return_404_when_domain_does_not_exist_on_delete_user_access() throws Exception {
+        when(mockDomainStore.domainExists("unknown")).thenReturn(false);
+
+        given()
+                .when()
+                .delete("/api/calm/domains/unknown/user-access/1")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid domain provided: unknown"));
+
+        verify(mockUserAccessStore, never()).deleteUserAccessForDomain(any(), any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -1,6 +1,5 @@
 package org.finos.calm.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -24,20 +23,17 @@ public class TestUserAccessResourceShould {
     @InjectMock
     UserAccessStore mockUserAccessStore;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     @Test
     void return_201_created_with_location_header_when_user_access_is_created() throws Exception {
-
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("finos");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
-        userAccess.setUserAccessId(101);
+        UserAccess created = new UserAccess();
+        created.setNamespace("finos");
+        created.setPermission(UserAccess.Permission.read);
+        created.setUsername("test_user");
+        created.setUserAccessId(101);
         when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
-                .thenReturn(userAccess);
+                .thenReturn(created);
+
+        String requestBody = "{\"username\":\"test_user\",\"permission\":\"read\"}";
 
         given()
                 .header("Content-Type", "application/json")
@@ -57,15 +53,9 @@ public class TestUserAccessResourceShould {
         when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
                 .thenThrow(new NamespaceNotFoundException());
 
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("invalid");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"test_user\",\"permission\":\"read\"}")
                 .when()
                 .post("/api/calm/namespaces/invalid/user-access")
                 .then()
@@ -78,55 +68,31 @@ public class TestUserAccessResourceShould {
 
     @Test
     void return_400_when_invalid_namespace_format() throws Exception {
-        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
-                .thenThrow(new NamespaceNotFoundException());
-
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("invalid &%*$% NAMESPACE");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"test_user\",\"permission\":\"read\"}")
                 .when()
-                .post("/api/calm/namespaces/invalid/user-access")
+                .post("/api/calm/namespaces/invalid &%*$% NAMESPACE/user-access")
                 .then()
                 .statusCode(400);
     }
 
     @Test
     void return_400_when_invalid_username_format() throws Exception {
-        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
-                .thenThrow(new NamespaceNotFoundException());
-
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("invalid");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("INVALID USER!");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"INVALID USER!\",\"permission\":\"read\"}")
                 .when()
-                .post("/api/calm/namespaces/invalid/user-access")
+                .post("/api/calm/namespaces/finos/user-access")
                 .then()
                 .statusCode(400);
     }
 
     @Test
     void return_400_when_double_wildcard_username() throws Exception {
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("finos");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("**");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"**\",\"permission\":\"read\"}")
                 .when()
                 .post("/api/calm/namespaces/finos/user-access")
                 .then()
@@ -135,19 +101,17 @@ public class TestUserAccessResourceShould {
 
     @Test
     void return_201_when_wildcard_username_is_used() throws Exception {
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("finos");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("*");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
-        userAccess.setUserAccessId(102);
+        UserAccess created = new UserAccess();
+        created.setNamespace("finos");
+        created.setPermission(UserAccess.Permission.read);
+        created.setUsername("*");
+        created.setUserAccessId(102);
         when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
-                .thenReturn(userAccess);
+                .thenReturn(created);
 
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"*\",\"permission\":\"read\"}")
                 .when()
                 .post("/api/calm/namespaces/finos/user-access")
                 .then()
@@ -156,43 +120,13 @@ public class TestUserAccessResourceShould {
     }
 
     @Test
-    void return_400_when_creating_user_access_with_invalid_namespace() throws Exception {
-        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
-                .thenThrow(new NamespaceNotFoundException());
-
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("invalid");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
-        given()
-                .header("Content-Type", "application/json")
-                .body(requestBody)
-                .when()
-                .post("/api/calm/namespaces/test/user-access")
-                .then()
-                .statusCode(400)
-                .body(containsString("Bad Request"));
-
-        verify(mockUserAccessStore, times(0))
-                .createUserAccessForNamespace(any(UserAccess.class));
-    }
-
-    @Test
     void return_500_when_internal_error_occurs_during_user_access_creation() throws Exception {
         when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class)))
                 .thenThrow(new RuntimeException("Unexpected error"));
 
-        UserAccess userAccess = new UserAccess();
-        userAccess.setNamespace("finos");
-        userAccess.setPermission(UserAccess.Permission.read);
-        userAccess.setUsername("test_user");
-        String requestBody = OBJECT_MAPPER.writeValueAsString(userAccess);
-
         given()
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body("{\"username\":\"test_user\",\"permission\":\"read\"}")
                 .when()
                 .post("/api/calm/namespaces/finos/user-access")
                 .then()
@@ -245,16 +179,16 @@ public class TestUserAccessResourceShould {
     }
 
     @Test
-    void return_404_when_no_user_access_associated_to_provided_namespace() throws Exception {
+    void return_200_with_empty_list_when_namespace_has_no_grants() throws Exception {
         when(mockUserAccessStore.getUserAccessForNamespace("test"))
-                .thenThrow(new UserAccessNotFoundException());
+                .thenReturn(java.util.Collections.emptyList());
 
         given()
                 .when()
                 .get("/api/calm/namespaces/test/user-access")
                 .then()
-                .statusCode(404)
-                .body(containsString("No access permissions found"));
+                .statusCode(200)
+                .body(containsString("[]"));
 
         verify(mockUserAccessStore, times(1)).getUserAccessForNamespace("test");
     }
@@ -324,5 +258,48 @@ public class TestUserAccessResourceShould {
 
         verify(mockUserAccessStore, times(1))
                 .getUserAccessForNamespaceAndId("test", 1);
+    }
+
+    @Test
+    void return_204_when_user_access_is_deleted() throws Exception {
+        doNothing().when(mockUserAccessStore).deleteUserAccessForNamespace("finos", 101);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos/user-access/101")
+                .then()
+                .statusCode(204);
+
+        verify(mockUserAccessStore, times(1)).deleteUserAccessForNamespace("finos", 101);
+    }
+
+    @Test
+    void return_404_when_deleting_user_access_with_invalid_namespace() throws Exception {
+        doThrow(new NamespaceNotFoundException())
+                .when(mockUserAccessStore).deleteUserAccessForNamespace("invalid", 1);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/invalid/user-access/1")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid namespace"));
+
+        verify(mockUserAccessStore, times(1)).deleteUserAccessForNamespace("invalid", 1);
+    }
+
+    @Test
+    void return_404_when_deleting_user_access_that_does_not_exist() throws Exception {
+        doThrow(new UserAccessNotFoundException())
+                .when(mockUserAccessStore).deleteUserAccessForNamespace("finos", 999);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos/user-access/999")
+                .then()
+                .statusCode(404)
+                .body(containsString("No access permissions found"));
+
+        verify(mockUserAccessStore, times(1)).deleteUserAccessForNamespace("finos", 999);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -72,7 +72,7 @@ public class TestUserAccessResourceShould {
                 .header("Content-Type", "application/json")
                 .body("{\"username\":\"test_user\",\"permission\":\"read\"}")
                 .when()
-                .post("/api/calm/namespaces/invalid &%*$% NAMESPACE/user-access")
+                .post("/api/calm/namespaces/invalid_namespace/user-access")
                 .then()
                 .statusCode(400);
     }

--- a/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
@@ -442,6 +442,42 @@ class TestCalmHubPermissionCheckerShould {
         assertTrue(checker.canWriteByDomain(mockIdentity, "payments"));
     }
 
+    // --- Global admin implies namespace admin ---
+
+    @Test
+    void global_admin_is_allowed_namespace_admin_on_any_namespace() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.allowNamespaceAdmin(mockIdentity, "finos"));
+        assertTrue(checker.allowNamespaceAdmin(mockIdentity, "org.payments.fx"));
+    }
+
+    @Test
+    void global_admin_can_manage_namespace_access_when_no_namespace_grants_exist() {
+        // Bootstrapping: global admin creates a namespace; no namespace-specific grants exist yet.
+        // Global admin must be able to grant the first namespace admin without needing a pre-existing grant.
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.allowNamespaceAdmin(mockIdentity, "brand-new-namespace"));
+    }
+
+    @Test
+    void wildcard_global_admin_grant_does_not_grant_namespace_admin() {
+        // A * grant on GLOBAL must not elevate all users to global admin.
+        givenAuthenticatedUser("alice");
+        UserAccess wildcardGlobal = new UserAccess.UserAccessBuilder()
+                .setUsername("*").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGlobal));
+
+        assertFalse(checker.allowNamespaceAdmin(mockIdentity, "finos"));
+    }
+
     // --- GLOBAL ADMIN checks (unchanged) ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceMigrationServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceMigrationServiceShould.java
@@ -2,7 +2,6 @@ package org.finos.calm.services;
 
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
@@ -43,7 +42,7 @@ class TestNamespaceMigrationServiceShould {
     @Test
     void inserts_wildcard_read_grant_when_namespace_has_no_grants() throws Exception {
         when(mockUserAccessStore.getUserAccessForNamespace("org"))
-                .thenThrow(new UserAccessNotFoundException());
+                .thenReturn(List.of());
 
         boolean result = service.backfillIfNeeded("org");
 
@@ -103,7 +102,7 @@ class TestNamespaceMigrationServiceShould {
     @Test
     void returns_false_when_grant_insertion_fails() throws Exception {
         when(mockUserAccessStore.getUserAccessForNamespace("org"))
-                .thenThrow(new UserAccessNotFoundException());
+                .thenReturn(List.of());
         doThrow(new NamespaceNotFoundException())
                 .when(mockUserAccessStore).createUserAccessForNamespace(any());
 
@@ -121,7 +120,7 @@ class TestNamespaceMigrationServiceShould {
                 new NamespaceInfo("org.ab", "")
         ));
         when(mockUserAccessStore.getUserAccessForNamespace(any()))
-                .thenThrow(new UserAccessNotFoundException());
+                .thenReturn(List.of());
 
         service.onStart(null);
 
@@ -144,7 +143,7 @@ class TestNamespaceMigrationServiceShould {
         // First run: no grants → inserts
         when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("org", "")));
         when(mockUserAccessStore.getUserAccessForNamespace("org"))
-                .thenThrow(new UserAccessNotFoundException())
+                .thenReturn(List.of())
                 .thenReturn(List.of(new UserAccess("*", UserAccess.Permission.read, "org")));
 
         service.onStart(null);

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDomainStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDomainStoreShould.java
@@ -74,6 +74,18 @@ public class TestMongoDomainStoreShould {
     }
 
     @Test
+    void domain_exists_returns_true_when_domain_is_present() {
+        when(domainsCollection.countDocuments(any(Bson.class))).thenReturn(1L);
+        assertThat(mongoDomainStore.domainExists("security"), is(true));
+    }
+
+    @Test
+    void domain_exists_returns_false_when_domain_is_absent() {
+        when(domainsCollection.countDocuments(any(Bson.class))).thenReturn(0L);
+        assertThat(mongoDomainStore.domainExists("unknown"), is(false));
+    }
+
+    @Test
     void get_domains_returns_an_empty_array_when_collection_is_empty() {
         //TODO Refactor across these iterables once other PRs in mongo work are in
         FindIterable<Document> findIterable = emptyFindIterableSetup();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -124,19 +124,17 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
-    void throw_exception_if_no_user_access_found_for_namespace() {
+    void return_empty_list_when_no_user_access_found_for_namespace() throws Exception {
         String namespace = "finos";
         DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
         DocumentMongoCursor mockMongoCursor = mock(DocumentMongoCursor.class);
         when(mockMongoCursor.hasNext()).thenReturn(false);
         when(findIterable.iterator()).thenReturn(mockMongoCursor);
 
-        when(userAccessCollection.find(Filters.eq("namespace", namespace)))
-                .thenReturn(findIterable);
+        when(userAccessCollection.find(Filters.eq("namespace", namespace))).thenReturn(findIterable);
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
 
-        assertThrows(UserAccessNotFoundException.class,
-                () -> mongoUserAccessStore.getUserAccessForNamespace(namespace));
+        assertThat(mongoUserAccessStore.getUserAccessForNamespace(namespace), hasSize(0));
     }
 
     @Test
@@ -256,7 +254,7 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
-    void throw_exception_if_no_user_access_found_for_domain() {
+    void return_empty_list_when_no_user_access_found_for_domain() {
         String domain = "payments";
         DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
         DocumentMongoCursor mockMongoCursor = mock(DocumentMongoCursor.class);
@@ -264,8 +262,7 @@ public class TestMongoUserAccessStoreShould {
         when(findIterable.iterator()).thenReturn(mockMongoCursor);
         when(userAccessCollection.find(Filters.eq("domain", domain))).thenReturn(findIterable);
 
-        assertThrows(UserAccessNotFoundException.class,
-                () -> mongoUserAccessStore.getUserAccessForDomain(domain));
+        assertThat(mongoUserAccessStore.getUserAccessForDomain(domain), hasSize(0));
     }
 
     @Test
@@ -323,6 +320,73 @@ public class TestMongoUserAccessStoreShould {
 
         assertThat(actual.getDomain(), is(domain));
         assertThat(actual.getUserAccessId(), is(userAccessId));
+    }
+
+    @Test
+    void delete_user_access_for_domain_succeeds() throws Exception {
+        String domain = "payments";
+        Integer userAccessId = 201;
+
+        com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(userAccessCollection.deleteOne(ArgumentMatchers.any(Bson.class))).thenReturn(deleteResult);
+
+        mongoUserAccessStore.deleteUserAccessForDomain(domain, userAccessId);
+
+        verify(userAccessCollection).deleteOne(ArgumentMatchers.any(Bson.class));
+    }
+
+    @Test
+    void throw_user_access_not_found_when_deleting_non_existent_domain_grant() {
+        String domain = "payments";
+        Integer userAccessId = 999;
+
+        com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(0L);
+        when(userAccessCollection.deleteOne(ArgumentMatchers.any(Bson.class))).thenReturn(deleteResult);
+
+        assertThrows(UserAccessNotFoundException.class,
+                () -> mongoUserAccessStore.deleteUserAccessForDomain(domain, userAccessId));
+    }
+
+    @Test
+    void delete_user_access_for_namespace_succeeds() throws Exception {
+        String namespace = "finos";
+        Integer userAccessId = 101;
+
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(userAccessCollection.deleteOne(ArgumentMatchers.any(Bson.class))).thenReturn(deleteResult);
+
+        mongoUserAccessStore.deleteUserAccessForNamespace(namespace, userAccessId);
+
+        verify(userAccessCollection).deleteOne(ArgumentMatchers.any(Bson.class));
+    }
+
+    @Test
+    void throw_namespace_not_found_exception_when_deleting_with_invalid_namespace() {
+        when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> mongoUserAccessStore.deleteUserAccessForNamespace("invalid", 1));
+        verify(userAccessCollection, never()).deleteOne(ArgumentMatchers.any(Bson.class));
+    }
+
+    @Test
+    void throw_user_access_not_found_exception_when_deleting_non_existent_grant() {
+        String namespace = "finos";
+        Integer userAccessId = 999;
+
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(0L);
+        when(userAccessCollection.deleteOne(ArgumentMatchers.any(Bson.class))).thenReturn(deleteResult);
+
+        assertThrows(UserAccessNotFoundException.class,
+                () -> mongoUserAccessStore.deleteUserAccessForNamespace(namespace, userAccessId));
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
@@ -261,11 +261,11 @@ public class TestNitriteUserAccessStoreShould {
     }
 
     @Test
-    public void testGetUserAccessForDomain_ThrowsExceptionWhenNotFound() {
+    public void testGetUserAccessForDomain_ReturnsEmptyListWhenNotFound() {
         when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
         when(mockCursor.iterator()).thenReturn(Collections.emptyIterator());
 
-        assertThrows(UserAccessNotFoundException.class, () -> userAccessStore.getUserAccessForDomain("payments"));
+        assertThat(userAccessStore.getUserAccessForDomain("payments"), hasSize(0));
     }
 
     @Test
@@ -293,5 +293,67 @@ public class TestNitriteUserAccessStoreShould {
         when(mockCursor.firstOrNull()).thenReturn(null);
 
         assertThrows(UserAccessNotFoundException.class, () -> userAccessStore.getUserAccessForDomainAndId("payments", 2));
+    }
+
+    @Test
+    public void deleteUserAccessForNamespace_removesDocumentAndSucceeds() throws Exception {
+        Document mockDoc = mock(Document.class);
+        when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(mockDoc);
+
+        userAccessStore.deleteUserAccessForNamespace("finos", 1);
+
+        verify(mockCollection).remove(mockDoc);
+    }
+
+    @Test
+    public void deleteUserAccessForNamespace_throwsNamespaceNotFoundException_whenNamespaceDoesNotExist() {
+        when(mockNamespaceStore.namespaceExists("nonexistent")).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> userAccessStore.deleteUserAccessForNamespace("nonexistent", 1));
+        verify(mockCollection, never()).remove(any(Document.class));
+    }
+
+    @Test
+    public void deleteUserAccessForNamespace_throwsUserAccessNotFoundException_whenGrantDoesNotExist() {
+        when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        assertThrows(UserAccessNotFoundException.class,
+                () -> userAccessStore.deleteUserAccessForNamespace("finos", 999));
+        verify(mockCollection, never()).remove(any(Document.class));
+    }
+
+    @Test
+    public void testGetUserAccessForNamespace_ReturnsEmptyListWhenNoGrantsExist() throws Exception {
+        when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(Collections.emptyIterator());
+
+        assertThat(userAccessStore.getUserAccessForNamespace("finos"), hasSize(0));
+    }
+
+    @Test
+    public void deleteUserAccessForDomain_removesDocumentAndSucceeds() throws Exception {
+        Document mockDoc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(mockDoc);
+
+        userAccessStore.deleteUserAccessForDomain("payments", 201);
+
+        verify(mockCollection).remove(mockDoc);
+    }
+
+    @Test
+    public void deleteUserAccessForDomain_throwsUserAccessNotFoundException_whenGrantDoesNotExist() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        assertThrows(UserAccessNotFoundException.class,
+                () -> userAccessStore.deleteUserAccessForDomain("payments", 999));
+        verify(mockCollection, never()).remove(any(Document.class));
     }
 }


### PR DESCRIPTION
## Description

Implements the backend user access management API required by #2676 — the foundation for the CALM Hub administrative UI for managing namespace and domain entitlements.

This PR delivers all seven API endpoints listed in the issue, plus a set of correctness and RESTfulness fixes identified during review. Every change is described below.

---

### New endpoints

#### `GET /api/calm/user-access/current`
Returns all grants for the authenticated user — both explicit named grants and wildcard (`*`) grants that confer implicit access. This is the intended load-time call for the admin UI: the frontend uses the response to determine which namespaces and domains the current user can administer, and whether to show the domain admin panel (indicated by a grant with `namespace = "GLOBAL"` and `permission = admin`).

Requires any authenticated identity (`@Authenticated`). Returns `200 []` when the user has no grants.

#### `DELETE /api/calm/namespaces/{namespace}/user-access/{userAccessId}`
Revokes a namespace-scoped grant by its ID. Returns `204 No Content` on success, `404` if the namespace does not exist, `404` if the grant ID is not found. Requires namespace admin or global admin (`CalmHubScopes.ADMIN`).

#### `DELETE /api/calm/domains/{domain}/user-access/{userAccessId}`
Revokes a domain-scoped grant by its ID. Returns `204 No Content` on success, `404` if the domain does not exist, `404` if the grant ID is not found. Requires global admin (`CalmHubScopes.GLOBAL_ADMIN`).

---

### RESTfulness fixes

A full REST review was conducted against the issue design. The following anti-patterns were identified and corrected:

#### 1. POST body included the path parameter
The original `POST /namespaces/{namespace}/user-access` accepted a `UserAccess` body that required the client to also supply `namespace`. This is an anti-pattern: the path param is the canonical authority for the resource scope, and repeating it in the body creates ambiguity and the possibility of mismatch.

**Fix:** Introduced a `UserAccessRequest` DTO carrying only `{ username, permission }`. The namespace (or domain) is set server-side from the `@PathParam`. The same fix was applied to `DomainUserAccessResource`.

#### 2. Empty grant lists returned `404`
`GET /namespaces/{ns}/user-access` and `GET /domains/{domain}/user-access` previously threw `UserAccessNotFoundException` when no grants existed for a valid namespace/domain, which the resource translated to `404`. An empty collection is a valid, successful state — `404` implies the resource itself does not exist, not that it is empty.

**Fix:** Store methods for listing grants now return an empty list rather than throwing. Both `MongoUserAccessStore` and `NitriteUserAccessStore` were updated, and `NamespaceMigrationService.backfillIfNeeded` was updated to check `list.isEmpty()` rather than catching the now-removed exception.

#### 3. Domain endpoints had no existence check
`GET` and `POST` on `/domains/{domain}/user-access` accepted any syntactically valid domain string and returned `200 []` or silently created a grant even when the domain did not exist in the system. This was inconsistent with namespace endpoints, which return `404` for unknown namespaces.

**Fix:** Added `domainExists(String name)` to the `DomainStore` interface and implemented it in both `MongoDomainStore` (using `countDocuments`) and `NitriteDomainStore` (promoting its existing private method to the interface). `DomainUserAccessResource` now injects `DomainStore` and checks existence before every operation, returning `404 "Invalid domain provided: {domain}"` if the domain is not registered.

#### 4. GLOBAL admin could not grant the first namespace admin (bootstrapping deadlock)
A global admin creates namespaces via `POST /api/calm/namespaces`, which requires `GLOBAL_ADMIN` scope. However, granting the first namespace admin via `POST /namespaces/{ns}/user-access` required `ADMIN` scope on that namespace — which no one held yet on a freshly created namespace. A global admin was therefore unable to bootstrap access for new namespaces.

**Fix:** `CalmHubPermissionChecker.hasNamespaceAccess` now checks for a GLOBAL admin grant within the already-fetched `getGrantsForUser` result before evaluating the namespace ancestor chain. This requires no additional store round-trip and uses `username.equals(g.getUsername())` to exclude wildcard grants from the GLOBAL admin check, preserving the correct semantic that `* admin GLOBAL` does not make every user a global admin.

#### 5. `GET /user-access/current` was filtering out wildcard grants
The initial implementation of `getCurrentUserAccess` called `getGrantsForUser` (which correctly fetches both named and wildcard grants) and then filtered out wildcards in Java before returning. This was wrong: wildcard grants represent real implicit access the user has, and the UI needs them to correctly render the full access picture.

**Fix:** The filter was removed. The endpoint returns the full result of `getGrantsForUser` unmodified.

---

### Why this API is RESTful

| Principle | How it is satisfied |
|---|---|
| **Resources are nouns, not verbs** | Collections: `/user-access`. Items: `/user-access/{id}`. No action verbs in paths. |
| **HTTP methods carry semantics** | `POST` creates, `GET` reads, `DELETE` removes. No tunnelling of operations through POST bodies. |
| **Path params are canonical** | Namespace and domain are taken from the path only; never repeated or validated against the request body. |
| **Status codes are meaningful** | `201` on create with `Location` header, `200` on read, `204` on delete, `404` for missing resources (not empty collections), `400` for invalid path param format. |
| **Empty collection ≠ missing resource** | `GET .../user-access` on a valid namespace/domain with no grants returns `200 []`, not `404`. |
| **Consistent error handling** | Unknown namespace → `404`. Unknown domain → `404`. Unknown grant ID → `404`. Invalid format → `400`. Matches behaviour across all resource types in the codebase. |
| **Permissions follow resource hierarchy** | Namespace-scoped operations require namespace admin (or global admin via inheritance). Domain-scoped operations require global admin. Current-user endpoint requires only authentication. |

---

## Type of Change
- [X] ✨ New feature (non-breaking change which adds functionality)
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [X] CALM Hub (`calm-hub/`)

## Testing
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

New test classes:
- `TestCurrentUserAccessResourceShould` — 4 tests covering authenticated response, empty list, wildcard inclusion, and unauthenticated `401`
- `TestCalmHubPermissionCheckerShould` — 3 new tests for GLOBAL admin namespace access, bootstrapping (no prior namespace grant), and wildcard exclusion from GLOBAL admin check

Updated test classes:
- `TestUserAccessResourceShould` — updated for new DTO body, empty-list 200, and DELETE coverage
- `TestDomainUserAccessResourceShould` — updated for new DTO body, domain existence checks, DELETE coverage
- `TestMongoUserAccessStoreShould` — updated for empty-list behaviour, DELETE operations, `domainExists`
- `TestNitriteUserAccessStoreShould` — updated for empty-list behaviour and DELETE operations
- `TestMongoDomainStoreShould` — new `domainExists` true/false tests

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [X] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards