### PR TITLE
feat(calm-hub,calm-hub-ui): user access admin UI (#2676)

### DIFF
--- a/calm-hub-ui/src/App.tsx
+++ b/calm-hub-ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter as Router, Route, Routes } from 'react-router-dom';
 import Hub from './hub/Hub.js';
 import Visualizer from './visualizer/Visualizer.js';
+import { AdminPage } from './admin/AdminPage.js';
 
 function App() {
     //TODO: The artifacts route will eventually need to be changed/replaced once we create a unique identifier for resources that can be used across CalmHubs.
@@ -12,6 +13,7 @@ function App() {
                 <Route path="/" element={<Hub />} />
                 <Route path="/:namespace/:type/:id/:version" element={<Hub />} />
                 <Route path="/visualizer" element={<Visualizer />} />
+                <Route path="/admin" element={<AdminPage />} />
             </Routes>
         </Router>
     );

--- a/calm-hub-ui/src/App.tsx
+++ b/calm-hub-ui/src/App.tsx
@@ -13,19 +13,19 @@ function App() {
     //Currently the format of the route allows deeplinks to only be used within a single CalmHub.
     return (
         <UserAccessProvider>
-        <Router>
-            <Routes>
-                <Route path="/" element={<Hub />} />
-                <Route path="/:namespace/:type/:id/:version" element={<Hub />} />
-                <Route path="/visualizer" element={<Visualizer />} />
-                <Route path="/admin" element={<AdminPage />}>
-                    <Route index element={<Navigate to="entitlements" replace />} />
-                    <Route path="namespaces" element={<NamespacesPanel />} />
-                    <Route path="domains" element={<DomainsPanel />} />
-                    <Route path="entitlements" element={<EntitlementsPanel />} />
-                </Route>
-            </Routes>
-        </Router>
+            <Router>
+                <Routes>
+                    <Route path="/" element={<Hub />} />
+                    <Route path="/:namespace/:type/:id/:version" element={<Hub />} />
+                    <Route path="/visualizer" element={<Visualizer />} />
+                    <Route path="/admin" element={<AdminPage />}>
+                        <Route index element={<Navigate to="entitlements" replace />} />
+                        <Route path="namespaces" element={<NamespacesPanel />} />
+                        <Route path="domains" element={<DomainsPanel />} />
+                        <Route path="entitlements" element={<EntitlementsPanel />} />
+                    </Route>
+                </Routes>
+            </Router>
         </UserAccessProvider>
     );
 }

--- a/calm-hub-ui/src/App.tsx
+++ b/calm-hub-ui/src/App.tsx
@@ -1,7 +1,10 @@
-import { HashRouter as Router, Route, Routes } from 'react-router-dom';
+import { HashRouter as Router, Navigate, Route, Routes } from 'react-router-dom';
 import Hub from './hub/Hub.js';
 import Visualizer from './visualizer/Visualizer.js';
 import { AdminPage } from './admin/AdminPage.js';
+import { NamespacesPanel } from './admin/panels/NamespacesPanel.js';
+import { DomainsPanel } from './admin/panels/DomainsPanel.js';
+import { EntitlementsPanel } from './admin/panels/EntitlementsPanel.js';
 
 function App() {
     //TODO: The artifacts route will eventually need to be changed/replaced once we create a unique identifier for resources that can be used across CalmHubs.
@@ -13,7 +16,12 @@ function App() {
                 <Route path="/" element={<Hub />} />
                 <Route path="/:namespace/:type/:id/:version" element={<Hub />} />
                 <Route path="/visualizer" element={<Visualizer />} />
-                <Route path="/admin" element={<AdminPage />} />
+                <Route path="/admin" element={<AdminPage />}>
+                    <Route index element={<Navigate to="entitlements" replace />} />
+                    <Route path="namespaces" element={<NamespacesPanel />} />
+                    <Route path="domains" element={<DomainsPanel />} />
+                    <Route path="entitlements" element={<EntitlementsPanel />} />
+                </Route>
             </Routes>
         </Router>
     );

--- a/calm-hub-ui/src/App.tsx
+++ b/calm-hub-ui/src/App.tsx
@@ -5,12 +5,14 @@ import { AdminPage } from './admin/AdminPage.js';
 import { NamespacesPanel } from './admin/panels/NamespacesPanel.js';
 import { DomainsPanel } from './admin/panels/DomainsPanel.js';
 import { EntitlementsPanel } from './admin/panels/EntitlementsPanel.js';
+import { UserAccessProvider } from './admin/context/UserAccessContext.js';
 
 function App() {
     //TODO: The artifacts route will eventually need to be changed/replaced once we create a unique identifier for resources that can be used across CalmHubs.
     //When this happens the logic to handle params in TreeNavigation will also have to be updated.
     //Currently the format of the route allows deeplinks to only be used within a single CalmHub.
     return (
+        <UserAccessProvider>
         <Router>
             <Routes>
                 <Route path="/" element={<Hub />} />
@@ -24,6 +26,7 @@ function App() {
                 </Route>
             </Routes>
         </Router>
+        </UserAccessProvider>
     );
 }
 

--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AdminPage } from './AdminPage.js';
+import { CalmService } from '../service/calm-service.js';
+import { UserAccessService } from '../service/user-access-service.js';
+import { UserAccess } from '../model/user-access.js';
+
+const NS_FINOS = 'finos';
+const NS_PAYMENTS = 'payments';
+
+const adminGrant = (ns: string): UserAccess => ({
+    userAccessId: 1,
+    username: 'alice',
+    permission: 'admin',
+    namespace: ns,
+});
+
+const globalAdminGrant: UserAccess = {
+    userAccessId: 99,
+    username: 'alice',
+    permission: 'admin',
+    namespace: 'GLOBAL',
+};
+
+const readOnlyGrant: UserAccess = {
+    userAccessId: 2,
+    username: 'alice',
+    permission: 'read',
+    namespace: NS_FINOS,
+};
+
+function mockServices(
+    namespaces: string[],
+    currentUserGrants: UserAccess[],
+    namespaceGrantOverride?: UserAccess[],
+    domains: string[] = []
+) {
+    const calmSvc = new CalmService();
+    vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue(namespaces);
+    vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue(domains);
+
+    const userAccessSvc = new UserAccessService();
+    vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue(currentUserGrants);
+    vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue(namespaceGrantOverride ?? []);
+    vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
+
+    return { calmSvc, userAccessSvc };
+}
+
+function renderPage(calmSvc: CalmService, userAccessSvc: UserAccessService) {
+    return render(
+        <BrowserRouter>
+            <AdminPage calmService={calmSvc} userAccessService={userAccessSvc} />
+        </BrowserRouter>
+    );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminPage', () => {
+
+    describe('loading state', () => {
+        it('shows a loading spinner initially', () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPage(calmSvc, userAccessSvc);
+            expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+        });
+
+        it('hides the spinner after data loads', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('no admin access', () => {
+        it('shows "no access" message when user has no grants', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], []);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
+            );
+        });
+
+        it('shows "no access" message when user has only read grants', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [readOnlyGrant]);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
+            );
+        });
+    });
+
+    describe('namespace dropdown', () => {
+        it('shows all adminnable namespaces as dropdown options', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+            );
+            renderPage(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(select).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
+        });
+
+        it('only shows namespaces the user can admin in the dropdown', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS)]
+            );
+            renderPage(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.queryByRole('option', { name: NS_PAYMENTS })).not.toBeInTheDocument();
+        });
+
+        it('shows all namespaces in the dropdown when user is global admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [globalAdminGrant]
+            );
+            renderPage(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
+        });
+
+        it('renders the panel for the selected namespace', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+            );
+            renderPage(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select namespace/i });
+            fireEvent.change(select, { target: { value: NS_FINOS } });
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: NS_FINOS })).toBeInTheDocument()
+            );
+            expect(screen.queryByRole('heading', { name: NS_PAYMENTS })).not.toBeInTheDocument();
+        });
+    });
+
+    describe('global admin section', () => {
+        it('shows Domain Access section for global admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('region', { name: /domain access/i })).toBeInTheDocument()
+            );
+        });
+
+        it('does not show Domain Access section for non-global admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPage(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.queryByRole('region', { name: /domain access/i })).not.toBeInTheDocument();
+        });
+    });
+
+    describe('domain dropdown', () => {
+        it('shows all domains as dropdown options when global admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
+            );
+            renderPage(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select domain/i });
+            expect(screen.getByRole('option', { name: 'retail' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'wholesale' })).toBeInTheDocument();
+        });
+
+        it('renders the panel for the selected domain', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
+            );
+            renderPage(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select domain/i });
+            fireEvent.change(select, { target: { value: 'retail' } });
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: 'retail' })).toBeInTheDocument()
+            );
+            expect(screen.queryByRole('heading', { name: 'wholesale' })).not.toBeInTheDocument();
+        });
+
+        it('shows "no domains found" when there are no domains', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant], [], []);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByText(/no domains found/i)).toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('error states', () => {
+        it('shows an error when namespace fetch fails', async () => {
+            const calmSvc = new CalmService();
+            vi.spyOn(calmSvc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
+            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
+            const userAccessSvc = new UserAccessService();
+            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue([]);
+
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
+            );
+        });
+
+        it('shows an error when user access fetch fails', async () => {
+            const calmSvc = new CalmService();
+            vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue([NS_FINOS]);
+            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
+            const userAccessSvc = new UserAccessService();
+            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockRejectedValue(new Error('fail'));
+            vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
+            vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
+
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load your access/i)
+            );
+        });
+    });
+
+    describe('page structure', () => {
+        it('renders the page heading', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([], []);
+            renderPage(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: /access management/i })).toBeInTheDocument()
+            );
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -1,236 +1,42 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
 import { AdminPage } from './AdminPage.js';
-import { CalmService } from '../service/calm-service.js';
-import { UserAccessService } from '../service/user-access-service.js';
-import { UserAccess } from '../model/user-access.js';
 
-const NS_FINOS = 'finos';
-const NS_PAYMENTS = 'payments';
-
-const adminGrant = (ns: string): UserAccess => ({
-    userAccessId: 1,
-    username: 'alice',
-    permission: 'admin',
-    namespace: ns,
-});
-
-const globalAdminGrant: UserAccess = {
-    userAccessId: 99,
-    username: 'alice',
-    permission: 'admin',
-    namespace: 'GLOBAL',
-};
-
-const readOnlyGrant: UserAccess = {
-    userAccessId: 2,
-    username: 'alice',
-    permission: 'read',
-    namespace: NS_FINOS,
-};
-
-function mockServices(
-    namespaces: string[],
-    currentUserGrants: UserAccess[],
-    namespaceGrantOverride?: UserAccess[],
-    domains: string[] = []
-) {
-    const calmSvc = new CalmService();
-    vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue(namespaces);
-    vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue(domains);
-
-    const userAccessSvc = new UserAccessService();
-    vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue(currentUserGrants);
-    vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue(namespaceGrantOverride ?? []);
-    vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
-
-    return { calmSvc, userAccessSvc };
-}
-
-function renderPage(calmSvc: CalmService, userAccessSvc: UserAccessService) {
+function renderLayout(initialPath = '/admin/entitlements') {
     return render(
-        <BrowserRouter>
-            <AdminPage calmService={calmSvc} userAccessService={userAccessSvc} />
-        </BrowserRouter>
+        <MemoryRouter initialEntries={[initialPath]}>
+            <Routes>
+                <Route path="/admin" element={<AdminPage />}>
+                    <Route path="namespaces" element={<div>Namespaces panel</div>} />
+                    <Route path="domains" element={<div>Domains panel</div>} />
+                    <Route path="entitlements" element={<div>Entitlements panel</div>} />
+                </Route>
+            </Routes>
+        </MemoryRouter>
     );
 }
 
-beforeEach(() => vi.clearAllMocks());
-
-describe('AdminPage', () => {
-
-    describe('loading state', () => {
-        it('shows a loading spinner initially', () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPage(calmSvc, userAccessSvc);
-            expect(screen.getByLabelText('Loading')).toBeInTheDocument();
-        });
-
-        it('hides the spinner after data loads', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
-            );
-        });
+describe('AdminPage (layout)', () => {
+    it('renders all three sidebar navigation links', () => {
+        renderLayout();
+        expect(screen.getByRole('link', { name: /namespaces/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /domains/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /entitlements/i })).toBeInTheDocument();
     });
 
-    describe('no admin access', () => {
-        it('shows "no access" message when user has no grants', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], []);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
-            );
-        });
-
-        it('shows "no access" message when user has only read grants', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [readOnlyGrant]);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
-            );
-        });
+    it('renders the active panel via Outlet', () => {
+        renderLayout('/admin/namespaces');
+        expect(screen.getByText('Namespaces panel')).toBeInTheDocument();
     });
 
-    describe('namespace dropdown', () => {
-        it('shows all adminnable namespaces as dropdown options', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
-            );
-            renderPage(calmSvc, userAccessSvc);
-            const select = await screen.findByRole('combobox', { name: /select namespace/i });
-            expect(select).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
-        });
-
-        it('only shows namespaces the user can admin in the dropdown', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS)]
-            );
-            renderPage(calmSvc, userAccessSvc);
-            await screen.findByRole('combobox', { name: /select namespace/i });
-            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
-            expect(screen.queryByRole('option', { name: NS_PAYMENTS })).not.toBeInTheDocument();
-        });
-
-        it('shows all namespaces in the dropdown when user is global admin', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [globalAdminGrant]
-            );
-            renderPage(calmSvc, userAccessSvc);
-            await screen.findByRole('combobox', { name: /select namespace/i });
-            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
-        });
-
-        it('renders the panel for the selected namespace', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
-            );
-            renderPage(calmSvc, userAccessSvc);
-            const select = await screen.findByRole('combobox', { name: /select namespace/i });
-            fireEvent.change(select, { target: { value: NS_FINOS } });
-            await waitFor(() =>
-                expect(screen.getByRole('heading', { name: NS_FINOS })).toBeInTheDocument()
-            );
-            expect(screen.queryByRole('heading', { name: NS_PAYMENTS })).not.toBeInTheDocument();
-        });
+    it('renders the entitlements panel when at that sub-route', () => {
+        renderLayout('/admin/entitlements');
+        expect(screen.getByText('Entitlements panel')).toBeInTheDocument();
     });
 
