### PR TITLE
fix(calm-suite): round-trip multi-child, interface, and options relationships in Studio

### DIFF
--- a/calm-suite/calm-studio/apps/studio/src/lib/canvas/CalmCanvas.svelte
+++ b/calm-suite/calm-studio/apps/studio/src/lib/canvas/CalmCanvas.svelte
@@ -381,12 +381,14 @@
 
 	let edgeMenu = $state<{ x: number; y: number; edgeId: string } | null>(null);
 
+	// 'options' is intentionally omitted: it has no decision-authoring UI and an
+	// options edge could only emit schema-invalid CALM. Loaded options relationships
+	// are preserved (calmModel.applyFromCanvas), just not authored on the canvas.
 	const EDGE_TYPE_OPTIONS = [
 		{ value: 'connects', label: 'Connects' },
 		{ value: 'interacts', label: 'Interacts' },
 		{ value: 'deployed-in', label: 'Deployed In' },
 		{ value: 'composed-of', label: 'Composed Of' },
-		{ value: 'options', label: 'Options' },
 	];
 
 	function handleEdgeContextMenu(event: { event: MouseEvent; edge: Edge }) {

--- a/calm-suite/calm-studio/apps/studio/src/lib/properties/EdgeProperties.svelte
+++ b/calm-suite/calm-studio/apps/studio/src/lib/properties/EdgeProperties.svelte
@@ -12,25 +12,32 @@
 		CalmRelationshipType,
 		CalmRelationshipVariant
 	} from '@calmstudio/calm-core';
-	import { updateEdgeProperty } from '$lib/stores/calmModel.svelte';
+	import { updateEdgeProperty, getModel } from '$lib/stores/calmModel.svelte';
 	import ControlsList from './ControlsList.svelte';
 
+	/**
+	 * Build a nested relationship-type from an anchor (connects-source / container
+	 * / actor) and its full member set. Switching the variant of a multi-child
+	 * relationship must preserve ALL members, not just the edited edge's child.
+	 */
 	function buildRelationshipType(
 		variant: CalmRelationshipVariant,
-		source: string,
-		target: string,
+		anchor: string,
+		members: string[],
 	): CalmRelationshipType {
 		switch (variant) {
 			case 'connects':
+				// connects is strictly 1:1 — no multi-target shape exists, so
+				// converting a multi-child relationship reduces to its first member.
 				return {
-					connects: { source: { node: source }, destination: { node: target } },
+					connects: { source: { node: anchor }, destination: { node: members[0] } },
 				};
 			case 'composed-of':
-				return { 'composed-of': { container: source, nodes: [target] } };
+				return { 'composed-of': { container: anchor, nodes: members } };
 			case 'deployed-in':
-				return { 'deployed-in': { container: source, nodes: [target] } };
+				return { 'deployed-in': { container: anchor, nodes: members } };
 			case 'interacts':
-				return { interacts: { actor: source, nodes: [target] } };
+				return { interacts: { actor: anchor, nodes: members } };
 			case 'options':
 				// Unreachable: 'options' is not offered as an edge type (Studio has
 				// no decision-authoring UI; an options edge could only emit invalid
@@ -122,14 +129,30 @@
 		}
 	}
 
+	/**
+	 * The relationship's anchor + full member set, read from the model (not just
+	 * this edge), so switching variant on a multi-child relationship keeps every
+	 * child. Falls back to this edge's endpoints for an un-aggregated/new edge.
+	 */
+	function currentAnchorMembers(): { anchor: string; members: string[] } {
+		const rt = getModel().relationships.find((r) => r['unique-id'] === relId)?.['relationship-type'];
+		if (rt) {
+			if ('connects' in rt) return { anchor: rt.connects.source.node, members: [rt.connects.destination.node] };
+			if ('composed-of' in rt) return { anchor: rt['composed-of'].container, members: rt['composed-of'].nodes };
+			if ('deployed-in' in rt) return { anchor: rt['deployed-in'].container, members: rt['deployed-in'].nodes };
+			if ('interacts' in rt) return { anchor: rt.interacts.actor, members: rt.interacts.nodes };
+		}
+		return { anchor: edge.source, members: [edge.target] };
+	}
+
 	function handleRelTypeChange(e: Event) {
 		const value = (e.target as HTMLSelectElement).value as CalmRelationshipVariant;
 		signalFirstEdit();
-		// CALM 1.2 nested form: build a fresh relationship-type object using the
-		// edge's current source/target endpoints. Switching variant preserves
-		// connectivity but reshapes the payload (e.g. connects.source.node →
-		// composed-of.container).
-		const nested = buildRelationshipType(value, edge.source, edge.target);
+		// CALM 1.2 nested form: rebuild from the relationship's FULL membership so
+		// switching the type of a multi-child relationship doesn't drop its other
+		// children. (connects, being 1:1, reduces to the first member.)
+		const { anchor, members } = currentAnchorMembers();
+		const nested = buildRelationshipType(value, anchor, members);
 		updateEdgeProperty(relId, 'relationship-type', nested);
 		onmutate?.();
 	}

--- a/calm-suite/calm-studio/apps/studio/src/lib/properties/EdgeProperties.svelte
+++ b/calm-suite/calm-studio/apps/studio/src/lib/properties/EdgeProperties.svelte
@@ -32,7 +32,10 @@
 			case 'interacts':
 				return { interacts: { actor: source, nodes: [target] } };
 			case 'options':
-				return { options: [] };
+				// Unreachable: 'options' is not offered as an edge type (Studio has
+				// no decision-authoring UI; an options edge could only emit invalid
+				// CALM). Throw rather than emit a schema-invalid `{ options: [] }`.
+				throw new Error('options is not an authorable edge type');
 		}
 	}
 
