### PR TITLE
fix(calm-suite): preserve CALM document-level keys through Studio round-trip

### DIFF
--- a/calm-suite/calm-studio/apps/studio/src/lib/io/export.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/io/export.ts
@@ -28,6 +28,42 @@ import { buildScalerToml } from '$lib/io/scalerToml';
 const IMAGE_WIDTH = 1920;
 const IMAGE_HEIGHT = 1080;
 
+/** Canonical CALM 1.2 meta-schema URL written into exported documents. */
+export const CALM_SCHEMA_URL = 'https://calm.finos.org/release/1.2/meta/calm.json';
+
+// ─── Write finalization (shared by Save / Save As / Export) ───────────────────
+
+/**
+ * Finalize a CALM JSON string for writing to disk — applied by every CALM-JSON
+ * writer (Save, Save As, Export) so the file is canonical regardless of which
+ * action produced it.
+ *
+ * - Strips Studio-internal `_template` scratch metadata (must never persist).
+ * - Injects the canonical CALM 1.2 `$schema` when absent, so written files are
+ *   self-describing and version-pinned; an existing `$schema` is left untouched.
+ *
+ * AIGF governance-decorator generation is intentionally NOT done here — it is
+ * Export-only (see `exportAsCalm`) so that a plain Save does not re-stamp a
+ * governance assessment date on every save.
+ *
+ * Pure string→string; returns the input unchanged if the JSON is malformed.
+ */
+export function finalizeCalmForWrite(json: string): string {
+	try {
+		const parsed = JSON.parse(json) as CalmArchitecture & { _template?: unknown; $schema?: string };
+		if ('_template' in parsed) {
+			delete parsed._template;
+		}
+		if (!parsed['$schema']) {
+			parsed['$schema'] = CALM_SCHEMA_URL;
+		}
+		return JSON.stringify(parsed, null, 2);
+	} catch {
+		// Malformed JSON — return original; the caller's write still proceeds.
+		return json;
+	}
+}
+
 // ─── AIGF decorator generation ────────────────────────────────────────────────
 
 /**
@@ -89,22 +125,23 @@ function generateAIGFDecorator(arch: CalmArchitecture, filename: string): CalmDe
  * @param filename  Output filename (default: architecture.calm.json)
  */
 export function exportAsCalm(json: string, filename = 'architecture.calm.json'): void {
-	// Strip _template metadata and inject AIGF decorator if AI nodes present.
-	let cleanJson = json;
+	// Apply the shared finalize pass (strip _template, inject $schema), then add
+	// the Export-only AIGF governance decorator if AI nodes are present.
+	let cleanJson = finalizeCalmForWrite(json);
 	try {
-		const parsed = JSON.parse(json) as CalmArchitecture & { _template?: unknown };
-		// Strip template metadata
-		if ('_template' in parsed) {
-			delete parsed._template;
-		}
-		// Inject AIGF governance decorator if AI nodes exist
+		const parsed = JSON.parse(cleanJson) as CalmArchitecture;
 		const decorator = generateAIGFDecorator(parsed, filename);
 		if (decorator !== null) {
-			parsed.decorators = [decorator];
+			// Merge, don't overwrite: keep any existing decorators, replacing only
+			// the managed AIGF overlay (idempotent across repeated exports).
+			const others = (parsed.decorators ?? []).filter(
+				(d) => d['unique-id'] !== 'aigf-governance-overlay'
+			);
+			parsed.decorators = [...others, decorator];
+			cleanJson = JSON.stringify(parsed, null, 2);
 		}
-		cleanJson = JSON.stringify(parsed, null, 2);
 	} catch {
-		// Malformed JSON — fall through with original content; export will still work
+		// Malformed JSON — fall through with finalized content; export will still work
 	}
 
 	const blob = new Blob([cleanJson], { type: 'application/json' });

--- a/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
@@ -52,7 +52,11 @@ function withMutex(fn: () => void): boolean {
  */
 export function applyFromJson(arch: CalmArchitecture): boolean {
 	return withMutex(() => {
-		model = { nodes: [...arch.nodes], relationships: [...arch.relationships] };
+		// Preserve ALL document-level keys ($schema, metadata, flows, adrs,
+		// decorators, controls, …); nodes/relationships are copied as arrays.
+		// Previously this rebuilt { nodes, relationships } only, silently dropping
+		// every other section on open→save.
+		model = { ...arch, nodes: [...arch.nodes], relationships: [...arch.relationships] };
 	});
 }
 
@@ -64,7 +68,10 @@ export function applyFromJson(arch: CalmArchitecture): boolean {
 export function applyFromCanvas(nodes: Node[], edges: Edge[]): boolean {
 	return withMutex(() => {
 		const arch = flowToCalm(nodes, edges);
-		model = { nodes: [...arch.nodes], relationships: [...arch.relationships] };
+		// Merge: graph (nodes/relationships) comes from the canvas; document-level
+		// keys are retained from the prior model so a canvas edit doesn't drop
+		// flows/metadata/decorators/etc.
+		model = { ...model, nodes: [...arch.nodes], relationships: [...arch.relationships] };
 	});
 }
 

--- a/calm-suite/calm-studio/apps/studio/src/routes/+page.svelte
+++ b/calm-suite/calm-studio/apps/studio/src/routes/+page.svelte
@@ -67,7 +67,7 @@
 	import { checkForUpdates } from '$lib/desktop/updater';
 	import { registerFileOpenHandler } from '$lib/desktop/fileOpen';
 	import { readTextFile } from '@tauri-apps/plugin-fs';
-	import { exportAsCalm, exportAsSvg, exportAsPng, exportAsCalmscript, exportAsScalerToml } from '$lib/io/export';
+	import { exportAsCalm, exportAsSvg, exportAsPng, exportAsCalmscript, exportAsScalerToml, finalizeCalmForWrite } from '$lib/io/export';
 	import type { CalmArchitecture, CalmRelationship } from '@calmstudio/calm-core';
 	import { getReferencedNodeIds } from '@calmstudio/calm-core';
 	import { detectPacksFromArch } from '$lib/io/sidecar';
@@ -690,7 +690,7 @@
 
 	async function handleSave() {
 		try {
-			const json = getModelJson();
+			const json = finalizeCalmForWrite(getModelJson());
 			const handle = await saveFile(json, getFileHandle(), getFileName() ?? 'architecture.calm.json');
 			markClean(undefined, handle);
 		} catch (e) {
@@ -700,7 +700,7 @@
 
 	async function handleSaveAs() {
 		try {
-			const json = getModelJson();
+			const json = finalizeCalmForWrite(getModelJson());
 			const handle = await saveFileAs(json, getFileName() ?? 'architecture.calm.json');
 			// saveFileAs returns:
 			// - string path (Tauri desktop)

--- a/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
@@ -25,6 +25,7 @@ import {
 	resetModel,
 } from '$lib/stores/calmModel.svelte';
 import { calmToFlow, flowToCalm } from '$lib/stores/projection';
+import { finalizeCalmForWrite } from '$lib/io/export';
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -201,6 +202,122 @@ describe('getModelJson round-trip', () => {
 		const json = getModelJson();
 		const reparsed = JSON.parse(json) as CalmArchitecture;
 		expect(reparsed.relationships).toHaveLength(arch.relationships.length);
+	});
+});
+
+// ─── document-level key preservation (cross-tool interop) ─────────────────────
+
+describe('document-level key preservation', () => {
+	const SCHEMA_URL = 'https://calm.finos.org/release/1.2/meta/calm.json';
+
+	/** A minimal arch carrying $schema, flows, and doc-level metadata. */
+	function fullArch(): CalmArchitecture & { '$schema'?: string } {
+		const arch = createMinimalArch({
+			flows: [
+				{
+					'unique-id': 'flow-1',
+					name: 'Example flow',
+					description: 'An example business flow',
+					transitions: [
+						{ 'relationship-unique-id': 'api-to-db', 'sequence-number': 1, description: 'call' },
+					],
+				},
+			],
+			metadata: { owner: 'platform-team' },
+		}) as CalmArchitecture & { '$schema'?: string };
+		// $schema is a valid CALM key but isn't on the CalmArchitecture type.
+		arch['$schema'] = SCHEMA_URL;
+		return arch;
+	}
+
+	it('preserves $schema, flows, and metadata through applyFromJson', () => {
+		applyFromJson(fullArch());
+		const model = getModel() as CalmArchitecture & { '$schema'?: string };
+		expect(model['$schema']).toBe(SCHEMA_URL);
+		expect(model.flows).toHaveLength(1);
+		expect(model.metadata).toEqual({ owner: 'platform-team' });
+	});
+
+	it('retains document-level keys through a subsequent canvas edit', () => {
+		applyFromJson(fullArch());
+		// Simulate a canvas round-trip (e.g. a drag): model -> flow -> model.
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		const model = getModel() as CalmArchitecture & { '$schema'?: string };
+		expect(model['$schema']).toBe(SCHEMA_URL);
+		expect(model.flows).toHaveLength(1);
+		expect(model.metadata).toEqual({ owner: 'platform-team' });
+	});
+
+	it('exposes loaded flows on the model (flow-overlay regression guard)', () => {
+		// flowState reads getModel().flows; before this fix it was always
+		// undefined for loaded docs, so the flow overlay never worked on open.
+		applyFromJson(fullArch());
+		expect(getModel().flows).toBeDefined();
+		expect(getModel().flows?.[0]['unique-id']).toBe('flow-1');
+	});
+
+	it('preserves adrs through applyFromJson and a canvas edit', () => {
+		const arch = createMinimalArch({ adrs: ['https://example.com/adrs/001'] });
+		applyFromJson(arch);
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		expect(getModel().adrs).toEqual(['https://example.com/adrs/001']);
+	});
+
+	it('preserves document-level controls through applyFromJson and a canvas edit', () => {
+		const arch = createMinimalArch({
+			controls: {
+				'data-residency': {
+					description: 'UK only',
+					requirements: [
+						{ 'requirement-url': 'https://example.com/req', 'config-url': 'https://example.com/cfg' },
+					],
+				},
+			},
+		});
+		applyFromJson(arch);
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		expect(getModel().controls?.['data-residency']).toBeDefined();
+	});
+
+	it('preserves decorators loaded from a document through a canvas edit', () => {
+		const arch = createMinimalArch({
+			decorators: [
+				{ 'unique-id': 'threat-model-overlay', type: 'threat-model', target: [], 'applies-to': [], data: {} },
+			],
+		});
+		applyFromJson(arch);
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		expect(getModel().decorators?.find((d) => d['unique-id'] === 'threat-model-overlay')).toBeDefined();
+	});
+
+	it('full Save-path composition: getModelJson -> finalizeCalmForWrite -> reparse keeps every doc-level key', () => {
+		// Mirrors handleSave/handleSaveAs: serialize the model, finalize for write,
+		// then re-parse (as a reopen would). $schema is injected by finalize.
+		const arch = createMinimalArch({
+			flows: [
+				{
+					'unique-id': 'f1',
+					name: 'Test',
+					description: 'Test flow',
+					transitions: [
+						{ 'relationship-unique-id': 'api-to-db', 'sequence-number': 1, description: 'call' },
+					],
+				},
+			],
+			adrs: ['https://example.com/adrs/001'],
+			metadata: { owner: 'team-a' },
+		});
+		applyFromJson(arch);
+		const finalJson = finalizeCalmForWrite(getModelJson());
+		const result = JSON.parse(finalJson) as CalmArchitecture & { '$schema'?: string };
+		expect(result['$schema']).toBe('https://calm.finos.org/release/1.2/meta/calm.json');
+		expect(result.flows).toHaveLength(1);
+		expect(result.adrs).toEqual(['https://example.com/adrs/001']);
+		expect(result.metadata).toEqual({ owner: 'team-a' });
 	});
 });
 

--- a/calm-suite/calm-studio/apps/studio/src/tests/io/export.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/io/export.test.ts
@@ -33,7 +33,7 @@ vi.mock('$lib/io/scalerToml', () => ({
 }));
 
 // Import export functions AFTER mocking their dependency
-import { exportAsCalm, exportAsScalerToml } from '$lib/io/export';
+import { exportAsCalm, exportAsScalerToml, finalizeCalmForWrite } from '$lib/io/export';
 import { downloadDataUrl } from '$lib/io/fileSystem';
 import { buildScalerToml } from '$lib/io/scalerToml';
 
@@ -90,6 +90,38 @@ afterEach(() => {
 	vi.runAllTimers(); // flush all pending setTimeout callbacks before teardown
 	vi.useRealTimers();
 	teardownBlobStubs();
+});
+
+// ─── finalizeCalmForWrite (shared by Save / Save As / Export) ────────────────
+
+describe('finalizeCalmForWrite', () => {
+	const SCHEMA_URL = 'https://calm.finos.org/release/1.2/meta/calm.json';
+
+	it('injects the canonical $schema when absent', () => {
+		const result = JSON.parse(finalizeCalmForWrite(JSON.stringify(createMinimalArch())));
+		expect(result['$schema']).toBe(SCHEMA_URL);
+	});
+
+	it('preserves an existing $schema untouched', () => {
+		const arch = { '$schema': 'https://example.com/custom/schema.json', ...createMinimalArch() };
+		const result = JSON.parse(finalizeCalmForWrite(JSON.stringify(arch)));
+		expect(result['$schema']).toBe('https://example.com/custom/schema.json');
+	});
+
+	it('strips _template scratch metadata', () => {
+		const arch = { ...createMinimalArch(), _template: { id: 'x', name: 'x' } };
+		const result = JSON.parse(finalizeCalmForWrite(JSON.stringify(arch)));
+		expect(result).not.toHaveProperty('_template');
+	});
+
+	it('does NOT add a governance decorator (AIGF is Export-only)', () => {
+		const result = JSON.parse(finalizeCalmForWrite(JSON.stringify(createAIGovernanceArch())));
+		expect(result.decorators).toBeUndefined();
+	});
+
+	it('returns the input unchanged for malformed JSON', () => {
+		expect(finalizeCalmForWrite('not-json')).toBe('not-json');
+	});
 });
 
 // ─── exportAsCalm — _template metadata stripping ─────────────────────────────
@@ -185,6 +217,45 @@ describe('exportAsCalm — AIGF decorator injection', () => {
 		exportAsCalm(JSON.stringify(createAIGovernanceArch(), null, 2));
 		const result = JSON.parse(getFirstBlobContent()!);
 		expect(result.decorators[0].data.framework).toBe('FINOS AI Governance Framework');
+	});
+
+	it('preserves a pre-existing non-AIGF decorator and adds the AIGF overlay (merge, not overwrite)', () => {
+		const arch = createAIGovernanceArch({
+			decorators: [
+				{ 'unique-id': 'threat-model-overlay', type: 'threat-model', target: [], 'applies-to': [], data: {} },
+			],
+		});
+		exportAsCalm(JSON.stringify(arch, null, 2));
+		const result = JSON.parse(getFirstBlobContent()!);
+		const ids: string[] = result.decorators.map((d: { 'unique-id': string }) => d['unique-id']);
+		expect(ids).toContain('threat-model-overlay');
+		expect(ids).toContain('aigf-governance-overlay');
+	});
+
+	it('re-exporting keeps foreign decorators and does not duplicate the AIGF overlay', () => {
+		// A user exports, reopens the exported file, and exports again. Their own
+		// (non-AIGF) decorators must survive every export, and the managed AIGF
+		// overlay must stay singular. The old overwrite code dropped foreign
+		// decorators on the FIRST export, so the `toContain` assertion below fails
+		// on pre-fix code — giving this test real teeth (count alone could not,
+		// since overwrite and merge both yield a single overlay).
+		const arch = createAIGovernanceArch({
+			decorators: [
+				{ 'unique-id': 'threat-model-overlay', type: 'threat-model', target: [], 'applies-to': [], data: {} },
+			],
+		});
+		exportAsCalm(JSON.stringify(arch, null, 2));
+		const firstExport = JSON.parse(getFirstBlobContent()!);
+
+		// Re-export the first output (simulating reopen → re-export).
+		teardownBlobStubs();
+		setupBlobStubs();
+		exportAsCalm(JSON.stringify(firstExport, null, 2));
+		const secondExport = JSON.parse(getFirstBlobContent()!);
+
+		const ids: string[] = secondExport.decorators.map((d: { 'unique-id': string }) => d['unique-id']);
+		expect(ids).toContain('threat-model-overlay');
+		expect(ids.filter((id) => id === 'aigf-governance-overlay')).toHaveLength(1);
 	});
 });
 


### PR DESCRIPTION
## Description

**The journey this fixes:** You open a CALM document in **CALM Studio** — one with `flows`, document-level `metadata`, `adrs`, `decorators`, a `$schema`, and/or document-level `controls`. You edit it (even just rearrange a node) and **save**. The saved file should differ from the original only by your edit.

Today it doesn't. Studio's model store held only `{ nodes, relationships }`, so the moment you **open** a document every other top-level section is dropped — and on **save** the file is rebuilt from that two-key model, so `$schema`, `flows`, `adrs`, `decorators`, document-level `metadata`, and document-level `controls` are silently gone. A document authored in the CLI/Hub (or anywhere) loses those sections the instant it passes through Studio, breaking the cross-tool round trip.

**After this PR**, the full document round-trips:

- ✅ All document-level keys (`$schema`, `metadata`, `flows`, `adrs`, `decorators`, `controls`) survive open → edit → save.
- ✅ Every file Studio writes is **self-describing** — Save, Save As, and Export inject the canonical CALM 1.2 `$schema` when absent.
- ✅ Export no longer overwrites existing `decorators` — it merges the managed AIGF overlay by `unique-id`.
- ✅ **Bonus:** Studio's flow overlay now works for *loaded* documents — `flowState` reads `model.flows`, which was always `undefined` for opened files before.

### What changed
- `applyFromJson` preserves all document-level keys; `applyFromCanvas` merges (graph from the canvas, doc-level keys retained), so a canvas edit no longer wipes them.
- A shared `finalizeCalmForWrite(json)` used by Save / Save As / Export strips Studio-internal `_template` scratch and injects the canonical `$schema` when absent. AIGF governance-decorator generation stays Export-only (no date-stamp churn on Save).
- `exportAsCalm` merges the AIGF decorator by `unique-id` instead of overwriting the array.

> ℹ️ **Components note:** the change is in CALM Studio (`calm-suite/calm-studio/`), which has no checkbox in the template's "Affected Components", so none are ticked.

> 🔗 **Stacked PR:** targets `fix/calmguard-canonical-relationship-type` (the CALMGuard fix) rather than `main` — re-point to `main` once that merges. (#1 is a different product; this PR is logically independent but chained per the stack.)

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore

## Affected Components
*(All unchecked — surface is CALM Studio (`calm-suite/calm-studio/`), no template checkbox.)*

## Commit Message Format ✅
Conventional Commits, DCO signed-off:
- `fix(calm-suite): preserve CALM document-level keys through Studio round-trip`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified on Node 22: `npm run test --workspace=@calmstudio/studio` (all pass, incl. new preservation/finalize/decorator-merge coverage), `npm run typecheck` (no new errors vs the pre-existing baseline), and `npm run build`. New tests cover preservation of `$schema`/`flows`/`metadata`/`adrs`/document-level `controls`/`decorators` through `applyFromJson` and a subsequent `applyFromCanvas`; the flow-overlay regression guard; the full `getModelJson → finalizeCalmForWrite → reparse` Save path; `finalizeCalmForWrite` (`$schema` inject/preserve, `_template` strip); and decorator merge keep-path + re-export idempotency. Each guard was checked to fail on pre-fix code.

## Checklist
- [x] Conventional commit format
- [x] Documentation updated if necessary
- [x] Tests added
- [x] Follows coding standards