-    describe('global admin section', () => {
-        it('shows Domain Access section for global admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('region', { name: /domain access/i })).toBeInTheDocument()
-            );
-        });
-
-        it('does not show Domain Access section for non-global admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPage(calmSvc, userAccessSvc);
-            await screen.findByRole('combobox', { name: /select namespace/i });
-            expect(screen.queryByRole('region', { name: /domain access/i })).not.toBeInTheDocument();
-        });
-    });
-
-    describe('domain dropdown', () => {
-        it('shows all domains as dropdown options when global admin', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
-            );
-            renderPage(calmSvc, userAccessSvc);
-            const select = await screen.findByRole('combobox', { name: /select domain/i });
-            expect(screen.getByRole('option', { name: 'retail' })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: 'wholesale' })).toBeInTheDocument();
-        });
-
-        it('renders the panel for the selected domain', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
-            );
-            renderPage(calmSvc, userAccessSvc);
-            const select = await screen.findByRole('combobox', { name: /select domain/i });
-            fireEvent.change(select, { target: { value: 'retail' } });
-            await waitFor(() =>
-                expect(screen.getByRole('heading', { name: 'retail' })).toBeInTheDocument()
-            );
-            expect(screen.queryByRole('heading', { name: 'wholesale' })).not.toBeInTheDocument();
-        });
-
-        it('shows "no domains found" when there are no domains', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant], [], []);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByText(/no domains found/i)).toBeInTheDocument()
-            );
-        });
-    });
-
-    describe('error states', () => {
-        it('shows an error when namespace fetch fails', async () => {
-            const calmSvc = new CalmService();
-            vi.spyOn(calmSvc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
-            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
-            const userAccessSvc = new UserAccessService();
-            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue([]);
-
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
-            );
-        });
-
-        it('shows an error when user access fetch fails', async () => {
-            const calmSvc = new CalmService();
-            vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue([NS_FINOS]);
-            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
-            const userAccessSvc = new UserAccessService();
-            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockRejectedValue(new Error('fail'));
-            vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
-            vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
-
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load your access/i)
-            );
-        });
-    });
-
-    describe('page structure', () => {
-        it('renders the page heading', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([], []);
-            renderPage(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('heading', { name: /access management/i })).toBeInTheDocument()
-            );
-        });
+    it('renders the domains panel when at that sub-route', () => {
+        renderLayout('/admin/domains');
+        expect(screen.getByText('Domains panel')).toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { AdminPage } from './AdminPage.js';
 import { UserAccessContext } from './context/UserAccessContext.js';
 import { CurrentUserAccessState } from './hooks/useCurrentUserAccess.js';
@@ -35,6 +36,21 @@ function renderLayout(state: CurrentUserAccessState, initialPath = '/admin/entit
             </MemoryRouter>
         </UserAccessContext.Provider>
     );
+}
+
+function mockMobileViewport(isMobile: boolean) {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+        matches: isMobile,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    return () => { window.matchMedia = original; };
 }
 
 const adminState = makeState({ isGlobalAdmin: true, grants: [globalAdminGrant] });
@@ -87,5 +103,57 @@ describe('AdminPage (access gate)', () => {
     it('shows access denied for a user with no grants at all', () => {
         renderLayout(noGrantsState);
         expect(screen.getByRole('alert')).toHaveTextContent(/do not have permission/i);
+    });
+});
+
+describe('AdminPage (mobile layout)', () => {
+    let restore: () => void;
+
+    afterEach(() => restore?.());
+
+    it('shows the Explore button on mobile and hides the desktop sidebar', () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState);
+        expect(screen.getByRole('button', { name: /toggle explorer/i })).toBeInTheDocument();
+        expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    });
+
+    it('opens the mobile nav overlay when Explore is tapped', async () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState);
+        const overlay = screen.getByRole('dialog', { hidden: true });
+        expect(overlay).toHaveAttribute('aria-hidden', 'true');
+        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
+        expect(overlay).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    it('closes the mobile nav overlay when the close button is tapped', async () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState);
+        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
+        await userEvent.click(screen.getByRole('button', { name: /close navigation/i }));
+        expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('shows all three nav links in the mobile overlay for a global admin', async () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState);
+        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
+        expect(screen.getByRole('link', { name: /namespaces/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /domains/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /entitlements/i })).toBeInTheDocument();
+    });
+
+    it('hides the Domains link in the mobile overlay for a namespace-scoped admin', async () => {
+        restore = mockMobileViewport(true);
+        renderLayout(nsAdminState);
+        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
+        expect(screen.queryByRole('link', { name: /domains/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show the Explore button on desktop', () => {
+        restore = mockMobileViewport(false);
+        renderLayout(adminState);
+        expect(screen.queryByRole('button', { name: /toggle explorer/i })).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, it, expect, afterEach } from 'vitest';
 import { AdminPage } from './AdminPage.js';
@@ -111,49 +110,32 @@ describe('AdminPage (mobile layout)', () => {
 
     afterEach(() => restore?.());
 
-    it('shows the Explore button on mobile and hides the desktop sidebar', () => {
+    it('shows a tab bar on mobile for an admin user', () => {
         restore = mockMobileViewport(true);
         renderLayout(adminState);
-        expect(screen.getByRole('button', { name: /toggle explorer/i })).toBeInTheDocument();
-        expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
-    });
-
-    it('opens the mobile nav overlay when Explore is tapped', async () => {
-        restore = mockMobileViewport(true);
-        renderLayout(adminState);
-        const overlay = screen.getByRole('dialog', { hidden: true });
-        expect(overlay).toHaveAttribute('aria-hidden', 'true');
-        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
-        expect(overlay).toHaveAttribute('aria-hidden', 'false');
-    });
-
-    it('closes the mobile nav overlay when the close button is tapped', async () => {
-        restore = mockMobileViewport(true);
-        renderLayout(adminState);
-        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
-        await userEvent.click(screen.getByRole('button', { name: /close navigation/i }));
-        expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
-    });
-
-    it('shows all three nav links in the mobile overlay for a global admin', async () => {
-        restore = mockMobileViewport(true);
-        renderLayout(adminState);
-        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
+        const nav = screen.getByRole('navigation', { name: /admin sections/i });
+        expect(nav).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /namespaces/i })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /domains/i })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /entitlements/i })).toBeInTheDocument();
     });
 
-    it('hides the Domains link in the mobile overlay for a namespace-scoped admin', async () => {
+    it('hides the Domains tab for a namespace-scoped admin', () => {
         restore = mockMobileViewport(true);
         renderLayout(nsAdminState);
-        await userEvent.click(screen.getByRole('button', { name: /toggle explorer/i }));
-        expect(screen.queryByRole('link', { name: /domains/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('navigation', { name: /admin sections/i })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /^domains$/i })).not.toBeInTheDocument();
     });
 
-    it('does not show the Explore button on desktop', () => {
+    it('hides the desktop sidebar on mobile', () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState);
+        expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    });
+
+    it('does not show the tab bar on desktop', () => {
         restore = mockMobileViewport(false);
         renderLayout(adminState);
-        expect(screen.queryByRole('button', { name: /toggle explorer/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('navigation', { name: /admin sections/i })).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -2,41 +2,90 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 import { AdminPage } from './AdminPage.js';
+import { UserAccessContext } from './context/UserAccessContext.js';
+import { CurrentUserAccessState } from './hooks/useCurrentUserAccess.js';
+import { UserAccess } from '../model/user-access.js';
 
-function renderLayout(initialPath = '/admin/entitlements') {
+const globalAdminGrant: UserAccess = { userAccessId: 1, username: 'alice', permission: 'admin', namespace: 'GLOBAL' };
+const nsAdminGrant: UserAccess = { userAccessId: 2, username: 'bob', permission: 'admin', namespace: 'finos' };
+const readOnlyGrant: UserAccess = { userAccessId: 3, username: 'carol', permission: 'read', namespace: 'finos' };
+
+function makeState(overrides: Partial<CurrentUserAccessState>): CurrentUserAccessState {
+    return {
+        grants: [],
+        loading: false,
+        error: null,
+        isGlobalAdmin: false,
+        canAdminNamespace: () => false,
+        ...overrides,
+    };
+}
+
+function renderLayout(state: CurrentUserAccessState, initialPath = '/admin/entitlements') {
     return render(
-        <MemoryRouter initialEntries={[initialPath]}>
-            <Routes>
-                <Route path="/admin" element={<AdminPage />}>
-                    <Route path="namespaces" element={<div>Namespaces panel</div>} />
-                    <Route path="domains" element={<div>Domains panel</div>} />
-                    <Route path="entitlements" element={<div>Entitlements panel</div>} />
-                </Route>
-            </Routes>
-        </MemoryRouter>
+        <UserAccessContext.Provider value={state}>
+            <MemoryRouter initialEntries={[initialPath]}>
+                <Routes>
+                    <Route path="/admin" element={<AdminPage />}>
+                        <Route path="namespaces" element={<div>Namespaces panel</div>} />
+                        <Route path="domains" element={<div>Domains panel</div>} />
+                        <Route path="entitlements" element={<div>Entitlements panel</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>
+        </UserAccessContext.Provider>
     );
 }
 
+const adminState = makeState({ isGlobalAdmin: true, grants: [globalAdminGrant] });
+const nsAdminState = makeState({ grants: [nsAdminGrant] });
+const readOnlyState = makeState({ grants: [readOnlyGrant] });
+const loadingState = makeState({ loading: true });
+const noGrantsState = makeState({});
+
 describe('AdminPage (layout)', () => {
-    it('renders all three sidebar navigation links', () => {
-        renderLayout();
+    it('renders all three sidebar navigation links for a global admin', () => {
+        renderLayout(adminState);
         expect(screen.getByRole('link', { name: /namespaces/i })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /domains/i })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /entitlements/i })).toBeInTheDocument();
     });
 
+    it('renders sidebar for a namespace-scoped admin', () => {
+        renderLayout(nsAdminState);
+        expect(screen.getByRole('link', { name: /namespaces/i })).toBeInTheDocument();
+    });
+
     it('renders the active panel via Outlet', () => {
-        renderLayout('/admin/namespaces');
+        renderLayout(adminState, '/admin/namespaces');
         expect(screen.getByText('Namespaces panel')).toBeInTheDocument();
     });
 
     it('renders the entitlements panel when at that sub-route', () => {
-        renderLayout('/admin/entitlements');
+        renderLayout(adminState, '/admin/entitlements');
         expect(screen.getByText('Entitlements panel')).toBeInTheDocument();
     });
 
     it('renders the domains panel when at that sub-route', () => {
-        renderLayout('/admin/domains');
+        renderLayout(adminState, '/admin/domains');
         expect(screen.getByText('Domains panel')).toBeInTheDocument();
+    });
+});
+
+describe('AdminPage (access gate)', () => {
+    it('shows a loading spinner while access is being checked', () => {
+        renderLayout(loadingState);
+        expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+    });
+
+    it('shows access denied for a user with no admin grants', () => {
+        renderLayout(readOnlyState);
+        expect(screen.getByRole('alert')).toHaveTextContent(/do not have permission/i);
+        expect(screen.queryByRole('link', { name: /namespaces/i })).not.toBeInTheDocument();
+    });
+
+    it('shows access denied for a user with no grants at all', () => {
+        renderLayout(noGrantsState);
+        expect(screen.getByRole('alert')).toHaveTextContent(/do not have permission/i);
     });
 });

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -28,7 +28,7 @@ export function AdminPage() {
                     <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
                         <ul className="menu p-4 gap-1">
                             <li><NavLink to="namespaces" className={navClass}>Namespaces</NavLink></li>
-                            <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>
+                            {isGlobalAdmin && <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>}
                             <li><NavLink to="entitlements" className={navClass}>Entitlements</NavLink></li>
                         </ul>
                     </aside>

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CalmService } from '../service/calm-service.js';
+import { UserAccessService } from '../service/user-access-service.js';
+import { useCurrentUserAccess } from './hooks/useCurrentUserAccess.js';
+import { NamespaceAccessPanel } from './components/namespace-access/NamespaceAccessPanel.js';
+import { DomainAccessPanel } from './components/domain-access/DomainAccessPanel.js';
+import { Navbar } from '../components/navbar/Navbar.js';
+
+interface AdminPageProps {
+    calmService?: CalmService;
+    userAccessService?: UserAccessService;
+}
+
+export function AdminPage({ calmService, userAccessService }: AdminPageProps) {
+    const calmSvc = useMemo(() => calmService ?? new CalmService(), [calmService]);
+    const userAccessSvc = useMemo(() => userAccessService ?? new UserAccessService(), [userAccessService]);
+
+    const [namespaces, setNamespaces] = useState<string[]>([]);
+    const [namespacesLoading, setNamespacesLoading] = useState(true);
+    const [namespacesError, setNamespacesError] = useState<string | null>(null);
+    const [selectedNamespace, setSelectedNamespace] = useState<string>('');
+
+    const [domains, setDomains] = useState<string[]>([]);
+    const [domainsLoading, setDomainsLoading] = useState(true);
+    const [domainsError, setDomainsError] = useState<string | null>(null);
+    const [selectedDomain, setSelectedDomain] = useState<string>('');
+
+    const { canAdminNamespace, isGlobalAdmin, loading: accessLoading, error: accessError } =
+        useCurrentUserAccess(userAccessSvc);
+
+    useEffect(() => {
+        calmSvc.fetchNamespaces()
+            .then(setNamespaces)
+            .catch(() => setNamespacesError('Failed to load namespaces.'))
+            .finally(() => setNamespacesLoading(false));
+    }, [calmSvc]);
+
+    useEffect(() => {
+        calmSvc.fetchDomains()
+            .then(setDomains)
+            .catch(() => setDomainsError('Failed to load domains.'))
+            .finally(() => setDomainsLoading(false));
+    }, [calmSvc]);
+
+    const loading = namespacesLoading || domainsLoading || accessLoading;
+    const adminNamespaces = namespaces.filter(canAdminNamespace);
+    const error = namespacesError ?? domainsError ?? accessError;
+
+    return (
+        <div className="flex flex-col h-screen overflow-hidden">
+            <Navbar />
+            <div className="flex-1 overflow-auto bg-base-300 p-6">
+                <h1 className="text-2xl font-bold mb-6">Access Management</h1>
+
+                {loading && (
+                    <div className="flex justify-center py-12">
+                        <span className="loading loading-spinner loading-lg" aria-label="Loading" />
+                    </div>
+                )}
+
+                {!loading && error && (
+                    <div className="alert alert-error mb-4" role="alert">
+                        <span>{error}</span>
+                    </div>
+                )}
+
+                {!loading && !error && adminNamespaces.length === 0 && (
+                    <div className="alert alert-info" role="status">
+                        <span>You have no admin access to any namespaces.</span>
+                    </div>
+                )}
+
+                {!loading && adminNamespaces.length > 0 && (
+                    <div className="flex flex-col gap-6">
+                        <section aria-label="Namespace access">
+                            <h2 className="text-lg font-semibold mb-3">Namespace Access</h2>
+                            <select
+                                className="select select-bordered select-sm w-full max-w-xs mb-4"
+                                value={selectedNamespace}
+                                onChange={(e) => setSelectedNamespace(e.target.value)}
+                                aria-label="Select namespace"
+                            >
+                                <option value="">Select a namespace…</option>
+                                {adminNamespaces.map((ns) => (
+                                    <option key={ns} value={ns}>{ns}</option>
+                                ))}
+                            </select>
+                            {selectedNamespace && (
+                                <NamespaceAccessPanel
+                                    key={selectedNamespace}
+                                    namespace={selectedNamespace}
+                                    service={userAccessSvc}
+                                />
+                            )}
+                        </section>
+
+                        {isGlobalAdmin && (
+                            <section aria-label="Domain access">
+                                <h2 className="text-lg font-semibold mb-3">Domain Access</h2>
+                                {domains.length === 0 ? (
+                                    <p className="text-base-content/50 text-sm italic">No domains found.</p>
+                                ) : (
+                                    <>
+                                        <select
+                                            className="select select-bordered select-sm w-full max-w-xs mb-4"
+                                            value={selectedDomain}
+                                            onChange={(e) => setSelectedDomain(e.target.value)}
+                                            aria-label="Select domain"
+                                        >
+                                            <option value="">Select a domain…</option>
+                                            {domains.map((domain) => (
+                                                <option key={domain} value={domain}>{domain}</option>
+                                            ))}
+                                        </select>
+                                        {selectedDomain && (
+                                            <DomainAccessPanel
+                                                key={selectedDomain}
+                                                domain={selectedDomain}
+                                                service={userAccessSvc}
+                                            />
+                                        )}
+                                    </>
+                                )}
+                            </section>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -1,130 +1,25 @@
-import { useEffect, useMemo, useState } from 'react';
-import { CalmService } from '../service/calm-service.js';
-import { UserAccessService } from '../service/user-access-service.js';
-import { useCurrentUserAccess } from './hooks/useCurrentUserAccess.js';
-import { NamespaceAccessPanel } from './components/namespace-access/NamespaceAccessPanel.js';
-import { DomainAccessPanel } from './components/domain-access/DomainAccessPanel.js';
+import { NavLink, Outlet } from 'react-router-dom';
 import { Navbar } from '../components/navbar/Navbar.js';
 
-interface AdminPageProps {
-    calmService?: CalmService;
-    userAccessService?: UserAccessService;
+function navClass({ isActive }: { isActive: boolean }) {
+    return isActive ? 'active' : '';
 }
 
-export function AdminPage({ calmService, userAccessService }: AdminPageProps) {
-    const calmSvc = useMemo(() => calmService ?? new CalmService(), [calmService]);
-    const userAccessSvc = useMemo(() => userAccessService ?? new UserAccessService(), [userAccessService]);
-
-    const [namespaces, setNamespaces] = useState<string[]>([]);
-    const [namespacesLoading, setNamespacesLoading] = useState(true);
-    const [namespacesError, setNamespacesError] = useState<string | null>(null);
-    const [selectedNamespace, setSelectedNamespace] = useState<string>('');
-
-    const [domains, setDomains] = useState<string[]>([]);
-    const [domainsLoading, setDomainsLoading] = useState(true);
-    const [domainsError, setDomainsError] = useState<string | null>(null);
-    const [selectedDomain, setSelectedDomain] = useState<string>('');
-
-    const { canAdminNamespace, isGlobalAdmin, loading: accessLoading, error: accessError } =
-        useCurrentUserAccess(userAccessSvc);
-
-    useEffect(() => {
-        calmSvc.fetchNamespaces()
-            .then(setNamespaces)
-            .catch(() => setNamespacesError('Failed to load namespaces.'))
-            .finally(() => setNamespacesLoading(false));
-    }, [calmSvc]);
-
-    useEffect(() => {
-        calmSvc.fetchDomains()
-            .then(setDomains)
-            .catch(() => setDomainsError('Failed to load domains.'))
-            .finally(() => setDomainsLoading(false));
-    }, [calmSvc]);
-
-    const loading = namespacesLoading || domainsLoading || accessLoading;
-    const adminNamespaces = namespaces.filter(canAdminNamespace);
-    const error = namespacesError ?? domainsError ?? accessError;
-
+export function AdminPage() {
     return (
         <div className="flex flex-col h-screen overflow-hidden">
             <Navbar />
-            <div className="flex-1 overflow-auto bg-base-300 p-6">
-                <h1 className="text-2xl font-bold mb-6">Access Management</h1>
-
-                {loading && (
-                    <div className="flex justify-center py-12">
-                        <span className="loading loading-spinner loading-lg" aria-label="Loading" />
-                    </div>
-                )}
-
-                {!loading && error && (
-                    <div className="alert alert-error mb-4" role="alert">
-                        <span>{error}</span>
-                    </div>
-                )}
-
-                {!loading && !error && adminNamespaces.length === 0 && (
-                    <div className="alert alert-info" role="status">
-                        <span>You have no admin access to any namespaces.</span>
-                    </div>
-                )}
-
-                {!loading && adminNamespaces.length > 0 && (
-                    <div className="flex flex-col gap-6">
-                        <section aria-label="Namespace access">
-                            <h2 className="text-lg font-semibold mb-3">Namespace Access</h2>
-                            <select
-                                className="select select-bordered select-sm w-full max-w-xs mb-4"
-                                value={selectedNamespace}
-                                onChange={(e) => setSelectedNamespace(e.target.value)}
-                                aria-label="Select namespace"
-                            >
-                                <option value="">Select a namespace…</option>
-                                {adminNamespaces.map((ns) => (
-                                    <option key={ns} value={ns}>{ns}</option>
-                                ))}
-                            </select>
-                            {selectedNamespace && (
-                                <NamespaceAccessPanel
-                                    key={selectedNamespace}
-                                    namespace={selectedNamespace}
-                                    service={userAccessSvc}
-                                />
-                            )}
-                        </section>
-
-                        {isGlobalAdmin && (
-                            <section aria-label="Domain access">
-                                <h2 className="text-lg font-semibold mb-3">Domain Access</h2>
-                                {domains.length === 0 ? (
-                                    <p className="text-base-content/50 text-sm italic">No domains found.</p>
-                                ) : (
-                                    <>
-                                        <select
-                                            className="select select-bordered select-sm w-full max-w-xs mb-4"
-                                            value={selectedDomain}
-                                            onChange={(e) => setSelectedDomain(e.target.value)}
-                                            aria-label="Select domain"
-                                        >
-                                            <option value="">Select a domain…</option>
-                                            {domains.map((domain) => (
-                                                <option key={domain} value={domain}>{domain}</option>
-                                            ))}
-                                        </select>
-                                        {selectedDomain && (
-                                            <DomainAccessPanel
-                                                key={selectedDomain}
-                                                domain={selectedDomain}
-                                                service={userAccessSvc}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            </section>
-                        )}
-                    </div>
-                )}
+            <div className="flex flex-1 overflow-hidden">
+                <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
+                    <ul className="menu p-4 gap-1">
+                        <li><NavLink to="namespaces" className={navClass}>Namespaces</NavLink></li>
+                        <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>
+                        <li><NavLink to="entitlements" className={navClass}>Entitlements</NavLink></li>
+                    </ul>
+                </aside>
+                <main className="flex-1 overflow-auto bg-base-300 p-6">
+                    <Outlet />
+                </main>
             </div>
         </div>
     );

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -43,6 +43,7 @@ export function AdminPage() {
                             role="dialog"
                             aria-modal={isMobileNavOpen}
                             aria-hidden={!isMobileNavOpen}
+                            inert={!isMobileNavOpen}
                         >
                             <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center gap-2">
                                 <h2 className="text-lg font-semibold flex-1 min-w-0 truncate">Admin</h2>

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -1,26 +1,42 @@
 import { NavLink, Outlet } from 'react-router-dom';
 import { Navbar } from '../components/navbar/Navbar.js';
+import { useUserAccess } from './context/UserAccessContext.js';
 
 function navClass({ isActive }: { isActive: boolean }) {
     return isActive ? 'active' : '';
 }
 
 export function AdminPage() {
+    const { loading, isGlobalAdmin, grants } = useUserAccess();
+    const hasAdminAccess = isGlobalAdmin || grants.some((g) => g.permission === 'admin');
+
     return (
         <div className="flex flex-col h-screen overflow-hidden">
             <Navbar />
-            <div className="flex flex-1 overflow-hidden">
-                <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
-                    <ul className="menu p-4 gap-1">
-                        <li><NavLink to="namespaces" className={navClass}>Namespaces</NavLink></li>
-                        <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>
-                        <li><NavLink to="entitlements" className={navClass}>Entitlements</NavLink></li>
-                    </ul>
-                </aside>
-                <main className="flex-1 overflow-auto bg-base-300 p-6">
-                    <Outlet />
-                </main>
-            </div>
+            {loading ? (
+                <div className="flex justify-center py-12">
+                    <span className="loading loading-spinner loading-lg" aria-label="Loading" />
+                </div>
+            ) : !hasAdminAccess ? (
+                <div className="flex flex-1 items-center justify-center p-6">
+                    <div className="alert alert-error max-w-md" role="alert">
+                        <span>You do not have permission to access the admin area.</span>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex flex-1 overflow-hidden">
+                    <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
+                        <ul className="menu p-4 gap-1">
+                            <li><NavLink to="namespaces" className={navClass}>Namespaces</NavLink></li>
+                            <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>
+                            <li><NavLink to="entitlements" className={navClass}>Entitlements</NavLink></li>
+                        </ul>
+                    </aside>
+                    <main className="flex-1 overflow-auto bg-base-300 p-6">
+                        <Outlet />
+                    </main>
+                </div>
+            )}
         </div>
     );
 }

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -6,7 +6,7 @@ import { useUserAccess } from './context/UserAccessContext.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
 
 function sidebarNavClass({ isActive }: { isActive: boolean }) {
-    return isActive ? 'active' : '';
+    return isActive ? 'menu-active' : '';
 }
 
 function mobileNavClass({ isActive }: { isActive: boolean }) {

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
-import { IoCloseOutline } from 'react-icons/io5';
 import { Navbar } from '../components/navbar/Navbar.js';
 import { useUserAccess } from './context/UserAccessContext.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
@@ -9,21 +7,18 @@ function sidebarNavClass({ isActive }: { isActive: boolean }) {
     return isActive ? 'menu-active' : '';
 }
 
-function mobileNavClass({ isActive }: { isActive: boolean }) {
-    return `w-full flex items-center px-4 py-3 text-left hover:bg-base-200 active:bg-base-200${isActive ? ' bg-base-200 font-semibold' : ''}`;
+function mobileTabClass({ isActive }: { isActive: boolean }) {
+    return `flex-1 text-center py-2 text-sm border-b-2 transition-colors ${isActive ? 'border-primary font-semibold text-primary' : 'border-transparent hover:border-base-content/20'}`;
 }
 
 export function AdminPage() {
     const { loading, isGlobalAdmin, grants } = useUserAccess();
     const hasAdminAccess = isGlobalAdmin || grants.some((g) => g.permission === 'admin');
     const isMobile = useIsMobile();
-    const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
-
-    const closeMobileNav = () => setIsMobileNavOpen(false);
 
     return (
         <div className="flex flex-col h-screen overflow-hidden">
-            <Navbar onExploreClick={isMobile ? () => setIsMobileNavOpen(true) : undefined} />
+            <Navbar />
             {loading ? (
                 <div className="flex justify-center py-12">
                     <span className="loading loading-spinner loading-lg" aria-label="Loading" />
@@ -36,45 +31,13 @@ export function AdminPage() {
                 </div>
             ) : (
                 <>
-                    {/* Mobile: full-screen overlay that slides in from the left */}
+                    {/* Mobile: tab bar for section navigation */}
                     {isMobile && (
-                        <div
-                            className={`fixed inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
-                            role="dialog"
-                            aria-modal={isMobileNavOpen}
-                            aria-hidden={!isMobileNavOpen}
-                            inert={!isMobileNavOpen}
-                        >
-                            <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center gap-2">
-                                <h2 className="text-lg font-semibold flex-1 min-w-0 truncate">Admin</h2>
-                                <button
-                                    aria-label="Close navigation"
-                                    className="btn btn-ghost btn-sm btn-circle"
-                                    onClick={closeMobileNav}
-                                >
-                                    <IoCloseOutline size={22} />
-                                </button>
-                            </div>
-                            <ul className="flex-1 overflow-auto divide-y divide-base-200">
-                                <li>
-                                    <NavLink to="namespaces" className={mobileNavClass} onClick={closeMobileNav}>
-                                        Namespaces
-                                    </NavLink>
-                                </li>
-                                {isGlobalAdmin && (
-                                    <li>
-                                        <NavLink to="domains" className={mobileNavClass} onClick={closeMobileNav}>
-                                            Domains
-                                        </NavLink>
-                                    </li>
-                                )}
-                                <li>
-                                    <NavLink to="entitlements" className={mobileNavClass} onClick={closeMobileNav}>
-                                        Entitlements
-                                    </NavLink>
-                                </li>
-                            </ul>
-                        </div>
+                        <nav className="flex border-b border-base-300 bg-base-200" aria-label="Admin sections">
+                            <NavLink to="namespaces" className={mobileTabClass}>Namespaces</NavLink>
+                            {isGlobalAdmin && <NavLink to="domains" className={mobileTabClass}>Domains</NavLink>}
+                            <NavLink to="entitlements" className={mobileTabClass}>Entitlements</NavLink>
+                        </nav>
                     )}
 
                     <div className="flex flex-1 overflow-hidden">

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -1,18 +1,29 @@
+import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import { IoCloseOutline } from 'react-icons/io5';
 import { Navbar } from '../components/navbar/Navbar.js';
 import { useUserAccess } from './context/UserAccessContext.js';
+import { useIsMobile } from '../hooks/useMediaQuery.js';
 
-function navClass({ isActive }: { isActive: boolean }) {
+function sidebarNavClass({ isActive }: { isActive: boolean }) {
     return isActive ? 'active' : '';
+}
+
+function mobileNavClass({ isActive }: { isActive: boolean }) {
+    return `w-full flex items-center px-4 py-3 text-left hover:bg-base-200 active:bg-base-200${isActive ? ' bg-base-200 font-semibold' : ''}`;
 }
 
 export function AdminPage() {
     const { loading, isGlobalAdmin, grants } = useUserAccess();
     const hasAdminAccess = isGlobalAdmin || grants.some((g) => g.permission === 'admin');
+    const isMobile = useIsMobile();
+    const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+
+    const closeMobileNav = () => setIsMobileNavOpen(false);
 
     return (
         <div className="flex flex-col h-screen overflow-hidden">
-            <Navbar />
+            <Navbar onExploreClick={isMobile ? () => setIsMobileNavOpen(true) : undefined} />
             {loading ? (
                 <div className="flex justify-center py-12">
                     <span className="loading loading-spinner loading-lg" aria-label="Loading" />
@@ -24,18 +35,63 @@ export function AdminPage() {
                     </div>
                 </div>
             ) : (
-                <div className="flex flex-1 overflow-hidden">
-                    <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
-                        <ul className="menu p-4 gap-1">
-                            <li><NavLink to="namespaces" className={navClass}>Namespaces</NavLink></li>
-                            {isGlobalAdmin && <li><NavLink to="domains" className={navClass}>Domains</NavLink></li>}
-                            <li><NavLink to="entitlements" className={navClass}>Entitlements</NavLink></li>
-                        </ul>
-                    </aside>
-                    <main className="flex-1 overflow-auto bg-base-300 p-6">
-                        <Outlet />
-                    </main>
-                </div>
+                <>
+                    {/* Mobile: full-screen overlay that slides in from the left */}
+                    {isMobile && (
+                        <div
+                            className={`fixed inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
+                            role="dialog"
+                            aria-modal={isMobileNavOpen}
+                            aria-hidden={!isMobileNavOpen}
+                        >
+                            <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center gap-2">
+                                <h2 className="text-lg font-semibold flex-1 min-w-0 truncate">Admin</h2>
+                                <button
+                                    aria-label="Close navigation"
+                                    className="btn btn-ghost btn-sm btn-circle"
+                                    onClick={closeMobileNav}
+                                >
+                                    <IoCloseOutline size={22} />
+                                </button>
+                            </div>
+                            <ul className="flex-1 overflow-auto divide-y divide-base-200">
+                                <li>
+                                    <NavLink to="namespaces" className={mobileNavClass} onClick={closeMobileNav}>
+                                        Namespaces
+                                    </NavLink>
+                                </li>
+                                {isGlobalAdmin && (
+                                    <li>
+                                        <NavLink to="domains" className={mobileNavClass} onClick={closeMobileNav}>
+                                            Domains
+                                        </NavLink>
+                                    </li>
+                                )}
+                                <li>
+                                    <NavLink to="entitlements" className={mobileNavClass} onClick={closeMobileNav}>
+                                        Entitlements
+                                    </NavLink>
+                                </li>
+                            </ul>
+                        </div>
+                    )}
+
+                    <div className="flex flex-1 overflow-hidden">
+                        {/* Desktop: inline sidebar, always visible */}
+                        {!isMobile && (
+                            <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
+                                <ul className="menu p-4 gap-1">
+                                    <li><NavLink to="namespaces" className={sidebarNavClass}>Namespaces</NavLink></li>
+                                    {isGlobalAdmin && <li><NavLink to="domains" className={sidebarNavClass}>Domains</NavLink></li>}
+                                    <li><NavLink to="entitlements" className={sidebarNavClass}>Entitlements</NavLink></li>
+                                </ul>
+                            </aside>
+                        )}
+                        <main className="flex-1 overflow-auto bg-base-300 p-6">
+                            <Outlet />
+                        </main>
+                    </div>
+                </>
             )}
         </div>
     );

--- a/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
@@ -60,6 +60,20 @@ describe('DomainAccessPanel', () => {
         });
     });
 
+    describe('sorting', () => {
+        it('renders grants sorted alphabetically by username', async () => {
+            const svc = mockSvc({
+                getDomainUserAccess: () => Promise.resolve([adminGrant, readGrant]), // bob, alice
+            });
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            const rows = screen.getAllByRole('row').slice(1); // skip header
+            expect(within(rows[0]).getByText('alice')).toBeInTheDocument();
+            expect(within(rows[1]).getByText('bob')).toBeInTheDocument();
+        });
+    });
+
     describe('wildcard grants', () => {
         it('renders wildcard username as "* (everyone)"', async () => {
             const svc = mockSvc({ getDomainUserAccess: () => Promise.resolve([wildcardGrant]) });

--- a/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
@@ -11,7 +11,7 @@ const wildcardGrant: UserAccess = { userAccessId: 3, username: '*', permission: 
 function mockSvc(overrides: Partial<Record<keyof UserAccessService, unknown>> = {}): UserAccessService {
     const svc = new UserAccessService();
     vi.spyOn(svc, 'getDomainUserAccess').mockResolvedValue([readGrant, adminGrant]);
-    vi.spyOn(svc, 'grantDomainAccess').mockResolvedValue({ ...readGrant, userAccessId: 99 });
+    vi.spyOn(svc, 'grantDomainAccess').mockResolvedValue(undefined);
     vi.spyOn(svc, 'revokeDomainAccess').mockResolvedValue(undefined);
     Object.entries(overrides).forEach(([k, v]) => {
         vi.spyOn(svc, k as keyof UserAccessService).mockImplementation(v as never);

--- a/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DomainAccessPanel } from './DomainAccessPanel.js';
+import { UserAccessService } from '../../../service/user-access-service.js';
+import { UserAccess } from '../../../model/user-access.js';
+
+const readGrant: UserAccess = { userAccessId: 1, username: 'alice', permission: 'read', domain: 'retail' };
+const adminGrant: UserAccess = { userAccessId: 2, username: 'bob', permission: 'admin', domain: 'retail' };
+const wildcardGrant: UserAccess = { userAccessId: 3, username: '*', permission: 'read', domain: 'retail' };
+
+function mockSvc(overrides: Partial<Record<keyof UserAccessService, unknown>> = {}): UserAccessService {
+    const svc = new UserAccessService();
+    vi.spyOn(svc, 'getDomainUserAccess').mockResolvedValue([readGrant, adminGrant]);
+    vi.spyOn(svc, 'grantDomainAccess').mockResolvedValue({ ...readGrant, userAccessId: 99 });
+    vi.spyOn(svc, 'revokeDomainAccess').mockResolvedValue(undefined);
+    Object.entries(overrides).forEach(([k, v]) => {
+        vi.spyOn(svc, k as keyof UserAccessService).mockImplementation(v as never);
+    });
+    return svc;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('DomainAccessPanel', () => {
+
+    describe('loading and fetching', () => {
+        it('shows a loading spinner initially', () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            expect(screen.getByLabelText('Loading grants')).toBeInTheDocument();
+        });
+
+        it('renders grant rows after loading', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+            expect(screen.getByText('bob')).toBeInTheDocument();
+        });
+
+        it('shows empty state when no grants exist', async () => {
+            const svc = mockSvc({ getDomainUserAccess: () => Promise.resolve([]) });
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByText(/no access grants/i)).toBeInTheDocument()
+            );
+        });
+
+        it('shows an error message when fetch fails', async () => {
+            const svc = mockSvc({ getDomainUserAccess: () => Promise.reject(new Error('fail')) });
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load/i)
+            );
+        });
+
+        it('displays the domain name', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => expect(screen.getByText('retail')).toBeInTheDocument());
+        });
+    });
+
+    describe('wildcard grants', () => {
+        it('renders wildcard username as "* (everyone)"', async () => {
+            const svc = mockSvc({ getDomainUserAccess: () => Promise.resolve([wildcardGrant]) });
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByText('* (everyone)')).toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('revoking access', () => {
+        it('calls revokeDomainAccess with correct args after confirmation', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^revoke$/i }));
+
+            await waitFor(() =>
+                expect(svc.revokeDomainAccess).toHaveBeenCalledWith('retail', readGrant.userAccessId)
+            );
+        });
+
+        it('removes the revoked grant from the table', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^revoke$/i }));
+
+            await waitFor(() =>
+                expect(screen.queryByText('alice')).not.toBeInTheDocument()
+            );
+        });
+
+        it('shows grant details in the confirmation dialog', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+
+            const dialog = screen.getByRole('dialog');
+            expect(within(dialog).getByText(/alice/)).toBeInTheDocument();
+            expect(within(dialog).getByText(/read/)).toBeInTheDocument();
+        });
+    });
+
+    describe('granting access', () => {
+        it('calls grantDomainAccess and refreshes the list', async () => {
+            const svc = mockSvc();
+            render(<DomainAccessPanel domain="retail" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+                target: { value: 'carol' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+            await waitFor(() =>
+                expect(svc.grantDomainAccess).toHaveBeenCalledWith('retail', {
+                    username: 'carol',
+                    permission: 'read',
+                })
+            );
+            expect(svc.getDomainUserAccess).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.tsx
+++ b/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.tsx
@@ -21,7 +21,7 @@ export function DomainAccessPanel({ domain, service }: DomainAccessPanelProps) {
         setLoading(true);
         setFetchError(null);
         svc.getDomainUserAccess(domain)
-            .then(setGrants)
+            .then((g) => setGrants([...g].sort((a, b) => a.username.localeCompare(b.username))))
             .catch(() => setFetchError('Failed to load access grants.'))
             .finally(() => setLoading(false));
     }, [svc, domain]);

--- a/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.tsx
+++ b/calm-hub-ui/src/admin/components/domain-access/DomainAccessPanel.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { UserAccess, UserAccessRequest } from '../../../model/user-access.js';
+import { UserAccessService } from '../../../service/user-access-service.js';
+import { GrantRow } from '../namespace-access/GrantRow.js';
+import { AddGrantForm } from '../namespace-access/AddGrantForm.js';
+
+interface DomainAccessPanelProps {
+    domain: string;
+    service?: UserAccessService;
+}
+
+export function DomainAccessPanel({ domain, service }: DomainAccessPanelProps) {
+    const svc = useMemo(() => service ?? new UserAccessService(), [service]);
+    const [grants, setGrants] = useState<UserAccess[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
+    const [pendingRevoke, setPendingRevoke] = useState<UserAccess | null>(null);
+    const [revoking, setRevoking] = useState(false);
+
+    const fetchGrants = useCallback(() => {
+        setLoading(true);
+        setFetchError(null);
+        svc.getDomainUserAccess(domain)
+            .then(setGrants)
+            .catch(() => setFetchError('Failed to load access grants.'))
+            .finally(() => setLoading(false));
+    }, [svc, domain]);
+
+    useEffect(() => { fetchGrants(); }, [fetchGrants]);
+
+    function handleRequestRevoke(grant: UserAccess) {
+        setPendingRevoke(grant);
+    }
+
+    async function handleConfirmRevoke() {
+        if (!pendingRevoke) return;
+        setRevoking(true);
+        try {
+            await svc.revokeDomainAccess(domain, pendingRevoke.userAccessId);
+            setGrants((prev) => prev.filter((g) => g.userAccessId !== pendingRevoke.userAccessId));
+            setPendingRevoke(null);
+        } catch {
+            // leave dialog open so user can retry or cancel
+        } finally {
+            setRevoking(false);
+        }
+    }
+
+    function handleCancelRevoke() {
+        setPendingRevoke(null);
+    }
+
+    async function handleGrantAccess(request: UserAccessRequest) {
+        await svc.grantDomainAccess(domain, request);
+        fetchGrants();
+    }
+
+    const revokeTarget = pendingRevoke?.username === '*' ? '* (everyone)' : pendingRevoke?.username;
+
+    return (
+        <div className="card bg-base-100 shadow-sm border border-base-300">
+            <div className="card-body gap-4">
+                <h3 className="card-title text-base">{domain}</h3>
+
+                {loading && <span className="loading loading-spinner loading-sm" aria-label="Loading grants" />}
+
+                {fetchError && (
+                    <div className="alert alert-error alert-sm" role="alert">
+                        <span>{fetchError}</span>
+                    </div>
+                )}
+
+                {!loading && !fetchError && (
+                    <div className="overflow-x-auto">
+                        <table className="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>User</th>
+                                    <th>Permission</th>
+                                    <th />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {grants.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={3} className="text-center text-base-content/50 italic text-sm">
+                                            No access grants
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    grants.map((grant) => (
+                                        <GrantRow
+                                            key={grant.userAccessId}
+                                            grant={grant}
+                                            onRequestRevoke={handleRequestRevoke}
+                                        />
+                                    ))
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+
+                <div className="divider my-0" />
+                <AddGrantForm onSubmit={handleGrantAccess} />
+            </div>
+
+            {pendingRevoke && (
+                <dialog open className="modal modal-open">
+                    <div className="modal-box">
+                        <h3 className="font-bold text-lg">Confirm revoke</h3>
+                        <p className="py-4">
+                            Remove <span className="font-mono font-semibold">{revokeTarget}</span>'s{' '}
+                            <span className="font-semibold">{pendingRevoke.permission}</span> access on{' '}
+                            <span className="font-semibold">{domain}</span>?
+                        </p>
+                        <div className="modal-action">
+                            <button
+                                className="btn btn-error"
+                                onClick={handleConfirmRevoke}
+                                disabled={revoking}
+                            >
+                                {revoking ? 'Revoking…' : 'Revoke'}
+                            </button>
+                            <button
+                                className="btn btn-ghost"
+                                onClick={handleCancelRevoke}
+                                disabled={revoking}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                    <form method="dialog" className="modal-backdrop">
+                        <button onClick={handleCancelRevoke}>close</button>
+                    </form>
+                </dialog>
+            )}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/admin/components/namespace-access/AddGrantForm.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/AddGrantForm.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AddGrantForm } from './AddGrantForm.js';
+
+describe('AddGrantForm', () => {
+    it('renders username input and permission select', () => {
+        render(<AddGrantForm onSubmit={vi.fn()} />);
+        expect(screen.getByRole('textbox', { name: /username/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /permission/i })).toBeInTheDocument();
+    });
+
+    it('submit button is disabled when username is empty', () => {
+        render(<AddGrantForm onSubmit={vi.fn()} />);
+        expect(screen.getByRole('button', { name: /grant access/i })).toBeDisabled();
+    });
+
+    it('submit button enables when username is entered', () => {
+        render(<AddGrantForm onSubmit={vi.fn()} />);
+        fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+            target: { value: 'alice' },
+        });
+        expect(screen.getByRole('button', { name: /grant access/i })).not.toBeDisabled();
+    });
+
+    it('calls onSubmit with trimmed username and selected permission', async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(<AddGrantForm onSubmit={onSubmit} />);
+
+        fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+            target: { value: '  alice  ' },
+        });
+        fireEvent.change(screen.getByRole('combobox', { name: /permission/i }), {
+            target: { value: 'write' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({ username: 'alice', permission: 'write' })
+        );
+    });
+
+    it('resets the form after a successful submit', async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(<AddGrantForm onSubmit={onSubmit} />);
+
+        const input = screen.getByRole('textbox', { name: /username/i });
+        fireEvent.change(input, { target: { value: 'alice' } });
+        fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+        await waitFor(() => expect((input as HTMLInputElement).value).toBe(''));
+    });
+
+    it('shows an error message when onSubmit rejects', async () => {
+        const onSubmit = vi.fn().mockRejectedValue(new Error('fail'));
+        render(<AddGrantForm onSubmit={onSubmit} />);
+
+        fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+            target: { value: 'alice' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+        await waitFor(() =>
+            expect(screen.getByRole('alert')).toHaveTextContent(/failed to grant/i)
+        );
+    });
+
+    it('disables inputs while submitting', async () => {
+        let resolve: () => void;
+        const onSubmit = vi.fn().mockImplementation(
+            () => new Promise<void>((r) => { resolve = r; })
+        );
+        render(<AddGrantForm onSubmit={onSubmit} />);
+
+        fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+            target: { value: 'alice' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+        await waitFor(() =>
+            expect(screen.getByRole('textbox', { name: /username/i })).toBeDisabled()
+        );
+        resolve!();
+    });
+});

--- a/calm-hub-ui/src/admin/components/namespace-access/AddGrantForm.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/AddGrantForm.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { UserAccessPermission, UserAccessRequest } from '../../../model/user-access.js';
+
+const PERMISSIONS: UserAccessPermission[] = ['read', 'write', 'admin'];
+
+interface AddGrantFormProps {
+    onSubmit: (request: UserAccessRequest) => Promise<void>;
+}
+
+export function AddGrantForm({ onSubmit }: AddGrantFormProps) {
+    const [username, setUsername] = useState('');
+    const [permission, setPermission] = useState<UserAccessPermission>('read');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const trimmed = username.trim();
+        if (!trimmed) return;
+
+        setSubmitting(true);
+        setError(null);
+        try {
+            await onSubmit({ username: trimmed, permission });
+            setUsername('');
+            setPermission('read');
+        } catch {
+            setError('Failed to grant access. Please try again.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="flex items-end gap-2 flex-wrap">
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-medium">Username</span>
+                <input
+                    className="input input-sm input-bordered w-48"
+                    type="text"
+                    placeholder="username or *"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    disabled={submitting}
+                    aria-label="Username"
+                />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-medium">Permission</span>
+                <select
+                    className="select select-sm select-bordered"
+                    value={permission}
+                    onChange={(e) => setPermission(e.target.value as UserAccessPermission)}
+                    disabled={submitting}
+                    aria-label="Permission"
+                >
+                    {PERMISSIONS.map((p) => (
+                        <option key={p} value={p}>{p}</option>
+                    ))}
+                </select>
+            </div>
+            <button
+                type="submit"
+                className="btn btn-sm btn-primary"
+                disabled={submitting || !username.trim()}
+            >
+                {submitting ? 'Granting…' : 'Grant Access'}
+            </button>
+            {error && (
+                <p className="text-error text-xs w-full" role="alert">{error}</p>
+            )}
+        </form>
+    );
+}

--- a/calm-hub-ui/src/admin/components/namespace-access/GrantRow.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/GrantRow.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { GrantRow } from './GrantRow.js';
+import { UserAccess } from '../../../model/user-access.js';
+
+const namedGrant: UserAccess = { userAccessId: 1, username: 'alice', permission: 'read', namespace: 'finos' };
+const wildcardGrant: UserAccess = { userAccessId: 2, username: '*', permission: 'read', namespace: 'finos' };
+const adminGrant: UserAccess = { userAccessId: 3, username: 'bob', permission: 'admin', namespace: 'finos' };
+
+describe('GrantRow', () => {
+    it('renders the username', () => {
+        render(<table><tbody><GrantRow grant={namedGrant} onRequestRevoke={() => {}} /></tbody></table>);
+        expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+
+    it('renders wildcard username as "* (everyone)"', () => {
+        render(<table><tbody><GrantRow grant={wildcardGrant} onRequestRevoke={() => {}} /></tbody></table>);
+        expect(screen.getByText('* (everyone)')).toBeInTheDocument();
+    });
+
+    it('renders the permission badge', () => {
+        render(<table><tbody><GrantRow grant={namedGrant} onRequestRevoke={() => {}} /></tbody></table>);
+        expect(screen.getByText('read')).toBeInTheDocument();
+    });
+
+    it('applies correct badge class for admin permission', () => {
+        render(<table><tbody><GrantRow grant={adminGrant} onRequestRevoke={() => {}} /></tbody></table>);
+        const badge = screen.getByText('admin');
+        expect(badge.className).toContain('badge-error');
+    });
+
+    it('calls onRequestRevoke with the grant when Revoke is clicked', () => {
+        const onRequestRevoke = vi.fn();
+        render(<table><tbody><GrantRow grant={namedGrant} onRequestRevoke={onRequestRevoke} /></tbody></table>);
+        fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+        expect(onRequestRevoke).toHaveBeenCalledWith(namedGrant);
+    });
+
+    it('uses wildcard display name in aria-label', () => {
+        render(<table><tbody><GrantRow grant={wildcardGrant} onRequestRevoke={() => {}} /></tbody></table>);
+        expect(screen.getByRole('button', { name: /revoke access for \* \(everyone\)/i })).toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/admin/components/namespace-access/GrantRow.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/GrantRow.tsx
@@ -1,0 +1,36 @@
+import { UserAccess, UserAccessPermission } from '../../../model/user-access.js';
+
+const PERMISSION_BADGE: Record<UserAccessPermission, string> = {
+    read: 'badge-info',
+    write: 'badge-warning',
+    admin: 'badge-error',
+};
+
+interface GrantRowProps {
+    grant: UserAccess;
+    onRequestRevoke: (grant: UserAccess) => void;
+}
+
+export function GrantRow({ grant, onRequestRevoke }: GrantRowProps) {
+    const displayUsername = grant.username === '*' ? '* (everyone)' : grant.username;
+
+    return (
+        <tr>
+            <td className="font-mono text-sm">{displayUsername}</td>
+            <td>
+                <span className={`badge badge-sm ${PERMISSION_BADGE[grant.permission]}`}>
+                    {grant.permission}
+                </span>
+            </td>
+            <td className="text-right">
+                <button
+                    className="btn btn-xs btn-error btn-outline"
+                    onClick={() => onRequestRevoke(grant)}
+                    aria-label={`Revoke access for ${displayUsername}`}
+                >
+                    Revoke
+                </button>
+            </td>
+        </tr>
+    );
+}

--- a/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
@@ -11,7 +11,7 @@ const wildcardGrant: UserAccess = { userAccessId: 3, username: '*', permission: 
 function mockSvc(overrides: Partial<Record<keyof UserAccessService, unknown>> = {}): UserAccessService {
     const svc = new UserAccessService();
     vi.spyOn(svc, 'getNamespaceUserAccess').mockResolvedValue([readGrant, adminGrant]);
-    vi.spyOn(svc, 'grantNamespaceAccess').mockResolvedValue({ ...readGrant, userAccessId: 99 });
+    vi.spyOn(svc, 'grantNamespaceAccess').mockResolvedValue(undefined);
     vi.spyOn(svc, 'revokeNamespaceAccess').mockResolvedValue(undefined);
     Object.entries(overrides).forEach(([k, v]) => {
         vi.spyOn(svc, k as keyof UserAccessService).mockImplementation(v as never);

--- a/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NamespaceAccessPanel } from './NamespaceAccessPanel.js';
+import { UserAccessService } from '../../../service/user-access-service.js';
+import { UserAccess } from '../../../model/user-access.js';
+
+const readGrant: UserAccess = { userAccessId: 1, username: 'alice', permission: 'read', namespace: 'finos' };
+const adminGrant: UserAccess = { userAccessId: 2, username: 'bob', permission: 'admin', namespace: 'finos' };
+const wildcardGrant: UserAccess = { userAccessId: 3, username: '*', permission: 'read', namespace: 'finos' };
+
+function mockSvc(overrides: Partial<Record<keyof UserAccessService, unknown>> = {}): UserAccessService {
+    const svc = new UserAccessService();
+    vi.spyOn(svc, 'getNamespaceUserAccess').mockResolvedValue([readGrant, adminGrant]);
+    vi.spyOn(svc, 'grantNamespaceAccess').mockResolvedValue({ ...readGrant, userAccessId: 99 });
+    vi.spyOn(svc, 'revokeNamespaceAccess').mockResolvedValue(undefined);
+    Object.entries(overrides).forEach(([k, v]) => {
+        vi.spyOn(svc, k as keyof UserAccessService).mockImplementation(v as never);
+    });
+    return svc;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NamespaceAccessPanel', () => {
+
+    describe('loading and fetching', () => {
+        it('shows a loading spinner initially', () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            expect(screen.getByLabelText('Loading grants')).toBeInTheDocument();
+        });
+
+        it('renders grant rows after loading', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+            expect(screen.getByText('bob')).toBeInTheDocument();
+        });
+
+        it('shows empty state when no grants exist', async () => {
+            const svc = mockSvc({ getNamespaceUserAccess: () => Promise.resolve([]) });
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByText(/no access grants/i)).toBeInTheDocument()
+            );
+        });
+
+        it('shows an error message when fetch fails', async () => {
+            const svc = mockSvc({ getNamespaceUserAccess: () => Promise.reject(new Error('fail')) });
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load/i)
+            );
+        });
+
+        it('displays the namespace name', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => expect(screen.getByText('finos')).toBeInTheDocument());
+        });
+    });
+
+    describe('wildcard grants', () => {
+        it('renders wildcard username as "* (everyone)"', async () => {
+            const svc = mockSvc({ getNamespaceUserAccess: () => Promise.resolve([wildcardGrant]) });
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() =>
+                expect(screen.getByText('* (everyone)')).toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('revoking access', () => {
+        it('calls revokeNamespaceAccess with correct args after confirmation', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^revoke$/i }));
+
+            await waitFor(() =>
+                expect(svc.revokeNamespaceAccess).toHaveBeenCalledWith('finos', readGrant.userAccessId)
+            );
+        });
+
+        it('removes the revoked grant from the table', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^revoke$/i }));
+
+            await waitFor(() =>
+                expect(screen.queryByText('alice')).not.toBeInTheDocument()
+            );
+        });
+
+        it('shows grant details in the confirmation dialog', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.click(screen.getByRole('button', { name: /revoke access for alice/i }));
+
+            const dialog = screen.getByRole('dialog');
+            expect(within(dialog).getByText(/alice/)).toBeInTheDocument();
+            expect(within(dialog).getByText(/read/)).toBeInTheDocument();
+        });
+    });
+
+    describe('granting access', () => {
+        it('calls grantNamespaceAccess and refreshes the list', async () => {
+            const svc = mockSvc();
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            fireEvent.change(screen.getByRole('textbox', { name: /username/i }), {
+                target: { value: 'carol' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /grant access/i }));
+
+            await waitFor(() =>
+                expect(svc.grantNamespaceAccess).toHaveBeenCalledWith('finos', {
+                    username: 'carol',
+                    permission: 'read',
+                })
+            );
+            expect(svc.getNamespaceUserAccess).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.test.tsx
@@ -60,6 +60,20 @@ describe('NamespaceAccessPanel', () => {
         });
     });
 
+    describe('sorting', () => {
+        it('renders grants sorted alphabetically by username', async () => {
+            const svc = mockSvc({
+                getNamespaceUserAccess: () => Promise.resolve([adminGrant, readGrant]), // bob, alice
+            });
+            render(<NamespaceAccessPanel namespace="finos" service={svc} />);
+            await waitFor(() => screen.getByText('alice'));
+
+            const rows = screen.getAllByRole('row').slice(1); // skip header
+            expect(within(rows[0]).getByText('alice')).toBeInTheDocument();
+            expect(within(rows[1]).getByText('bob')).toBeInTheDocument();
+        });
+    });
+
     describe('wildcard grants', () => {
         it('renders wildcard username as "* (everyone)"', async () => {
             const svc = mockSvc({ getNamespaceUserAccess: () => Promise.resolve([wildcardGrant]) });

--- a/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.tsx
@@ -21,7 +21,7 @@ export function NamespaceAccessPanel({ namespace, service }: NamespaceAccessPane
         setLoading(true);
         setFetchError(null);
         svc.getNamespaceUserAccess(namespace)
-            .then(setGrants)
+            .then((g) => setGrants([...g].sort((a, b) => a.username.localeCompare(b.username))))
             .catch(() => setFetchError('Failed to load access grants.'))
             .finally(() => setLoading(false));
     }, [svc, namespace]);

--- a/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.tsx
+++ b/calm-hub-ui/src/admin/components/namespace-access/NamespaceAccessPanel.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { UserAccess, UserAccessRequest } from '../../../model/user-access.js';
+import { UserAccessService } from '../../../service/user-access-service.js';
+import { GrantRow } from './GrantRow.js';
+import { AddGrantForm } from './AddGrantForm.js';
+
+interface NamespaceAccessPanelProps {
+    namespace: string;
+    service?: UserAccessService;
+}
+
+export function NamespaceAccessPanel({ namespace, service }: NamespaceAccessPanelProps) {
+    const svc = useMemo(() => service ?? new UserAccessService(), [service]);
+    const [grants, setGrants] = useState<UserAccess[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
+    const [pendingRevoke, setPendingRevoke] = useState<UserAccess | null>(null);
+    const [revoking, setRevoking] = useState(false);
+
+    const fetchGrants = useCallback(() => {
+        setLoading(true);
+        setFetchError(null);
+        svc.getNamespaceUserAccess(namespace)
+            .then(setGrants)
+            .catch(() => setFetchError('Failed to load access grants.'))
+            .finally(() => setLoading(false));
+    }, [svc, namespace]);
+
+    useEffect(() => { fetchGrants(); }, [fetchGrants]);
+
+    function handleRequestRevoke(grant: UserAccess) {
+        setPendingRevoke(grant);
+    }
+
+    async function handleConfirmRevoke() {
+        if (!pendingRevoke) return;
+        setRevoking(true);
+        try {
+            await svc.revokeNamespaceAccess(namespace, pendingRevoke.userAccessId);
+            setGrants((prev) => prev.filter((g) => g.userAccessId !== pendingRevoke.userAccessId));
+            setPendingRevoke(null);
+        } catch {
+            // leave dialog open so user can retry or cancel
+        } finally {
+            setRevoking(false);
+        }
+    }
+
+    function handleCancelRevoke() {
+        setPendingRevoke(null);
+    }
+
+    async function handleGrantAccess(request: UserAccessRequest) {
+        await svc.grantNamespaceAccess(namespace, request);
+        fetchGrants();
+    }
+
+    const revokeTarget = pendingRevoke?.username === '*' ? '* (everyone)' : pendingRevoke?.username;
+
+    return (
+        <div className="card bg-base-100 shadow-sm border border-base-300">
+            <div className="card-body gap-4">
+                <h3 className="card-title text-base">{namespace}</h3>
+
+                {loading && <span className="loading loading-spinner loading-sm" aria-label="Loading grants" />}
+
+                {fetchError && (
+                    <div className="alert alert-error alert-sm" role="alert">
+                        <span>{fetchError}</span>
+                    </div>
+                )}
+
+                {!loading && !fetchError && (
+                    <div className="overflow-x-auto">
+                        <table className="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>User</th>
+                                    <th>Permission</th>
+                                    <th />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {grants.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={3} className="text-center text-base-content/50 italic text-sm">
+                                            No access grants
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    grants.map((grant) => (
+                                        <GrantRow
+                                            key={grant.userAccessId}
+                                            grant={grant}
+                                            onRequestRevoke={handleRequestRevoke}
+                                        />
+                                    ))
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+
+                <div className="divider my-0" />
+                <AddGrantForm onSubmit={handleGrantAccess} />
+            </div>
+
+            {pendingRevoke && (
+                <dialog open className="modal modal-open">
+                    <div className="modal-box">
+                        <h3 className="font-bold text-lg">Confirm revoke</h3>
+                        <p className="py-4">
+                            Remove <span className="font-mono font-semibold">{revokeTarget}</span>'s{' '}
+                            <span className="font-semibold">{pendingRevoke.permission}</span> access on{' '}
+                            <span className="font-semibold">{namespace}</span>?
+                        </p>
+                        <div className="modal-action">
+                            <button
+                                className="btn btn-error"
+                                onClick={handleConfirmRevoke}
+                                disabled={revoking}
+                            >
+                                {revoking ? 'Revoking…' : 'Revoke'}
+                            </button>
+                            <button
+                                className="btn btn-ghost"
+                                onClick={handleCancelRevoke}
+                                disabled={revoking}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                    <form method="dialog" className="modal-backdrop">
+                        <button onClick={handleCancelRevoke}>close</button>
+                    </form>
+                </dialog>
+            )}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/admin/context/UserAccessContext.tsx
+++ b/calm-hub-ui/src/admin/context/UserAccessContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, ReactNode } from 'react';
+import { CurrentUserAccessState, useCurrentUserAccess } from '../hooks/useCurrentUserAccess.js';
+import { UserAccessService } from '../../service/user-access-service.js';
+
+const defaultState: CurrentUserAccessState = {
+    grants: [],
+    loading: true,
+    error: null,
+    isGlobalAdmin: false,
+    canAdminNamespace: () => false,
+};
+
+export const UserAccessContext = createContext<CurrentUserAccessState>(defaultState);
+
+export function UserAccessProvider({
+    children,
+    service,
+}: {
+    children: ReactNode;
+    service?: UserAccessService;
+}) {
+    const state = useCurrentUserAccess(service);
+    return <UserAccessContext.Provider value={state}>{children}</UserAccessContext.Provider>;
+}
+
+export function useUserAccess(): CurrentUserAccessState {
+    return useContext(UserAccessContext);
+}

--- a/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.test.ts
+++ b/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCurrentUserAccess } from './useCurrentUserAccess.js';
+import { UserAccessService } from '../../service/user-access-service.js';
+import { UserAccess } from '../../model/user-access.js';
+
+const namespaceGrant = (namespace: string, permission: UserAccess['permission'], id = 1): UserAccess => ({
+    userAccessId: id,
+    username: 'alice',
+    permission,
+    namespace,
+});
+
+const globalAdminGrant: UserAccess = namespaceGrant('GLOBAL', 'admin', 99);
+const wildcardReadGrant: UserAccess = { userAccessId: 50, username: '*', permission: 'read', namespace: 'finos' };
+
+function mockService(resolvesWith: UserAccess[]): UserAccessService {
+    const svc = new UserAccessService();
+    vi.spyOn(svc, 'getCurrentUserAccess').mockResolvedValue(resolvesWith);
+    return svc;
+}
+
+function rejectingService(): UserAccessService {
+    const svc = new UserAccessService();
+    vi.spyOn(svc, 'getCurrentUserAccess').mockRejectedValue(new Error('network error'));
+    return svc;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCurrentUserAccess', () => {
+
+    describe('loading state', () => {
+        it('starts in loading state', () => {
+            const svc = mockService([]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            expect(result.current.loading).toBe(true);
+        });
+
+        it('clears loading after grants resolve', async () => {
+            const svc = mockService([namespaceGrant('finos', 'read')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.loading).toBe(false));
+        });
+
+        it('clears loading even when the service rejects', async () => {
+            const svc = rejectingService();
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.loading).toBe(false));
+        });
+    });
+
+    describe('grants', () => {
+        it('returns grants from the service', async () => {
+            const grants = [namespaceGrant('finos', 'read'), namespaceGrant('payments', 'write', 2)];
+            const svc = mockService(grants);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.grants).toEqual(grants));
+        });
+
+        it('includes wildcard grants', async () => {
+            const svc = mockService([wildcardReadGrant]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() =>
+                expect(result.current.grants.some((g) => g.username === '*')).toBe(true)
+            );
+        });
+
+        it('returns empty grants on error', async () => {
+            const svc = rejectingService();
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.grants).toEqual([]));
+        });
+    });
+
+    describe('error state', () => {
+        it('has no error on success', async () => {
+            const svc = mockService([]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.error).toBeNull());
+        });
+
+        it('sets an error message when the service rejects', async () => {
+            const svc = rejectingService();
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.error).not.toBeNull());
+        });
+    });
+
+    describe('isGlobalAdmin', () => {
+        it('is false when user has no grants', async () => {
+            const svc = mockService([]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.isGlobalAdmin).toBe(false));
+        });
+
+        it('is false when user has namespace admin but not GLOBAL', async () => {
+            const svc = mockService([namespaceGrant('finos', 'admin')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.isGlobalAdmin).toBe(false));
+        });
+
+        it('is true when user has a GLOBAL admin grant', async () => {
+            const svc = mockService([globalAdminGrant]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.isGlobalAdmin).toBe(true));
+        });
+
+        it('is false when GLOBAL grant has non-admin permission', async () => {
+            const svc = mockService([namespaceGrant('GLOBAL', 'read')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.isGlobalAdmin).toBe(false));
+        });
+    });
+
+    describe('canAdminNamespace', () => {
+        it('returns false when user has no grants', async () => {
+            const svc = mockService([]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.canAdminNamespace('finos')).toBe(false));
+        });
+
+        it('returns false when user has only read on the namespace', async () => {
+            const svc = mockService([namespaceGrant('finos', 'read')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.canAdminNamespace('finos')).toBe(false));
+        });
+
+        it('returns true when user has admin on the specific namespace', async () => {
+            const svc = mockService([namespaceGrant('finos', 'admin')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.canAdminNamespace('finos')).toBe(true));
+        });
+
+        it('returns false when user has admin on a different namespace', async () => {
+            const svc = mockService([namespaceGrant('payments', 'admin')]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.canAdminNamespace('finos')).toBe(false));
+        });
+
+        it('returns true for any namespace when user is global admin', async () => {
+            const svc = mockService([globalAdminGrant]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => {
+                expect(result.current.canAdminNamespace('finos')).toBe(true);
+                expect(result.current.canAdminNamespace('payments')).toBe(true);
+                expect(result.current.canAdminNamespace('anything')).toBe(true);
+            });
+        });
+
+        it('wildcard grants do not confer namespace admin', async () => {
+            const svc = mockService([wildcardReadGrant]);
+            const { result } = renderHook(() => useCurrentUserAccess(svc));
+            await waitFor(() => expect(result.current.canAdminNamespace('finos')).toBe(false));
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
+++ b/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
@@ -30,7 +30,7 @@ export function useCurrentUserAccess(service?: UserAccessService): CurrentUserAc
 
     const isGlobalAdmin = useMemo(
         () => grants.some(
-            (g) => g.namespace === GLOBAL_NAMESPACE && g.permission === 'admin'
+            (g) => g.namespace === GLOBAL_NAMESPACE && g.permission === 'admin' && g.username !== '*'
         ),
         [grants]
     );

--- a/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
+++ b/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { UserAccess } from '../../model/user-access.js';
+import { UserAccessService } from '../../service/user-access-service.js';
+
+const GLOBAL_NAMESPACE = 'GLOBAL';
+
+export interface CurrentUserAccessState {
+    grants: UserAccess[];
+    loading: boolean;
+    error: string | null;
+    isGlobalAdmin: boolean;
+    canAdminNamespace: (namespace: string) => boolean;
+}
+
+export function useCurrentUserAccess(service?: UserAccessService): CurrentUserAccessState {
+    const [grants, setGrants] = useState<UserAccess[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const svc = useMemo(() => service ?? new UserAccessService(), [service]);
+
+    useEffect(() => {
+        setLoading(true);
+        setError(null);
+        svc.getCurrentUserAccess()
+            .then(setGrants)
+            .catch(() => setError('Failed to load your access permissions.'))
+            .finally(() => setLoading(false));
+    }, [svc]);
+
+    const isGlobalAdmin = useMemo(
+        () => grants.some(
+            (g) => g.namespace === GLOBAL_NAMESPACE && g.permission === 'admin'
+        ),
+        [grants]
+    );
+
+    const canAdminNamespace = useCallback(
+        (namespace: string) =>
+            isGlobalAdmin ||
+            grants.some((g) => g.namespace === namespace && g.permission === 'admin'),
+        [grants, isGlobalAdmin]
+    );
+
+    return { grants, loading, error, isGlobalAdmin, canAdminNamespace };
+}

--- a/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
+++ b/calm-hub-ui/src/admin/hooks/useCurrentUserAccess.ts
@@ -38,7 +38,13 @@ export function useCurrentUserAccess(service?: UserAccessService): CurrentUserAc
     const canAdminNamespace = useCallback(
         (namespace: string) =>
             isGlobalAdmin ||
-            grants.some((g) => g.namespace === namespace && g.permission === 'admin'),
+            grants.some(
+                (g) =>
+                    g.permission === 'admin' &&
+                    g.namespace != null &&
+                    // OR across ancestors: admin on 'org' covers 'org', 'org.ab', 'org.ab.cd', etc.
+                    (namespace === g.namespace || namespace.startsWith(g.namespace + '.'))
+            ),
         [grants, isGlobalAdmin]
     );
 

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DomainsPanel } from './DomainsPanel.js';
+import { CalmService } from '../../service/calm-service.js';
+
+function mockService(domains: string[], createResult: 'ok' | 'fail' = 'ok') {
+    const svc = new CalmService();
+    vi.spyOn(svc, 'fetchDomains').mockResolvedValue(domains);
+    vi.spyOn(svc, 'createDomain').mockImplementation(() =>
+        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('fail'))
+    );
+    return svc;
+}
+
+function renderPanel(svc: CalmService) {
+    return render(<DomainsPanel calmService={svc} />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('DomainsPanel', () => {
+
+    describe('loading', () => {
+        it('shows a loading spinner while fetching', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByLabelText('Loading domains')).toBeInTheDocument();
+        });
+
+        it('hides the spinner after loading', async () => {
+            const svc = mockService(['retail']);
+            renderPanel(svc);
+            await waitFor(() =>
+                expect(screen.queryByLabelText('Loading domains')).not.toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('existing domains list', () => {
+        it('renders each domain as a badge', async () => {
+            const svc = mockService(['retail', 'wholesale']);
+            renderPanel(svc);
+            expect(await screen.findByText('retail')).toBeInTheDocument();
+            expect(await screen.findByText('wholesale')).toBeInTheDocument();
+        });
+
+        it('shows empty state message when no domains exist', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(await screen.findByText(/no domains yet/i)).toBeInTheDocument();
+        });
+
+        it('shows a load error when fetch fails', async () => {
+            const svc = new CalmService();
+            vi.spyOn(svc, 'fetchDomains').mockRejectedValue(new Error('fail'));
+            renderPanel(svc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load domains/i)
+            );
+        });
+    });
+
+    describe('create domain form', () => {
+        it('renders the domain name input', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+            expect(screen.getByLabelText('Domain name')).toBeInTheDocument();
+        });
+
+        it('disables the create button when name is empty', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+            expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
+        });
+
+        it('enables the create button when name is filled', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: 'retail' },
+            });
+            expect(screen.getByRole('button', { name: /create/i })).not.toBeDisabled();
+        });
+
+        it('calls createDomain with trimmed name on submit', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: '  retail  ' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(svc.createDomain).toHaveBeenCalledWith('retail')
+            );
+        });
+
+        it('shows success message after creation', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: 'retail' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/retail.*created/i)
+            );
+        });
+
+        it('clears the name field after successful creation', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: 'retail' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() => screen.getByRole('status'));
+            expect(screen.getByLabelText('Domain name')).toHaveValue('');
+        });
+
+        it('refreshes the domain list after successful creation', async () => {
+            const svc = new CalmService();
+            vi.spyOn(svc, 'fetchDomains')
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce(['retail']);
+            vi.spyOn(svc, 'createDomain').mockResolvedValue();
+            renderPanel(svc);
+            await screen.findByText(/no domains yet/i);
+
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: 'retail' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            expect(await screen.findByText('retail')).toBeInTheDocument();
+        });
+
+        it('shows error message when creation fails', async () => {
+            const svc = mockService([], 'fail');
+            renderPanel(svc);
+            await screen.findByLabelText('Domain name');
+
+            fireEvent.change(screen.getByLabelText('Domain name'), {
+                target: { value: 'retail' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to create domain/i)
+            );
+        });
+    });
+
+    describe('headings', () => {
+        it('renders the Domains page heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /domains/i, level: 1 })).toBeInTheDocument();
+        });
+
+        it('renders the Create Domain section heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /create domain/i })).toBeInTheDocument();
+        });
+
+        it('renders the Existing Domains section heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /existing domains/i })).toBeInTheDocument();
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
@@ -55,7 +55,7 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
                     <form onSubmit={handleSubmit} className="flex flex-col gap-3 max-w-sm">
                         <input
                             className="input input-bordered input-sm"
-                            placeholder="Name (e.g. payments)"
+                            placeholder="Name (e.g. security)"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             required

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CalmService } from '../../service/calm-service.js';
+
+interface DomainsPanelProps {
+    calmService?: CalmService;
+}
+
+export function DomainsPanel({ calmService }: DomainsPanelProps) {
+    const svc = useMemo(() => calmService ?? new CalmService(), [calmService]);
+
+    const [domains, setDomains] = useState<string[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [name, setName] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    const load = useCallback(() => {
+        setLoading(true);
+        setLoadError(null);
+        svc.fetchDomains()
+            .then(setDomains)
+            .catch(() => setLoadError('Failed to load domains.'))
+            .finally(() => setLoading(false));
+    }, [svc]);
+
+    useEffect(() => { load(); }, [load]);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setSubmitting(true);
+        setSubmitError(null);
+        setSuccess(null);
+        try {
+            await svc.createDomain(name.trim());
+            setSuccess(`Domain '${name.trim()}' created.`);
+            setName('');
+            load();
+        } catch {
+            setSubmitError('Failed to create domain.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div>
+            <h1 className="text-2xl font-bold mb-6">Domains</h1>
+
+            <section aria-label="Create domain" className="card bg-base-100 shadow mb-8">
+                <div className="card-body">
+                    <h2 className="card-title text-lg">Create Domain</h2>
+                    <form onSubmit={handleSubmit} className="flex flex-col gap-3 max-w-sm">
+                        <input
+                            className="input input-bordered input-sm"
+                            placeholder="Name (e.g. payments)"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            required
+                            aria-label="Domain name"
+                        />
+                        {submitError && <p className="text-error text-sm" role="alert">{submitError}</p>}
+                        {success && <p className="text-success text-sm" role="status">{success}</p>}
+                        <button
+                            className="btn btn-primary btn-sm self-start"
+                            type="submit"
+                            disabled={submitting || !name.trim()}
+                        >
+                            {submitting ? 'Creating…' : 'Create'}
+                        </button>
+                    </form>
+                </div>
+            </section>
+
+            <section aria-label="Existing domains">
+                <h2 className="text-lg font-semibold mb-3">Existing Domains</h2>
+                {loading && <span className="loading loading-spinner" aria-label="Loading domains" />}
+                {!loading && loadError && <p className="text-error text-sm" role="alert">{loadError}</p>}
+                {!loading && !loadError && domains.length === 0 && (
+                    <p className="text-base-content/50 text-sm italic">No domains yet.</p>
+                )}
+                {!loading && domains.length > 0 && (
+                    <ul className="flex flex-wrap gap-2">
+                        {domains.map((d) => (
+                            <li key={d} className="badge badge-ghost badge-lg">{d}</li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EntitlementsPanel } from './EntitlementsPanel.js';
 import { CalmService } from '../../service/calm-service.js';
@@ -48,6 +48,25 @@ function renderPanel(
             <BrowserRouter>
                 <EntitlementsPanel calmService={calmSvc} userAccessService={userAccessSvc} />
             </BrowserRouter>
+        </UserAccessContext.Provider>
+    );
+}
+
+function renderPanelWithUrl(
+    accessState: CurrentUserAccessState,
+    calmSvc: CalmService,
+    userAccessSvc: UserAccessService,
+    initialUrl: string
+) {
+    return render(
+        <UserAccessContext.Provider value={accessState}>
+            <MemoryRouter initialEntries={[initialUrl]}>
+                <Routes>
+                    <Route path="*" element={
+                        <EntitlementsPanel calmService={calmSvc} userAccessService={userAccessSvc} />
+                    } />
+                </Routes>
+            </MemoryRouter>
         </UserAccessContext.Provider>
     );
 }
@@ -240,6 +259,48 @@ describe('EntitlementsPanel', () => {
             renderPanel(makeAccessState({}), calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('heading', { name: /access management/i })).toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('URL search param persistence', () => {
+        it('pre-selects the namespace from the URL and shows its grants panel', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanelWithUrl(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS || ns === NS_PAYMENTS }),
+                calmSvc,
+                userAccessSvc,
+                `/?namespace=${NS_FINOS}`
+            );
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: NS_FINOS })).toBeInTheDocument()
+            );
+            const select = screen.getByRole('combobox', { name: /select namespace/i });
+            expect((select as HTMLSelectElement).value).toBe(NS_FINOS);
+        });
+
+        it('pre-selects the domain from the URL and shows its grants panel', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], ['retail', 'wholesale']);
+            renderPanelWithUrl(globalAdminState, calmSvc, userAccessSvc, '/?domain=retail');
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: 'retail' })).toBeInTheDocument()
+            );
+            const select = screen.getByRole('combobox', { name: /select domain/i });
+            expect((select as HTMLSelectElement).value).toBe('retail');
+        });
+
+        it('updates the URL when the namespace selection changes', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanelWithUrl(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS || ns === NS_PAYMENTS }),
+                calmSvc,
+                userAccessSvc,
+                '/'
+            );
+            const select = await screen.findByRole('combobox', { name: /select namespace/i });
+            fireEvent.change(select, { target: { value: NS_PAYMENTS } });
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: NS_PAYMENTS })).toBeInTheDocument()
             );
         });
     });

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
@@ -159,6 +159,30 @@ describe('EntitlementsPanel', () => {
             await screen.findByRole('combobox', { name: /select namespace/i });
             expect(screen.queryByRole('region', { name: /domain access/i })).not.toBeInTheDocument();
         });
+
+        it('shows Global Admin Access section for global admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('region', { name: /global admin access/i })).toBeInTheDocument()
+            );
+        });
+
+        it('does not show Global Admin Access section for namespace-scoped admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPanel(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.queryByRole('region', { name: /global admin access/i })).not.toBeInTheDocument();
+        });
+
+        it('loads GLOBAL namespace grants in the Global Admin Access panel', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('region', { name: /global admin access/i })).toBeInTheDocument()
+            );
+            expect(userAccessSvc.getNamespaceUserAccess).toHaveBeenCalledWith('GLOBAL');
+        });
     });
 
     describe('domain dropdown', () => {

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
@@ -4,55 +4,51 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EntitlementsPanel } from './EntitlementsPanel.js';
 import { CalmService } from '../../service/calm-service.js';
 import { UserAccessService } from '../../service/user-access-service.js';
-import { UserAccess } from '../../model/user-access.js';
+import { UserAccessContext } from '../context/UserAccessContext.js';
+import { CurrentUserAccessState } from '../hooks/useCurrentUserAccess.js';
 
 const NS_FINOS = 'finos';
 const NS_PAYMENTS = 'payments';
 
-const adminGrant = (ns: string): UserAccess => ({
-    userAccessId: 1,
-    username: 'alice',
-    permission: 'admin',
-    namespace: ns,
+function makeAccessState(overrides: Partial<CurrentUserAccessState>): CurrentUserAccessState {
+    return {
+        grants: [],
+        loading: false,
+        error: null,
+        isGlobalAdmin: false,
+        canAdminNamespace: () => false,
+        ...overrides,
+    };
+}
+
+const globalAdminState = makeAccessState({
+    isGlobalAdmin: true,
+    canAdminNamespace: () => true,
 });
 
-const globalAdminGrant: UserAccess = {
-    userAccessId: 99,
-    username: 'alice',
-    permission: 'admin',
-    namespace: 'GLOBAL',
-};
-
-const readOnlyGrant: UserAccess = {
-    userAccessId: 2,
-    username: 'alice',
-    permission: 'read',
-    namespace: NS_FINOS,
-};
-
-function mockServices(
-    namespaces: string[],
-    currentUserGrants: UserAccess[],
-    namespaceGrantOverride?: UserAccess[],
-    domains: string[] = []
-) {
+function mockServices(namespaces: string[], domains: string[] = []) {
     const calmSvc = new CalmService();
     vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue(namespaces);
     vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue(domains);
 
     const userAccessSvc = new UserAccessService();
-    vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue(currentUserGrants);
-    vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue(namespaceGrantOverride ?? []);
+    vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
     vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
 
     return { calmSvc, userAccessSvc };
 }
 
-function renderPanel(calmSvc: CalmService, userAccessSvc: UserAccessService) {
+function renderPanel(
+    accessState: CurrentUserAccessState,
+    calmSvc: CalmService,
+    userAccessSvc: UserAccessService
+) {
     return render(
-        <BrowserRouter>
-            <EntitlementsPanel calmService={calmSvc} userAccessService={userAccessSvc} />
-        </BrowserRouter>
+        <UserAccessContext.Provider value={accessState}>
+            <BrowserRouter>
+                <EntitlementsPanel calmService={calmSvc} userAccessService={userAccessSvc} />
+            </BrowserRouter>
+        </UserAccessContext.Provider>
     );
 }
 
@@ -61,15 +57,19 @@ beforeEach(() => vi.clearAllMocks());
 describe('EntitlementsPanel', () => {
 
     describe('loading state', () => {
-        it('shows a loading spinner initially', () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPanel(calmSvc, userAccessSvc);
+        it('shows a loading spinner while access state is loading', () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(makeAccessState({ loading: true }), calmSvc, userAccessSvc);
             expect(screen.getByLabelText('Loading')).toBeInTheDocument();
         });
 
-        it('hides the spinner after data loads', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPanel(calmSvc, userAccessSvc);
+        it('hides the spinner after access state loads', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS }),
+                calmSvc,
+                userAccessSvc
+            );
             await waitFor(() =>
                 expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
             );
@@ -77,17 +77,9 @@ describe('EntitlementsPanel', () => {
     });
 
     describe('no admin access', () => {
-        it('shows "no access" message when user has no grants', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], []);
-            renderPanel(calmSvc, userAccessSvc);
-            await waitFor(() =>
-                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
-            );
-        });
-
-        it('shows "no access" message when user has only read grants', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [readOnlyGrant]);
-            renderPanel(calmSvc, userAccessSvc);
+        it('shows "no access" message when user has no admin namespaces', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(makeAccessState({}), calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
             );
@@ -95,46 +87,46 @@ describe('EntitlementsPanel', () => {
     });
 
     describe('namespace dropdown', () => {
-        it('shows all adminnable namespaces as dropdown options', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+        it('shows adminnable namespaces as dropdown options', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanel(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS || ns === NS_PAYMENTS }),
+                calmSvc,
+                userAccessSvc
             );
-            renderPanel(calmSvc, userAccessSvc);
             const select = await screen.findByRole('combobox', { name: /select namespace/i });
             expect(select).toBeInTheDocument();
             expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
         });
 
-        it('only shows namespaces the user can admin in the dropdown', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS)]
+        it('only shows namespaces the user can admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanel(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS }),
+                calmSvc,
+                userAccessSvc
             );
-            renderPanel(calmSvc, userAccessSvc);
             await screen.findByRole('combobox', { name: /select namespace/i });
             expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
             expect(screen.queryByRole('option', { name: NS_PAYMENTS })).not.toBeInTheDocument();
         });
 
-        it('shows all namespaces in the dropdown when user is global admin', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [globalAdminGrant]
-            );
-            renderPanel(calmSvc, userAccessSvc);
+        it('shows all namespaces when user is global admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await screen.findByRole('combobox', { name: /select namespace/i });
             expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
         });
 
         it('renders the panel for the selected namespace', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS, NS_PAYMENTS],
-                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS, NS_PAYMENTS]);
+            renderPanel(
+                makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS || ns === NS_PAYMENTS }),
+                calmSvc,
+                userAccessSvc
             );