@@ -48,12 +51,15 @@
 		onmutate?: () => void;
 	} = $props();
 
+	// 'options' is intentionally omitted: Studio has no decision-authoring UI, so
+	// an options edge could only produce schema-invalid CALM. Options relationships
+	// loaded from a file are preserved (calmModel.applyFromCanvas), just not
+	// authored on the canvas.
 	const RELATIONSHIP_TYPES: CalmRelationshipVariant[] = [
 		'connects',
 		'interacts',
 		'deployed-in',
 		'composed-of',
-		'options',
 	];
 
 	const PROTOCOL_TYPES = ['connects', 'interacts'];
@@ -101,6 +107,11 @@
 	);
 	const showProtocol: boolean = $derived(PROTOCOL_TYPES.includes(relType));
 
+	// Edits target the underlying relationship. A multi-child edge's id is
+	// `<relId>#<i>`, so resolve the real relationship id via calmRelId; otherwise
+	// the model lookup (keyed by relationship unique-id) would miss.
+	const relId: string = $derived((edge.data?.calmRelId as string | undefined) ?? edge.id);
+
 	let descTimer: ReturnType<typeof setTimeout>;
 	let protocolTimer: ReturnType<typeof setTimeout>;
 
@@ -119,7 +130,7 @@
 		// connectivity but reshapes the payload (e.g. connects.source.node →
 		// composed-of.container).
 		const nested = buildRelationshipType(value, edge.source, edge.target);
-		updateEdgeProperty(edge.id, 'relationship-type', nested);
+		updateEdgeProperty(relId, 'relationship-type', nested);
 		onmutate?.();
 	}
 
@@ -133,7 +144,7 @@
 		showCustomProtocol = false;
 		localProtocol = value;
 		signalFirstEdit();
-		updateEdgeProperty(edge.id, 'protocol', value);
+		updateEdgeProperty(relId, 'protocol', value);
 		onmutate?.();
 	}
 
@@ -143,7 +154,7 @@
 		signalFirstEdit();
 		clearTimeout(protocolTimer);
 		protocolTimer = setTimeout(() => {
-			updateEdgeProperty(edge.id, 'protocol', value);
+			updateEdgeProperty(relId, 'protocol', value);
 			onmutate?.();
 		}, 300);
 	}
@@ -154,7 +165,7 @@
 		signalFirstEdit();
 		clearTimeout(descTimer);
 		descTimer = setTimeout(() => {
-			updateEdgeProperty(edge.id, 'description', value);
+			updateEdgeProperty(relId, 'description', value);
 			onmutate?.();
 		}, 300);
 	}
@@ -179,7 +190,9 @@
 		<!-- unique-id: read-only -->
 		<div class="field">
 			<label class="field-label" for="edge-unique-id">Unique ID</label>
-			<div class="read-only-field" id="edge-unique-id" title={edge.id}>{edge.id}</div>
+			<!-- Show the relationship's id (relId), not the suffixed edge id, so a
+			     multi-child edge displays the relationship that edits actually target. -->
+			<div class="read-only-field" id="edge-unique-id" title={relId}>{relId}</div>
 		</div>
 
 		<!-- relationship-type dropdown -->
@@ -264,7 +277,7 @@
 		controls={edge.data?.controls}
 		onupdate={(newControls) => {
 			signalFirstEdit();
-			updateEdgeProperty(edge.id, 'controls', newControls);
+			updateEdgeProperty(relId, 'controls', newControls);
 			onmutate?.();
 		}}
 		readonly={!onmutate}

--- a/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
@@ -17,7 +17,7 @@
 
 import type { Node, Edge } from '@xyflow/svelte';
 import type { CalmArchitecture, CalmInterface, CalmNode, CalmRelationship } from '@calmstudio/calm-core';
-import { flowToCalm } from '$lib/stores/projection';
+import { flowToCalm, variantOf } from '$lib/stores/projection';
 
 // ─── Module-level state ───────────────────────────────────────────────────────
 
