### PR TITLE
#2679 - fix storage of name/description when updating resources

### DIFF
--- a/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
@@ -206,7 +206,7 @@ public class MongoMappingControllerIntegration {
     @Test
     @Order(14)
     void return_409_when_specific_version_already_exists() {
-        String payload = "{\"name\": \"front-controller-test-dup\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test v2\", \"name\": \"front-controller-test-dup\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
 
         given()
                 .body(payload)
@@ -219,7 +219,7 @@ public class MongoMappingControllerIntegration {
     @Test
     @Order(15)
     void return_400_when_versioned_id_does_not_match_path() {
-        String payload = "{\"name\": \"mismatch\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/4.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test v3\", \"name\": \"mismatch\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/4.0.0\"}";
 
         given()
                 .body(payload)
@@ -233,7 +233,7 @@ public class MongoMappingControllerIntegration {
     @Test
     @Order(16)
     void return_400_when_first_version_is_not_1_0_0() {
-        String payload = "{\"name\": \"seeded\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/seeded-pattern/versions/2.0.0\"}";
+        String payload = "{\"title\": \"first\", \"name\": \"seeded\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/seeded-pattern/versions/2.0.0\"}";
 
         given()
                 .body(payload)
@@ -298,7 +298,7 @@ public class MongoMappingControllerIntegration {
     @Test
     @Order(21)
     void user_facing_create_control_returns_201_with_name_based_location() {
-        String payload = "{\"type\":\"requirement\",\"description\":\"Ensure proper access control\",\"$id\":\"http://localhost:8080/calm/domains/security/controls/access-control/requirement/versions/1.0.0\"}";
+        String payload = "{\"title\": \"ACL control\", \"type\":\"requirement\",\"description\":\"Ensure proper access control\",\"$id\":\"http://localhost:8080/calm/domains/security/controls/access-control/requirement/versions/1.0.0\"}";
         given()
                 .header("Content-Type", "application/json")
                 .body(payload)

--- a/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
@@ -145,7 +145,7 @@ public class NitriteMappingControllerIntegration {
     @Test
     @Order(12)
     void add_specific_version_via_versioned_endpoint() {
-        String payload = "{\"name\": \"front-controller-test-v4\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test v4\", \"name\": \"front-controller-test-v4\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
 
         given()
                 .body(payload)
@@ -159,7 +159,7 @@ public class NitriteMappingControllerIntegration {
     @Test
     @Order(13)
     void return_409_when_specific_version_already_exists() {
-        String payload = "{\"name\": \"front-controller-test-dup\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test Dup\", \"name\": \"front-controller-test-dup\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/2.0.0\"}";
 
         given()
                 .body(payload)
@@ -172,7 +172,7 @@ public class NitriteMappingControllerIntegration {
     @Test
     @Order(14)
     void return_400_when_versioned_id_does_not_match_path() {
-        String payload = "{\"name\": \"mismatch\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/4.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test Mismatch\", \"name\": \"mismatch\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/test-pattern/versions/4.0.0\"}";
 
         given()
                 .body(payload)
@@ -186,7 +186,7 @@ public class NitriteMappingControllerIntegration {
     @Test
     @Order(15)
     void return_400_when_first_version_is_not_1_0_0() {
-        String payload = "{\"name\": \"seeded\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/seeded-pattern/versions/2.0.0\"}";
+        String payload = "{\"title\": \"Front Controller Test First\", \"name\": \"seeded\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/seeded-pattern/versions/2.0.0\"}";
 
         given()
                 .body(payload)
@@ -251,7 +251,7 @@ public class NitriteMappingControllerIntegration {
     @Test
     @Order(20)
     void user_facing_create_control_returns_201_with_name_based_location() {
-        String payload = "{\"type\":\"requirement\",\"description\":\"Ensure proper access control\",\"$id\":\"http://localhost:8080/calm/domains/security/controls/access-control/requirement/versions/1.0.0\"}";
+        String payload = "{\"title\": \"ACL control\", \"type\":\"requirement\",\"description\":\"Ensure proper access control\",\"$id\":\"http://localhost:8080/calm/domains/security/controls/access-control/requirement/versions/1.0.0\"}";
         given()
                 .header("Content-Type", "application/json")
                 .body(payload)

--- a/calm-hub/src/main/java/org/finos/calm/resources/MappingControllerResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/MappingControllerResource.java
@@ -203,8 +203,15 @@ public class MappingControllerResource {
             return CalmResourceErrorResponses.invalidNamespaceResponse(canonical.namespace());
         }
         String storedBody = documentParser.stripId(requestBody);
+        String title = documentParser.extractStringField(requestBody, "title");
+        if (title.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("'title' is required in the document body").build();
+        }
+        String description = documentParser.extractStringField(requestBody, "description");
         return service.updateVersionedResource(canonical.resourceType(), canonical.namespace(),
-                canonical.type(), canonical.name(), existing.getNumericId(), canonical.version(), storedBody);
+                canonical.type(), canonical.name(), existing.getNumericId(), canonical.version(),
+                title, description, storedBody);
     }
 
     // =========================================================================

--- a/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
@@ -105,9 +105,9 @@ public class MappingControllerService {
      */
     public Response updateVersionedResource(ResourceType resourceType, String namespace, String type,
                                             String name, int numericId, String version,
-                                            String storedBody) throws URISyntaxException {
+                                            String title, String description, String storedBody) throws URISyntaxException {
         try {
-            updateVersionedResourceInStore(resourceType, namespace, numericId, version, storedBody);
+            updateVersionedResourceInStore(resourceType, namespace, numericId, version, title, description, storedBody);
             URI location = new URI("/calm/namespaces/" + namespace + "/" + type
                     + "/" + name + "/versions/" + version);
             return Response.created(location).build();
@@ -491,8 +491,14 @@ public class MappingControllerService {
                                 + STRICT_SANITIZATION_POLICY.sanitize(name)).build();
             }
             String newVersion = versionSpec.version();
+            String title = documentParser.extractStringField(json, "title");
+            if (title.isBlank()) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("'title' is required in the document body").build();
+            }
+            String description = documentParser.extractStringField(json, "description");
             createVersionedResourceInStore(mapping.getResourceType(), namespace,
-                    mapping.getNumericId(), newVersion, json);
+                    mapping.getNumericId(), newVersion, json, title, description);
 
             URI location = new URI("/calm/namespaces/" + namespace + "/" + typePath + "/" + name + "/versions/" + newVersion);
             return Response.created(location).build();
@@ -557,7 +563,7 @@ public class MappingControllerService {
      * Creates a new version of an existing resource in the type-specific store.
      */
     private void createVersionedResourceInStore(ResourceType type, String namespace, int numericId,
-                                                 String version, String json) throws Exception {
+                                                 String version, String json, String title, String description) throws Exception {
         // Strip the verified $id before storage (re-derived on read; Mongo rejects a top-level $id).
         json = documentParser.stripId(json);
         switch (type) {
@@ -567,6 +573,8 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setPattern(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 patternStore.createPatternForVersion(pattern);
             }
@@ -576,6 +584,8 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setArchitecture(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 architectureStore.createArchitectureForVersion(arch);
             }
@@ -585,15 +595,17 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setFlow(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 flowStore.createFlowForVersion(flow);
             }
             case STANDARD -> {
-                CreateStandardRequest req = new CreateStandardRequest("", "", json);
+                CreateStandardRequest req = new CreateStandardRequest(title, description, json);
                 standardStore.createStandardForVersion(req, namespace, numericId, version);
             }
             case INTERFACE -> {
-                CreateInterfaceRequest req = new CreateInterfaceRequest("", "", json);
+                CreateInterfaceRequest req = new CreateInterfaceRequest(title, description, json);
                 interfaceStore.createInterfaceForVersion(req, namespace, numericId, version);
             }
         }
@@ -605,7 +617,7 @@ public class MappingControllerService {
      * and {@link ResourceType#FLOW} only.
      */
     private void updateVersionedResourceInStore(ResourceType type, String namespace, int numericId,
-                                                String version, String json) throws Exception {
+                                                String version, String json, String title, String description) throws Exception {
         switch (type) {
             case PATTERN -> {
                 Pattern pattern = new Pattern.PatternBuilder()
@@ -613,6 +625,8 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setPattern(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 patternStore.updatePatternForVersion(pattern);
             }
@@ -622,6 +636,8 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setArchitecture(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 architectureStore.updateArchitectureForVersion(arch);
             }
@@ -631,6 +647,8 @@ public class MappingControllerService {
                         .setId(numericId)
                         .setVersion(version)
                         .setFlow(json)
+                        .setName(title)
+                        .setDescription(description)
                         .build();
                 flowStore.updateFlowForVersion(flow);
             }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourcePutShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourcePutShould.java
@@ -44,9 +44,9 @@ public class TestMappingControllerResourcePutShould {
         when(mockPermissionChecker.canWriteByDomain(any(), any())).thenReturn(true);
     }
 
-    private static String versionedDoc(String namespace, String type, String name, String version) {
-        return "{\"$id\":\"http://localhost:8080/calm/namespaces/"
-                + namespace + "/" + type + "/" + name + "/versions/" + version + "\"}";
+    private static String versionedDoc(String namespace, String type, String name, String version, String title) {
+        String id = "http://localhost:8080/calm/namespaces/" + namespace + "/" + type + "/" + name + "/versions/" + version;
+        return "{\"$id\":\"" + id + "\", \"title\": \"" + title + "\"}";
     }
 
     @Test
@@ -57,8 +57,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0", "test pattern"))
+                .when().put("/calm")
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/patterns/api-gateway/versions/1.0.0"));
 
@@ -73,8 +73,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "my-arch")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "architectures", "my-arch", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "architectures", "my-arch", "1.0.0", "test architecture"))
+                .when().put("/calm")
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/architectures/my-arch/versions/1.0.0"));
 
@@ -89,8 +89,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "my-flow")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "flows", "my-flow", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "flows", "my-flow", "1.0.0", "test flow"))
+                .when().put("/calm")
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/flows/my-flow/versions/1.0.0"));
 
@@ -105,8 +105,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "my-standard")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "standards", "my-standard", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "standards", "my-standard", "1.0.0", "test standard"))
+                .when().put("/calm")
                 .then().statusCode(501).body(containsString("not supported"));
     }
 
@@ -118,8 +118,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "my-interface")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "interfaces", "my-interface", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "interfaces", "my-interface", "1.0.0", "test interface"))
+                .when().put("/calm")
                 .then().statusCode(501).body(containsString("not supported"));
     }
 
@@ -128,8 +128,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("finos", "nonexistent")).thenThrow(new MappingNotFoundException());
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "patterns", "nonexistent", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("finos", "patterns", "nonexistent", "1.0.0", "whatever"))
+                .when().put("/calm")
                 .then().statusCode(404).body(containsString("nonexistent"));
     }
 
@@ -145,8 +145,8 @@ public class TestMappingControllerResourcePutShould {
         when(mockMappingStore.getMapping("invalid", "api-gateway")).thenThrow(new NamespaceNotFoundException());
 
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("invalid", "patterns", "api-gateway", "1.0.0")).when()
-                .put("/calm")
+                .body(versionedDoc("invalid", "patterns", "api-gateway", "1.0.0", "test pattern"))
+                .when().put("/calm")
                 .then().statusCode(404);
     }
 
@@ -170,7 +170,7 @@ public class TestMappingControllerResourcePutShould {
     void return_403_when_put_is_forbidden_for_namespace() {
         when(mockPermissionChecker.canWrite(any(), eq("finos"))).thenReturn(false);
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0"))
+                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0", "test pattern"))
                 .when().put("/calm")
                 .then().statusCode(403).body(containsString("finos"));
     }
@@ -184,7 +184,7 @@ public class TestMappingControllerResourcePutShould {
         doThrow(new NamespaceNotFoundException()).when(mockPatternStore)
                 .updatePatternForVersion(any(Pattern.class));
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0"))
+                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0", "test pattern"))
                 .when().put("/calm")
                 .then().statusCode(404);
     }
@@ -198,7 +198,7 @@ public class TestMappingControllerResourcePutShould {
         doThrow(new RuntimeException("unexpected store failure")).when(mockPatternStore)
                 .updatePatternForVersion(any(Pattern.class));
         given().header("Content-Type", "application/json")
-                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0"))
+                .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0", "test pattern"))
                 .when().put("/calm")
                 .then().statusCode(500);
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceWithBaseUrlShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceWithBaseUrlShould.java
@@ -239,7 +239,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
         when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
 
-        String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\" }";
+        String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\", \"title\": \"API gateway pattern\" }";
 
         given()
                 .header("Content-Type", "application/json")


### PR DESCRIPTION
## Description
CalmHub currently only sets name/description from the document on create, not update.
This means name becomes null after any updates are applied, meaning the navbar breaks and falls back to the default naming of [Resource NUMBER].

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