-            renderPanel(calmSvc, userAccessSvc);
             const select = await screen.findByRole('combobox', { name: /select namespace/i });
             fireEvent.change(select, { target: { value: NS_FINOS } });
             await waitFor(() =>
@@ -144,40 +136,40 @@ describe('EntitlementsPanel', () => {
         });
     });
 
-    describe('global admin section', () => {
+    describe('global admin sections', () => {
         it('shows Domain Access section for global admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('region', { name: /domain access/i })).toBeInTheDocument()
             );
         });
 
-        it('does not show Domain Access section for non-global admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPanel(calmSvc, userAccessSvc);
+        it('does not show Domain Access section for namespace-scoped admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS }), calmSvc, userAccessSvc);
             await screen.findByRole('combobox', { name: /select namespace/i });
             expect(screen.queryByRole('region', { name: /domain access/i })).not.toBeInTheDocument();
         });
 
         it('shows Global Admin Access section for global admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('region', { name: /global admin access/i })).toBeInTheDocument()
             );
         });
 
         it('does not show Global Admin Access section for namespace-scoped admins', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(makeAccessState({ canAdminNamespace: (ns) => ns === NS_FINOS }), calmSvc, userAccessSvc);
             await screen.findByRole('combobox', { name: /select namespace/i });
             expect(screen.queryByRole('region', { name: /global admin access/i })).not.toBeInTheDocument();
         });
 
         it('loads GLOBAL namespace grants in the Global Admin Access panel', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('region', { name: /global admin access/i })).toBeInTheDocument()
             );