@@ -67,12 +67,48 @@ export function applyFromJson(arch: CalmArchitecture): boolean {
  */
 export function applyFromCanvas(nodes: Node[], edges: Edge[]): boolean {
 	return withMutex(() => {
-		const arch = flowToCalm(nodes, edges);
-		// Merge: graph (nodes/relationships) comes from the canvas; document-level
-		// keys are retained from the prior model so a canvas edit doesn't drop
-		// flows/metadata/decorators/etc.
-		model = { ...model, nodes: [...arch.nodes], relationships: [...arch.relationships] };
+		const projected = flowToCalm(nodes, edges);
+
+		// `options` relationships have no edge representation, so they never come
+		// back from flowToCalm. Carry them from the prior model, but GC any
+		// decision whose node/relationship references no longer resolve (and drop
+		// an options rel left with no decisions), so we never write a dangling ref.
+		const nodeIds = new Set(projected.nodes.map((n) => n['unique-id']));
+		const relIds = new Set(projected.relationships.map((r) => r['unique-id']));
+		const preservedOptions = model.relationships
+			.filter((r) => variantOf(r['relationship-type']) === 'options')
+			.map((r) => gcDecisions(r, nodeIds, relIds))
+			.filter((r) => ((r['relationship-type'].options ?? []).length > 0));
+
+		// Merge: graph from the canvas; document-level keys retained from the prior
+		// model so a canvas edit doesn't drop flows/metadata/decorators/etc.
+		model = {
+			...model,
+			nodes: [...projected.nodes],
+			relationships: [...projected.relationships, ...preservedOptions]
+		};
 	});
+}
+
+/**
+ * Drop decisions whose node/relationship references no longer resolve in the
+ * post-edit graph. A reference is dangling only when an id is *present but
+ * missing* from the graph — empty `nodes`/`relationships` arrays are valid and
+ * are kept. Returns a new relationship with the surviving decisions.
+ */
+function gcDecisions(
+	rel: CalmRelationship,
+	nodeIds: Set<string>,
+	relIds: Set<string>
+): CalmRelationship {
+	const rt = rel['relationship-type'];
+	const decisions = rt.options ?? [];
+	const kept = decisions.filter(
+		(dec) =>
+			(dec.nodes ?? []).every((id) => nodeIds.has(id)) &&
+			(dec.relationships ?? []).every((id) => relIds.has(id))
+	);
+	return { ...rel, 'relationship-type': { ...rt, options: kept } };
 }
 
 // ─── Read accessors ───────────────────────────────────────────────────────────

--- a/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/stores/calmModel.svelte.ts
@@ -70,15 +70,16 @@ export function applyFromCanvas(nodes: Node[], edges: Edge[]): boolean {
 		const projected = flowToCalm(nodes, edges);
 
 		// `options` relationships have no edge representation, so they never come
-		// back from flowToCalm. Carry them from the prior model, but GC any
-		// decision whose node/relationship references no longer resolve (and drop
-		// an options rel left with no decisions), so we never write a dangling ref.
+		// back from flowToCalm. Carry them from the prior model, GC'ing any
+		// decision whose node/relationship references no longer resolve so we never
+		// write a dangling ref. The relationship itself is kept even when its
+		// decisions array ends up empty — `options: []` is valid CALM (no minItems),
+		// so dropping it would be lossy for a legitimately-empty options input.
 		const nodeIds = new Set(projected.nodes.map((n) => n['unique-id']));
 		const relIds = new Set(projected.relationships.map((r) => r['unique-id']));
 		const preservedOptions = model.relationships
 			.filter((r) => variantOf(r['relationship-type']) === 'options')
-			.map((r) => gcDecisions(r, nodeIds, relIds))
-			.filter((r) => ((r['relationship-type'].options ?? []).length > 0));
+			.map((r) => gcDecisions(r, nodeIds, relIds));
 
 		// Merge: graph from the canvas; document-level keys retained from the prior
 		// model so a canvas edit doesn't drop flows/metadata/decorators/etc.

--- a/calm-suite/calm-studio/apps/studio/src/lib/stores/projection.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/stores/projection.ts
@@ -26,6 +26,7 @@
 import type { Node, Edge } from '@xyflow/svelte';
 import type {
 	CalmArchitecture,
+	CalmConnectsEndpoint,
 	CalmControls,
 	CalmInterface,
 	CalmNode,
@@ -42,10 +43,26 @@ const CONTAINMENT_VARIANTS: ReadonlySet<CalmRelationshipVariant> = new Set([
 ]);
 
 /**
+ * Loose shape of the `data` carried on a Svelte Flow edge by `calmToFlow`.
+ * Single source of truth for the edge-data contract on both projection sides.
+ */
+type EdgeData = {
+	calmRelId?: string;
+	calmVariant?: CalmRelationshipVariant;
+	protocol?: string;
+	description?: string;
+	controls?: CalmControls;
+	metadata?: Record<string, unknown> | Record<string, unknown>[];
+	/** connects-only: interface unique-ids on each endpoint (CALM `node-interface.interfaces`). */
+	sourceInterfaces?: string[];
+	destinationInterfaces?: string[];
+};
+
+/**
  * Discover the variant key actually present on a relationship-type object.
  * Returns null when the variant is malformed (no recognised key).
  */
-function variantOf(rt: CalmRelationshipType): CalmRelationshipVariant | null {
+export function variantOf(rt: CalmRelationshipType): CalmRelationshipVariant | null {
 	if ('connects' in rt) return 'connects';
 	if ('composed-of' in rt) return 'composed-of';
 	if ('interacts' in rt) return 'interacts';
@@ -98,25 +115,37 @@ function expandEdgePairs(
 }
 
 /**
- * Build a CALM 1.2 nested `relationship-type` from a flat (source, target,
- * variant) triple. Used when projecting Svelte Flow edges back to CALM.
+ * Build a CALM 1.2 nested `relationship-type` from an aggregated edge group:
+ * one `source` (container/actor/connects-source) and one or more `targets`.
+ * `connects` is strictly 1:1 (uses `targets[0]`) and restores endpoint
+ * interfaces; `composed-of`/`deployed-in`/`interacts` aggregate all `targets`
+ * into one `nodes[]`.
  */
 function buildRelationshipType(
 	variant: CalmRelationshipVariant,
-	source: string,
-	target: string
+	g: { source: string; targets: string[]; sourceInterfaces?: string[]; destinationInterfaces?: string[] }
 ): CalmRelationshipType {
 	switch (variant) {
-		case 'connects':
-			return { connects: { source: { node: source }, destination: { node: target } } };
+		case 'connects': {
+			const source: CalmConnectsEndpoint = { node: g.source };
+			if (g.sourceInterfaces?.length) source.interfaces = g.sourceInterfaces;
+			const destination: CalmConnectsEndpoint = { node: g.targets[0] };
+			if (g.destinationInterfaces?.length) destination.interfaces = g.destinationInterfaces;
+			return { connects: { source, destination } };
+		}
 		case 'composed-of':
-			return { 'composed-of': { container: source, nodes: [target] } };
+			return { 'composed-of': { container: g.source, nodes: g.targets } };
 		case 'deployed-in':
-			return { 'deployed-in': { container: source, nodes: [target] } };
+			return { 'deployed-in': { container: g.source, nodes: g.targets } };
 		case 'interacts':
-			return { interacts: { actor: source, nodes: [target] } };
+			return { interacts: { actor: g.source, nodes: g.targets } };
 		case 'options':
-			return { options: [] };
+			// Unreachable: `options` has no edge representation (expandEdgePairs
+			// returns []), so no edge group ever resolves to this variant. Throw
+			// loudly rather than emit a schema-invalid `{ options: [] }`.
+			throw new Error(
+				'buildRelationshipType: options relationships have no edge form; they are preserved via applyFromCanvas, not reconstructed from edges'
+			);
 	}
 }
 
@@ -207,22 +236,33 @@ export function calmToFlow(
 	// multi-child case (documented trade-off).
 	const edges: Edge[] = [];
 	for (const cr of arch.relationships) {
+		const crt = cr['relationship-type'];
+		// connects carries endpoint interfaces that must survive the round-trip.
+		const connectsIfaces =
+			'connects' in crt
+				? {
+						sourceInterfaces: crt.connects.source.interfaces,
+						destinationInterfaces: crt.connects.destination.interfaces
+					}
+				: {};
 		const pairs = expandEdgePairs(cr);
 		const multi = pairs.length > 1;
 		pairs.forEach((pair, i) => {
+			const data: EdgeData = {
+				calmRelId: cr['unique-id'],
+				calmVariant: pair.variant,
+				protocol: cr.protocol,
+				description: cr.description,
+				controls: cr.controls,
+				metadata: cr.metadata,
+				...connectsIfaces
+			};
 			edges.push({
 				id: multi ? `${cr['unique-id']}#${i}` : cr['unique-id'],
 				source: pair.source,
 				target: pair.target,
 				type: pair.variant,
-				data: {
-					calmRelId: cr['unique-id'],
-					calmVariant: pair.variant,
-					protocol: cr.protocol,
-					description: cr.description,
-					controls: cr.controls,
-					metadata: cr.metadata
-				}
+				data
 			});
 		});
 	}
@@ -272,38 +312,55 @@ export function flowToCalm(nodes: Node[], edges: Edge[]): CalmArchitecture {
 		return node;
 	});
 
-	const calmRelationships: CalmRelationship[] = edges.map((e: Edge) => {
-		const edgeData = (e.data ?? {}) as {
-			calmRelId?: string;
-			calmVariant?: CalmRelationshipVariant;
-			protocol?: string;
-			description?: string;
-			controls?: CalmControls;
-			metadata?: Record<string, unknown>;
-		};
+	// Group edges by their source relationship. `calmRelId` re-aggregates the
+	// edges of a multi-child relationship back into ONE relationship (restoring
+	// the original unique-id); a user-drawn edge has no calmRelId and falls back
+	// to its own id, becoming one relationship on its own. Map preserves insertion
+	// order, so groups emerge in original-relationship order.
+	const groups = new Map<string, Edge[]>();
+	for (const e of edges) {
+		const key = (e.data as EdgeData | undefined)?.calmRelId ?? e.id;
+		const existing = groups.get(key);
+		if (existing) existing.push(e);
+		else groups.set(key, [e]);
+	}
 
-		const variant =
-			edgeData.calmVariant ??
-			((e.type as CalmRelationshipVariant | undefined) ?? 'connects');
-		const sourceId = flowIdToCalmId.get(e.source) ?? e.source;
-		const targetId = flowIdToCalmId.get(e.target) ?? e.target;
+	const srcOf = (e: Edge) => flowIdToCalmId.get(e.source) ?? e.source;
+	const tgtOf = (e: Edge) => flowIdToCalmId.get(e.target) ?? e.target;
 
+	function buildRel(variant: CalmRelationshipVariant, id: string, group: Edge[]): CalmRelationship {
+		const first = group[0];
+		const d = (first.data ?? {}) as EdgeData;
 		const rel: CalmRelationship = {
-			'unique-id': e.id,
-			'relationship-type': buildRelationshipType(variant, sourceId, targetId)
+			'unique-id': id,
+			'relationship-type': buildRelationshipType(variant, {
+				source: srcOf(first),
+				targets: group.map(tgtOf),
+				sourceInterfaces: d.sourceInterfaces,
+				destinationInterfaces: d.destinationInterfaces
+			})
 		};
-
-		if (edgeData.protocol) rel.protocol = edgeData.protocol;
-		if (edgeData.description) rel.description = edgeData.description;
-		if (edgeData.controls && Object.keys(edgeData.controls).length > 0) {
-			rel.controls = edgeData.controls;
-		}
-		if (edgeData.metadata && Object.keys(edgeData.metadata).length > 0) {
-			rel.metadata = edgeData.metadata;
-		}
-
+		if (d.protocol) rel.protocol = d.protocol as CalmRelationship['protocol'];
+		if (d.description) rel.description = d.description;
+		if (d.controls && Object.keys(d.controls).length > 0) rel.controls = d.controls;
+		if (d.metadata && Object.keys(d.metadata).length > 0) rel.metadata = d.metadata;
 		return rel;
-	});
+	}
+
+	const calmRelationships: CalmRelationship[] = [];
+	for (const [relId, group] of groups) {
+		const d0 = (group[0].data ?? {}) as EdgeData;
+		const variant = d0.calmVariant ?? (group[0].type as CalmRelationshipVariant | undefined) ?? 'connects';
+
+		if (variant === 'connects') {
+			// connects is strictly 1:1 — never aggregate. A group is normally one
+			// edge; a >1 group is corrupt, so emit one rel per edge (no silent loss).
+			for (const e of group) calmRelationships.push(buildRel(variant, e.id, [e]));
+		} else {
+			// Multi-child variants aggregate to one rel keyed by the original id.
+			calmRelationships.push(buildRel(variant, relId, group));
+		}
+	}
 
 	return { nodes: calmNodes, relationships: calmRelationships };
 }

--- a/calm-suite/calm-studio/apps/studio/src/lib/stores/projection.ts
+++ b/calm-suite/calm-studio/apps/studio/src/lib/stores/projection.ts
@@ -15,9 +15,12 @@
  *   unique-id (`<base>#<i>`) so Svelte Flow stays 1-edge-per-row.
  *
  * flowToCalm: converts Svelte Flow nodes[] and edges[] back to
- * CalmArchitecture. Each Svelte Flow edge becomes exactly one
- * CalmRelationship; multi-child round-trips therefore split into
- * separate single-child rels (a documented, lossy-but-correct trade-off).
+ * CalmArchitecture. Edges are re-aggregated by their source relationship id
+ * (`data.calmRelId`), so a multi-child composed-of/deployed-in/interacts that
+ * expanded to N edges round-trips back to ONE relationship with its original
+ * unique-id (lossless). A user-drawn edge with no `calmRelId` becomes its own
+ * relationship. (`options` relationships have no edge form — they are preserved
+ * separately via `calmModel.applyFromCanvas`.)
  *
  * IMPORTANT: This file must NOT import from .svelte.ts files (not testable
  * in vitest without additional Svelte transform setup).

--- a/calm-suite/calm-studio/apps/studio/src/tests/components/EdgeProperties.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/components/EdgeProperties.test.ts
@@ -148,8 +148,15 @@ describe('EdgeProperties', () => {
 
 		// The edit must land on 'box-children' (keyed by calmRelId), not the
 		// non-existent 'box-children#1'. With the old edit-by-edge.id it no-ops.
-		const rel = getModel().relationships.find((r) => r['unique-id'] === 'box-children');
-		expect(rel).toBeDefined();
-		expect('interacts' in rel!['relationship-type']).toBe(true);
+		const rt = getModel().relationships.find((r) => r['unique-id'] === 'box-children')?.[
+			'relationship-type'
+		];
+		expect(rt && 'interacts' in rt).toBe(true);
+		// Switching the type must PRESERVE all children, not collapse to the edited
+		// edge's single child (the original composed-of had c1 AND c2).
+		if (rt && 'interacts' in rt) {
+			expect(rt.interacts.actor).toBe('box');
+			expect(new Set(rt.interacts.nodes)).toEqual(new Set(['c1', 'c2']));
+		}
 	});
 });

--- a/calm-suite/calm-studio/apps/studio/src/tests/components/EdgeProperties.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/components/EdgeProperties.test.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import type { Edge } from '@xyflow/svelte';
 import EdgeProperties from '$lib/properties/EdgeProperties.svelte';
-import { applyFromJson, resetModel } from '$lib/stores/calmModel.svelte';
+import { applyFromJson, resetModel, getModel } from '$lib/stores/calmModel.svelte';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -95,7 +95,7 @@ describe('EdgeProperties', () => {
 		expect(protocolSelect).toBeNull();
 	});
 
-	it('relationship type select has all 5 standard relationship types as options', () => {
+	it('relationship type select offers exactly the 4 authorable types (no options)', () => {
 		const { getByRole } = render(EdgeProperties, {
 			props: { edge: makeFlowEdge('rel-1', 'connects', 'svc-1', 'db-1', 'HTTPS') },
 		});
@@ -105,6 +105,9 @@ describe('EdgeProperties', () => {
 		expect(options).toContain('interacts');
 		expect(options).toContain('deployed-in');
 		expect(options).toContain('composed-of');
+		// 'options' is intentionally not authorable (no decision UI; would emit invalid CALM).
+		expect(options).not.toContain('options');
+		expect(options).toHaveLength(4);
 	});
 
 	it('renders unique-id in read-only field', () => {
@@ -112,5 +115,41 @@ describe('EdgeProperties', () => {
 			props: { edge: makeFlowEdge('rel-1', 'connects', 'svc-1', 'db-1', 'HTTPS') },
 		});
 		expect(getByText('rel-1')).toBeTruthy();
+	});
+
+	it('edits a multi-child edge via its calmRelId, not the suffixed edge id', async () => {
+		// A multi-child relationship's edges have ids `<relId>#<i>`; the underlying
+		// relationship in the model is keyed by the un-suffixed `calmRelId`. Editing
+		// must resolve via calmRelId or it silently no-ops.
+		resetModel();
+		applyFromJson({
+			nodes: [
+				{ 'unique-id': 'box', 'node-type': 'system', name: 'Box', description: 'Box' },
+				{ 'unique-id': 'c1', 'node-type': 'service', name: 'C1', description: 'C1' },
+				{ 'unique-id': 'c2', 'node-type': 'service', name: 'C2', description: 'C2' },
+			],
+			relationships: [
+				{
+					'unique-id': 'box-children',
+					'relationship-type': { 'composed-of': { container: 'box', nodes: ['c1', 'c2'] } },
+				},
+			],
+		});
+		const edge = {
+			id: 'box-children#1',
+			source: 'box',
+			target: 'c2',
+			type: 'composed-of',
+			data: { calmRelId: 'box-children', calmVariant: 'composed-of', description: '' },
+		} as unknown as Edge;
+		const { getByRole } = render(EdgeProperties, { props: { edge } });
+		const select = getByRole('combobox', { name: /relationship type/i }) as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: 'interacts' } });
+
+		// The edit must land on 'box-children' (keyed by calmRelId), not the
+		// non-existent 'box-children#1'. With the old edit-by-edge.id it no-ops.
+		const rel = getModel().relationships.find((r) => r['unique-id'] === 'box-children');
+		expect(rel).toBeDefined();
+		expect('interacts' in rel!['relationship-type']).toBe(true);
 	});
 });

--- a/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
@@ -506,8 +506,26 @@ describe('options preservation through applyFromCanvas', () => {
 		const nodes2 = nodes.filter((n) => (n.data as { calmId?: string }).calmId !== 'b');
 		const edges2 = edges.filter((e) => e.source !== 'b' && e.target !== 'b');
 		applyFromCanvas(nodes2, edges2);
-		// decision-1 references the now-missing 'b'/'conn' → GC'd → options rel dropped.
-		expect(getModel().relationships.find((r) => 'options' in r['relationship-type'])).toBeUndefined();
+		// decision-1 references the now-missing 'b'/'conn' → the decision is GC'd.
+		// The options relationship itself is KEPT (empty `options: []` is valid CALM),
+		// just with the dangling decision removed.
+		const opts = getModel().relationships.find((r) => 'options' in r['relationship-type']);
+		expect(opts).toBeDefined();
+		expect(opts?.['relationship-type'].options).toHaveLength(0);
+	});
+
+	it('preserves a legitimately-empty options relationship (options: []) across a round-trip', () => {
+		// `option-type` has no minItems, so `options: []` is valid CALM and must not
+		// be dropped (PR feedback). Would fail on the old `.filter(length > 0)`.
+		applyFromJson({
+			nodes: [{ 'unique-id': 'a', 'node-type': 'service', name: 'A', description: 'A' }],
+			relationships: [{ 'unique-id': 'empty-opts', 'relationship-type': { options: [] } }]
+		});
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		const opts = getModel().relationships.find((r) => r['unique-id'] === 'empty-opts');
+		expect(opts).toBeDefined();
+		expect(opts?.['relationship-type'].options).toEqual([]);
 	});
 
 	it('flowToCalm never emits an options relationship', () => {

--- a/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
+++ b/calm-suite/calm-studio/apps/studio/src/tests/integration/sync-integration.test.ts
@@ -338,3 +338,215 @@ describe('flowToCalm from calmToFlow output', () => {
 		expect(result.relationships).toHaveLength(arch.relationships.length);
 	});
 });
+
+// ─── flowToCalm graph fidelity (lossless canvas round-trip) ───────────────────
+
+describe('flowToCalm graph fidelity', () => {
+	it('round-trips connects endpoint interfaces', () => {
+		const arch: CalmArchitecture = {
+			nodes: [
+				{ 'unique-id': 'a', 'node-type': 'service', name: 'A', description: 'A' },
+				{ 'unique-id': 'b', 'node-type': 'service', name: 'B', description: 'B' }
+			],
+			relationships: [
+				{
+					'unique-id': 'a-b',
+					'relationship-type': {
+						connects: {
+							source: { node: 'a', interfaces: ['a-http'] },
+							destination: { node: 'b', interfaces: ['b-http'] }
+						}
+					}
+				}
+			]
+		};
+		const { nodes, edges } = calmToFlow(arch);
+		const rt = flowToCalm(nodes, edges).relationships[0]['relationship-type'];
+		expect(rt.connects?.source.interfaces).toEqual(['a-http']);
+		expect(rt.connects?.destination.interfaces).toEqual(['b-http']);
+	});
+
+	it('re-aggregates a multi-child composed-of into ONE relationship with the original id', () => {
+		const arch: CalmArchitecture = {
+			nodes: [
+				{ 'unique-id': 'box', 'node-type': 'system', name: 'Box', description: 'Box' },
+				{ 'unique-id': 'c1', 'node-type': 'service', name: 'C1', description: 'C1' },
+				{ 'unique-id': 'c2', 'node-type': 'service', name: 'C2', description: 'C2' },
+				{ 'unique-id': 'c3', 'node-type': 'service', name: 'C3', description: 'C3' }
+			],
+			relationships: [
+				{
+					'unique-id': 'box-children',
+					'relationship-type': { 'composed-of': { container: 'box', nodes: ['c1', 'c2', 'c3'] } }
+				}
+			]
+		};
+		const { nodes, edges } = calmToFlow(arch);
+		expect(edges).toHaveLength(3); // expands to one edge per child
+		const rels = flowToCalm(nodes, edges).relationships;
+		expect(rels).toHaveLength(1); // re-aggregated, not fragmented
+		expect(rels[0]['unique-id']).toBe('box-children'); // original id restored
+		expect(new Set(rels[0]['relationship-type']['composed-of']?.nodes)).toEqual(
+			new Set(['c1', 'c2', 'c3'])
+		);
+	});
+
+	it('re-aggregates multi-child deployed-in and interacts', () => {
+		const arch: CalmArchitecture = {
+			nodes: [
+				{ 'unique-id': 'host', 'node-type': 'system', name: 'Host', description: 'h' },
+				{ 'unique-id': 's1', 'node-type': 'service', name: 'S1', description: 's1' },
+				{ 'unique-id': 's2', 'node-type': 'service', name: 'S2', description: 's2' },
+				{ 'unique-id': 'actor', 'node-type': 'actor', name: 'Actor', description: 'a' },
+				{ 'unique-id': 'x1', 'node-type': 'service', name: 'X1', description: 'x1' },
+				{ 'unique-id': 'x2', 'node-type': 'service', name: 'X2', description: 'x2' }
+			],
+			relationships: [
+				{ 'unique-id': 'dep', 'relationship-type': { 'deployed-in': { container: 'host', nodes: ['s1', 's2'] } } },
+				{ 'unique-id': 'int', 'relationship-type': { interacts: { actor: 'actor', nodes: ['x1', 'x2'] } } }
+			]
+		};
+		const { nodes, edges } = calmToFlow(arch);
+		const rels = flowToCalm(nodes, edges).relationships;
+		const dep = rels.find((r) => r['unique-id'] === 'dep');
+		const int = rels.find((r) => r['unique-id'] === 'int');
+		expect(rels).toHaveLength(2);
+		expect(dep?.['relationship-type']['deployed-in']?.container).toBe('host');
+		expect(int?.['relationship-type'].interacts?.actor).toBe('actor');
+		expect(new Set(dep?.['relationship-type']['deployed-in']?.nodes)).toEqual(new Set(['s1', 's2']));
+		expect(new Set(int?.['relationship-type'].interacts?.nodes)).toEqual(new Set(['x1', 'x2']));
+	});
+
+	it('does NOT absorb a drawn edge (no calmRelId) into an existing multi-child group', () => {
+		// Pins the grouping contract: keying on calmRelId (not source/variant). A
+		// user draws box→c3 with no calmRelId; it must become its OWN relationship,
+		// not merge into the existing box-children composed-of.
+		const base = calmToFlow({
+			nodes: [
+				{ 'unique-id': 'box', 'node-type': 'system', name: 'Box', description: 'Box' },
+				{ 'unique-id': 'c1', 'node-type': 'service', name: 'C1', description: 'C1' },
+				{ 'unique-id': 'c2', 'node-type': 'service', name: 'C2', description: 'C2' },
+				{ 'unique-id': 'c3', 'node-type': 'service', name: 'C3', description: 'C3' }
+			],
+			relationships: [
+				{ 'unique-id': 'box-children', 'relationship-type': { 'composed-of': { container: 'box', nodes: ['c1', 'c2'] } } }
+			]
+		});
+		const drawn = {
+			id: 'drawn-1',
+			source: 'box',
+			target: 'c3',
+			type: 'composed-of',
+			data: { calmVariant: 'composed-of' }
+		} as (typeof base.edges)[number];
+		const rels = flowToCalm(base.nodes, [...base.edges, drawn]).relationships;
+		expect(rels).toHaveLength(2);
+		expect(new Set(rels.find((r) => r['unique-id'] === 'box-children')?.['relationship-type']['composed-of']?.nodes)).toEqual(
+			new Set(['c1', 'c2'])
+		);
+		expect(rels.find((r) => r['unique-id'] === 'drawn-1')).toBeDefined();
+	});
+
+	it('re-aggregates a multi-child composed-of through the full applyFromCanvas path', () => {
+		// The pure-function tests above bypass the store; this guards the wiring
+		// (flowToCalm result is actually stored re-aggregated, not overridden).
+		applyFromJson({
+			nodes: [
+				{ 'unique-id': 'box', 'node-type': 'system', name: 'Box', description: 'Box' },
+				{ 'unique-id': 'c1', 'node-type': 'service', name: 'C1', description: 'C1' },
+				{ 'unique-id': 'c2', 'node-type': 'service', name: 'C2', description: 'C2' },
+				{ 'unique-id': 'c3', 'node-type': 'service', name: 'C3', description: 'C3' }
+			],
+			relationships: [
+				{ 'unique-id': 'box-children', 'relationship-type': { 'composed-of': { container: 'box', nodes: ['c1', 'c2', 'c3'] } } }
+			]
+		});
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		const rels = getModel().relationships;
+		expect(rels).toHaveLength(1);
+		expect(rels[0]['unique-id']).toBe('box-children');
+		expect(new Set(rels[0]['relationship-type']['composed-of']?.nodes)).toEqual(new Set(['c1', 'c2', 'c3']));
+	});
+});
+
+// ─── options preservation (no edge form; carried via applyFromCanvas + GC) ─────
+
+describe('options preservation through applyFromCanvas', () => {
+	function archWithOptions(): CalmArchitecture {
+		return {
+			nodes: [
+				{ 'unique-id': 'a', 'node-type': 'service', name: 'A', description: 'A' },
+				{ 'unique-id': 'b', 'node-type': 'service', name: 'B', description: 'B' }
+			],
+			relationships: [
+				{ 'unique-id': 'conn', 'relationship-type': { connects: { source: { node: 'a' }, destination: { node: 'b' } } } },
+				{
+					'unique-id': 'decision-1',
+					'relationship-type': {
+						options: [{ description: 'pick a or b', nodes: ['a', 'b'], relationships: ['conn'] }]
+					}
+				}
+			]
+		};
+	}
+
+	it('preserves a loaded options relationship across a canvas round-trip', () => {
+		applyFromJson(archWithOptions());
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		const opts = getModel().relationships.find((r) => 'options' in r['relationship-type']);
+		expect(opts?.['unique-id']).toBe('decision-1');
+	});
+
+	it('GCs an options decision whose referenced node/relationship was deleted on canvas', () => {
+		applyFromJson(archWithOptions());
+		const { nodes, edges } = calmToFlow(getModel());
+		// Simulate deleting node 'b' (and its connects edge) on the canvas.
+		const nodes2 = nodes.filter((n) => (n.data as { calmId?: string }).calmId !== 'b');
+		const edges2 = edges.filter((e) => e.source !== 'b' && e.target !== 'b');
+		applyFromCanvas(nodes2, edges2);
+		// decision-1 references the now-missing 'b'/'conn' → GC'd → options rel dropped.
+		expect(getModel().relationships.find((r) => 'options' in r['relationship-type'])).toBeUndefined();
+	});
+
+	it('flowToCalm never emits an options relationship', () => {
+		const { nodes, edges } = calmToFlow(archWithOptions());
+		const rels = flowToCalm(nodes, edges).relationships;
+		expect(rels.some((r) => 'options' in r['relationship-type'])).toBe(false);
+	});
+
+	it('GCs only the dangling decision, keeping the surviving one (partial survival)', () => {
+		applyFromJson({
+			nodes: [{ 'unique-id': 'a', 'node-type': 'service', name: 'A', description: 'A' }],
+			relationships: [
+				{
+					'unique-id': 'opts',
+					'relationship-type': {
+						options: [
+							{ description: 'good', nodes: ['a'], relationships: [] },
+							{ description: 'bad', nodes: ['a', 'missing-node'], relationships: [] }
+						]
+					}
+				}
+			]
+		});
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		const opts = getModel().relationships.find((r) => 'options' in r['relationship-type']);
+		expect(opts?.['relationship-type'].options).toHaveLength(1);
+		expect(opts?.['relationship-type'].options?.[0].description).toBe('good');
+	});
+
+	it('keeps an options decision with empty nodes/relationships arrays (empty is valid CALM)', () => {
+		applyFromJson({
+			nodes: [{ 'unique-id': 'a', 'node-type': 'service', name: 'A', description: 'A' }],
+			relationships: [
+				{ 'unique-id': 'opts', 'relationship-type': { options: [{ description: 'open', nodes: [], relationships: [] }] } }
+			]
+		});
+		const { nodes, edges } = calmToFlow(getModel());
+		applyFromCanvas(nodes, edges);
+		expect(getModel().relationships.find((r) => 'options' in r['relationship-type'])).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Description

**The journey this fixes:** You open a CALM architecture in **CALM Studio** — one with a container that holds several children (a `composed-of`/`deployed-in` with many nodes), some `connects` relationships that bind specific interfaces, and maybe an `options` decision. You **rearrange the nodes on the canvas** and **save**. The saved file should be structurally identical to what you loaded — only positions changed.

Today it isn't. Studio's CALM↔canvas projection (`projection.ts`) silently degrades the graph on that round-trip:

- **Multi-child relationships fragment.** A single `composed-of` with 3 children comes back as **three separate single-child relationships** with mangled ids (`box-children#0`, `#1`, `#2`) — destroying the original `unique-id` that **flows and `options` decisions reference by id**.
- **`connects` interface bindings are dropped.** `{ node, interfaces }` → `{ node }`, so endpoint interface references are lost.
- **`options` relationships vanish or go invalid.** Loaded decisions are dropped entirely on a canvas edit, and the "Options" edge-type could only ever emit schema-invalid `{ options: [] }` (Studio has no UI to author a decision's `description`/`nodes`/`relationships`).

The net effect: any tool downstream of Studio (the CLI validator, the Hub, flow overlays, generators) sees a structurally degraded document. This is the graph-payload counterpart to the document-level-key loss fixed in the parent PR.

**After this PR**, the round-trip is lossless:

- ✅ Multi-child `composed-of`/`deployed-in`/`interacts` relationships re-aggregate into **one** relationship with the **original `unique-id`** and all children intact.
- ✅ `connects` endpoint interfaces survive the round-trip.
- ✅ `options` relationships loaded from a file are preserved, with **referential GC** (a decision whose referenced node/relationship was deleted on the canvas is dropped rather than left dangling).

### What changed
- **`calmToFlow`** now carries `connects` endpoint interfaces on the edge; **`flowToCalm`** re-aggregates edges by their source-relationship id (`calmRelId`), restoring the original `unique-id` and merging multi-child targets into one relationship. `buildRelationshipType` restores interfaces and **throws** on `options` (it has no edge form) instead of emitting invalid CALM.
- **`applyFromCanvas`** preserves loaded `options` relationships from the prior model with referential GC, since `options` have no edge representation.
- **`EdgeProperties`** edits resolve the relationship via `calmRelId`, so editing a multi-child edge updates its (aggregated) relationship instead of silently no-opping; the read-only Unique ID field shows the relationship id.

> ⚠️ **User-visible behavior change (intentional, reviewed):** the **"Options" edge-type affordance** is removed from the relationship-type dropdown and the canvas context menu. Studio has no decision-authoring UI, so that affordance could *only* produce schema-invalid CALM. Options relationships **loaded from a file still round-trip** — this only removes the ability to create one on the canvas, which never worked correctly. A real decision-authoring UI would be a separate feature.

> 🔗 **Stacked PR:** targets `fix/calmstudio-roundtrip-document-keys` (the document-level-keys fix) rather than `main`, so the diff is scoped to this change. Re-point to `main` once the parent merges.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD
<!-- Surface is CALM Studio (calm-suite/calm-studio/), which has no checkbox in this template. -->

## Commit Message Format ✅
Conventional Commits, DCO signed-off:
- `fix(calm-suite): round-trip multi-child, interface, and options relationships in Studio`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified on Node 22: `npm run test --workspace=@calmstudio/studio` (**457 pass**, incl. new fidelity/options coverage), `npm run typecheck --workspace=@calmstudio/studio` (no new errors vs the pre-existing baseline), and `npm run build --workspace=@calmstudio/studio` all pass. New tests cover: connects-interface round-trip; multi-child re-aggregation for `composed-of`/`deployed-in`/`interacts` (set-equality of `nodes`, original `unique-id`, `container`/`actor` preserved); the full `applyFromJson → calmToFlow → applyFromCanvas` wiring path; a drawn edge staying its own relationship (not absorbed into a group); `options` preservation; decision GC on a deleted reference (including partial-survival and empty-ref-kept); `flowToCalm` never emitting `options`; and editing a multi-child edge by `calmRelId`. Each fidelity guard was checked to fail on pre-fix code.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