@@ -187,20 +179,16 @@ describe('EntitlementsPanel', () => {
 
     describe('domain dropdown', () => {
         it('shows all domains as dropdown options when global admin', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
-            );
-            renderPanel(calmSvc, userAccessSvc);
-            const select = await screen.findByRole('combobox', { name: /select domain/i });
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], ['retail', 'wholesale']);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select domain/i });
             expect(screen.getByRole('option', { name: 'retail' })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'wholesale' })).toBeInTheDocument();
         });
 
         it('renders the panel for the selected domain', async () => {
-            const { calmSvc, userAccessSvc } = mockServices(
-                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
-            );
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], ['retail', 'wholesale']);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             const select = await screen.findByRole('combobox', { name: /select domain/i });
             fireEvent.change(select, { target: { value: 'retail' } });
             await waitFor(() =>
@@ -210,8 +198,8 @@ describe('EntitlementsPanel', () => {
         });
 
         it('shows "no domains found" when there are no domains', async () => {
-            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant], [], []);
-            renderPanel(calmSvc, userAccessSvc);
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], []);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByText(/no domains found/i)).toBeInTheDocument()
             );
@@ -224,24 +212,22 @@ describe('EntitlementsPanel', () => {
             vi.spyOn(calmSvc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
             vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
             const userAccessSvc = new UserAccessService();
-            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue([]);
+            vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
+            vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
 
-            renderPanel(calmSvc, userAccessSvc);
+            renderPanel(globalAdminState, calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
             );
         });
 
-        it('shows an error when user access fetch fails', async () => {
-            const calmSvc = new CalmService();
-            vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue([NS_FINOS]);
-            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
-            const userAccessSvc = new UserAccessService();
-            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockRejectedValue(new Error('fail'));
-            vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
-            vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
-
-            renderPanel(calmSvc, userAccessSvc);
+        it('shows an error when access state has an error', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS]);
+            renderPanel(
+                makeAccessState({ error: 'Failed to load your access permissions.' }),
+                calmSvc,
+                userAccessSvc
+            );
             await waitFor(() =>
                 expect(screen.getByRole('alert')).toHaveTextContent(/failed to load your access/i)
             );
@@ -251,7 +237,7 @@ describe('EntitlementsPanel', () => {
     describe('panel heading', () => {
         it('renders the Access Management heading', async () => {
             const { calmSvc, userAccessSvc } = mockServices([], []);
-            renderPanel(calmSvc, userAccessSvc);
+            renderPanel(makeAccessState({}), calmSvc, userAccessSvc);
             await waitFor(() =>
                 expect(screen.getByRole('heading', { name: /access management/i })).toBeInTheDocument()
             );

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EntitlementsPanel } from './EntitlementsPanel.js';
+import { CalmService } from '../../service/calm-service.js';
+import { UserAccessService } from '../../service/user-access-service.js';
+import { UserAccess } from '../../model/user-access.js';
+
+const NS_FINOS = 'finos';
+const NS_PAYMENTS = 'payments';
+
+const adminGrant = (ns: string): UserAccess => ({
+    userAccessId: 1,
+    username: 'alice',
+    permission: 'admin',
+    namespace: ns,
+});
+
+const globalAdminGrant: UserAccess = {
+    userAccessId: 99,
+    username: 'alice',
+    permission: 'admin',
+    namespace: 'GLOBAL',
+};
+
+const readOnlyGrant: UserAccess = {
+    userAccessId: 2,
+    username: 'alice',
+    permission: 'read',
+    namespace: NS_FINOS,
+};
+
+function mockServices(
+    namespaces: string[],
+    currentUserGrants: UserAccess[],
+    namespaceGrantOverride?: UserAccess[],
+    domains: string[] = []
+) {
+    const calmSvc = new CalmService();
+    vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue(namespaces);
+    vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue(domains);
+
+    const userAccessSvc = new UserAccessService();
+    vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue(currentUserGrants);
+    vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue(namespaceGrantOverride ?? []);
+    vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
+
+    return { calmSvc, userAccessSvc };
+}
+
+function renderPanel(calmSvc: CalmService, userAccessSvc: UserAccessService) {
+    return render(
+        <BrowserRouter>
+            <EntitlementsPanel calmService={calmSvc} userAccessService={userAccessSvc} />
+        </BrowserRouter>
+    );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('EntitlementsPanel', () => {
+
+    describe('loading state', () => {
+        it('shows a loading spinner initially', () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPanel(calmSvc, userAccessSvc);
+            expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+        });
+
+        it('hides the spinner after data loads', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('no admin access', () => {
+        it('shows "no access" message when user has no grants', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], []);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
+            );
+        });
+
+        it('shows "no access" message when user has only read grants', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [readOnlyGrant]);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/no admin access/i)
+            );
+        });
+    });
+
+    describe('namespace dropdown', () => {
+        it('shows all adminnable namespaces as dropdown options', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(select).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
+        });
+
+        it('only shows namespaces the user can admin in the dropdown', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS)]
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.queryByRole('option', { name: NS_PAYMENTS })).not.toBeInTheDocument();
+        });
+
+        it('shows all namespaces in the dropdown when user is global admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [globalAdminGrant]
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.getByRole('option', { name: NS_FINOS })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: NS_PAYMENTS })).toBeInTheDocument();
+        });
+
+        it('renders the panel for the selected namespace', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS, NS_PAYMENTS],
+                [adminGrant(NS_FINOS), adminGrant(NS_PAYMENTS)]
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select namespace/i });
+            fireEvent.change(select, { target: { value: NS_FINOS } });
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: NS_FINOS })).toBeInTheDocument()
+            );
+            expect(screen.queryByRole('heading', { name: NS_PAYMENTS })).not.toBeInTheDocument();
+        });
+    });
+
+    describe('global admin section', () => {
+        it('shows Domain Access section for global admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant]);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('region', { name: /domain access/i })).toBeInTheDocument()
+            );
+        });
+
+        it('does not show Domain Access section for non-global admins', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [adminGrant(NS_FINOS)]);
+            renderPanel(calmSvc, userAccessSvc);
+            await screen.findByRole('combobox', { name: /select namespace/i });
+            expect(screen.queryByRole('region', { name: /domain access/i })).not.toBeInTheDocument();
+        });
+    });
+
+    describe('domain dropdown', () => {
+        it('shows all domains as dropdown options when global admin', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select domain/i });
+            expect(screen.getByRole('option', { name: 'retail' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'wholesale' })).toBeInTheDocument();
+        });
+
+        it('renders the panel for the selected domain', async () => {
+            const { calmSvc, userAccessSvc } = mockServices(
+                [NS_FINOS], [globalAdminGrant], [], ['retail', 'wholesale']
+            );
+            renderPanel(calmSvc, userAccessSvc);
+            const select = await screen.findByRole('combobox', { name: /select domain/i });
+            fireEvent.change(select, { target: { value: 'retail' } });
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: 'retail' })).toBeInTheDocument()
+            );
+            expect(screen.queryByRole('heading', { name: 'wholesale' })).not.toBeInTheDocument();
+        });
+
+        it('shows "no domains found" when there are no domains', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([NS_FINOS], [globalAdminGrant], [], []);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByText(/no domains found/i)).toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('error states', () => {
+        it('shows an error when namespace fetch fails', async () => {
+            const calmSvc = new CalmService();
+            vi.spyOn(calmSvc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
+            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
+            const userAccessSvc = new UserAccessService();
+            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockResolvedValue([]);
+
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
+            );
+        });
+
+        it('shows an error when user access fetch fails', async () => {
+            const calmSvc = new CalmService();
+            vi.spyOn(calmSvc, 'fetchNamespaces').mockResolvedValue([NS_FINOS]);
+            vi.spyOn(calmSvc, 'fetchDomains').mockResolvedValue([]);
+            const userAccessSvc = new UserAccessService();
+            vi.spyOn(userAccessSvc, 'getCurrentUserAccess').mockRejectedValue(new Error('fail'));
+            vi.spyOn(userAccessSvc, 'getNamespaceUserAccess').mockResolvedValue([]);
+            vi.spyOn(userAccessSvc, 'getDomainUserAccess').mockResolvedValue([]);
+
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load your access/i)
+            );
+        });
+    });
+
+    describe('panel heading', () => {
+        it('renders the Access Management heading', async () => {
+            const { calmSvc, userAccessSvc } = mockServices([], []);
+            renderPanel(calmSvc, userAccessSvc);
+            await waitFor(() =>
+                expect(screen.getByRole('heading', { name: /access management/i })).toBeInTheDocument()
+            );
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -92,6 +92,16 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
                     </section>
 
                     {isGlobalAdmin && (
+                        <section aria-label="Global admin access">
+                            <h2 className="text-lg font-semibold mb-3">Global Admin Access</h2>
+                            <NamespaceAccessPanel
+                                namespace="GLOBAL"
+                                service={userAccessSvc}
+                            />
+                        </section>
+                    )}
+
+                    {isGlobalAdmin && (
                         <section aria-label="Domain access">
                             <h2 className="text-lg font-semibold mb-3">Domain Access</h2>
                             {domains.length === 0 ? (

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -36,13 +36,13 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
 
     useEffect(() => {
         calmSvc.fetchDomains()
-            .then(setDomains)
+            .then((d) => setDomains([...d].sort()))
             .catch(() => setDomainsError('Failed to load domains.'))
             .finally(() => setDomainsLoading(false));
     }, [calmSvc]);
 
     const loading = namespacesLoading || domainsLoading || accessLoading;
-    const adminNamespaces = namespaces.filter(canAdminNamespace);
+    const adminNamespaces = namespaces.filter(canAdminNamespace).sort();
     const error = namespacesError ?? domainsError ?? accessError;
 
     return (

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CalmService } from '../../service/calm-service.js';
+import { UserAccessService } from '../../service/user-access-service.js';
+import { useCurrentUserAccess } from '../hooks/useCurrentUserAccess.js';
+import { NamespaceAccessPanel } from '../components/namespace-access/NamespaceAccessPanel.js';
+import { DomainAccessPanel } from '../components/domain-access/DomainAccessPanel.js';
+
+interface EntitlementsPanelProps {
+    calmService?: CalmService;
+    userAccessService?: UserAccessService;
+}
+
+export function EntitlementsPanel({ calmService, userAccessService }: EntitlementsPanelProps) {
+    const calmSvc = useMemo(() => calmService ?? new CalmService(), [calmService]);
+    const userAccessSvc = useMemo(() => userAccessService ?? new UserAccessService(), [userAccessService]);
+
+    const [namespaces, setNamespaces] = useState<string[]>([]);
+    const [namespacesLoading, setNamespacesLoading] = useState(true);
+    const [namespacesError, setNamespacesError] = useState<string | null>(null);
+    const [selectedNamespace, setSelectedNamespace] = useState<string>('');
+
+    const [domains, setDomains] = useState<string[]>([]);
+    const [domainsLoading, setDomainsLoading] = useState(true);
+    const [domainsError, setDomainsError] = useState<string | null>(null);
+    const [selectedDomain, setSelectedDomain] = useState<string>('');
+
+    const { canAdminNamespace, isGlobalAdmin, loading: accessLoading, error: accessError } =
+        useCurrentUserAccess(userAccessSvc);
+
+    useEffect(() => {
+        calmSvc.fetchNamespaces()
+            .then(setNamespaces)
+            .catch(() => setNamespacesError('Failed to load namespaces.'))
+            .finally(() => setNamespacesLoading(false));
+    }, [calmSvc]);
+
+    useEffect(() => {
+        calmSvc.fetchDomains()
+            .then(setDomains)
+            .catch(() => setDomainsError('Failed to load domains.'))
+            .finally(() => setDomainsLoading(false));
+    }, [calmSvc]);
+
+    const loading = namespacesLoading || domainsLoading || accessLoading;
+    const adminNamespaces = namespaces.filter(canAdminNamespace);
+    const error = namespacesError ?? domainsError ?? accessError;
+
+    return (
+        <div>
+            <h1 className="text-2xl font-bold mb-6">Access Management</h1>
+
+            {loading && (
+                <div className="flex justify-center py-12">
+                    <span className="loading loading-spinner loading-lg" aria-label="Loading" />
+                </div>
+            )}
+
+            {!loading && error && (
+                <div className="alert alert-error mb-4" role="alert">
+                    <span>{error}</span>
+                </div>
+            )}
+
+            {!loading && !error && adminNamespaces.length === 0 && (
+                <div className="alert alert-info" role="status">
+                    <span>You have no admin access to any namespaces.</span>
+                </div>
+            )}
+
+            {!loading && adminNamespaces.length > 0 && (
+                <div className="flex flex-col gap-6">
+                    <section aria-label="Namespace access">
+                        <h2 className="text-lg font-semibold mb-3">Namespace Access</h2>
+                        <select
+                            className="select select-bordered select-sm w-full max-w-xs mb-4"
+                            value={selectedNamespace}
+                            onChange={(e) => setSelectedNamespace(e.target.value)}
+                            aria-label="Select namespace"
+                        >
+                            <option value="">Select a namespace…</option>
+                            {adminNamespaces.map((ns) => (
+                                <option key={ns} value={ns}>{ns}</option>
+                            ))}
+                        </select>
+                        {selectedNamespace && (
+                            <NamespaceAccessPanel
+                                key={selectedNamespace}
+                                namespace={selectedNamespace}
+                                service={userAccessSvc}
+                            />
+                        )}
+                    </section>
+
+                    {isGlobalAdmin && (
+                        <section aria-label="Domain access">
+                            <h2 className="text-lg font-semibold mb-3">Domain Access</h2>
+                            {domains.length === 0 ? (
+                                <p className="text-base-content/50 text-sm italic">No domains found.</p>
+                            ) : (
+                                <>
+                                    <select
+                                        className="select select-bordered select-sm w-full max-w-xs mb-4"
+                                        value={selectedDomain}
+                                        onChange={(e) => setSelectedDomain(e.target.value)}
+                                        aria-label="Select domain"
+                                    >
+                                        <option value="">Select a domain…</option>
+                                        {domains.map((domain) => (
+                                            <option key={domain} value={domain}>{domain}</option>
+                                        ))}
+                                    </select>
+                                    {selectedDomain && (
+                                        <DomainAccessPanel
+                                            key={selectedDomain}
+                                            domain={selectedDomain}
+                                            service={userAccessSvc}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        </section>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { CalmService } from '../../service/calm-service.js';
 import { UserAccessService } from '../../service/user-access-service.js';
 import { useUserAccess } from '../context/UserAccessContext.js';
@@ -14,15 +15,17 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
     const calmSvc = useMemo(() => calmService ?? new CalmService(), [calmService]);
     const userAccessSvc = useMemo(() => userAccessService ?? new UserAccessService(), [userAccessService]);
 
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedNamespace = searchParams.get('namespace') ?? '';
+    const selectedDomain = searchParams.get('domain') ?? '';
+
     const [namespaces, setNamespaces] = useState<string[]>([]);
     const [namespacesLoading, setNamespacesLoading] = useState(true);
     const [namespacesError, setNamespacesError] = useState<string | null>(null);
-    const [selectedNamespace, setSelectedNamespace] = useState<string>('');
 
     const [domains, setDomains] = useState<string[]>([]);
     const [domainsLoading, setDomainsLoading] = useState(true);
     const [domainsError, setDomainsError] = useState<string | null>(null);
-    const [selectedDomain, setSelectedDomain] = useState<string>('');
 
     const { canAdminNamespace, isGlobalAdmin, loading: accessLoading, error: accessError } =
         useUserAccess();
@@ -74,7 +77,12 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
                         <select
                             className="select select-bordered select-sm w-full max-w-xs mb-4"
                             value={selectedNamespace}
-                            onChange={(e) => setSelectedNamespace(e.target.value)}
+                            onChange={(e) => setSearchParams(prev => {
+                                const next = new URLSearchParams(prev);
+                                if (e.target.value) next.set('namespace', e.target.value);
+                                else next.delete('namespace');
+                                return next;
+                            })}
                             aria-label="Select namespace"
                         >
                             <option value="">Select a namespace…</option>
@@ -111,7 +119,12 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
                                     <select
                                         className="select select-bordered select-sm w-full max-w-xs mb-4"
                                         value={selectedDomain}
-                                        onChange={(e) => setSelectedDomain(e.target.value)}
+                                        onChange={(e) => setSearchParams(prev => {
+                                    const next = new URLSearchParams(prev);
+                                    if (e.target.value) next.set('domain', e.target.value);
+                                    else next.delete('domain');
+                                    return next;
+                                })}
                                         aria-label="Select domain"
                                     >
                                         <option value="">Select a domain…</option>

--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
 import { UserAccessService } from '../../service/user-access-service.js';
-import { useCurrentUserAccess } from '../hooks/useCurrentUserAccess.js';
+import { useUserAccess } from '../context/UserAccessContext.js';
 import { NamespaceAccessPanel } from '../components/namespace-access/NamespaceAccessPanel.js';
 import { DomainAccessPanel } from '../components/domain-access/DomainAccessPanel.js';
 
@@ -25,7 +25,7 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
     const [selectedDomain, setSelectedDomain] = useState<string>('');
 
     const { canAdminNamespace, isGlobalAdmin, loading: accessLoading, error: accessError } =
-        useCurrentUserAccess(userAccessSvc);
+        useUserAccess();
 
     useEffect(() => {
         calmSvc.fetchNamespaces()

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NamespacesPanel } from './NamespacesPanel.js';
+import { CalmService } from '../../service/calm-service.js';
+
+function mockService(namespaces: string[], createResult: 'ok' | 'fail' = 'ok') {
+    const svc = new CalmService();
+    vi.spyOn(svc, 'fetchNamespaces').mockResolvedValue(namespaces);
+    vi.spyOn(svc, 'createNamespace').mockImplementation(() =>
+        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('fail'))
+    );
+    return svc;
+}
+
+function renderPanel(svc: CalmService) {
+    return render(<NamespacesPanel calmService={svc} />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NamespacesPanel', () => {
+
+    describe('loading', () => {
+        it('shows a loading spinner while fetching', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByLabelText('Loading namespaces')).toBeInTheDocument();
+        });
+
+        it('hides the spinner after loading', async () => {
+            const svc = mockService(['finos']);
+            renderPanel(svc);
+            await waitFor(() =>
+                expect(screen.queryByLabelText('Loading namespaces')).not.toBeInTheDocument()
+            );
+        });
+    });
+
+    describe('existing namespaces list', () => {
+        it('renders each namespace as a badge', async () => {
+            const svc = mockService(['finos', 'finos.payments']);
+            renderPanel(svc);
+            expect(await screen.findByText('finos')).toBeInTheDocument();
+            expect(await screen.findByText('finos.payments')).toBeInTheDocument();
+        });
+
+        it('shows empty state message when no namespaces exist', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(await screen.findByText(/no namespaces yet/i)).toBeInTheDocument();
+        });
+
+        it('shows a load error when fetch fails', async () => {
+            const svc = new CalmService();
+            vi.spyOn(svc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
+            renderPanel(svc);
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
+            );
+        });
+    });
+
+    describe('create namespace form', () => {
+        it('renders the name and description inputs', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+            expect(screen.getByLabelText('Namespace name')).toBeInTheDocument();
+            expect(screen.getByLabelText('Namespace description')).toBeInTheDocument();
+        });
+
+        it('disables the create button when name is empty', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+            expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
+        });
+
+        it('enables the create button when name is filled', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            expect(screen.getByRole('button', { name: /create/i })).not.toBeDisabled();
+        });
+
+        it('calls createNamespace with trimmed name and description on submit', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: '  my-ns  ' },
+            });
+            fireEvent.change(screen.getByLabelText('Namespace description'), {
+                target: { value: '  My namespace  ' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(svc.createNamespace).toHaveBeenCalledWith('my-ns', 'My namespace')
+            );
+        });
+
+        it('shows success message after creation', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(screen.getByRole('status')).toHaveTextContent(/my-ns.*created/i)
+            );
+        });
+
+        it('clears the form fields after successful creation', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            fireEvent.change(screen.getByLabelText('Namespace description'), {
+                target: { value: 'some description' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() => screen.getByRole('status'));
+            expect(screen.getByLabelText('Namespace name')).toHaveValue('');
+            expect(screen.getByLabelText('Namespace description')).toHaveValue('');
+        });
+
+        it('refreshes the namespace list after successful creation', async () => {
+            const svc = new CalmService();
+            vi.spyOn(svc, 'fetchNamespaces')
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce(['my-ns']);
+            vi.spyOn(svc, 'createNamespace').mockResolvedValue();
+            renderPanel(svc);
+            await screen.findByText(/no namespaces yet/i);
+
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            expect(await screen.findByText('my-ns')).toBeInTheDocument();
+        });
+
+        it('shows error message when creation fails', async () => {
+            const svc = mockService([], 'fail');
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+            await waitFor(() =>
+                expect(screen.getByRole('alert')).toHaveTextContent(/failed to create namespace/i)
+            );
+        });
+    });
+
+    describe('headings', () => {
+        it('renders the Namespaces page heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /namespaces/i, level: 1 })).toBeInTheDocument();
+        });
+
+        it('renders the Create Namespace section heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /create namespace/i })).toBeInTheDocument();
+        });
+
+        it('renders the Existing Namespaces section heading', () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            expect(screen.getByRole('heading', { name: /existing namespaces/i })).toBeInTheDocument();
+        });
+    });
+});

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CalmService } from '../../service/calm-service.js';
+
+interface NamespacesPanelProps {
+    calmService?: CalmService;
+}
+
+export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
+    const svc = useMemo(() => calmService ?? new CalmService(), [calmService]);
+
+    const [namespaces, setNamespaces] = useState<string[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    const load = useCallback(() => {
+        setLoading(true);
+        setLoadError(null);
+        svc.fetchNamespaces()
+            .then(setNamespaces)
+            .catch(() => setLoadError('Failed to load namespaces.'))
+            .finally(() => setLoading(false));
+    }, [svc]);
+
+    useEffect(() => { load(); }, [load]);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setSubmitting(true);
+        setSubmitError(null);
+        setSuccess(null);
+        try {
+            await svc.createNamespace(name.trim(), description.trim());
+            setSuccess(`Namespace '${name.trim()}' created.`);
+            setName('');
+            setDescription('');
+            load();
+        } catch {
+            setSubmitError('Failed to create namespace.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div>
+            <h1 className="text-2xl font-bold mb-6">Namespaces</h1>
+
+            <section aria-label="Create namespace" className="card bg-base-100 shadow mb-8">
+                <div className="card-body">
+                    <h2 className="card-title text-lg">Create Namespace</h2>
+                    <form onSubmit={handleSubmit} className="flex flex-col gap-3 max-w-sm">
+                        <input
+                            className="input input-bordered input-sm"
+                            placeholder="Name (e.g. org.team)"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            required
+                            aria-label="Namespace name"
+                        />
+                        <input
+                            className="input input-bordered input-sm"
+                            placeholder="Description (optional)"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            aria-label="Namespace description"
+                        />
+                        {submitError && <p className="text-error text-sm" role="alert">{submitError}</p>}
+                        {success && <p className="text-success text-sm" role="status">{success}</p>}
+                        <button
+                            className="btn btn-primary btn-sm self-start"
+                            type="submit"
+                            disabled={submitting || !name.trim()}
+                        >
+                            {submitting ? 'Creating…' : 'Create'}
+                        </button>
+                    </form>
+                </div>
+            </section>
+
+            <section aria-label="Existing namespaces">
+                <h2 className="text-lg font-semibold mb-3">Existing Namespaces</h2>
+                {loading && <span className="loading loading-spinner" aria-label="Loading namespaces" />}
+                {!loading && loadError && <p className="text-error text-sm" role="alert">{loadError}</p>}
+                {!loading && !loadError && namespaces.length === 0 && (
+                    <p className="text-base-content/50 text-sm italic">No namespaces yet.</p>
+                )}
+                {!loading && namespaces.length > 0 && (
+                    <ul className="flex flex-wrap gap-2">
+                        {namespaces.map((ns) => (
+                            <li key={ns} className="badge badge-ghost badge-lg">{ns}</li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/components/navbar/Navbar.test.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import { Navbar } from './Navbar.js';
+import { UserAccessContext } from '../../admin/context/UserAccessContext.js';
+import { CurrentUserAccessState } from '../../admin/hooks/useCurrentUserAccess.js';
+
+function makeState(overrides: Partial<CurrentUserAccessState>): CurrentUserAccessState {
+    return {
+        grants: [],
+        loading: false,
+        error: null,
+        isGlobalAdmin: false,
+        canAdminNamespace: () => false,
+        ...overrides,
+    };
+}
+
+function renderNavbar(state: CurrentUserAccessState) {
+    return render(
+        <UserAccessContext.Provider value={state}>
+            <MemoryRouter>
+                <Navbar />
+            </MemoryRouter>
+        </UserAccessContext.Provider>
+    );
+}
+
+describe('Navbar Admin link visibility', () => {
+    it('shows the Admin link for a global admin', () => {
+        renderNavbar(makeState({ isGlobalAdmin: true }));
+        expect(screen.getAllByRole('link', { name: /admin/i }).length).toBeGreaterThan(0);
+    });
+
+    it('shows the Admin link for a namespace-scoped admin', () => {
+        renderNavbar(makeState({
+            grants: [{ userAccessId: 1, username: 'bob', permission: 'admin', namespace: 'finos' }],
+        }));
+        expect(screen.getAllByRole('link', { name: /admin/i }).length).toBeGreaterThan(0);
+    });
+
+    it('hides the Admin link for a read-only user', () => {
+        renderNavbar(makeState({
+            grants: [{ userAccessId: 1, username: 'carol', permission: 'read', namespace: 'finos' }],
+        }));
+        expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
+    });
+
+    it('hides the Admin link while access is loading', () => {
+        renderNavbar(makeState({ loading: true }));
+        expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
+    });
+
+    it('hides the Admin link when user has no grants', () => {
+        renderNavbar(makeState({ grants: [] }));
+        expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
+    });
+
+    it('always shows Hub and Visualizer links', () => {
+        renderNavbar(makeState({}));
+        expect(screen.getAllByRole('link', { name: /hub/i }).length).toBeGreaterThan(0);
+        expect(screen.getAllByRole('link', { name: /visualizer/i }).length).toBeGreaterThan(0);
+    });
+});

--- a/calm-hub-ui/src/components/navbar/Navbar.test.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 import { Navbar } from './Navbar.js';
@@ -26,39 +27,67 @@ function renderNavbar(state: CurrentUserAccessState) {
     );
 }
 
-describe('Navbar Admin link visibility', () => {
-    it('shows the Admin link for a global admin', () => {
-        renderNavbar(makeState({ isGlobalAdmin: true }));
-        expect(screen.getAllByRole('link', { name: /admin/i }).length).toBeGreaterThan(0);
+describe('Navbar menu button', () => {
+    it('always renders the hamburger menu button', () => {
+        renderNavbar(makeState({}));
+        expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
     });
 
-    it('shows the Admin link for a namespace-scoped admin', () => {
+    it('opens the destinations overlay when the menu button is clicked', async () => {
+        renderNavbar(makeState({}));
+        const overlay = screen.getByRole('dialog', { hidden: true });
+        expect(overlay).toHaveAttribute('aria-hidden', 'true');
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+        expect(overlay).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    it('shows Hub and Visualizer links in the open menu', async () => {
+        renderNavbar(makeState({}));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+        expect(screen.getByRole('link', { name: /^hub$/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /^visualizer$/i })).toBeInTheDocument();
+    });
+
+    it('closes the overlay when the hamburger is clicked again', async () => {
+        renderNavbar(makeState({}));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+        await userEvent.click(screen.getByRole('button', { name: /close menu/i }));
+        expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+    });
+});
+
+describe('Navbar Admin link visibility', () => {
+    it('shows the Admin link in the open menu for a global admin', async () => {
+        renderNavbar(makeState({ isGlobalAdmin: true }));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+        expect(screen.getByRole('link', { name: /^admin$/i })).toBeInTheDocument();
+    });
+
+    it('shows the Admin link in the open menu for a namespace-scoped admin', async () => {
         renderNavbar(makeState({
             grants: [{ userAccessId: 1, username: 'bob', permission: 'admin', namespace: 'finos' }],
         }));
-        expect(screen.getAllByRole('link', { name: /admin/i }).length).toBeGreaterThan(0);
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
+        expect(screen.getByRole('link', { name: /^admin$/i })).toBeInTheDocument();
     });
 
-    it('hides the Admin link for a read-only user', () => {
+    it('hides the Admin link in the open menu for a read-only user', async () => {
         renderNavbar(makeState({
             grants: [{ userAccessId: 1, username: 'carol', permission: 'read', namespace: 'finos' }],
         }));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
         expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
     });
 
-    it('hides the Admin link while access is loading', () => {
+    it('hides the Admin link in the open menu while access is loading', async () => {
         renderNavbar(makeState({ loading: true }));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
         expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
     });
 
-    it('hides the Admin link when user has no grants', () => {
+    it('hides the Admin link in the open menu when user has no grants', async () => {
         renderNavbar(makeState({ grants: [] }));
+        await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
         expect(screen.queryByRole('link', { name: /^admin$/i })).not.toBeInTheDocument();
-    });
-
-    it('always shows Hub and Visualizer links', () => {
-        renderNavbar(makeState({}));
-        expect(screen.getAllByRole('link', { name: /hub/i }).length).toBeGreaterThan(0);
-        expect(screen.getAllByRole('link', { name: /visualizer/i }).length).toBeGreaterThan(0);
     });
 });

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -1,36 +1,31 @@
 import './Navbar.css';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { IoMenuOutline } from 'react-icons/io5';
 import { GlobalSearchBar } from './GlobalSearchBar.js';
 import { UserAccessContext } from '../../admin/context/UserAccessContext.js';
 
-interface NavbarProps {
-    /**
-     * When provided, renders an "Explore" button in the navbar that toggles the
-     * navigation/explorer (the desktop sidebar, or the mobile drill-down panel).
-     * Pages without an explorer (e.g. the Visualizer) omit this.
-     */
-    onExploreClick?: () => void;
+function menuNavClass({ isActive }: { isActive: boolean }) {
+    return `w-full flex items-center px-4 py-3 text-left hover:bg-base-200 active:bg-base-200${isActive ? ' bg-base-200 font-semibold' : ''}`;
 }
 
-export function Navbar({ onExploreClick }: NavbarProps) {
+export function Navbar() {
     const { loading, isGlobalAdmin, grants } = useContext(UserAccessContext);
     const showAdminLink = !loading && (isGlobalAdmin || grants.some((g) => g.permission === 'admin'));
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+    const closeMenu = () => setIsMenuOpen(false);
 
     return (
         <div className="navbar relative bg-base-100 border-b-2 border-base-200 text-primary-content gap-1">
             <div className="navbar-start flex items-center gap-1 min-w-0">
-                {onExploreClick && (
-                    <button
-                        className="btn btn-ghost gap-2 text-primary shrink-0"
-                        onClick={onExploreClick}
-                        aria-label="Toggle explorer"
-                    >
-                        <IoMenuOutline className="h-5 w-5" />
-                        <span className="hidden sm:inline">Explore</span>
-                    </button>
-                )}
+                <button
+                    className="btn btn-ghost gap-2 text-primary shrink-0"
+                    onClick={() => setIsMenuOpen((v) => !v)}
+                    aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+                >
+                    <IoMenuOutline className="h-5 w-5" />
+                </button>
             </div>
             <div className="navbar-center absolute left-1/2 -translate-x-1/2">
                 <Link to="/" className="btn btn-ghost min-w-0 px-1" aria-label="CALM Hub home">
@@ -45,26 +40,45 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                 {/* Portal target for page-level actions (e.g. the diagram's
                     view-options menu), always visible across breakpoints. */}
                 <div id="navbar-actions" className="flex items-center" />
-                {/* Admin link visible on mobile only — desktop renders it inside the lg:flex block below. */}
-                {showAdminLink && (
-                    <NavLink className="btn btn-ghost text-primary lg:hidden" to="/admin">
-                        Admin
-                    </NavLink>
-                )}
-                {/* Desktop keeps the Visualizer link and search in the navbar; on
-                    mobile both live inside the explorer panel instead, so they are
-                    hidden here below the lg breakpoint. */}
-                <div className="hidden lg:flex items-center gap-1">
-                    <NavLink className="btn btn-ghost text-primary" to="/visualizer">
-                        Visualizer
-                    </NavLink>
-                    {showAdminLink && (
-                        <NavLink className="btn btn-ghost text-primary" to="/admin">
-                            Admin
-                        </NavLink>
-                    )}
+                <div className="hidden lg:flex items-center">
                     <GlobalSearchBar />
                 </div>
+            </div>
+
+            {/* Backdrop — dims the page behind the drawer; tap to close */}
+            <div
+                className={`fixed inset-x-0 bottom-0 top-16 z-40 bg-black/30 transition-opacity duration-300 ${isMenuOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+                aria-hidden="true"
+                onClick={closeMenu}
+            />
+
+            {/* Destinations drawer — slides in from the left */}
+            <div
+                className={`fixed left-0 bottom-0 top-16 z-40 w-64 bg-base-100 text-base-content flex flex-col shadow-xl transition-transform duration-300 ${isMenuOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
+                role="dialog"
+                aria-modal={isMenuOpen}
+                aria-hidden={!isMenuOpen}
+                inert={!isMenuOpen}
+            >
+                <ul className="flex-1 overflow-auto divide-y divide-base-200">
+                    <li>
+                        <NavLink to="/" className={menuNavClass} onClick={closeMenu} end>
+                            Hub
+                        </NavLink>
+                    </li>
+                    <li>
+                        <NavLink to="/visualizer" className={menuNavClass} onClick={closeMenu}>
+                            Visualizer
+                        </NavLink>
+                    </li>
+                    {showAdminLink && (
+                        <li>
+                            <NavLink to="/admin" className={menuNavClass} onClick={closeMenu}>
+                                Admin
+                            </NavLink>
+                        </li>
+                    )}
+                </ul>
             </div>
         </div>
     );

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -45,6 +45,12 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                 {/* Portal target for page-level actions (e.g. the diagram's
                     view-options menu), always visible across breakpoints. */}
                 <div id="navbar-actions" className="flex items-center" />
+                {/* Admin link visible on mobile only — desktop renders it inside the lg:flex block below. */}
+                {showAdminLink && (
+                    <NavLink className="btn btn-ghost text-primary lg:hidden" to="/admin">
+                        Admin
+                    </NavLink>
+                )}
                 {/* Desktop keeps the Visualizer link and search in the navbar; on
                     mobile both live inside the explorer panel instead, so they are
                     hidden here below the lg breakpoint. */}

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -47,6 +47,9 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                     <NavLink className="btn btn-ghost text-primary" to="/visualizer">
                         Visualizer
                     </NavLink>
+                    <NavLink className="btn btn-ghost text-primary" to="/admin">
+                        Admin
+                    </NavLink>
                     <GlobalSearchBar />
                 </div>
             </div>

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -1,7 +1,9 @@
 import './Navbar.css';
+import { useContext } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { IoMenuOutline } from 'react-icons/io5';
 import { GlobalSearchBar } from './GlobalSearchBar.js';
+import { UserAccessContext } from '../../admin/context/UserAccessContext.js';
 
 interface NavbarProps {
     /**
@@ -13,6 +15,9 @@ interface NavbarProps {
 }
 
 export function Navbar({ onExploreClick }: NavbarProps) {
+    const { loading, isGlobalAdmin, grants } = useContext(UserAccessContext);
+    const showAdminLink = !loading && (isGlobalAdmin || grants.some((g) => g.permission === 'admin'));
+
     return (
         <div className="navbar relative bg-base-100 border-b-2 border-base-200 text-primary-content gap-1">
             <div className="navbar-start flex items-center gap-1 min-w-0">
@@ -47,9 +52,11 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                     <NavLink className="btn btn-ghost text-primary" to="/visualizer">
                         Visualizer
                     </NavLink>
-                    <NavLink className="btn btn-ghost text-primary" to="/admin">
-                        Admin
-                    </NavLink>
+                    {showAdminLink && (
+                        <NavLink className="btn btn-ghost text-primary" to="/admin">
+                            Admin
+                        </NavLink>
+                    )}
                     <GlobalSearchBar />
                 </div>
             </div>

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -335,29 +335,14 @@ describe('Hub', () => {
             })) as unknown as typeof window.matchMedia;
         });
 
-        it('keeps the drill-down menu mounted off-canvas with an Explore button by default', () => {
+        it('opens the drill-down panel immediately on mobile so the explorer is visible on landing', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            // The drill-down menu stays mounted (so deep-link / search loading still
-            // runs) but the full-screen panel is closed (aria-hidden, so excluded from
-            // the dialog role) until the Explore button is pressed. The desktop tree is
-            // not rendered on mobile.
+            // On mobile the explorer opens straight away — the mobile equivalent of
+            // the desktop tree being visible. The desktop tree is not rendered on mobile.
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
-            expect(screen.getByLabelText('Explore')).toBeInTheDocument();
-            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-
-            restore();
-        });
-
-        it('opens the full-screen drill-down panel when the Explore button is clicked', () => {
-            const restore = mockMobileViewport(true);
-            renderWithRouter(<Hub />);
-
-            fireEvent.click(screen.getByLabelText('Explore'));
-            expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
-            // The panel is now exposed (not aria-hidden), so the dialog is present.
             expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             restore();
@@ -367,14 +352,24 @@ describe('Hub', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            fireEvent.click(screen.getByLabelText('Explore'));
-            expect(screen.getByRole('dialog')).toBeInTheDocument();
-
             fireEvent.click(screen.getByText('Mobile Load Test Data'));
             // Panel closes (aria-hidden again) but the menu remains mounted.
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             expect(screen.getByTestId('diagram-section')).toBeInTheDocument();
+
+            restore();
+        });
+
+        it('reopens the drill-down panel when the Explore button is clicked after closing', () => {
+            const restore = mockMobileViewport(true);
+            renderWithRouter(<Hub />);
+
+            fireEvent.click(screen.getByText('Mobile Load Test Data'));
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+            fireEvent.click(screen.getByLabelText('Explore'));
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             restore();
         });

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -144,16 +144,7 @@ vi.mock('./components/interface-detail-section/InterfaceDetailSection', () => ({
 }));
 
 vi.mock('../components/navbar/Navbar', () => ({
-    Navbar: ({ onExploreClick }: { onExploreClick?: () => void }) => (
-        <nav data-testid="navbar">
-            Navbar
-            {onExploreClick && (
-                <button aria-label="Toggle explorer" onClick={onExploreClick}>
-                    Explore
-                </button>
-            )}
-        </nav>
-    ),
+    Navbar: () => <nav data-testid="navbar">Navbar</nav>,
 }));
 
 vi.mock('./components/diagram-section/DiagramSection', () => ({
@@ -327,16 +318,6 @@ describe('Hub', () => {
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
         });
 
-        it('toggles the desktop sidebar from the navbar Explore button', () => {
-            renderWithRouter(<Hub />);
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
-
-            fireEvent.click(screen.getByLabelText('Toggle explorer'));
-            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
-
-            fireEvent.click(screen.getByLabelText('Toggle explorer'));
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
-        });
     });
 
     describe('mobile layout', () => {
@@ -354,27 +335,27 @@ describe('Hub', () => {
             })) as unknown as typeof window.matchMedia;
         });
 
-        it('keeps the drill-down menu mounted off-canvas with a menu button by default', () => {
+        it('keeps the drill-down menu mounted off-canvas with an Explore button by default', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
             // The drill-down menu stays mounted (so deep-link / search loading still
             // runs) but the full-screen panel is closed (aria-hidden, so excluded from
-            // the dialog role) until the menu button is pressed. The desktop tree is
+            // the dialog role) until the Explore button is pressed. The desktop tree is
             // not rendered on mobile.
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
-            expect(screen.getByLabelText('Toggle explorer')).toBeInTheDocument();
+            expect(screen.getByLabelText('Explore')).toBeInTheDocument();
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
             restore();
         });
 
-        it('opens the full-screen drill-down panel when the menu button is clicked', () => {
+        it('opens the full-screen drill-down panel when the Explore button is clicked', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            fireEvent.click(screen.getByLabelText('Toggle explorer'));
+            fireEvent.click(screen.getByLabelText('Explore'));
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             // The panel is now exposed (not aria-hidden), so the dialog is present.
             expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -386,7 +367,7 @@ describe('Hub', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            fireEvent.click(screen.getByLabelText('Toggle explorer'));
+            fireEvent.click(screen.getByLabelText('Explore'));
             expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             fireEvent.click(screen.getByText('Mobile Load Test Data'));

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -100,7 +100,7 @@ export default function Hub() {
     return (
         <div className="flex flex-col h-screen overflow-hidden">
             <Navbar />
-            {isMobile && (
+            {isMobile && !isMobileNavOpen && (
                 <button
                     aria-label="Explore"
                     className="w-full flex items-center gap-2 px-4 py-2 bg-base-200 border-b border-base-300 text-sm text-primary"
@@ -132,13 +132,14 @@ export default function Hub() {
                     </div>
                 )}
 
-                {/* Mobile: full-screen drill-down navigation panel that slides in from
-                    the left. Kept mounted (slid off screen) so deep-link / global-search
-                    loading — which lives inside MobileNavMenu — runs even while the panel
-                    is closed. Dismissed via the panel's own close button. */}
+                {/* Mobile: drill-down navigation panel that slides in from the left,
+                    anchored below the Explore bar. Kept mounted (slid off screen) so
+                    deep-link / global-search loading — which lives inside MobileNavMenu
+                    — runs even while the panel is closed. Dismissed via the panel's own
+                    close button. */}
                 {isMobile && (
                     <div
-                        className={`fixed inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
+                        className={`absolute inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-y-0' : '-translate-y-full pointer-events-none'}`}
                         role="dialog"
                         aria-modal={isMobileNavOpen}
                         aria-hidden={!isMobileNavOpen}

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { IoChevronForwardOutline } from 'react-icons/io5';
+import { IoChevronForwardOutline, IoCompassOutline } from 'react-icons/io5';
 import { TreeNavigation } from './components/tree-navigation/TreeNavigation.js';
 import { MobileNavMenu } from './components/tree-navigation/MobileNavMenu.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
@@ -99,7 +99,17 @@ export default function Hub() {
 
     return (
         <div className="flex flex-col h-screen overflow-hidden">
-            <Navbar onExploreClick={() => (isMobile ? setIsMobileNavOpen(true) : setIsSidebarOpen((v) => !v))} />
+            <Navbar />
+            {isMobile && (
+                <button
+                    aria-label="Explore"
+                    className="w-full flex items-center gap-2 px-4 py-2 bg-base-200 border-b border-base-300 text-sm text-primary"
+                    onClick={() => setIsMobileNavOpen(true)}
+                >
+                    <IoCompassOutline size={16} />
+                    <span>Explore</span>
+                </button>
+            )}
             <div className="relative flex flex-row flex-1 overflow-hidden bg-base-300">
                 {/* Desktop: inline, collapsible tree-navigation column */}
                 {!isMobile && (

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -22,7 +22,7 @@ export default function Hub() {
     const [controlData, setControlData] = useState<ControlData | undefined>();
     const [interfaceData, setInterfaceData] = useState<InterfaceData | undefined>();
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-    const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+    const [isMobileNavOpen, setIsMobileNavOpen] = useState(true);
     const [selectedItem, setSelectedItem] = useState<SelectedItem>(null);
     const isMobile = useIsMobile();
 

--- a/calm-hub-ui/src/model/user-access.ts
+++ b/calm-hub-ui/src/model/user-access.ts
@@ -1,0 +1,16 @@
+export type UserAccessPermission = 'read' | 'write' | 'admin';
+
+export interface UserAccess {
+    userAccessId: number;
+    username: string;
+    permission: UserAccessPermission;
+    namespace?: string;
+    domain?: string;
+    creationDateTime?: string;
+    updateDateTime?: string;
+}
+
+export interface UserAccessRequest {
+    username: string;
+    permission: UserAccessPermission;
+}

--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -55,6 +55,30 @@ export class CalmService {
             });
     }
 
+    public async createNamespace(name: string, description: string): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .post('/api/calm/namespaces', { name, description }, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = `Error creating namespace ${name}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async createDomain(name: string): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .post('/api/calm/domains', { name }, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = `Error creating domain ${name}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
     public async fetchPatternSummaries(namespace: string): Promise<ResourceSummary[]> {
         const headers = await getAuthHeaders();
         return this.ax

--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -41,6 +41,20 @@ export class CalmService {
             });
     }
 
+    public async fetchDomains(): Promise<string[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get('/api/calm/domains', { headers })
+            .then((res) => {
+                return Array.isArray(res.data?.values) ? res.data.values : [];
+            })
+            .catch((error) => {
+                const errorMessage = 'Error fetching domains:';
+                console.error(errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
     public async fetchPatternSummaries(namespace: string): Promise<ResourceSummary[]> {
         const headers = await getAuthHeaders();
         return this.ax

--- a/calm-hub-ui/src/service/user-access-service.test.ts
+++ b/calm-hub-ui/src/service/user-access-service.test.ts
@@ -90,18 +90,16 @@ describe('UserAccessService', () => {
     describe('grantNamespaceAccess', () => {
         const request: UserAccessRequest = { username: 'alice', permission: 'read' };
 
-        it('posts to the correct endpoint and returns the created grant', async () => {
-            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`).reply(201, grant1);
+        it('posts to the correct endpoint and resolves void on success', async () => {
+            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`).reply(201);
 
-            const result = await service.grantNamespaceAccess(namespace, request);
-            expect(result).toEqual(grant1);
+            await expect(service.grantNamespaceAccess(namespace, request)).resolves.toBeUndefined();
         });
 
         it('sends the request body', async () => {
-            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`, request).reply(201, grant1);
+            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`, request).reply(201);
 
-            const result = await service.grantNamespaceAccess(namespace, request);
-            expect(result).toEqual(grant1);
+            await expect(service.grantNamespaceAccess(namespace, request)).resolves.toBeUndefined();
         });
 
         it('rejects on server error', async () => {
@@ -159,11 +157,10 @@ describe('UserAccessService', () => {
     describe('grantDomainAccess', () => {
         const request: UserAccessRequest = { username: 'carol', permission: 'admin' };
 
-        it('posts to the correct endpoint and returns the created grant', async () => {
-            mock.onPost(`/api/calm/domains/${domain}/user-access`).reply(201, domainGrant);
+        it('posts to the correct endpoint and resolves void on success', async () => {
+            mock.onPost(`/api/calm/domains/${domain}/user-access`).reply(201);
 
-            const result = await service.grantDomainAccess(domain, request);
-            expect(result).toEqual(domainGrant);
+            await expect(service.grantDomainAccess(domain, request)).resolves.toBeUndefined();
         });
 
         it('rejects on server error', async () => {

--- a/calm-hub-ui/src/service/user-access-service.test.ts
+++ b/calm-hub-ui/src/service/user-access-service.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import AxiosMockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import { UserAccessService } from './user-access-service.js';
+import { UserAccess, UserAccessRequest } from '../model/user-access.js';
+
+const ax = axios.create();
+const mock = new AxiosMockAdapter(ax as never);
+const service = new UserAccessService(ax);
+
+const namespace = 'finos';
+const domain = 'payments';
+
+const grant1: UserAccess = { userAccessId: 1, username: 'alice', permission: 'read', namespace };
+const grant2: UserAccess = { userAccessId: 2, username: 'bob', permission: 'write', namespace };
+const wildcardGrant: UserAccess = { userAccessId: 3, username: '*', permission: 'read', namespace };
+const domainGrant: UserAccess = { userAccessId: 10, username: 'carol', permission: 'admin', domain };
+
+afterEach(() => mock.reset());
+
+describe('UserAccessService', () => {
+
+    // ──────────────────────────────────────────────────
+    // getCurrentUserAccess
+    // ──────────────────────────────────────────────────
+    describe('getCurrentUserAccess', () => {
+        it('returns grants from the current user endpoint', async () => {
+            mock.onGet('/api/calm/user-access/current').reply(200, [grant1, wildcardGrant]);
+
+            const result = await service.getCurrentUserAccess();
+            expect(result).toEqual([grant1, wildcardGrant]);
+        });
+
+        it('returns empty array when response is empty', async () => {
+            mock.onGet('/api/calm/user-access/current').reply(200, []);
+
+            const result = await service.getCurrentUserAccess();
+            expect(result).toEqual([]);
+        });
+
+        it('returns empty array when response is not an array', async () => {
+            mock.onGet('/api/calm/user-access/current').reply(200, null);
+
+            const result = await service.getCurrentUserAccess();
+            expect(result).toEqual([]);
+        });
+
+        it('includes wildcard grants in the result', async () => {
+            mock.onGet('/api/calm/user-access/current').reply(200, [grant1, wildcardGrant]);
+
+            const result = await service.getCurrentUserAccess();
+            expect(result.some((g) => g.username === '*')).toBe(true);
+        });
+
+        it('rejects on server error', async () => {
+            mock.onGet('/api/calm/user-access/current').reply(500);
+
+            await expect(service.getCurrentUserAccess()).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // getNamespaceUserAccess
+    // ──────────────────────────────────────────────────
+    describe('getNamespaceUserAccess', () => {
+        it('returns grants for the given namespace', async () => {
+            mock.onGet(`/api/calm/namespaces/${namespace}/user-access`).reply(200, [grant1, grant2]);
+
+            const result = await service.getNamespaceUserAccess(namespace);
+            expect(result).toEqual([grant1, grant2]);
+        });
+
+        it('returns empty array when no grants exist', async () => {
+            mock.onGet(`/api/calm/namespaces/${namespace}/user-access`).reply(200, []);
+
+            const result = await service.getNamespaceUserAccess(namespace);
+            expect(result).toEqual([]);
+        });
+
+        it('rejects on server error', async () => {
+            mock.onGet(`/api/calm/namespaces/${namespace}/user-access`).reply(500);
+
+            await expect(service.getNamespaceUserAccess(namespace)).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // grantNamespaceAccess
+    // ──────────────────────────────────────────────────
+    describe('grantNamespaceAccess', () => {
+        const request: UserAccessRequest = { username: 'alice', permission: 'read' };
+
+        it('posts to the correct endpoint and returns the created grant', async () => {
+            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`).reply(201, grant1);
+
+            const result = await service.grantNamespaceAccess(namespace, request);
+            expect(result).toEqual(grant1);
+        });
+
+        it('sends the request body', async () => {
+            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`, request).reply(201, grant1);
+
+            const result = await service.grantNamespaceAccess(namespace, request);
+            expect(result).toEqual(grant1);
+        });
+
+        it('rejects on server error', async () => {
+            mock.onPost(`/api/calm/namespaces/${namespace}/user-access`).reply(400);
+
+            await expect(service.grantNamespaceAccess(namespace, request)).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // revokeNamespaceAccess
+    // ──────────────────────────────────────────────────
+    describe('revokeNamespaceAccess', () => {
+        it('sends DELETE to the correct endpoint', async () => {
+            mock.onDelete(`/api/calm/namespaces/${namespace}/user-access/1`).reply(204);
+
+            await expect(service.revokeNamespaceAccess(namespace, 1)).resolves.toBeUndefined();
+        });
+
+        it('rejects when the grant is not found', async () => {
+            mock.onDelete(`/api/calm/namespaces/${namespace}/user-access/999`).reply(404);
+
+            await expect(service.revokeNamespaceAccess(namespace, 999)).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // getDomainUserAccess
+    // ──────────────────────────────────────────────────
+    describe('getDomainUserAccess', () => {
+        it('returns grants for the given domain', async () => {
+            mock.onGet(`/api/calm/domains/${domain}/user-access`).reply(200, [domainGrant]);
+
+            const result = await service.getDomainUserAccess(domain);
+            expect(result).toEqual([domainGrant]);
+        });
+
+        it('returns empty array when response body is not an array', async () => {
+            mock.onGet(`/api/calm/domains/${domain}/user-access`).reply(200, null);
+
+            const result = await service.getDomainUserAccess(domain);
+            expect(result).toEqual([]);
+        });
+
+        it('rejects on server error', async () => {
+            mock.onGet(`/api/calm/domains/${domain}/user-access`).reply(500);
+
+            await expect(service.getDomainUserAccess(domain)).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // grantDomainAccess
+    // ──────────────────────────────────────────────────
+    describe('grantDomainAccess', () => {
+        const request: UserAccessRequest = { username: 'carol', permission: 'admin' };
+
+        it('posts to the correct endpoint and returns the created grant', async () => {
+            mock.onPost(`/api/calm/domains/${domain}/user-access`).reply(201, domainGrant);
+
+            const result = await service.grantDomainAccess(domain, request);
+            expect(result).toEqual(domainGrant);
+        });
+
+        it('rejects on server error', async () => {
+            mock.onPost(`/api/calm/domains/${domain}/user-access`).reply(400);
+
+            await expect(service.grantDomainAccess(domain, request)).rejects.toThrow();
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // revokeDomainAccess
+    // ──────────────────────────────────────────────────
+    describe('revokeDomainAccess', () => {
+        it('sends DELETE to the correct endpoint', async () => {
+            mock.onDelete(`/api/calm/domains/${domain}/user-access/10`).reply(204);
+
+            await expect(service.revokeDomainAccess(domain, 10)).resolves.toBeUndefined();
+        });
+
+        it('rejects when the grant is not found', async () => {
+            mock.onDelete(`/api/calm/domains/${domain}/user-access/999`).reply(404);
+
+            await expect(service.revokeDomainAccess(domain, 999)).rejects.toThrow();
+        });
+    });
+});

--- a/calm-hub-ui/src/service/user-access-service.ts
+++ b/calm-hub-ui/src/service/user-access-service.ts
@@ -34,11 +34,11 @@ export class UserAccessService {
             });
     }
 
-    public async grantNamespaceAccess(namespace: string, request: UserAccessRequest): Promise<UserAccess> {
+    public async grantNamespaceAccess(namespace: string, request: UserAccessRequest): Promise<void> {
         const headers = await getAuthHeaders();
         return this.ax
             .post(`/api/calm/namespaces/${encodeURIComponent(namespace)}/user-access`, request, { headers })
-            .then((res) => res.data)
+            .then(() => undefined)
             .catch((error) => {
                 const errorMessage = `Error granting access on namespace ${namespace}:`;
                 console.error('%s', errorMessage, error);
@@ -70,11 +70,11 @@ export class UserAccessService {
             });
     }
 
-    public async grantDomainAccess(domain: string, request: UserAccessRequest): Promise<UserAccess> {
+    public async grantDomainAccess(domain: string, request: UserAccessRequest): Promise<void> {
         const headers = await getAuthHeaders();
         return this.ax
             .post(`/api/calm/domains/${encodeURIComponent(domain)}/user-access`, request, { headers })
-            .then((res) => res.data)
+            .then(() => undefined)
             .catch((error) => {
                 const errorMessage = `Error granting access on domain ${domain}:`;
                 console.error('%s', errorMessage, error);

--- a/calm-hub-ui/src/service/user-access-service.ts
+++ b/calm-hub-ui/src/service/user-access-service.ts
@@ -1,0 +1,96 @@
+import { AxiosInstance } from 'axios';
+import { getAuthHeaders } from '../authService.js';
+import { UserAccess, UserAccessRequest } from '../model/user-access.js';
+import { apiClient } from './utils/api-client.js';
+
+export class UserAccessService {
+    private readonly ax: AxiosInstance;
+
+    constructor(axiosInstance?: AxiosInstance) {
+        this.ax = axiosInstance ?? apiClient;
+    }
+
+    public async getCurrentUserAccess(): Promise<UserAccess[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get('/api/calm/user-access/current', { headers })
+            .then((res) => (Array.isArray(res.data) ? res.data : []))
+            .catch((error) => {
+                const errorMessage = 'Error fetching current user access:';
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async getNamespaceUserAccess(namespace: string): Promise<UserAccess[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get(`/api/calm/namespaces/${encodeURIComponent(namespace)}/user-access`, { headers })
+            .then((res) => (Array.isArray(res.data) ? res.data : []))
+            .catch((error) => {
+                const errorMessage = `Error fetching user access for namespace ${namespace}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async grantNamespaceAccess(namespace: string, request: UserAccessRequest): Promise<UserAccess> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .post(`/api/calm/namespaces/${encodeURIComponent(namespace)}/user-access`, request, { headers })
+            .then((res) => res.data)
+            .catch((error) => {
+                const errorMessage = `Error granting access on namespace ${namespace}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async revokeNamespaceAccess(namespace: string, userAccessId: number): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .delete(`/api/calm/namespaces/${encodeURIComponent(namespace)}/user-access/${userAccessId}`, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = `Error revoking access ${userAccessId} on namespace ${namespace}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async getDomainUserAccess(domain: string): Promise<UserAccess[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get(`/api/calm/domains/${encodeURIComponent(domain)}/user-access`, { headers })
+            .then((res) => (Array.isArray(res.data) ? res.data : []))
+            .catch((error) => {
+                const errorMessage = `Error fetching user access for domain ${domain}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async grantDomainAccess(domain: string, request: UserAccessRequest): Promise<UserAccess> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .post(`/api/calm/domains/${encodeURIComponent(domain)}/user-access`, request, { headers })
+            .then((res) => res.data)
+            .catch((error) => {
+                const errorMessage = `Error granting access on domain ${domain}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async revokeDomainAccess(domain: string, userAccessId: number): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .delete(`/api/calm/domains/${encodeURIComponent(domain)}/user-access/${userAccessId}`, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = `Error revoking access ${userAccessId} on domain ${domain}:`;
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+}

--- a/calm-hub/PERMISSIONS.md
+++ b/calm-hub/PERMISSIONS.md
@@ -88,8 +88,8 @@ All grants apply equally to named users and the `*` wildcard (any user).
 | `read` | Domain `D` | Read content in `D` | Flat — no hierarchy | — |
 | `write` | Namespace `N` | Read + write content in `N` and descendants | **OR any ancestor** — one ancestor grant covers all descendants | — |
 | `write` | Domain `D` | Read + write content in `D` | Flat — no hierarchy | — |
-| `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** | `NamespaceResource.createNamespace` requires `GLOBAL_ADMIN` — child namespace creation not yet enforced |
-| `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy | `DomainUserAccessResource` requires `GLOBAL_ADMIN` — domain entitlement management not yet enforced |
+| `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** | — |
+| `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy | — |
 | `admin` | `GLOBAL` | Create/delete any namespace or domain; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` | Only `admin` is valid on `GLOBAL`; `read`/`write` grants are rejected with 400 |
 
 ---

--- a/calm-hub/PERMISSIONS.md
+++ b/calm-hub/PERMISSIONS.md
@@ -78,23 +78,39 @@ canWrite(username, namespace):
 
 ---
 
+## Permission reference
+
+All grants apply equally to named users and the `*` wildcard (any user).
+
+| Permission | Scope | Capabilities | Evaluation rule | Implementation gaps |
+|------------|-------|--------------|-----------------|---------------------|
+| `read` | Namespace `N` | Read content in `N` | **AND all ancestors** — every ancestor level must have a matching grant | — |
+| `read` | Domain `D` | Read content in `D` | Flat — no hierarchy | — |
+| `write` | Namespace `N` | Read + write content in `N` and descendants | **OR any ancestor** — one ancestor grant covers all descendants | — |
+| `write` | Domain `D` | Read + write content in `D` | Flat — no hierarchy | — |
+| `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** | `NamespaceResource.createNamespace` requires `GLOBAL_ADMIN` — child namespace creation not yet enforced |
+| `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy | `DomainUserAccessResource` requires `GLOBAL_ADMIN` — domain entitlement management not yet enforced |
+| `admin` | `GLOBAL` | Create/delete any namespace or domain; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` | Only `admin` is valid on `GLOBAL`; `read`/`write` grants are rejected with 400 |
+
+---
+
 ## Special bypasses
 
 ### `allow-public-read` config flag
 
 `calm.auth.allow-public-read=true` is a global bypass in `CalmHubPermissionChecker.canRead`. It short-circuits all namespace checks. Intended for fully-open deployments; default is `false`.
 
-### GLOBAL admin
+### GLOBAL admin bootstrap
 
-A user with `admin` on `GLOBAL` bypasses all namespace-level permission checks via `hasGlobalAdmin`. Domain access is also granted. `GLOBAL` is not part of the namespace hierarchy.
+`GLOBAL` is a sentinel value — not a real namespace in the store. To bootstrap a new deployment, create the first `GLOBAL admin` grant directly via the API in `no-auth` mode (or via Swagger UI), then switch to a secured auth profile.
 
 ---
 
-## Default-open namespace behaviour
+## Default-open behaviour
 
-When a namespace is created via `NamespaceService`, a `UserAccess("*", read, namespace)` record is inserted automatically. This keeps the hub open by default.
+When a namespace is created via `NamespaceService`, a `UserAccess("*", read, namespace)` record is inserted automatically. When a domain is created, a `UserAccess("*", read, domain)` record is inserted in the same way. This keeps both namespaces and domains open by default.
 
-To restrict a namespace: delete the `* read` record. The AND rule for child namespaces means restriction cascades automatically.
+To restrict a namespace: delete the `* read` record. The AND rule for child namespaces means restriction cascades automatically. To restrict a domain: delete the `* read` record for that domain.
 
 ---
 

--- a/calm-hub/PERMISSIONS.md
+++ b/calm-hub/PERMISSIONS.md
@@ -80,17 +80,17 @@ canWrite(username, namespace):
 
 ## Permission reference
 
-All grants apply equally to named users and the `*` wildcard (any user).
+`read` and `write` grants may use either a named username or the `*` wildcard. **`admin` grants must always use a named username** — attempts to create a wildcard admin grant on any namespace, domain, or GLOBAL are rejected with `400 Bad Request`. The permission checker additionally ignores any wildcard admin grant that exists in the store (e.g. from hand-edited data), so `*` can never confer administrative access at runtime.
 
-| Permission | Scope | Capabilities | Evaluation rule | Implementation gaps |
-|------------|-------|--------------|-----------------|---------------------|
-| `read` | Namespace `N` | Read content in `N` | **AND all ancestors** — every ancestor level must have a matching grant | — |
-| `read` | Domain `D` | Read content in `D` | Flat — no hierarchy | — |
-| `write` | Namespace `N` | Read + write content in `N` and descendants | **OR any ancestor** — one ancestor grant covers all descendants | — |
-| `write` | Domain `D` | Read + write content in `D` | Flat — no hierarchy | — |
-| `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** | — |
-| `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy | — |
-| `admin` | `GLOBAL` | Create/delete any namespace or domain; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` | Only `admin` is valid on `GLOBAL`; `read`/`write` grants are rejected with 400 |
+| Permission | Scope | Capabilities | Evaluation rule |
+|------------|-------|--------------|-----------------|
+| `read` | Namespace `N` | Read content in `N` | **AND all ancestors** — every ancestor level must have a matching grant |
+| `read` | Domain `D` | Read content in `D` | Flat — no hierarchy |
+| `write` | Namespace `N` | Read + write content in `N` and descendants | **OR any ancestor** — one ancestor grant covers all descendants |
+| `write` | Domain `D` | Read + write content in `D` | Flat — no hierarchy |
+| `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** |
+| `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy |
+| `admin` | `GLOBAL` | Create/delete any namespace or domain; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` — only `admin` is valid; `read`/`write` grants on `GLOBAL` are rejected with 400 |
 
 ---
 

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceParentNotFoundException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceParentNotFoundException.java
@@ -1,0 +1,7 @@
+package org.finos.calm.domain.exception;
+
+public class NamespaceParentNotFoundException extends RuntimeException {
+    public NamespaceParentNotFoundException(String parentNamespace) {
+        super("Parent namespace does not exist: " + parentNamespace);
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/CurrentUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CurrentUserAccessResource.java
@@ -9,12 +9,15 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.store.UserAccessStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.finos.calm.security.CalmHubPermissionChecker.GLOBAL_ACCESS;
 
 @Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
 @Path("/api/calm/user-access")
@@ -25,6 +28,10 @@ public class CurrentUserAccessResource {
 
     @Inject
     SecurityIdentity identity;
+
+    @Inject
+    @ConfigProperty(name = "calm.auth.enabled", defaultValue = "false")
+    boolean authEnabled;
 
     public CurrentUserAccessResource(UserAccessStore store) {
         this.store = store;
@@ -40,6 +47,15 @@ public class CurrentUserAccessResource {
     )
     public Response getCurrentUserAccess() {
         String username = identity.getPrincipal().getName();
+        if (!authEnabled) {
+            logger.debug("Auth disabled — returning synthetic GLOBAL admin grant for user [{}]", username);
+            UserAccess syntheticGrant = new UserAccess.UserAccessBuilder()
+                    .setUsername(username)
+                    .setPermission(UserAccess.Permission.admin)
+                    .setNamespace(GLOBAL_ACCESS)
+                    .build();
+            return Response.ok(List.of(syntheticGrant)).build();
+        }
         logger.debug("Fetching grants for user [{}]", username);
         List<UserAccess> grants = store.getGrantsForUser(username);
         return Response.ok(grants).build();

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
@@ -15,7 +15,7 @@ import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
 import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.security.CalmHubScopes;
-import org.finos.calm.store.DomainStore;
+import org.finos.calm.services.DomainService;
 
 import java.net.URI;
 
@@ -26,23 +26,13 @@ import java.net.URI;
 @Path("/api/calm/domains")
 public class DomainResource {
 
-    private final DomainStore store;
+    private final DomainService service;
 
-    /**
-     * Constructor for DomainSchemaResource.
-     *
-     * @param store the DomainStore instance
-     */
     @Inject
-    public DomainResource(DomainStore store) {
-        this.store = store;
+    public DomainResource(DomainService service) {
+        this.service = service;
     }
 
-    /**
-     * Retrieves the list of domains.
-     *
-     * @return a Response containing the list of domains
-     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
@@ -51,14 +41,9 @@ public class DomainResource {
     )
     @Authenticated
     public Response getDomains() {
-        return Response.ok(new ValueWrapper<>(store.getDomains())).build();
+        return Response.ok(new ValueWrapper<>(service.getDomains())).build();
     }
 
-    /**
-     * Creates a new domain if it does not already exist and is of the correct structure
-     * @param domain the domain to create
-     * @return a Response indicating the result of the operation
-     */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
@@ -77,7 +62,7 @@ public class DomainResource {
         }
 
         try {
-            store.createDomain(domainName);
+            service.createDomain(domainName);
         } catch (DomainAlreadyExistsException e) {
             return Response.status(Response.Status.CONFLICT).entity("{\"error\":\"Domain already exists\"}").build();
         }

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
@@ -47,7 +47,7 @@ public class DomainUserAccessResource {
             summary = "Create user access for domain",
             description = "Creates a user-access grant for a given domain"
     )
-    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    @PermissionsAllowed(CalmHubScopes.DOMAIN_ADMIN)
     public Response createUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
                                               @Valid @NotNull UserAccessRequest request) {
 
@@ -77,7 +77,7 @@ public class DomainUserAccessResource {
             summary = "Get user-access for a given domain",
             description = "Get user-access details for a given domain"
     )
-    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    @PermissionsAllowed(CalmHubScopes.DOMAIN_ADMIN)
     public Response getUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain) {
         if (!domainStore.domainExists(domain)) {
             return invalidDomainResponse(domain);
@@ -92,7 +92,7 @@ public class DomainUserAccessResource {
             summary = "Get the user-access record for a given domain and Id",
             description = "Get user-access details for a given domain and Id"
     )
-    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    @PermissionsAllowed(CalmHubScopes.DOMAIN_ADMIN)
     public Response getUserAccessForDomainAndId(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
                                                 @PathParam("userAccessId") @NotNull Integer userAccessId) {
         if (!domainStore.domainExists(domain)) {
@@ -113,7 +113,7 @@ public class DomainUserAccessResource {
             summary = "Revoke a domain user-access grant",
             description = "Deletes the user-access record for the given domain and id"
     )
-    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    @PermissionsAllowed(CalmHubScopes.DOMAIN_ADMIN)
     public Response deleteUserAccessForDomain(@PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain,
                                               @PathParam("userAccessId") @NotNull Integer userAccessId) {
         if (!domainStore.domainExists(domain)) {

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
@@ -54,6 +54,11 @@ public class DomainUserAccessResource {
         if (!domainStore.domainExists(domain)) {
             return invalidDomainResponse(domain);
         }
+        if ("*".equals(request.getUsername()) && request.getPermission() == UserAccess.Permission.admin) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Wildcard username is not permitted for admin permission on a domain")
+                    .build();
+        }
         UserAccess userAccess = new UserAccess.UserAccessBuilder()
                 .setDomain(domain)
                 .setUsername(request.getUsername())

--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -1,8 +1,8 @@
 package org.finos.calm.resources;
 
 import io.quarkus.security.Authenticated;
-import io.quarkus.security.PermissionsAllowed;
 import jakarta.inject.Inject;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
@@ -15,7 +15,6 @@ import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.security.CalmHubPermissionChecker;
-import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.NamespaceService;
 
 import java.net.URI;
@@ -26,6 +25,12 @@ import java.net.URISyntaxException;
 public class NamespaceResource {
 
     private final NamespaceService namespaceService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    CalmHubPermissionChecker permissionChecker;
 
     @Inject
     public NamespaceResource(NamespaceService namespaceService) {
@@ -49,7 +54,7 @@ public class NamespaceResource {
             summary = "Create Namespace",
             description = "Create a new namespace in the Calm Hub"
     )
-    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    @Authenticated
     public Response createNamespace(@Valid @NotNull(message = "Request must not be null") NamespaceRequest request) throws URISyntaxException {
 
         String name = request.getName().trim();
@@ -58,6 +63,17 @@ public class NamespaceResource {
         if (CalmHubPermissionChecker.GLOBAL_ACCESS.equalsIgnoreCase(name)) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("{\"error\":\"'GLOBAL' is a reserved namespace name\"}")
+                    .build();
+        }
+
+        boolean isGlobalAdmin = permissionChecker.hasGlobalAdmin(identity);
+        boolean isChildNamespace = name.contains(".");
+        boolean isParentAdmin = isChildNamespace
+                && permissionChecker.allowNamespaceAdmin(identity, name.substring(0, name.lastIndexOf('.')));
+
+        if (!isGlobalAdmin && !isParentAdmin) {
+            return Response.status(Response.Status.FORBIDDEN)
+                    .entity("{\"error\":\"Insufficient permissions to create namespace\"}")
                     .build();
         }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.NamespaceRequest;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.services.NamespaceService;
@@ -79,6 +80,10 @@ public class NamespaceResource {
 
         try {
             namespaceService.createNamespace(name, description);
+        } catch (NamespaceParentNotFoundException e) {
+            return Response.status(422)
+                    .entity("{\"error\":\"" + e.getMessage() + "\"}")
+                    .build();
         } catch (NamespaceAlreadyExistsException e) {
             return Response.status(Response.Status.CONFLICT)
                     .entity("{\"error\":\"Namespace already exists\"}")

--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -55,6 +55,8 @@ public class NamespaceResource {
             summary = "Create Namespace",
             description = "Create a new namespace in the Calm Hub"
     )
+    // @Authenticated + manual check rather than @PermissionsAllowed because the namespace name
+    // is in the request body (not a path param), so Quarkus Security cannot bind it declaratively.
     @Authenticated
     public Response createNamespace(@Valid @NotNull(message = "Request must not be null") NamespaceRequest request) throws URISyntaxException {
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -50,10 +50,17 @@ public class UserAccessResource {
     public Response createUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
                                                  @Valid @NotNull UserAccessRequest request) {
 
-        if (GLOBAL_ACCESS.equals(namespace) && request.getPermission() != UserAccess.Permission.admin) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Only 'admin' permission is valid for the GLOBAL namespace")
-                    .build();
+        if (GLOBAL_ACCESS.equals(namespace)) {
+            if ("*".equals(request.getUsername())) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("Wildcard username is not permitted for the GLOBAL namespace")
+                        .build();
+            }
+            if (request.getPermission() != UserAccess.Permission.admin) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("Only 'admin' permission is valid for the GLOBAL namespace")
+                        .build();
+            }
         }
 
         UserAccess userAccess = new UserAccess.UserAccessBuilder()

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
 import static org.finos.calm.resources.ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
+import static org.finos.calm.security.CalmHubPermissionChecker.GLOBAL_ACCESS;
 
 @Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
 @Path("/api/calm/namespaces")
@@ -48,6 +49,12 @@ public class UserAccessResource {
     @PermissionsAllowed(CalmHubScopes.ADMIN)
     public Response createUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
                                                  @Valid @NotNull UserAccessRequest request) {
+
+        if (GLOBAL_ACCESS.equals(namespace) && request.getPermission() != UserAccess.Permission.admin) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Only 'admin' permission is valid for the GLOBAL namespace")
+                    .build();
+        }
 
         UserAccess userAccess = new UserAccess.UserAccessBuilder()
                 .setNamespace(namespace)

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -50,12 +50,13 @@ public class UserAccessResource {
     public Response createUserAccessForNamespace(@PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
                                                  @Valid @NotNull UserAccessRequest request) {
 
+        if ("*".equals(request.getUsername()) && request.getPermission() == UserAccess.Permission.admin) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Wildcard username is not permitted for admin permission")
+                    .build();
+        }
+
         if (GLOBAL_ACCESS.equals(namespace)) {
-            if ("*".equals(request.getUsername())) {
-                return Response.status(Response.Status.BAD_REQUEST)
-                        .entity("Wildcard username is not permitted for the GLOBAL namespace")
-                        .build();
-            }
             if (request.getPermission() != UserAccess.Permission.admin) {
                 return Response.status(Response.Status.BAD_REQUEST)
                         .entity("Only 'admin' permission is valid for the GLOBAL namespace")

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
@@ -127,7 +127,7 @@ public class CalmHubPermissionChecker {
 
         List<UserAccess> grants = userAccessStore.getGrantsForUser(username);
 
-        if (action == UserAction.ADMIN && isGlobalAdminFromGrants(username, grants)) {
+        if (isGlobalAdminFromGrants(username, grants)) {
             logger.debug("User [{}] AUTHORIZED for [{}] in namespace [{}] via GLOBAL admin grant", username, action, namespace);
             return true;
         }

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
@@ -177,7 +177,9 @@ public class CalmHubPermissionChecker {
         }
 
         boolean result = grants.stream().anyMatch(g ->
-                domain.equals(g.getDomain()) && permissionSufficient(g, action));
+                domain.equals(g.getDomain())
+                        && permissionSufficient(g, action)
+                        && !(action == UserAction.ADMIN && "*".equals(g.getUsername())));
 
         if (result) {
             logger.debug("User [{}] AUTHORIZED for [{}] in domain [{}]", username, action, domain);

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
@@ -7,7 +7,6 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.UserAction;
-import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.store.UserAccessStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,23 +100,14 @@ public class CalmHubPermissionChecker {
         }
         String username = identity.getPrincipal().getName();
         logger.debug("Checking global admin access for user [{}]", username);
-        try {
-            boolean granted =
-                    userAccessStore.getUserAccessForUsername(username)
-                            .stream()
-                            .anyMatch(grant -> GLOBAL_ACCESS.equals(grant.getNamespace())
-                                    && permissionSufficient(grant, UserAction.ADMIN));
-
-            if (granted) {
-                logger.debug("User [{}] AUTHORIZED for GLOBAL admin privileges", username);
-            } else {
-                logger.debug("User [{}] DENIED for GLOBAL admin privileges", username);
-            }
-            return granted;
-        } catch (UserAccessNotFoundException e) {
-            logger.debug("No access grants found for user [{}]", username);
-            return false;
+        List<UserAccess> grants = userAccessStore.getGrantsForUser(username);
+        boolean granted = isGlobalAdminFromGrants(username, grants);
+        if (granted) {
+            logger.debug("User [{}] AUTHORIZED for GLOBAL admin privileges", username);
+        } else {
+            logger.debug("User [{}] DENIED for GLOBAL admin privileges", username);
         }
+        return granted;
     }
 
     private boolean hasNamespaceAccess(SecurityIdentity identity, String namespace, UserAction action) {

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubPermissionChecker.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 
 @ApplicationScoped
@@ -85,6 +84,12 @@ public class CalmHubPermissionChecker {
     public boolean canWriteByDomain(SecurityIdentity identity, String domain) {
         return isAuthDisabled()
                 || hasDomainAccess(identity, domain, UserAction.WRITE);
+    }
+
+    @PermissionChecker(CalmHubScopes.DOMAIN_ADMIN)
+    public boolean allowDomainAdmin(SecurityIdentity identity, String domain) {
+        return isAuthDisabled()
+                || hasDomainAccess(identity, domain, UserAction.ADMIN);
     }
 
     @PermissionChecker(CalmHubScopes.GLOBAL_ADMIN)
@@ -170,28 +175,26 @@ public class CalmHubPermissionChecker {
     }
 
     private boolean hasDomainAccess(SecurityIdentity identity, String domain, UserAction action) {
-        return hasAccess(identity, "domain", domain, action,
-                grant -> domain != null && domain.equals(grant.getDomain()));
-    }
-
-    private boolean hasAccess(SecurityIdentity identity, String scopeType, String scopeValue,
-                              UserAction action, Predicate<UserAccess> grantMatcher) {
+        if (domain == null) return false;
         String username = identity.getPrincipal().getName();
-        logger.debug("Checking {} access for user [{}] on {} [{}] action=[{}]",
-                scopeType, username, scopeType, scopeValue, action);
-        try {
-            boolean result = userAccessStore.getUserAccessForUsername(username).stream()
-                    .anyMatch(grant -> grantMatcher.test(grant) && permissionSufficient(grant, action));
-            if (result) {
-                logger.debug("User [{}] AUTHORIZED for [{}] in {} [{}]", username, action, scopeType, scopeValue);
-            } else {
-                logger.debug("User [{}] DENIED for [{}] in {} [{}]", username, action, scopeType, scopeValue);
-            }
-            return result;
-        } catch (UserAccessNotFoundException e) {
-            logger.debug("No access grants found for user [{}]", username);
-            return false;
+        logger.debug("Checking domain access for user [{}] on domain [{}] action=[{}]", username, domain, action);
+
+        List<UserAccess> grants = userAccessStore.getGrantsForUser(username);
+
+        if (isGlobalAdminFromGrants(username, grants)) {
+            logger.debug("User [{}] AUTHORIZED for [{}] in domain [{}] via GLOBAL admin grant", username, action, domain);
+            return true;
         }
+
+        boolean result = grants.stream().anyMatch(g ->
+                domain.equals(g.getDomain()) && permissionSufficient(g, action));
+
+        if (result) {
+            logger.debug("User [{}] AUTHORIZED for [{}] in domain [{}]", username, action, domain);
+        } else {
+            logger.debug("User [{}] DENIED for [{}] in domain [{}]", username, action, domain);
+        }
+        return result;
     }
 
     private boolean permissionSufficient(UserAccess grant, UserAction action) {

--- a/calm-hub/src/main/java/org/finos/calm/security/CalmHubScopes.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/CalmHubScopes.java
@@ -15,6 +15,7 @@ public class CalmHubScopes {
 
     public static final String DOMAIN_READ = "domain_read";
     public static final String DOMAIN_WRITE = "domain_write";
+    public static final String DOMAIN_ADMIN = "domain_admin";
 
     public static final String GLOBAL_ADMIN = "global_admin";
 }

--- a/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
@@ -1,0 +1,50 @@
+package org.finos.calm.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.finos.calm.domain.UserAccess;
+import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.store.DomainStore;
+import org.finos.calm.store.UserAccessStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+@ApplicationScoped
+public class DomainService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DomainService.class);
+
+    private final DomainStore domainStore;
+    private final UserAccessStore userAccessStore;
+
+    @Inject
+    public DomainService(DomainStore domainStore, UserAccessStore userAccessStore) {
+        this.domainStore = domainStore;
+        this.userAccessStore = userAccessStore;
+    }
+
+    public List<String> getDomains() {
+        return domainStore.getDomains();
+    }
+
+    public void createDomain(String name) throws DomainAlreadyExistsException {
+        domainStore.createDomain(name);
+        insertPublicReadGrant(name);
+    }
+
+    private void insertPublicReadGrant(String domain) {
+        try {
+            UserAccess grant = new UserAccess.UserAccessBuilder()
+                    .setUsername("*")
+                    .setPermission(UserAccess.Permission.read)
+                    .setDomain(domain)
+                    .build();
+            userAccessStore.createUserAccessForDomain(grant);
+            LOG.info("Inserted default * read grant for domain [{}]", domain);
+        } catch (Exception e) {
+            LOG.warn("Could not insert default * read grant for domain [{}]: {}", domain, e.getMessage());
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
@@ -32,6 +33,14 @@ public class NamespaceService {
     }
 
     public void createNamespace(String name, String description) throws NamespaceAlreadyExistsException {
+        if (name.contains(".")) {
+            String parent = name.substring(0, name.lastIndexOf('.'));
+            boolean parentExists = namespaceStore.getNamespaces().stream()
+                    .anyMatch(ns -> parent.equals(ns.getName()));
+            if (!parentExists) {
+                throw new NamespaceParentNotFoundException(parent);
+            }
+        }
         namespaceStore.createNamespace(name, description);
         insertPublicReadGrant(name);
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -11,6 +11,8 @@ import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.store.UserAccessStore;
+
+import static org.finos.calm.security.CalmHubPermissionChecker.GLOBAL_ACCESS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +41,7 @@ public class MongoUserAccessStore implements UserAccessStore {
             throws NamespaceNotFoundException {
 
         log.info("User-access details: {}", userAccess);
-        if (!namespaceStore.namespaceExists(userAccess.getNamespace())) {
+        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace()) && !namespaceStore.namespaceExists(userAccess.getNamespace())) {
             throw new NamespaceNotFoundException();
         }
 
@@ -112,7 +114,7 @@ public class MongoUserAccessStore implements UserAccessStore {
 
     @Override
     public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
+        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
         List<UserAccess> userAccessList = new ArrayList<>();
@@ -179,7 +181,7 @@ public class MongoUserAccessStore implements UserAccessStore {
     public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        if (!namespaceStore.namespaceExists(namespace)) {
+        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -12,6 +12,8 @@ import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.store.UserAccessStore;
+
+import static org.finos.calm.security.CalmHubPermissionChecker.GLOBAL_ACCESS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +62,8 @@ public class NitriteUserAccessStore implements UserAccessStore {
     @Override
     public UserAccess createUserAccessForNamespace(UserAccess userAccess) throws NamespaceNotFoundException {
         LOG.info("User-access details: {}", userAccess);
-        
-        if (!namespaceStore.namespaceExists(userAccess.getNamespace())) {
+
+        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace()) && !namespaceStore.namespaceExists(userAccess.getNamespace())) {
             throw new NamespaceNotFoundException();
         }
 
@@ -121,7 +123,7 @@ public class NitriteUserAccessStore implements UserAccessStore {
 
     @Override
     public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
+        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
         Filter filter = where(NAMESPACE_FIELD).eq(namespace);
@@ -223,7 +225,7 @@ public class NitriteUserAccessStore implements UserAccessStore {
     public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        if (!namespaceStore.namespaceExists(namespace)) {
+        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
             throw new NamespaceNotFoundException();
         }
 

--- a/calm-hub/src/test/java/org/finos/calm/resources/AuthDisabledProfile.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/AuthDisabledProfile.java
@@ -1,0 +1,12 @@
+package org.finos.calm.resources;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class AuthDisabledProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("calm.auth.enabled", "false");
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceNoAuthShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceNoAuthShould.java
@@ -1,0 +1,37 @@
+package org.finos.calm.resources;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+import org.finos.calm.store.UserAccessStore;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@QuarkusTest
+@TestProfile(AuthDisabledProfile.class)
+public class TestCurrentUserAccessResourceNoAuthShould {
+
+    @InjectMock
+    UserAccessStore mockUserAccessStore;
+
+    @Test
+    @TestSecurity(user = "alice")
+    void return_synthetic_global_admin_grant_when_auth_disabled() {
+        given()
+                .when()
+                .get("/api/calm/user-access/current")
+                .then()
+                .statusCode(200)
+                .body(containsString("GLOBAL"))
+                .body(containsString("admin"))
+                .body(containsString("alice"));
+
+        verify(mockUserAccessStore, never()).getGrantsForUser(any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceNoAuthShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCurrentUserAccessResourceNoAuthShould.java
@@ -3,7 +3,6 @@ package org.finos.calm.resources;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +20,6 @@ public class TestCurrentUserAccessResourceNoAuthShould {
     UserAccessStore mockUserAccessStore;
 
     @Test
-    @TestSecurity(user = "alice")
     void return_synthetic_global_admin_grant_when_auth_disabled() {
         given()
                 .when()
@@ -30,7 +28,7 @@ public class TestCurrentUserAccessResourceNoAuthShould {
                 .statusCode(200)
                 .body(containsString("GLOBAL"))
                 .body(containsString("admin"))
-                .body(containsString("alice"));
+                .body(containsString("no-auth"));
 
         verify(mockUserAccessStore, never()).getGrantsForUser(any());
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
@@ -5,7 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
-import org.finos.calm.store.DomainStore;
+import org.finos.calm.services.DomainService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,11 +28,11 @@ public class TestDomainResourceShould {
     private static final String TEST_DOMAIN = "test-domain";
 
     @InjectMock
-    DomainStore mockControlStore;
+    DomainService mockDomainService;
 
     @Test
     void return_an_empty_list_when_no_domains_exist() {
-        when(mockControlStore.getDomains()).thenReturn(new ArrayList<>());
+        when(mockDomainService.getDomains()).thenReturn(new ArrayList<>());
 
         given()
             .when().get(CALM_DOMAINS)
@@ -40,12 +40,12 @@ public class TestDomainResourceShould {
             .statusCode(200)
             .body(is("{\"values\":[]}"));
 
-        verify(mockControlStore).getDomains();
+        verify(mockDomainService).getDomains();
     }
 
     @Test
     void return_a_domain_list_when_domains_exist() {
-        when(mockControlStore.getDomains()).thenReturn(List.of(TEST_DOMAIN));
+        when(mockDomainService.getDomains()).thenReturn(List.of(TEST_DOMAIN));
 
         given()
             .when().get(CALM_DOMAINS)
@@ -53,13 +53,12 @@ public class TestDomainResourceShould {
             .statusCode(200)
             .body(is("{\"values\":[\"test-domain\"]}"));
 
-        verify(mockControlStore).getDomains();
+        verify(mockDomainService).getDomains();
     }
 
     @Test
     void create_a_domain_with_a_valid_name() throws DomainAlreadyExistsException {
         Domain expectedDomain = new Domain(TEST_DOMAIN);
-        when(mockControlStore.createDomain("test-domain")).thenReturn(expectedDomain);
 
         given()
             .header("Content-Type", "application/json")
@@ -67,9 +66,9 @@ public class TestDomainResourceShould {
             .when().post(CALM_DOMAINS)
             .then()
             .statusCode(201)
-            .header("Location", "http://localhost:8081/api/calm/domains/" + expectedDomain.getName());
+            .header("Location", "http://localhost:8081/api/calm/domains/" + TEST_DOMAIN);
 
-        verify(mockControlStore).createDomain("test-domain");
+        verify(mockDomainService).createDomain(TEST_DOMAIN);
     }
 
     @Test
@@ -84,7 +83,7 @@ public class TestDomainResourceShould {
             .statusCode(400)
             .body(containsString(DOMAIN_MESSAGE));
 
-        verify(mockControlStore, never()).createDomain("invalid-domain");
+        verify(mockDomainService, never()).createDomain(any());
     }
 
     @Test
@@ -97,7 +96,7 @@ public class TestDomainResourceShould {
                 .statusCode(400)
                 .body(containsString("reserved"));
 
-        verify(mockControlStore, never()).createDomain(any());
+        verify(mockDomainService, never()).createDomain(any());
     }
 
     @Test
@@ -110,13 +109,14 @@ public class TestDomainResourceShould {
                 .statusCode(400)
                 .body(containsString("reserved"));
 
-        verify(mockControlStore, never()).createDomain(any());
+        verify(mockDomainService, never()).createDomain(any());
     }
 
     @Test
     void create_a_domain_that_already_exists_returns_a_409() throws DomainAlreadyExistsException {
         Domain expectedDomain = new Domain(TEST_DOMAIN);
-        when(mockControlStore.createDomain("test-domain")).thenThrow(new DomainAlreadyExistsException("Domain already exists"));
+        doThrow(new DomainAlreadyExistsException("Domain already exists"))
+                .when(mockDomainService).createDomain(TEST_DOMAIN);
 
         given()
                 .header("Content-Type", "application/json")
@@ -125,6 +125,6 @@ public class TestDomainResourceShould {
                 .then()
                 .statusCode(409);
 
-        verify(mockControlStore).createDomain("test-domain");
+        verify(mockDomainService).createDomain(TEST_DOMAIN);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainUserAccessResourceShould.java
@@ -292,6 +292,38 @@ public class TestDomainUserAccessResourceShould {
     }
 
     @Test
+    void return_400_when_wildcard_admin_grant_attempted_on_domain() {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"*\",\"permission\":\"admin\"}")
+                .when()
+                .post("/api/calm/domains/payments/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString("Wildcard username is not permitted for admin"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForDomain(any());
+    }
+
+    @Test
+    void return_201_when_wildcard_read_grant_is_created_on_domain() {
+        UserAccess created = new UserAccess();
+        created.setDomain("payments");
+        created.setPermission(UserAccess.Permission.read);
+        created.setUsername("*");
+        created.setUserAccessId(202);
+        when(mockUserAccessStore.createUserAccessForDomain(any(UserAccess.class))).thenReturn(created);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"*\",\"permission\":\"read\"}")
+                .when()
+                .post("/api/calm/domains/payments/user-access")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
     void return_404_when_domain_does_not_exist_on_delete_user_access() throws Exception {
         when(mockDomainStore.domainExists("unknown")).thenReturn(false);
 

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
@@ -5,7 +5,9 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
+import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.services.NamespaceService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,6 +19,8 @@ import static io.restassured.RestAssured.given;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @TestSecurity(authorizationEnabled = false)
@@ -26,6 +30,15 @@ public class TestNamespaceResourceShould {
 
     @InjectMock
     NamespaceService namespaceService;
+
+    @InjectMock
+    CalmHubPermissionChecker mockPermissionChecker;
+
+    @BeforeEach
+    void setUpPermissions() {
+        lenient().when(mockPermissionChecker.hasGlobalAdmin(any())).thenReturn(true);
+        lenient().when(mockPermissionChecker.allowNamespaceAdmin(any(), any())).thenReturn(false);
+    }
 
     @Test
     void return_empty_wrapper_when_no_namespaces_in_store() {
@@ -223,6 +236,56 @@ public class TestNamespaceResourceShould {
                 .then()
                 .statusCode(400)
                 .body(containsString("Request must not be null"));
+
+        verify(namespaceService, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void return_403_when_non_admin_creates_top_level_namespace() throws NamespaceAlreadyExistsException {
+        when(mockPermissionChecker.hasGlobalAdmin(any())).thenReturn(false);
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"newteam\",\"description\":\"desc\"}")
+                .when()
+                .post("/api/calm/namespaces")
+                .then()
+                .statusCode(403)
+                .body(containsString("Insufficient permissions"));
+
+        verify(namespaceService, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void return_201_when_namespace_admin_creates_child_namespace() throws NamespaceAlreadyExistsException {
+        when(mockPermissionChecker.hasGlobalAdmin(any())).thenReturn(false);
+        when(mockPermissionChecker.allowNamespaceAdmin(any(), eq("org"))).thenReturn(true);
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"org.finos\",\"description\":\"FINOS sub-namespace\"}")
+                .when()
+                .post("/api/calm/namespaces")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/api/calm/namespaces/org.finos"));
+
+        verify(namespaceService).createNamespace("org.finos", "FINOS sub-namespace");
+    }
+
+    @Test
+    void return_403_when_non_admin_creates_child_namespace_without_parent_admin() throws NamespaceAlreadyExistsException {
+        when(mockPermissionChecker.hasGlobalAdmin(any())).thenReturn(false);
+        when(mockPermissionChecker.allowNamespaceAdmin(any(), eq("org"))).thenReturn(false);
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"org.finos\",\"description\":\"desc\"}")
+                .when()
+                .post("/api/calm/namespaces")
+                .then()
+                .statusCode(403)
+                .body(containsString("Insufficient permissions"));
 
         verify(namespaceService, never()).createNamespace(any(), any());
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
@@ -4,6 +4,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.services.NamespaceService;
@@ -271,6 +272,23 @@ public class TestNamespaceResourceShould {
                 .header("Location", containsString("/api/calm/namespaces/org.finos"));
 
         verify(namespaceService).createNamespace("org.finos", "FINOS sub-namespace");
+    }
+
+    @Test
+    void return_422_when_direct_parent_namespace_does_not_exist() throws Exception {
+        doThrow(new NamespaceParentNotFoundException("org.ecosystem.a"))
+                .when(namespaceService).createNamespace("org.ecosystem.a.b", "desc");
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"org.ecosystem.a.b\",\"description\":\"desc\"}")
+                .when()
+                .post("/api/calm/namespaces")
+                .then()
+                .statusCode(422)
+                .body(containsString("org.ecosystem.a"));
+
+        verify(namespaceService).createNamespace("org.ecosystem.a.b", "desc");
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -326,9 +326,41 @@ public class TestUserAccessResourceShould {
                 .post("/api/calm/namespaces/GLOBAL/user-access")
                 .then()
                 .statusCode(400)
-                .body(containsString("Wildcard username is not permitted for the GLOBAL namespace"));
+                .body(containsString("Wildcard username is not permitted for admin permission"));
 
         verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
+    }
+
+    @Test
+    void return_400_when_wildcard_admin_grant_attempted_on_regular_namespace() throws Exception {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"*\",\"permission\":\"admin\"}")
+                .when()
+                .post("/api/calm/namespaces/finos/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString("Wildcard username is not permitted for admin permission"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
+    }
+
+    @Test
+    void return_201_when_wildcard_read_grant_is_created_on_regular_namespace() throws Exception {
+        UserAccess created = new UserAccess();
+        created.setNamespace("finos");
+        created.setPermission(UserAccess.Permission.read);
+        created.setUsername("*");
+        created.setUserAccessId(103);
+        when(mockUserAccessStore.createUserAccessForNamespace(any(UserAccess.class))).thenReturn(created);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"*\",\"permission\":\"read\"}")
+                .when()
+                .post("/api/calm/namespaces/finos/user-access")
+                .then()
+                .statusCode(201);
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -302,4 +302,32 @@ public class TestUserAccessResourceShould {
 
         verify(mockUserAccessStore, times(1)).deleteUserAccessForNamespace("finos", 999);
     }
+
+    @Test
+    void return_400_when_non_admin_permission_is_used_for_global_namespace() throws Exception {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"alice\",\"permission\":\"read\"}")
+                .when()
+                .post("/api/calm/namespaces/GLOBAL/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString("Only 'admin' permission is valid for the GLOBAL namespace"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
+    }
+
+    @Test
+    void return_400_when_write_permission_is_used_for_global_namespace() throws Exception {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"alice\",\"permission\":\"write\"}")
+                .when()
+                .post("/api/calm/namespaces/GLOBAL/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString("Only 'admin' permission is valid for the GLOBAL namespace"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestUserAccessResourceShould.java
@@ -318,6 +318,20 @@ public class TestUserAccessResourceShould {
     }
 
     @Test
+    void return_400_when_wildcard_username_is_used_for_global_namespace() throws Exception {
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"username\":\"*\",\"permission\":\"admin\"}")
+                .when()
+                .post("/api/calm/namespaces/GLOBAL/user-access")
+                .then()
+                .statusCode(400)
+                .body(containsString("Wildcard username is not permitted for the GLOBAL namespace"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
+    }
+
+    @Test
     void return_400_when_write_permission_is_used_for_global_namespace() throws Exception {
         given()
                 .header("Content-Type", "application/json")

--- a/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
@@ -2,7 +2,6 @@ package org.finos.calm.security;
 
 import io.quarkus.security.identity.SecurityIdentity;
 import org.finos.calm.domain.UserAccess;
-import org.finos.calm.domain.exception.UserAccessNotFoundException;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -505,10 +504,10 @@ class TestCalmHubPermissionCheckerShould {
     }
 
     @Test
-    void public_read_enabled_does_not_grant_global_admin() throws UserAccessNotFoundException {
+    void public_read_enabled_does_not_grant_global_admin() {
         checker.allowPublicRead = true;
         givenAuthenticatedUser("alice");
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenThrow(new UserAccessNotFoundException());
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(Collections.emptyList());
 
         assertFalse(checker.hasGlobalAdmin(mockIdentity));
     }
@@ -619,38 +618,48 @@ class TestCalmHubPermissionCheckerShould {
     // --- GLOBAL ADMIN checks (unchanged) ---
 
     @Test
-    void global_admin_grant_on_global_namespace_grants_global_admin() throws UserAccessNotFoundException {
+    void global_admin_grant_on_global_namespace_grants_global_admin() {
         givenAuthenticatedUser("alice");
         UserAccess globalGrant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(globalGrant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
 
         assertTrue(checker.hasGlobalAdmin(mockIdentity));
     }
 
     @Test
-    void write_grant_on_global_namespace_denies_global_admin() throws UserAccessNotFoundException {
+    void write_grant_on_global_namespace_denies_global_admin() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.write).setNamespace("GLOBAL").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertFalse(checker.hasGlobalAdmin(mockIdentity));
     }
 
     @Test
-    void admin_grant_on_non_global_namespace_denies_global_admin() throws UserAccessNotFoundException {
+    void admin_grant_on_non_global_namespace_denies_global_admin() {
         givenAuthenticatedUser("alice");
-        when(mockUserAccessStore.getUserAccessForUsername("alice"))
+        when(mockUserAccessStore.getGrantsForUser("alice"))
                 .thenReturn(List.of(grant("alice", UserAccess.Permission.admin, "finos")));
 
         assertFalse(checker.hasGlobalAdmin(mockIdentity));
     }
 
     @Test
-    void user_with_no_grants_is_denied_global_admin() throws UserAccessNotFoundException {
+    void user_with_no_grants_is_denied_global_admin() {
         givenAuthenticatedUser("alice");
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenThrow(new UserAccessNotFoundException());
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(Collections.emptyList());
+
+        assertFalse(checker.hasGlobalAdmin(mockIdentity));
+    }
+
+    @Test
+    void wildcard_global_admin_grant_does_not_grant_global_admin() {
+        givenAuthenticatedUser("alice");
+        UserAccess wildcardGlobal = new UserAccess.UserAccessBuilder()
+                .setUsername("*").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGlobal));
 
         assertFalse(checker.hasGlobalAdmin(mockIdentity));
     }

--- a/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
@@ -477,6 +477,43 @@ class TestCalmHubPermissionCheckerShould {
     }
 
     @Test
+    void wildcard_admin_grant_for_domain_allows_domain_admin() {
+        givenAuthenticatedUser("alice");
+        UserAccess wildcardGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("*").setPermission(UserAccess.Permission.admin).setDomain("payments").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGrant));
+
+        assertTrue(checker.allowDomainAdmin(mockIdentity, "payments"));
+    }
+
+    @Test
+    void public_read_enabled_does_not_grant_domain_write() {
+        checker.allowPublicRead = true;
+        givenAuthenticatedUser("alice");
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(Collections.emptyList());
+
+        assertFalse(checker.canWriteByDomain(mockIdentity, "payments"));
+    }
+
+    @Test
+    void public_read_enabled_does_not_grant_domain_admin() {
+        checker.allowPublicRead = true;
+        givenAuthenticatedUser("alice");
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(Collections.emptyList());
+
+        assertFalse(checker.allowDomainAdmin(mockIdentity, "payments"));
+    }
+
+    @Test
+    void public_read_enabled_does_not_grant_global_admin() throws UserAccessNotFoundException {
+        checker.allowPublicRead = true;
+        givenAuthenticatedUser("alice");
+        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenThrow(new UserAccessNotFoundException());
+
+        assertFalse(checker.hasGlobalAdmin(mockIdentity));
+    }
+
+    @Test
     void no_auth_mode_grants_domain_admin_without_store_lookup() {
         checker.authEnabled = false;
 
@@ -522,6 +559,28 @@ class TestCalmHubPermissionCheckerShould {
     }
 
     // --- Global admin implies namespace admin ---
+
+    @Test
+    void global_admin_is_allowed_namespace_read_without_namespace_grant() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.canRead(mockIdentity, "finos"));
+        assertTrue(checker.canRead(mockIdentity, "org.payments.fx"));
+    }
+
+    @Test
+    void global_admin_is_allowed_namespace_write_without_namespace_grant() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.canWrite(mockIdentity, "finos"));
+        assertTrue(checker.canWrite(mockIdentity, "org.payments.fx"));
+    }
 
     @Test
     void global_admin_is_allowed_namespace_admin_on_any_namespace() {

--- a/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
@@ -326,53 +326,73 @@ class TestCalmHubPermissionCheckerShould {
         assertFalse(checker.allowNamespaceAdmin(mockIdentity, "foo"));
     }
 
-    // --- Domain READ checks (unchanged — still use getUserAccessForUsername) ---
+    // --- Domain READ checks ---
 
     @Test
-    void read_grant_for_domain_allows_domain_read() throws UserAccessNotFoundException {
+    void read_grant_for_domain_allows_domain_read() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.read).setDomain("payments").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertTrue(checker.canReadByDomain(mockIdentity, "payments"));
     }
 
     @Test
-    void write_grant_for_domain_allows_domain_read() throws UserAccessNotFoundException {
+    void write_grant_for_domain_allows_domain_read() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.write).setDomain("payments").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertTrue(checker.canReadByDomain(mockIdentity, "payments"));
     }
 
     @Test
-    void grant_for_different_domain_denies_domain_read() throws UserAccessNotFoundException {
+    void grant_for_different_domain_denies_domain_read() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.read).setDomain("orders").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertFalse(checker.canReadByDomain(mockIdentity, "payments"));
     }
 
     @Test
-    void namespace_grant_does_not_satisfy_domain_read() throws UserAccessNotFoundException {
+    void namespace_grant_does_not_satisfy_domain_read() {
         givenAuthenticatedUser("alice");
-        when(mockUserAccessStore.getUserAccessForUsername("alice"))
+        when(mockUserAccessStore.getGrantsForUser("alice"))
                 .thenReturn(List.of(grant("alice", UserAccess.Permission.read, "payments")));
 
         assertFalse(checker.canReadByDomain(mockIdentity, "payments"));
     }
 
     @Test
-    void user_with_no_grants_is_denied_domain_read() throws UserAccessNotFoundException {
+    void user_with_no_grants_is_denied_domain_read() {
         givenAuthenticatedUser("alice");
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenThrow(new UserAccessNotFoundException());
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(Collections.emptyList());
 
         assertFalse(checker.canReadByDomain(mockIdentity, "payments"));
+    }
+
+    @Test
+    void wildcard_read_grant_for_domain_allows_domain_read() {
+        givenAuthenticatedUser("alice");
+        UserAccess wildcardGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("*").setPermission(UserAccess.Permission.read).setDomain("payments").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGrant));
+
+        assertTrue(checker.canReadByDomain(mockIdentity, "payments"));
+    }
+
+    @Test
+    void global_admin_is_allowed_domain_read_without_domain_grant() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.canReadByDomain(mockIdentity, "payments"));
     }
 
     @Test
@@ -385,23 +405,82 @@ class TestCalmHubPermissionCheckerShould {
     // --- Domain WRITE checks ---
 
     @Test
-    void read_grant_for_domain_denies_domain_write() throws UserAccessNotFoundException {
+    void read_grant_for_domain_denies_domain_write() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.read).setDomain("payments").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertFalse(checker.canWriteByDomain(mockIdentity, "payments"));
     }
 
     @Test
-    void write_grant_for_domain_allows_domain_write() throws UserAccessNotFoundException {
+    void write_grant_for_domain_allows_domain_write() {
         givenAuthenticatedUser("alice");
         UserAccess grant = new UserAccess.UserAccessBuilder()
                 .setUsername("alice").setPermission(UserAccess.Permission.write).setDomain("payments").build();
-        when(mockUserAccessStore.getUserAccessForUsername("alice")).thenReturn(List.of(grant));
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
 
         assertTrue(checker.canWriteByDomain(mockIdentity, "payments"));
+    }
+
+    @Test
+    void wildcard_write_grant_for_domain_allows_domain_write() {
+        givenAuthenticatedUser("alice");
+        UserAccess wildcardGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("*").setPermission(UserAccess.Permission.write).setDomain("payments").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGrant));
+
+        assertTrue(checker.canWriteByDomain(mockIdentity, "payments"));
+    }
+
+    @Test
+    void global_admin_is_allowed_domain_write_without_domain_grant() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.canWriteByDomain(mockIdentity, "payments"));
+    }
+
+    // --- Domain ADMIN checks ---
+
+    @Test
+    void admin_grant_for_domain_allows_domain_admin() {
+        givenAuthenticatedUser("alice");
+        UserAccess grant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setDomain("payments").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
+
+        assertTrue(checker.allowDomainAdmin(mockIdentity, "payments"));
+    }
+
+    @Test
+    void write_grant_for_domain_denies_domain_admin() {
+        givenAuthenticatedUser("alice");
+        UserAccess grant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.write).setDomain("payments").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(grant));
+
+        assertFalse(checker.allowDomainAdmin(mockIdentity, "payments"));
+    }
+
+    @Test
+    void global_admin_is_allowed_domain_admin_without_domain_grant() {
+        givenAuthenticatedUser("alice");
+        UserAccess globalGrant = new UserAccess.UserAccessBuilder()
+                .setUsername("alice").setPermission(UserAccess.Permission.admin).setNamespace("GLOBAL").build();
+        when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(globalGrant));
+
+        assertTrue(checker.allowDomainAdmin(mockIdentity, "payments"));
+    }
+
+    @Test
+    void no_auth_mode_grants_domain_admin_without_store_lookup() {
+        checker.authEnabled = false;
+
+        assertTrue(checker.allowDomainAdmin(mockIdentity, "payments"));
     }
 
     // --- authEnabled=false (no-auth mode) ---

--- a/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestCalmHubPermissionCheckerShould.java
@@ -476,13 +476,13 @@ class TestCalmHubPermissionCheckerShould {
     }
 
     @Test
-    void wildcard_admin_grant_for_domain_allows_domain_admin() {
+    void wildcard_admin_grant_for_domain_does_not_grant_domain_admin() {
         givenAuthenticatedUser("alice");
         UserAccess wildcardGrant = new UserAccess.UserAccessBuilder()
                 .setUsername("*").setPermission(UserAccess.Permission.admin).setDomain("payments").build();
         when(mockUserAccessStore.getGrantsForUser("alice")).thenReturn(List.of(wildcardGrant));
 
-        assertTrue(checker.allowDomainAdmin(mockIdentity, "payments"));
+        assertFalse(checker.allowDomainAdmin(mockIdentity, "payments"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
@@ -1,0 +1,84 @@
+package org.finos.calm.services;
+
+import org.finos.calm.domain.UserAccess;
+import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.store.DomainStore;
+import org.finos.calm.store.UserAccessStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TestDomainServiceShould {
+
+    @Mock
+    DomainStore mockDomainStore;
+
+    @Mock
+    UserAccessStore mockUserAccessStore;
+
+    DomainService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DomainService(mockDomainStore, mockUserAccessStore);
+    }
+
+    @Test
+    void get_domains_delegates_to_store() {
+        when(mockDomainStore.getDomains()).thenReturn(List.of("retail", "wholesale"));
+
+        List<String> result = service.getDomains();
+
+        assertThat(result, hasSize(2));
+        verify(mockDomainStore).getDomains();
+    }
+
+    @Test
+    void create_domain_and_insert_wildcard_read_grant() throws Exception {
+        service.createDomain("retail");
+
+        verify(mockDomainStore).createDomain("retail");
+
+        ArgumentCaptor<UserAccess> captor = ArgumentCaptor.forClass(UserAccess.class);
+        verify(mockUserAccessStore).createUserAccessForDomain(captor.capture());
+        UserAccess grant = captor.getValue();
+        assertThat(grant.getUsername(), is("*"));
+        assertThat(grant.getPermission(), is(UserAccess.Permission.read));
+        assertThat(grant.getDomain(), is("retail"));
+    }
+
+    @Test
+    void propagate_domain_already_exists_exception_and_skip_grant() throws Exception {
+        doThrow(new DomainAlreadyExistsException("already exists"))
+                .when(mockDomainStore).createDomain("retail");
+
+        assertThrows(DomainAlreadyExistsException.class,
+                () -> service.createDomain("retail"));
+
+        verify(mockUserAccessStore, never()).createUserAccessForDomain(any());
+    }
+
+    @Test
+    void log_warning_and_continue_when_grant_insertion_fails() throws Exception {
+        doThrow(new RuntimeException("store error"))
+                .when(mockUserAccessStore).createUserAccessForDomain(any());
+
+        // should not throw — grant insertion failure is non-fatal
+        service.createDomain("retail");
+
+        verify(mockDomainStore).createDomain("retail");
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
@@ -3,6 +3,7 @@ package org.finos.calm.services;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
@@ -52,25 +53,25 @@ class TestNamespaceServiceShould {
 
     @Test
     void create_namespace_and_insert_wildcard_read_grant() throws Exception {
-        service.createNamespace("org.ab", "description");
+        service.createNamespace("myteam", "description");
 
-        verify(mockNamespaceStore).createNamespace("org.ab", "description");
+        verify(mockNamespaceStore).createNamespace("myteam", "description");
 
         ArgumentCaptor<UserAccess> captor = ArgumentCaptor.forClass(UserAccess.class);
         verify(mockUserAccessStore).createUserAccessForNamespace(captor.capture());
         UserAccess grant = captor.getValue();
         assertThat(grant.getUsername(), is("*"));
         assertThat(grant.getPermission(), is(UserAccess.Permission.read));
-        assertThat(grant.getNamespace(), is("org.ab"));
+        assertThat(grant.getNamespace(), is("myteam"));
     }
 
     @Test
     void propagate_namespace_already_exists_exception_and_skip_grant() throws Exception {
         doThrow(new NamespaceAlreadyExistsException("already exists"))
-                .when(mockNamespaceStore).createNamespace("org.ab", "desc");
+                .when(mockNamespaceStore).createNamespace("myteam", "desc");
 
         assertThrows(NamespaceAlreadyExistsException.class,
-                () -> service.createNamespace("org.ab", "desc"));
+                () -> service.createNamespace("myteam", "desc"));
 
         verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
     }
@@ -81,8 +82,45 @@ class TestNamespaceServiceShould {
                 .when(mockUserAccessStore).createUserAccessForNamespace(any());
 
         // should not throw — grant insertion failure is non-fatal
+        service.createNamespace("myteam", "desc");
+
+        verify(mockNamespaceStore).createNamespace("myteam", "desc");
+    }
+
+    @Test
+    void throw_parent_not_found_when_direct_parent_does_not_exist() throws NamespaceAlreadyExistsException {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of());
+
+        assertThrows(NamespaceParentNotFoundException.class,
+                () -> service.createNamespace("org.ab", "desc"));
+
+        verify(mockNamespaceStore, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void throw_parent_not_found_when_grandparent_exists_but_direct_parent_does_not() throws NamespaceAlreadyExistsException {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("org", "org")));
+
+        assertThrows(NamespaceParentNotFoundException.class,
+                () -> service.createNamespace("org.ab.cd", "desc"));
+
+        verify(mockNamespaceStore, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void create_child_namespace_successfully_when_direct_parent_exists() throws NamespaceAlreadyExistsException {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("org", "org")));
+
         service.createNamespace("org.ab", "desc");
 
         verify(mockNamespaceStore).createNamespace("org.ab", "desc");
+    }
+
+    @Test
+    void skip_parent_check_for_top_level_namespaces() throws NamespaceAlreadyExistsException {
+        service.createNamespace("newteam", "desc");
+
+        verify(mockNamespaceStore, never()).getNamespaces();
+        verify(mockNamespaceStore).createNamespace("newteam", "desc");
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -375,6 +375,50 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
+    void create_user_access_for_global_namespace_without_namespace_existence_check() throws NamespaceNotFoundException {
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(202);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace("GLOBAL")
+                .setUsername("alice")
+                .setPermission(Permission.admin)
+                .build();
+
+        UserAccess actual = mongoUserAccessStore.createUserAccessForNamespace(userAccess);
+
+        assertThat(actual.getUserAccessId(), is(202));
+        assertThat(actual.getNamespace(), is("GLOBAL"));
+        verify(namespaceStore, never()).namespaceExists("GLOBAL");
+        verify(userAccessCollection).insertOne(ArgumentMatchers.any(Document.class));
+    }
+
+    @Test
+    void get_user_access_for_global_namespace_without_namespace_existence_check() throws NamespaceNotFoundException {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        DocumentMongoCursor cursor = mock(DocumentMongoCursor.class);
+        when(cursor.hasNext()).thenReturn(false);
+        when(findIterable.iterator()).thenReturn(cursor);
+        when(userAccessCollection.find(Filters.eq("namespace", "GLOBAL"))).thenReturn(findIterable);
+
+        List<UserAccess> actual = mongoUserAccessStore.getUserAccessForNamespace("GLOBAL");
+
+        assertThat(actual, hasSize(0));
+        verify(namespaceStore, never()).namespaceExists("GLOBAL");
+    }
+
+    @Test
+    void delete_user_access_for_global_namespace_without_namespace_existence_check() throws NamespaceNotFoundException, UserAccessNotFoundException {
+        com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(userAccessCollection.deleteOne(ArgumentMatchers.any(Bson.class))).thenReturn(deleteResult);
+
+        mongoUserAccessStore.deleteUserAccessForNamespace("GLOBAL", 202);
+
+        verify(namespaceStore, never()).namespaceExists("GLOBAL");
+        verify(userAccessCollection).deleteOne(ArgumentMatchers.any(Bson.class));
+    }
+
+    @Test
     void throw_user_access_not_found_exception_when_deleting_non_existent_grant() {
         String namespace = "finos";
         Integer userAccessId = 999;

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
@@ -356,4 +356,45 @@ public class TestNitriteUserAccessStoreShould {
                 () -> userAccessStore.deleteUserAccessForDomain("payments", 999));
         verify(mockCollection, never()).remove(any(Document.class));
     }
+
+    @Test
+    public void createUserAccessForNamespace_succeedsForGlobalWithoutNamespaceExistenceCheck() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextUserAccessSequenceValue()).thenReturn(303);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace("GLOBAL")
+                .setUsername("alice")
+                .setPermission(UserAccess.Permission.admin)
+                .build();
+
+        UserAccess result = userAccessStore.createUserAccessForNamespace(userAccess);
+
+        assertThat(result.getUserAccessId(), is(303));
+        assertThat(result.getNamespace(), is("GLOBAL"));
+        verify(mockNamespaceStore, never()).namespaceExists("GLOBAL");
+        verify(mockCollection).insert(any(Document.class));
+    }
+
+    @Test
+    public void getUserAccessForNamespace_succeedsForGlobalWithoutNamespaceExistenceCheck() throws NamespaceNotFoundException {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(Collections.emptyIterator());
+
+        List<UserAccess> result = userAccessStore.getUserAccessForNamespace("GLOBAL");
+
+        assertThat(result, hasSize(0));
+        verify(mockNamespaceStore, never()).namespaceExists("GLOBAL");
+    }
+
+    @Test
+    public void deleteUserAccessForNamespace_succeedsForGlobalWithoutNamespaceExistenceCheck() throws Exception {
+        Document mockDoc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(mockDoc);
+
+        userAccessStore.deleteUserAccessForNamespace("GLOBAL", 303);
+
+        verify(mockNamespaceStore, never()).namespaceExists("GLOBAL");
+        verify(mockCollection).remove(mockDoc);
+    }
 }

--- a/docs/docs/working-with-calm/calm-hub-entitlements.md
+++ b/docs/docs/working-with-calm/calm-hub-entitlements.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 # CALM Hub Entitlements
 
-CALM Hub uses a hierarchical permission model to control who can read, write, and administer namespaces. This page explains how that model works and how to configure access.
+CALM Hub uses a hierarchical permission model to control who can read, write, and administer namespaces, and a flat permission model for control domains. This page explains how both models work and how to configure access.
 
 ---
 
@@ -16,13 +16,15 @@ Every access grant specifies one of three permission levels:
 
 | Permission | What it allows |
 | :--- | :--- |
-| `read` | Read any document in the namespace |
-| `write` | Create documents in the namespace (implies `read`) |
-| `admin` | Full control: read, write, and manage entitlements for other users in the namespace (implies `read` and `write`) |
+| `read` | Read any document in the namespace or domain |
+| `write` | Create documents (implies `read`) |
+| `admin` | Full control: read, write, and manage entitlements for other users (implies `read` and `write`) |
 
 ---
 
-## Namespace Hierarchy
+## Namespace Permissions
+
+### Hierarchy
 
 Namespaces in CALM Hub use `.` as a separator to express parent/child relationships:
 
@@ -61,11 +63,31 @@ To **write** or **admin** a namespace, a user must have a sufficient grant at th
 
 A grant at `org` is sufficient to write anything under `org.ecosystem`, `org.ecosystem.system`, and so on. This lets you delegate broad access with a single grant rather than one per sub-namespace.
 
+### Creating Namespaces
+
+To create a **top-level namespace** (e.g. `org`), a user must be a global admin.
+
+To create a **child namespace** (e.g. `org.ecosystem`), a user must be a global admin **or** have `admin` on the direct parent namespace (`org` in this example).
+
+---
+
+## Domain Permissions
+
+Control domains use a **flat** permission model — there is no ancestor chain. A grant on domain `payments` applies only to `payments`; it does not cascade to any other domain.
+
+| Permission | What it allows |
+| :--- | :--- |
+| `read` | Read content in the domain |
+| `write` | Read and write content in the domain |
+| `admin` | Read, write, and manage entitlements for the domain |
+
+Only global admins can create and delete domains. Domain admin grants are managed through the admin UI or the `/api/calm/domains/{domain}/user-access` endpoints.
+
 ---
 
 ## Public Access: the `*` Username
 
-The reserved username `*` represents **anyone** — including unauthenticated users if your deployment allows it. A `*` grant at a namespace means that namespace is open to all users at that permission level.
+The reserved username `*` represents **anyone** — including unauthenticated users if your deployment allows it. A `*` grant at a namespace or domain means it is open to all users at that permission level.
 
 ```
 username: *
@@ -73,12 +95,12 @@ permission: read
 namespace: org.ab
 ```
 
-`*` grants are evaluated by the same AND/OR rules as named user grants. You manage them through the same API — `*` is just a username value that matches everyone.
+`*` grants are evaluated by the same AND/OR rules as named user grants. You manage them through the same API or admin UI — `*` is just a username value that matches everyone.
 
-When a namespace is created, CALM Hub automatically inserts a `* read` grant so the namespace is publicly readable by default. To restrict a namespace, delete that `*` grant.
+When a namespace is created, CALM Hub automatically inserts a `* read` grant so the namespace is publicly readable by default. To restrict a namespace, delete that `* read` grant. The same applies to domains.
 
-:::tip
-`*` can be granted `write` or `admin` as well — useful for private internal deployments where all authenticated users should be able to contribute freely.
+:::warning
+`*` can be granted `write`, but **not `admin`** — attempts to create a wildcard admin grant on any namespace or domain are rejected with `400 Bad Request`. This prevents accidental elevation of all users to administrators.
 :::
 
 ---
@@ -91,7 +113,17 @@ Setting `calm.auth.allow-public-read=true` makes every namespace readable by eve
 
 ### Global admin
 
-A user with `admin` on the special `GLOBAL` namespace bypasses all namespace-level permission checks. Use this for super-administrators who need unrestricted access. Global admins can also manage control domains.
+A user with `admin` on the special `GLOBAL` namespace bypasses all namespace-level and domain-level permission checks. Use this for super-administrators who need unrestricted access. Global admins can:
+
+- Read and write all namespaces and domains
+- Create and delete namespaces and domains
+- Manage entitlements for any namespace or domain, including granting further GLOBAL admin access
+
+To bootstrap a new deployment, create the first GLOBAL admin grant via the admin UI in `no-auth` mode (or via the Swagger UI at `/q/swagger-ui`), then switch to a secured auth profile.
+
+:::note
+The GLOBAL namespace is a sentinel value — it is not a real namespace in the store and cannot be used to store documents.
+:::
 
 ---
 
@@ -118,40 +150,60 @@ Consider three users on a hub with the following grants:
 
 ---
 
-## Managing Entitlements via the API
+## Managing Entitlements
 
-Entitlements are managed through the `/user-access` REST endpoints. Use the [Swagger UI](http://localhost:8080/q/swagger-ui) to explore available operations.
+### Admin UI
+
+The easiest way to manage entitlements is the built-in admin UI, available at `/admin` in your CALM Hub instance. Users with any admin entitlement can access it; the sections visible depend on your permission level:
+
+- **Namespace Access** — available to any namespace admin; manage grants for namespaces you administer
+- **Domain Access** — available to global admins only; manage grants for any domain
+- **Global Admin Access** — available to global admins only; grant or revoke GLOBAL admin access for other users
+
+### REST API
+
+Entitlements can also be managed directly through the REST API. Use the [Swagger UI](http://localhost:8080/q/swagger-ui) to explore available operations.
 
 **Grant `bob` read access to `org.ab.cd`:**
 
 ```http
-POST /user-access
+POST /api/calm/namespaces/org.ab.cd/user-access
 Content-Type: application/json
 
 {
   "username": "bob",
-  "permission": "read",
-  "namespace": "org.ab.cd"
+  "permission": "read"
 }
 ```
 
 **Make `org.ab` publicly readable:**
 
 ```http
-POST /user-access
+POST /api/calm/namespaces/org.ab/user-access
 Content-Type: application/json
 
 {
   "username": "*",
-  "permission": "read",
-  "namespace": "org.ab"
+  "permission": "read"
 }
 ```
 
 **Remove public access from `org.ab`:**
 
 ```http
-DELETE /user-access/{id}
+DELETE /api/calm/namespaces/org.ab/user-access/{id}
+```
+
+**Grant `carol` admin access to the `payments` domain:**
+
+```http
+POST /api/calm/domains/payments/user-access
+Content-Type: application/json
+
+{
+  "username": "carol",
+  "permission": "admin"
+}
 ```
 
 ---
@@ -160,8 +212,8 @@ DELETE /user-access/{id}
 
 To make a namespace private:
 
-1. Find the `* read` grant for the namespace using `GET /user-access?namespace=org.ab`.
-2. Delete it with `DELETE /user-access/{id}`.
+1. Find the `* read` grant for the namespace using `GET /api/calm/namespaces/org.ab/user-access`.
+2. Delete it with `DELETE /api/calm/namespaces/org.ab/user-access/{id}`.
 
 Once removed, only users with explicit grants — or a write/admin grant on an ancestor — can access that namespace.
 


### PR DESCRIPTION
## Description

Closes #2676.

Adds a browser-based admin UI for managing user entitlements in CALM Hub, and hardens the permission model to close several gaps identified during review. Permission model is documented - essentially the specification - in calm-hub/PERMISSIONS.md

This PR comprises multiple commits to tell the story of implementation and aid review

### What's new

**Admin UI** (`calm-hub-ui`)
- New `/admin` route with a sidebar layout (Namespaces, Domains, Entitlements panels)
- **Entitlements panel** — namespace-scoped admins can grant/revoke read, write, and admin permissions on their own namespaces; global admins additionally see a Domain Access section (per-domain grants) and a Global Admin Access section (GLOBAL namespace grants)
- **Namespaces panel** — list all namespaces; global admins can create new top-level and child namespaces
- **Domains panel** — list all domains; global admins can create new domains
- Admin link hidden from the navbar for users with no admin entitlement; the `/admin` route itself is access-gated (non-admins see an error, never the UI)
- Shared `UserAccessContext` at the app root ensures the navbar, admin page, and all panels share a single `/current` API call

**Permission model** (`calm-hub`)
- GLOBAL admin users now bypass namespace `read`/`write` checks (as documented in PERMISSIONS.md)
- New child-namespace creation requires either GLOBAL admin or `admin` on the parent namespace
- Wildcard admin grants blocked at the API level on both the GLOBAL namespace and all domain namespaces (wildcard read/write still permitted)
- `CalmHubPermissionChecker.hasGlobalAdmin` refactored to use `getGrantsForUser` + `isGlobalAdminFromGrants`, aligning it with all other permission checks and removing the try/catch around `getUserAccessForUsername`
- `NamespaceResource.createNamespace` uses `@Authenticated` + inline check (rather than `@PermissionsAllowed`) because the namespace name is in the request body, not a path param — documented with an inline comment
- New `PERMISSIONS.md` documenting the complete permission model

**Automatic setup**
- A wildcard read grant is inserted automatically when a new domain is created, so domain resources are publicly readable by default
- No-auth mode synthesises a GLOBAL admin grant for the anonymous user so the full admin UI works out of the box for local development

### Screenshots
CALMHub, showing the `Admin` route in the hamburger for an entitled user:
<img width="589" height="481" alt="image" src="https://github.com/user-attachments/assets/06674b15-dd1f-478e-a34c-84b510505067" />

CALMHub Admin, showing ability to create a namespace:
<img width="681" height="526" alt="image" src="https://github.com/user-attachments/assets/8363c3e0-d1ef-4c7a-ba35-b02da26ee1de" />

CALMHub Admin, showing ability to manage entitlements - and the route in URL for deeplinking
<img width="1878" height="859" alt="image" src="https://github.com/user-attachments/assets/bb97bd60-7c96-4c3c-a413-7fac3794cefd" />

Admin in "mobile" responsive layout:
<img width="501" height="911" alt="image" src="https://github.com/user-attachments/assets/a918b308-9e31-4b73-9c77-37024c1fd721" />

### Key design decisions

- The admin UI is embedded in the existing `calm-hub-ui` React app (no separate build or deploy step)
- `UserAccessContext` is a React context at the `App` root, not inside `AdminPage`, so the navbar Admin link works correctly when navigating from Hub or Visualizer pages
- The `isGlobalAdmin` flag explicitly excludes `username === '*'` to prevent a hypothetical wildcard GLOBAL grant from ever conferring system admin

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Refactoring (no functional changes)
- [x] ✅ Test additions or updates

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅

All commits follow conventional commit format (`feat`, `fix`, `refactor`, `docs`).

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

**Java**: 2 058 unit tests pass (`../mvnw test`)  
**TypeScript**: 886 tests pass (`npm test --workspace calm-hub-ui`)  
**Lint**: 0 errors (`npm run lint --workspace calm-hub-ui`)

New tests cover:
- `CalmHubPermissionChecker` — wildcard GLOBAL grant does not confer global admin; `hasGlobalAdmin` uses `getGrantsForUser`
- `DomainUserAccessResource` — wildcard admin grant blocked (400); wildcard read grant permitted (201)
- `EntitlementsPanel` — full component test suite using `UserAccessContext.Provider` covering loading, no-access, namespace/domain dropdowns, global admin sections, and error states
- `UserAccessService` — grant methods resolve void on 201

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards