### PR TITLE
feat(calm-hub-ui): responsive mobile layout

### DIFF
--- a/calm-hub-ui/index.html
+++ b/calm-hub-ui/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" href="/brand/Icon/2025_CALM_Icon.svg" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
         <link href="./output.css" rel="stylesheet" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.test.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ExplorerSearch } from './ExplorerSearch.js';
+import { SearchService } from '../../service/search-service.js';
+import { GroupedSearchResults } from '../../model/search.js';
+
+const emptyResults: GroupedSearchResults = {
+    architectures: [],
+    patterns: [],
+    flows: [],
+    standards: [],
+    interfaces: [],
+    controls: [],
+    adrs: [],
+};
+
+const mockResults: GroupedSearchResults = {
+    architectures: [{ namespace: 'finos', id: 1, name: 'Test Architecture', description: 'A test architecture' }],
+    patterns: [{ namespace: 'finos', id: 2, name: 'Test Pattern', description: 'A test pattern' }],
+    flows: [],
+    standards: [],
+    interfaces: [],
+    controls: [],
+    adrs: [],
+};
+
+function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
+    return { search: searchFn } as unknown as SearchService;
+}
+
+function renderSearch(searchService?: SearchService, onSearchingChange?: (a: boolean) => void) {
+    return render(
+        <MemoryRouter>
+            <ExplorerSearch searchService={searchService} onSearchingChange={onSearchingChange} />
+        </MemoryRouter>
+    );
+}
+
+describe('ExplorerSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders search input', () => {
+        renderSearch();
+        expect(screen.getByPlaceholderText('Search CALM Hub...')).toBeInTheDocument();
+    });
+
+    it('debounces API calls', async () => {
+        const searchFn = vi.fn().mockResolvedValue(emptyResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 't' } });
+            fireEvent.change(input, { target: { value: 'te' } });
+            fireEvent.change(input, { target: { value: 'tes' } });
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+
+        expect(searchFn).not.toHaveBeenCalled();
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(searchFn).toHaveBeenCalledTimes(1);
+        expect(searchFn).toHaveBeenCalledWith('test');
+    });
+
+    it('displays grouped results inline', async () => {
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        expect(screen.getByText('Test Architecture')).toBeInTheDocument();
+        expect(screen.getByText('Test Pattern')).toBeInTheDocument();
+        expect(screen.getByText('Architectures')).toBeInTheDocument();
+        expect(screen.getByText('Patterns')).toBeInTheDocument();
+    });
+
+    it('notifies the parent when a search becomes active and inactive', async () => {
+        const onSearchingChange = vi.fn();
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        renderSearch(createMockSearchService(searchFn), onSearchingChange);
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        expect(onSearchingChange).toHaveBeenLastCalledWith(true);
+
+        await act(async () => {
+            fireEvent.click(screen.getByLabelText('Clear search'));
+        });
+        expect(onSearchingChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('shows no results message when search returns empty', async () => {
+        const searchFn = vi.fn().mockResolvedValue(emptyResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+
+    it('navigates with keyboard ArrowDown and Enter', async () => {
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+        await act(async () => {
+            fireEvent.keyDown(input, { key: 'ArrowDown' });
+        });
+
+        const firstOption = screen.getAllByRole('option')[0];
+        expect(firstOption).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('clears results on Escape', async () => {
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+        await act(async () => {
+            fireEvent.keyDown(input, { key: 'Escape' });
+        });
+
+        expect(screen.queryByText('Test Architecture')).not.toBeInTheDocument();
+    });
+
+    it('clears search on clear button click', async () => {
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByLabelText('Clear search'));
+        });
+
+        expect(input).toHaveValue('');
+        expect(screen.queryByText('Test Architecture')).not.toBeInTheDocument();
+    });
+
+    it('handles API errors gracefully', async () => {
+        const searchFn = vi.fn().mockRejectedValue(new Error('Network error'));
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText('Search failed, please try again')).toBeInTheDocument();
+    });
+
+    it('does not search when input is empty', async () => {
+        const searchFn = vi.fn().mockResolvedValue(emptyResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: '   ' } });
+        });
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(searchFn).not.toHaveBeenCalled();
+    });
+});

--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
@@ -1,0 +1,318 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { IoSearchOutline, IoCloseOutline } from 'react-icons/io5';
+import { SearchService } from '../../service/search-service.js';
+import { CalmService } from '../../service/calm-service.js';
+import { AdrService } from '../../service/adr-service/adr-service.js';
+import { GroupedSearchResults, SearchResult } from '../../model/search.js';
+
+interface FlatResult {
+    type: string;
+    result: SearchResult;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+    architectures: 'Architectures',
+    patterns: 'Patterns',
+    flows: 'Flows',
+    standards: 'Standards',
+    interfaces: 'Interfaces',
+    controls: 'Controls',
+    adrs: 'ADRs',
+};
+
+const TYPE_ROUTES: Record<string, string> = {
+    architectures: 'architectures',
+    patterns: 'patterns',
+    flows: 'flows',
+    standards: 'standards',
+    interfaces: 'interfaces',
+    controls: 'controls',
+    adrs: 'adrs',
+};
+
+function flattenResults(grouped: GroupedSearchResults): FlatResult[] {
+    const flat: FlatResult[] = [];
+    for (const [type, results] of Object.entries(grouped)) {
+        for (const result of results as SearchResult[]) {
+            flat.push({ type, result });
+        }
+    }
+    return flat;
+}
+
+interface ExplorerSearchProps {
+    searchService?: SearchService;
+    calmService?: CalmService;
+    adrService?: AdrService;
+    /** Notifies the parent explorer when a search is active so it can hide its nav. */
+    onSearchingChange?: (active: boolean) => void;
+}
+
+/**
+ * Always-visible search bar for the explorer. While a query is present the
+ * results render inline and take over the explorer body (the parent hides its
+ * tree / drill-down). Selecting a result navigates to the resource.
+ */
+export function ExplorerSearch({
+    searchService,
+    calmService: calmServiceProp,
+    adrService: adrServiceProp,
+    onSearchingChange,
+}: ExplorerSearchProps) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<GroupedSearchResults | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(false);
+    const [selectedIndex, setSelectedIndex] = useState(-1);
+
+    const inputRef = useRef<HTMLInputElement>(null);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const service = useMemo(() => searchService ?? new SearchService(), [searchService]);
+    const calmService = useMemo(() => calmServiceProp ?? new CalmService(), [calmServiceProp]);
+    const adrService = useMemo(() => adrServiceProp ?? new AdrService(), [adrServiceProp]);
+
+    const navigate = useNavigate();
+
+    const active = query.trim().length > 0;
+    const flatResults = results ? flattenResults(results) : [];
+
+    useEffect(() => {
+        onSearchingChange?.(active);
+    }, [active, onSearchingChange]);
+
+    const performSearch = useCallback(
+        async (searchQuery: string) => {
+            if (!searchQuery.trim()) {
+                setResults(null);
+                setError(false);
+                return;
+            }
+
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+            const controller = new AbortController();
+            abortControllerRef.current = controller;
+
+            setLoading(true);
+            setError(false);
+            try {
+                const data = await service.search(searchQuery);
+                if (controller.signal.aborted) return;
+                setResults(data);
+                setSelectedIndex(-1);
+            } catch {
+                if (controller.signal.aborted) return;
+                setResults(null);
+                setError(true);
+            } finally {
+                if (!controller.signal.aborted) {
+                    setLoading(false);
+                }
+            }
+        },
+        [service]
+    );
+
+    const handleInputChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const value = e.target.value;
+            setQuery(value);
+
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+
+            debounceRef.current = setTimeout(() => {
+                performSearch(value);
+            }, 300);
+        },
+        [performSearch]
+    );
+
+    const resolveLatestVersion = useCallback(
+        async (type: string, namespace: string, id: string): Promise<string> => {
+            let versions: (string | number)[];
+            switch (type) {
+                case 'architectures':
+                    versions = await calmService.fetchArchitectureVersions(namespace, id);
+                    break;
+                case 'patterns':
+                    versions = await calmService.fetchPatternVersions(namespace, id);
+                    break;
+                case 'flows':
+                    versions = await calmService.fetchFlowVersions(namespace, id);
+                    break;
+                case 'standards':
+                    versions = await calmService.fetchStandardVersions(namespace, id);
+                    break;
+                case 'adrs':
+                    versions = await adrService.fetchAdrRevisions(namespace, id);
+                    break;
+                default:
+                    throw new Error(`Unknown type: ${type}`);
+            }
+            if (!versions || versions.length === 0) throw new Error('No versions found');
+            return String(versions[versions.length - 1]);
+        },
+        [calmService, adrService]
+    );
+
+    const navigateToResult = useCallback(
+        (flatResult: FlatResult) => {
+            const { type, result } = flatResult;
+            setQuery('');
+            setResults(null);
+
+            if (type === 'controls') {
+                navigate(`/${result.namespace}/controls/${result.id}/detail`);
+                return;
+            }
+
+            if (type === 'interfaces') {
+                navigate(`/${result.namespace}/interfaces/${result.id}/detail`);
+                return;
+            }
+
+            const route = TYPE_ROUTES[type];
+            const id = String(result.id);
+            resolveLatestVersion(type, result.namespace, id)
+                .then((version) => {
+                    navigate(`/${result.namespace}/${route}/${id}/${version}`);
+                })
+                .catch(() => {
+                    navigate(`/${result.namespace}/${route}`);
+                });
+        },
+        [navigate, resolveLatestVersion]
+    );
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (!active || flatResults.length === 0) return;
+
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setSelectedIndex((prev) => (prev < flatResults.length - 1 ? prev + 1 : 0));
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setSelectedIndex((prev) => (prev > 0 ? prev - 1 : flatResults.length - 1));
+            } else if (e.key === 'Enter' && selectedIndex >= 0) {
+                e.preventDefault();
+                navigateToResult(flatResults[selectedIndex]);
+            } else if (e.key === 'Escape') {
+                handleClear();
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [active, flatResults, selectedIndex, navigateToResult]
+    );
+
+    const handleClear = useCallback(() => {
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+        }
+        if (abortControllerRef.current) {
+            abortControllerRef.current.abort();
+        }
+        setQuery('');
+        setResults(null);
+        setSelectedIndex(-1);
+        setError(false);
+        inputRef.current?.focus();
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+        };
+    }, []);
+
+    const renderGroupedResults = () => {
+        if (error) {
+            return <div className="p-3 text-sm text-error">Search failed, please try again</div>;
+        }
+
+        if (!results) {
+            return loading ? null : null;
+        }
+
+        const groups = Object.entries(results).filter(([, items]) => (items as SearchResult[]).length > 0);
+
+        if (groups.length === 0) {
+            return <div className="p-3 text-sm text-base-content/60">No results found</div>;
+        }
+
+        let globalIndex = 0;
+
+        return groups.map(([type, items]) => (
+            <div key={type}>
+                <div className="px-3 py-1 text-xs font-semibold text-base-content/50 uppercase tracking-wide bg-base-200">
+                    {TYPE_LABELS[type] ?? type}
+                </div>
+                {(items as SearchResult[]).map((item) => {
+                    const currentIndex = globalIndex++;
+                    return (
+                        <button
+                            key={`${type}-${item.namespace}-${item.id}`}
+                            className={`w-full text-left px-3 py-2 text-sm hover:bg-base-200 cursor-pointer ${
+                                currentIndex === selectedIndex ? 'bg-base-200' : ''
+                            }`}
+                            onMouseDown={() => navigateToResult({ type, result: item })}
+                            role="option"
+                            aria-selected={currentIndex === selectedIndex}
+                        >
+                            <div className="font-medium text-base-content">{item.name}</div>
+                            {item.description && (
+                                <div className="text-xs text-base-content/60 truncate">{item.description}</div>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+        ));
+    };
+
+    return (
+        <>
+            <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-base-300 bg-base-100">
+                <IoSearchOutline className="text-base-content/50 h-4 w-4 shrink-0" />
+                <input
+                    ref={inputRef}
+                    type="text"
+                    placeholder="Search CALM Hub..."
+                    className="flex-1 min-w-0 bg-transparent border-none outline-none text-sm text-base-content placeholder:text-base-content/40"
+                    value={query}
+                    onChange={handleInputChange}
+                    onKeyDown={handleKeyDown}
+                    aria-label="Search"
+                    role="combobox"
+                    aria-expanded={active}
+                    aria-haspopup="listbox"
+                />
+                {loading && <span className="loading loading-spinner loading-xs text-base-content/50" />}
+                {query && (
+                    <button
+                        onClick={handleClear}
+                        className="text-base-content/50 hover:text-base-content cursor-pointer"
+                        aria-label="Clear search"
+                    >
+                        <IoCloseOutline className="h-4 w-4" />
+                    </button>
+                )}
+            </div>
+            {active && (
+                <div className="flex-1 min-h-0 overflow-y-auto" role="listbox">
+                    {renderGroupedResults()}
+                </div>
+            )}
+        </>
+    );
+}

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
@@ -289,7 +289,7 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
                     ref={inputRef}
                     type="text"
                     placeholder="Search CALM Hub..."
-                    className="bg-transparent border-none outline-none text-sm text-base-content placeholder:text-base-content/40 w-48 lg:w-64"
+                    className="bg-transparent border-none outline-none text-sm text-base-content placeholder:text-base-content/40 w-28 sm:w-48 lg:w-64"
                     value={query}
                     onChange={handleInputChange}
                     onKeyDown={handleKeyDown}
@@ -313,7 +313,7 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
             </div>
             {showDropdown && (
                 <div
-                    className="absolute right-0 top-full mt-1 w-80 max-h-96 overflow-y-auto bg-base-100 border border-base-300 rounded-lg shadow-lg z-50"
+                    className="absolute right-0 top-full mt-1 w-80 max-w-[calc(100vw-2rem)] max-h-96 overflow-y-auto bg-base-100 border border-base-300 rounded-lg shadow-lg z-50"
                     role="listbox"
                 >
                     {renderGroupedResults()}

--- a/calm-hub-ui/src/components/navbar/Navbar.css
+++ b/calm-hub-ui/src/components/navbar/Navbar.css
@@ -1,4 +1,15 @@
 .logo {
-    max-width: unset;
+    /* Allow the logo to shrink within the navbar instead of forcing the bar
+       wider than the viewport on narrow screens. */
+    max-width: 100%;
     height: inherit;
+}
+
+/* Respect device safe areas (notch / rounded corners) and never let the bar
+   exceed the viewport width. */
+.navbar {
+    padding-top: max(0.5rem, env(safe-area-inset-top));
+    padding-left: max(0.5rem, env(safe-area-inset-left));
+    padding-right: max(0.5rem, env(safe-area-inset-right));
+    max-width: 100vw;
 }

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -1,40 +1,30 @@
 import './Navbar.css';
-import { NavLink } from 'react-router-dom';
+import { IoMenuOutline } from 'react-icons/io5';
 import { GlobalSearchBar } from './GlobalSearchBar.js';
 
-export function Navbar() {
+interface NavbarProps {
+    /**
+     * When provided, renders an "Explore" button in the navbar that toggles the
+     * navigation/explorer (the desktop sidebar, or the mobile drill-down panel).
+     * Pages without an explorer (e.g. the Visualizer) omit this.
+     */
+    onExploreClick?: () => void;
+}
+
+export function Navbar({ onExploreClick }: NavbarProps) {
     return (
         <div className="navbar bg-base-100 border-b-2 border-base-200 text-primary-content">
-            <div className="navbar-start flex items-center">
-                <div className="dropdown lg:hidden">
-                    <div tabIndex={0} role="button" className="btn btn-ghost text-primary" aria-label="Open Menu">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className="h-5 w-5"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth="2"
-                                d="M4 6h16M4 12h8m-8 6h16"
-                            />
-                        </svg>
-                    </div>
-                    <ul
-                        tabIndex={0}
-                        className="menu menu-xs dropdown-content bg-base-100 text-primary rounded-box z-[1] mt-3 w-52 p-2 shadow"
+            <div className="navbar-start flex items-center gap-1">
+                {onExploreClick && (
+                    <button
+                        className="btn btn-ghost gap-2 text-primary"
+                        onClick={onExploreClick}
+                        aria-label="Toggle explorer"
                     >
-                        <li>
-                            <NavLink to="/">Hub</NavLink>
-                        </li>
-                        <li>
-                            <NavLink to="/visualizer">Visualizer</NavLink>
-                        </li>
-                    </ul>
-                </div>
+                        <IoMenuOutline className="h-5 w-5" />
+                        <span className="hidden sm:inline">Explore</span>
+                    </button>
+                )}
                 <a className="btn btn-ghost">
                     <img
                         src="/brand/Horizontal/2025_CALM_Horizontal_Navbar_Logo.svg"
@@ -42,20 +32,6 @@ export function Navbar() {
                         className="h-10 logo"
                     />
                 </a>
-                <div className="hidden lg:flex">
-                    <ul className="menu menu-horizontal px-1">
-                        <li>
-                            <NavLink className="btn-ghost btn text-primary" to="/">
-                                Hub
-                            </NavLink>
-                        </li>
-                        <li>
-                            <NavLink className="btn-ghost btn text-primary" to="/visualizer">
-                                Visualizer
-                            </NavLink>
-                        </li>
-                    </ul>
-                </div>
             </div>
             <div className="navbar-end">
                 <GlobalSearchBar />

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -33,7 +33,9 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                     />
                 </a>
             </div>
-            <div className="navbar-end">
+            {/* Desktop keeps search in the navbar; on mobile it lives inside the
+                explorer panel instead, so it is hidden here below the lg breakpoint. */}
+            <div className="navbar-end hidden lg:flex">
                 <GlobalSearchBar />
             </div>
         </div>

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -33,10 +33,15 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                     />
                 </a>
             </div>
-            {/* Desktop keeps search in the navbar; on mobile it lives inside the
-                explorer panel instead, so it is hidden here below the lg breakpoint. */}
-            <div className="navbar-end hidden lg:flex">
-                <GlobalSearchBar />
+            <div className="navbar-end flex items-center gap-1">
+                {/* Portal target for page-level actions (e.g. the diagram's
+                    view-options menu), always visible across breakpoints. */}
+                <div id="navbar-actions" className="flex items-center" />
+                {/* Desktop keeps search in the navbar; on mobile it lives inside the
+                    explorer panel instead, so it is hidden here below the lg breakpoint. */}
+                <div className="hidden lg:flex">
+                    <GlobalSearchBar />
+                </div>
             </div>
         </div>
     );

--- a/calm-hub-ui/src/components/navbar/Navbar.tsx
+++ b/calm-hub-ui/src/components/navbar/Navbar.tsx
@@ -13,11 +13,11 @@ interface NavbarProps {
 
 export function Navbar({ onExploreClick }: NavbarProps) {
     return (
-        <div className="navbar bg-base-100 border-b-2 border-base-200 text-primary-content">
-            <div className="navbar-start flex items-center gap-1">
+        <div className="navbar relative bg-base-100 border-b-2 border-base-200 text-primary-content gap-1">
+            <div className="navbar-start flex items-center gap-1 min-w-0">
                 {onExploreClick && (
                     <button
-                        className="btn btn-ghost gap-2 text-primary"
+                        className="btn btn-ghost gap-2 text-primary shrink-0"
                         onClick={onExploreClick}
                         aria-label="Toggle explorer"
                     >
@@ -25,7 +25,9 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                         <span className="hidden sm:inline">Explore</span>
                     </button>
                 )}
-                <a className="btn btn-ghost">
+            </div>
+            <div className="navbar-center absolute left-1/2 -translate-x-1/2">
+                <a className="btn btn-ghost min-w-0 px-1">
                     <img
                         src="/brand/Horizontal/2025_CALM_Horizontal_Navbar_Logo.svg"
                         alt="CALM Logo"
@@ -33,7 +35,7 @@ export function Navbar({ onExploreClick }: NavbarProps) {
                     />
                 </a>
             </div>
-            <div className="navbar-end flex items-center gap-1">
+            <div className="navbar-end flex items-center gap-1 min-w-0 shrink-0">
                 {/* Portal target for page-level actions (e.g. the diagram's
                     view-options menu), always visible across breakpoints. */}
                 <div id="navbar-actions" className="flex items-center" />

--- a/calm-hub-ui/src/diff/Diff.css
+++ b/calm-hub-ui/src/diff/Diff.css
@@ -65,6 +65,23 @@
     border-right: none;
 }
 
+/* Stack the two comparison graphs vertically on narrow viewports so each one
+ * has enough room to be legible instead of being squeezed side by side. */
+@media (width <= 1023px) {
+    .architectures-container {
+        flex-direction: column;
+    }
+
+    .architecture-panel {
+        border-right: none;
+        border-bottom: 1px solid #e5e7eb;
+    }
+
+    .architecture-panel:last-child {
+        border-bottom: none;
+    }
+}
+
 .architecture-header {
     padding: 12px 16px;
     background: #f9fafb;

--- a/calm-hub-ui/src/diff/components/DiffGraph.tsx
+++ b/calm-hub-ui/src/diff/components/DiffGraph.tsx
@@ -18,6 +18,7 @@ import { DecisionGroupNode } from '../../visualizer/components/reactflow/Decisio
 import { THEME } from '../../visualizer/components/reactflow/theme.js';
 import { parseCALMDataWithDiff } from './utils/diffTransformer.js';
 import { parsePatternDataWithDiff } from './utils/patternDiffTransformer.js';
+import { useIsMobile } from '../../hooks/useMediaQuery.js';
 import type { DiffGraphProps } from '../model/diff-ui-types.js';
 
 const edgeTypes = { custom: FloatingEdge };
@@ -30,6 +31,7 @@ function DiffGraphInner({ source, sourceType, diffResult, isFirst }: DiffGraphPr
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
     const { fitView } = useReactFlow();
     const nodesInitialized = useNodesInitialized();
+    const isMobile = useIsMobile();
     const containerRef = useRef<HTMLDivElement>(null);
     const fitFrameRef = useRef<number>();
 
@@ -93,14 +95,16 @@ function DiffGraphInner({ source, sourceType, diffResult, isFirst }: DiffGraphPr
                     borderRadius: '8px',
                 }}
             />
-            <MiniMap
-                style={{
-                    background: THEME.colors.backgroundSecondary,
-                    border: `1px solid ${THEME.colors.border}`,
-                }}
-                nodeColor={THEME.colors.accent}
-                maskColor={`${THEME.colors.background}cc`}
-            />
+            {!isMobile && (
+                <MiniMap
+                    style={{
+                        background: THEME.colors.backgroundSecondary,
+                        border: `1px solid ${THEME.colors.border}`,
+                    }}
+                    nodeColor={THEME.colors.accent}
+                    maskColor={`${THEME.colors.background}cc`}
+                />
+            )}
         </ReactFlow>
         </div>
     );

--- a/calm-hub-ui/src/diff/components/DiffGraph.tsx
+++ b/calm-hub-ui/src/diff/components/DiffGraph.tsx
@@ -88,13 +88,15 @@ function DiffGraphInner({ source, sourceType, diffResult, isFirst }: DiffGraphPr
             style={{ background: THEME.colors.background }}
         >
             <Background color={THEME.colors.border} gap={16} />
-            <Controls
-                style={{
-                    background: THEME.colors.card,
-                    border: `1px solid ${THEME.colors.border}`,
-                    borderRadius: '8px',
-                }}
-            />
+            {!isMobile && (
+                <Controls
+                    style={{
+                        background: THEME.colors.card,
+                        border: `1px solid ${THEME.colors.border}`,
+                        borderRadius: '8px',
+                    }}
+                />
+            )}
             {!isMobile && (
                 <MiniMap
                     style={{

--- a/calm-hub-ui/src/hooks/useMediaQuery.test.ts
+++ b/calm-hub-ui/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useMediaQuery, useIsMobile } from './useMediaQuery.js';
+
+type Listener = () => void;
+
+/**
+ * Install a controllable matchMedia mock and return a helper to flip the
+ * match state and notify subscribers.
+ */
+function installMatchMedia(initialMatches: boolean) {
+    let matches = initialMatches;
+    const listeners = new Set<Listener>();
+
+    const matchMedia = vi.fn((query: string) => ({
+        get matches() {
+            return matches;
+        },
+        media: query,
+        onchange: null,
+        addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+        removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+        addListener: (cb: Listener) => listeners.add(cb),
+        removeListener: (cb: Listener) => listeners.delete(cb),
+        dispatchEvent: () => false,
+    }));
+
+    window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+
+    return {
+        setMatches(next: boolean) {
+            matches = next;
+            listeners.forEach((cb) => cb());
+        },
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('useMediaQuery', () => {
+    it('returns the initial match state', () => {
+        installMatchMedia(true);
+        const { result } = renderHook(() => useMediaQuery('(max-width: 1023px)'));
+        expect(result.current).toBe(true);
+    });
+
+    it('updates when the media query changes', () => {
+        const mm = installMatchMedia(false);
+        const { result } = renderHook(() => useMediaQuery('(max-width: 1023px)'));
+        expect(result.current).toBe(false);
+
+        act(() => mm.setMatches(true));
+        expect(result.current).toBe(true);
+    });
+
+    it('returns false when matchMedia is unavailable', () => {
+        // @ts-expect-error - simulate an environment without matchMedia
+        window.matchMedia = undefined;
+        const { result } = renderHook(() => useMediaQuery('(max-width: 1023px)'));
+        expect(result.current).toBe(false);
+    });
+});
+
+describe('useIsMobile', () => {
+    it('is true when the viewport is below the lg breakpoint', () => {
+        installMatchMedia(true);
+        const { result } = renderHook(() => useIsMobile());
+        expect(result.current).toBe(true);
+    });
+
+    it('is false on wide viewports', () => {
+        installMatchMedia(false);
+        const { result } = renderHook(() => useIsMobile());
+        expect(result.current).toBe(false);
+    });
+});

--- a/calm-hub-ui/src/hooks/useMediaQuery.ts
+++ b/calm-hub-ui/src/hooks/useMediaQuery.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribe to a CSS media query and return whether it currently matches.
+ *
+ * Safe to call in environments without `window.matchMedia` (e.g. older jsdom
+ * test setups): it returns `false` and never subscribes, so components fall
+ * back to their desktop layout.
+ */
+export function useMediaQuery(query: string): boolean {
+    const getMatches = (): boolean => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return false;
+        }
+        return window.matchMedia(query).matches;
+    };
+
+    const [matches, setMatches] = useState<boolean>(getMatches);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+        const mediaQueryList = window.matchMedia(query);
+        const handleChange = () => setMatches(mediaQueryList.matches);
+
+        // Sync immediately in case the query changed between render and effect.
+        handleChange();
+        mediaQueryList.addEventListener('change', handleChange);
+        return () => mediaQueryList.removeEventListener('change', handleChange);
+    }, [query]);
+
+    return matches;
+}
+
+/**
+ * Tailwind's `lg` breakpoint is 1024px. Anything narrower (phones and
+ * tablet-portrait) is treated as "mobile" and gets the off-canvas layout.
+ */
+export function useIsMobile(): boolean {
+    return useMediaQuery('(max-width: 1023px)');
+}

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -310,36 +310,37 @@ describe('Hub', () => {
             renderWithRouter(<Hub />);
 
             // Tree stays mounted (so deep-link / search loading still runs) but the
-            // drawer is closed — no backdrop — until the menu button is pressed.
+            // full-screen panel is closed (aria-hidden, so excluded from the dialog
+            // role) until the menu button is pressed.
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
             expect(screen.getByLabelText('Open navigation')).toBeInTheDocument();
-            expect(screen.queryByLabelText('Close navigation')).not.toBeInTheDocument();
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
             restore();
         });
 
-        it('opens the tree navigation drawer when the menu button is clicked', () => {
+        it('opens the full-screen tree navigation panel when the menu button is clicked', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
             fireEvent.click(screen.getByLabelText('Open navigation'));
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
-            // Backdrop present means the drawer is open.
-            expect(screen.getByLabelText('Close navigation')).toBeInTheDocument();
+            // The panel is now exposed (not aria-hidden), so the dialog is present.
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             restore();
         });
 
-        it('closes the drawer after a resource is loaded', () => {
+        it('closes the panel after a resource is loaded', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
             fireEvent.click(screen.getByLabelText('Open navigation'));
-            expect(screen.getByLabelText('Close navigation')).toBeInTheDocument();
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             fireEvent.click(screen.getByText('Load Test Data'));
-            // Drawer closes (backdrop gone) but the tree remains mounted.
-            expect(screen.queryByLabelText('Close navigation')).not.toBeInTheDocument();
+            // Panel closes (aria-hidden again) but the tree remains mounted.
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
             expect(screen.getByTestId('diagram-section')).toBeInTheDocument();
 

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -144,7 +144,16 @@ vi.mock('./components/interface-detail-section/InterfaceDetailSection', () => ({
 }));
 
 vi.mock('../components/navbar/Navbar', () => ({
-    Navbar: () => <nav data-testid="navbar">Navbar</nav>,
+    Navbar: ({ onExploreClick }: { onExploreClick?: () => void }) => (
+        <nav data-testid="navbar">
+            Navbar
+            {onExploreClick && (
+                <button aria-label="Toggle explorer" onClick={onExploreClick}>
+                    Explore
+                </button>
+            )}
+        </nav>
+    ),
 }));
 
 vi.mock('./components/diagram-section/DiagramSection', () => ({
@@ -317,6 +326,17 @@ describe('Hub', () => {
             fireEvent.click(screen.getByLabelText('Expand sidebar'));
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
         });
+
+        it('toggles the desktop sidebar from the navbar Explore button', () => {
+            renderWithRouter(<Hub />);
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByLabelText('Toggle explorer'));
+            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
+
+            fireEvent.click(screen.getByLabelText('Toggle explorer'));
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+        });
     });
 
     describe('mobile layout', () => {
@@ -344,7 +364,7 @@ describe('Hub', () => {
             // not rendered on mobile.
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
-            expect(screen.getByLabelText('Open navigation')).toBeInTheDocument();
+            expect(screen.getByLabelText('Toggle explorer')).toBeInTheDocument();
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
             restore();
@@ -354,7 +374,7 @@ describe('Hub', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            fireEvent.click(screen.getByLabelText('Open navigation'));
+            fireEvent.click(screen.getByLabelText('Toggle explorer'));
             expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             // The panel is now exposed (not aria-hidden), so the dialog is present.
             expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -366,7 +386,7 @@ describe('Hub', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            fireEvent.click(screen.getByLabelText('Open navigation'));
+            fireEvent.click(screen.getByLabelText('Toggle explorer'));
             expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             fireEvent.click(screen.getByText('Mobile Load Test Data'));

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -305,13 +305,15 @@ describe('Hub', () => {
             })) as unknown as typeof window.matchMedia;
         });
 
-        it('hides the tree navigation behind a menu button by default', () => {
+        it('keeps tree navigation mounted off-canvas with a menu button by default', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            // Tree is not rendered until the drawer is opened.
-            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
+            // Tree stays mounted (so deep-link / search loading still runs) but the
+            // drawer is closed — no backdrop — until the menu button is pressed.
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
             expect(screen.getByLabelText('Open navigation')).toBeInTheDocument();
+            expect(screen.queryByLabelText('Close navigation')).not.toBeInTheDocument();
 
             restore();
         });
@@ -322,6 +324,8 @@ describe('Hub', () => {
 
             fireEvent.click(screen.getByLabelText('Open navigation'));
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+            // Backdrop present means the drawer is open.
+            expect(screen.getByLabelText('Close navigation')).toBeInTheDocument();
 
             restore();
         });
@@ -331,10 +335,12 @@ describe('Hub', () => {
             renderWithRouter(<Hub />);
 
             fireEvent.click(screen.getByLabelText('Open navigation'));
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+            expect(screen.getByLabelText('Close navigation')).toBeInTheDocument();
 
             fireEvent.click(screen.getByText('Load Test Data'));
-            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
+            // Drawer closes (backdrop gone) but the tree remains mounted.
+            expect(screen.queryByLabelText('Close navigation')).not.toBeInTheDocument();
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
             expect(screen.getByTestId('diagram-section')).toBeInTheDocument();
 
             restore();

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -2,7 +2,28 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import Hub from './Hub.js';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+/**
+ * Force `useIsMobile()` (which reads window.matchMedia) to report a mobile
+ * viewport. Returns a restore function.
+ */
+function mockMobileViewport(isMobile: boolean) {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+        matches: isMobile,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    return () => {
+        window.matchMedia = original;
+    };
+}
 
 vi.mock('./components/tree-navigation/TreeNavigation', () => ({
     TreeNavigation: ({
@@ -266,6 +287,57 @@ describe('Hub', () => {
 
             fireEvent.click(screen.getByLabelText('Expand sidebar'));
             expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+        });
+    });
+
+    describe('mobile layout', () => {
+        afterEach(() => {
+            // Restore the default desktop matchMedia mock from vitest.setup.ts.
+            window.matchMedia = ((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => false,
+            })) as unknown as typeof window.matchMedia;
+        });
+
+        it('hides the tree navigation behind a menu button by default', () => {
+            const restore = mockMobileViewport(true);
+            renderWithRouter(<Hub />);
+
+            // Tree is not rendered until the drawer is opened.
+            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
+            expect(screen.getByLabelText('Open navigation')).toBeInTheDocument();
+
+            restore();
+        });
+
+        it('opens the tree navigation drawer when the menu button is clicked', () => {
+            const restore = mockMobileViewport(true);
+            renderWithRouter(<Hub />);
+
+            fireEvent.click(screen.getByLabelText('Open navigation'));
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+
+            restore();
+        });
+
+        it('closes the drawer after a resource is loaded', () => {
+            const restore = mockMobileViewport(true);
+            renderWithRouter(<Hub />);
+
+            fireEvent.click(screen.getByLabelText('Open navigation'));
+            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText('Load Test Data'));
+            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
+            expect(screen.getByTestId('diagram-section')).toBeInTheDocument();
+
+            restore();
         });
     });
 });

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -90,6 +90,35 @@ vi.mock('./components/tree-navigation/TreeNavigation', () => ({
     ),
 }));
 
+vi.mock('./components/tree-navigation/MobileNavMenu', () => ({
+    MobileNavMenu: ({
+        onDataLoad,
+        onClose,
+    }: {
+        onDataLoad: (data: unknown) => void;
+        onClose: () => void;
+    }) => (
+        <div data-testid="mobile-nav-menu">
+            <button aria-label="Close navigation" onClick={onClose}>
+                Close
+            </button>
+            <button
+                onClick={() =>
+                    onDataLoad({
+                        id: 'test',
+                        version: '1.0',
+                        calmType: 'Patterns',
+                        name: 'test-namespace',
+                        data: {},
+                    })
+                }
+            >
+                Mobile Load Test Data
+            </button>
+        </div>
+    ),
+}));
+
 vi.mock('./components/json-renderer/JsonRenderer', () => ({
     JsonRenderer: ({ json }: { json: unknown }) => (
         <div data-testid="json-renderer">{json ? 'JSON' : ''}</div>
@@ -305,26 +334,28 @@ describe('Hub', () => {
             })) as unknown as typeof window.matchMedia;
         });
 
-        it('keeps tree navigation mounted off-canvas with a menu button by default', () => {
+        it('keeps the drill-down menu mounted off-canvas with a menu button by default', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
-            // Tree stays mounted (so deep-link / search loading still runs) but the
-            // full-screen panel is closed (aria-hidden, so excluded from the dialog
-            // role) until the menu button is pressed.
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+            // The drill-down menu stays mounted (so deep-link / search loading still
+            // runs) but the full-screen panel is closed (aria-hidden, so excluded from
+            // the dialog role) until the menu button is pressed. The desktop tree is
+            // not rendered on mobile.
+            expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
+            expect(screen.queryByTestId('tree-navigation')).not.toBeInTheDocument();
             expect(screen.getByLabelText('Open navigation')).toBeInTheDocument();
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
             restore();
         });
 
-        it('opens the full-screen tree navigation panel when the menu button is clicked', () => {
+        it('opens the full-screen drill-down panel when the menu button is clicked', () => {
             const restore = mockMobileViewport(true);
             renderWithRouter(<Hub />);
 
             fireEvent.click(screen.getByLabelText('Open navigation'));
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+            expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             // The panel is now exposed (not aria-hidden), so the dialog is present.
             expect(screen.getByRole('dialog')).toBeInTheDocument();
 
@@ -338,10 +369,10 @@ describe('Hub', () => {
             fireEvent.click(screen.getByLabelText('Open navigation'));
             expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-            fireEvent.click(screen.getByText('Load Test Data'));
-            // Panel closes (aria-hidden again) but the tree remains mounted.
+            fireEvent.click(screen.getByText('Mobile Load Test Data'));
+            // Panel closes (aria-hidden again) but the menu remains mounted.
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-            expect(screen.getByTestId('tree-navigation')).toBeInTheDocument();
+            expect(screen.getByTestId('mobile-nav-menu')).toBeInTheDocument();
             expect(screen.getByTestId('diagram-section')).toBeInTheDocument();
 
             restore();

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { IoChevronForwardOutline, IoMenuOutline } from 'react-icons/io5';
 import { TreeNavigation } from './components/tree-navigation/TreeNavigation.js';
+import { MobileNavMenu } from './components/tree-navigation/MobileNavMenu.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
 import { Data, Adr } from '../model/calm.js';
 import { ControlData } from '../model/control.js';
@@ -80,7 +81,7 @@ export default function Hub() {
             onAdrLoad={memoizedAdrLoad}
             onControlLoad={handleControlLoad}
             onInterfaceLoad={handleInterfaceLoad}
-            onCollapse={isMobile ? () => setIsMobileNavOpen(false) : () => setIsSidebarOpen(false)}
+            onCollapse={() => setIsSidebarOpen(false)}
         />
     );
 
@@ -121,10 +122,10 @@ export default function Hub() {
                     </div>
                 )}
 
-                {/* Mobile: full-screen tree-navigation panel that slides in from the
-                    left. Kept mounted (slid off screen) so deep-link / global-search
-                    loading — which lives inside TreeNavigation — runs even while the
-                    panel is closed. Dismissed via the panel's own back button. */}
+                {/* Mobile: full-screen drill-down navigation panel that slides in from
+                    the left. Kept mounted (slid off screen) so deep-link / global-search
+                    loading — which lives inside MobileNavMenu — runs even while the panel
+                    is closed. Dismissed via the panel's own close button. */}
                 {isMobile && (
                     <div
                         className={`fixed inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
@@ -132,7 +133,15 @@ export default function Hub() {
                         aria-modal={isMobileNavOpen}
                         aria-hidden={!isMobileNavOpen}
                     >
-                        <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
+                        <div className="flex-1 min-h-0 overflow-hidden">
+                            <MobileNavMenu
+                                onDataLoad={memoizedDataLoad}
+                                onAdrLoad={memoizedAdrLoad}
+                                onControlLoad={handleControlLoad}
+                                onInterfaceLoad={handleInterfaceLoad}
+                                onClose={() => setIsMobileNavOpen(false)}
+                            />
+                        </div>
                     </div>
                 )}
 

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -121,34 +121,41 @@ export default function Hub() {
                     </div>
                 )}
 
-                {/* Mobile: off-canvas tree-navigation drawer */}
-                {isMobile && isMobileNavOpen && (
-                    <div className="fixed inset-0 z-40 flex" role="dialog" aria-modal="true">
-                        <button
-                            aria-label="Close navigation"
-                            className="absolute inset-0 bg-black/40"
-                            onClick={() => setIsMobileNavOpen(false)}
-                        />
-                        <div className="relative h-full w-80 max-w-[85%] p-3 pr-0">
+                {/* Mobile: off-canvas tree-navigation drawer. Kept mounted (slid off
+                    screen) so deep-link / global-search loading — which lives inside
+                    TreeNavigation — runs even while the drawer is closed. */}
+                {isMobile && (
+                    <>
+                        {isMobileNavOpen && (
+                            <button
+                                aria-label="Close navigation"
+                                className="fixed inset-0 z-40 bg-black/40"
+                                onClick={() => setIsMobileNavOpen(false)}
+                            />
+                        )}
+                        <div
+                            className={`fixed top-0 left-0 z-40 h-full w-80 max-w-[85%] p-3 pr-0 transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
+                            role="dialog"
+                            aria-modal={isMobileNavOpen}
+                            aria-hidden={!isMobileNavOpen}
+                        >
                             <div className="h-full bg-base-100 rounded-box overflow-hidden shadow-xl flex flex-col">
                                 <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
                             </div>
                         </div>
-                    </div>
+                    </>
                 )}
 
                 <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
                     {isMobile && (
-                        <div className="px-3 pt-3 shrink-0">
-                            <button
-                                aria-label="Open navigation"
-                                className="btn btn-sm btn-ghost gap-2"
-                                onClick={() => setIsMobileNavOpen(true)}
-                            >
-                                <IoMenuOutline className="text-lg" />
-                                Explore
-                            </button>
-                        </div>
+                        <button
+                            aria-label="Open navigation"
+                            className="btn btn-xs btn-ghost gap-1 self-start m-2 shrink-0"
+                            onClick={() => setIsMobileNavOpen(true)}
+                        >
+                            <IoMenuOutline className="text-base" />
+                            Explore
+                        </button>
                     )}
                     <div className="flex-1 overflow-auto min-w-0">{detailContent}</div>
                 </div>

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -92,7 +92,7 @@ export default function Hub() {
     ) : adrData ? (
         <AdrRenderer adrDetails={adrData} />
     ) : isDiagramView ? (
-        <DiagramSection data={data} onItemSelect={handleItemSelect} hasDetailsPanel={!!selectedItem} />
+        <DiagramSection data={data} onItemSelect={handleItemSelect} />
     ) : (
         <DocumentDetailSection data={data} />
     );

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -121,29 +121,19 @@ export default function Hub() {
                     </div>
                 )}
 
-                {/* Mobile: off-canvas tree-navigation drawer. Kept mounted (slid off
-                    screen) so deep-link / global-search loading — which lives inside
-                    TreeNavigation — runs even while the drawer is closed. */}
+                {/* Mobile: full-screen tree-navigation panel that slides in from the
+                    left. Kept mounted (slid off screen) so deep-link / global-search
+                    loading — which lives inside TreeNavigation — runs even while the
+                    panel is closed. Dismissed via the panel's own back button. */}
                 {isMobile && (
-                    <>
-                        {isMobileNavOpen && (
-                            <button
-                                aria-label="Close navigation"
-                                className="fixed inset-0 z-40 bg-black/40"
-                                onClick={() => setIsMobileNavOpen(false)}
-                            />
-                        )}
-                        <div
-                            className={`fixed top-0 left-0 z-40 h-full w-80 max-w-[85%] p-3 pr-0 transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
-                            role="dialog"
-                            aria-modal={isMobileNavOpen}
-                            aria-hidden={!isMobileNavOpen}
-                        >
-                            <div className="h-full bg-base-100 rounded-box overflow-hidden shadow-xl flex flex-col">
-                                <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
-                            </div>
-                        </div>
-                    </>
+                    <div
+                        className={`fixed inset-0 z-40 bg-base-100 flex flex-col transition-transform duration-300 ${isMobileNavOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}`}
+                        role="dialog"
+                        aria-modal={isMobileNavOpen}
+                        aria-hidden={!isMobileNavOpen}
+                    >
+                        <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
+                    </div>
                 )}
 
                 <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -162,15 +152,12 @@ export default function Hub() {
 
                 {selectedItem && isDiagramView && (
                     isMobile ? (
-                        <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true">
-                            <button
-                                aria-label="Close details"
-                                className="absolute inset-0 bg-black/40"
-                                onClick={closeSidebar}
-                            />
-                            <div className="relative h-full w-full max-w-sm">
-                                <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
-                            </div>
+                        <div
+                            className="fixed inset-0 z-40 bg-base-100 animate-slide-in-right"
+                            role="dialog"
+                            aria-modal="true"
+                        >
+                            <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
                         </div>
                     ) : (
                         <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
-import { IoChevronForwardOutline } from 'react-icons/io5';
+import { IoChevronForwardOutline, IoMenuOutline } from 'react-icons/io5';
 import { TreeNavigation } from './components/tree-navigation/TreeNavigation.js';
+import { useIsMobile } from '../hooks/useMediaQuery.js';
 import { Data, Adr } from '../model/calm.js';
 import { ControlData } from '../model/control.js';
 import { InterfaceData } from '../model/interface.js';
@@ -20,7 +21,9 @@ export default function Hub() {
     const [controlData, setControlData] = useState<ControlData | undefined>();
     const [interfaceData, setInterfaceData] = useState<InterfaceData | undefined>();
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+    const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [selectedItem, setSelectedItem] = useState<SelectedItem>(null);
+    const isMobile = useIsMobile();
 
     function handleDataLoad(data: Data) {
         setData(data);
@@ -28,6 +31,7 @@ export default function Hub() {
         setControlData(undefined);
         setInterfaceData(undefined);
         setSelectedItem(null);
+        setIsMobileNavOpen(false);
     }
 
     function handleAdrLoad(adr: Adr) {
@@ -36,6 +40,7 @@ export default function Hub() {
         setControlData(undefined);
         setInterfaceData(undefined);
         setSelectedItem(null);
+        setIsMobileNavOpen(false);
     }
 
     function handleControlLoad(control: ControlData) {
@@ -44,6 +49,7 @@ export default function Hub() {
         setAdrData(undefined);
         setInterfaceData(undefined);
         setSelectedItem(null);
+        setIsMobileNavOpen(false);
     }
 
     function handleInterfaceLoad(iface: InterfaceData) {
@@ -52,6 +58,7 @@ export default function Hub() {
         setAdrData(undefined);
         setControlData(undefined);
         setSelectedItem(null);
+        setIsMobileNavOpen(false);
     }
 
     const handleItemSelect = useCallback((item: SelectedItem) => {
@@ -67,44 +74,100 @@ export default function Hub() {
     const memoizedDataLoad = useMemo(() => handleDataLoad, []);
     const memoizedAdrLoad = useMemo(() => handleAdrLoad, []);
 
+    const treeNavigation = (
+        <TreeNavigation
+            onDataLoad={memoizedDataLoad}
+            onAdrLoad={memoizedAdrLoad}
+            onControlLoad={handleControlLoad}
+            onInterfaceLoad={handleInterfaceLoad}
+            onCollapse={isMobile ? () => setIsMobileNavOpen(false) : () => setIsSidebarOpen(false)}
+        />
+    );
+
+    const detailContent = interfaceData ? (
+        <InterfaceDetailSection interfaceData={interfaceData} />
+    ) : controlData ? (
+        <ControlDetailSection controlData={controlData} />
+    ) : adrData ? (
+        <AdrRenderer adrDetails={adrData} />
+    ) : isDiagramView ? (
+        <DiagramSection data={data} onItemSelect={handleItemSelect} hasDetailsPanel={!!selectedItem} />
+    ) : (
+        <DocumentDetailSection data={data} />
+    );
+
     return (
         <div className="flex flex-col h-screen overflow-hidden">
             <Navbar />
-            <div className="flex flex-row flex-1 overflow-hidden bg-base-300">
-                <div className={`${isSidebarOpen ? 'w-1/4' : 'w-12'} p-4 pr-2 transition-all duration-300`}>
-                    <div className="h-full bg-base-100 rounded-box overflow-hidden shadow-xl flex flex-col">
-                        {isSidebarOpen ? (
-                            <div className="flex-1 min-h-0 overflow-hidden">
-                                <TreeNavigation onDataLoad={memoizedDataLoad} onAdrLoad={memoizedAdrLoad} onControlLoad={handleControlLoad} onInterfaceLoad={handleInterfaceLoad} onCollapse={() => setIsSidebarOpen(false)} />
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-center pt-3">
-                                <button
-                                    aria-label="Expand sidebar"
-                                    className="btn btn-ghost btn-xs btn-circle"
-                                    onClick={() => setIsSidebarOpen(true)}
-                                >
-                                    <IoChevronForwardOutline />
-                                </button>
-                            </div>
-                        )}
+            <div className="relative flex flex-row flex-1 overflow-hidden bg-base-300">
+                {/* Desktop: inline, collapsible tree-navigation column */}
+                {!isMobile && (
+                    <div className={`${isSidebarOpen ? 'w-1/4' : 'w-12'} p-4 pr-2 transition-all duration-300`}>
+                        <div className="h-full bg-base-100 rounded-box overflow-hidden shadow-xl flex flex-col">
+                            {isSidebarOpen ? (
+                                <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
+                            ) : (
+                                <div className="flex items-center justify-center pt-3">
+                                    <button
+                                        aria-label="Expand sidebar"
+                                        className="btn btn-ghost btn-xs btn-circle"
+                                        onClick={() => setIsSidebarOpen(true)}
+                                    >
+                                        <IoChevronForwardOutline />
+                                    </button>
+                                </div>
+                            )}
+                        </div>
                     </div>
-                </div>
-                <div className="flex-1 overflow-auto min-w-0">
-                    {interfaceData ? (
-                        <InterfaceDetailSection interfaceData={interfaceData} />
-                    ) : controlData ? (
-                        <ControlDetailSection controlData={controlData} />
-                    ) : adrData ? (
-                        <AdrRenderer adrDetails={adrData} />
-                    ) : isDiagramView ? (
-                        <DiagramSection data={data} onItemSelect={handleItemSelect} hasDetailsPanel={!!selectedItem} />
-                    ) : (
-                        <DocumentDetailSection data={data} />
+                )}
+
+                {/* Mobile: off-canvas tree-navigation drawer */}
+                {isMobile && isMobileNavOpen && (
+                    <div className="fixed inset-0 z-40 flex" role="dialog" aria-modal="true">
+                        <button
+                            aria-label="Close navigation"
+                            className="absolute inset-0 bg-black/40"
+                            onClick={() => setIsMobileNavOpen(false)}
+                        />
+                        <div className="relative h-full w-80 max-w-[85%] p-3 pr-0">
+                            <div className="h-full bg-base-100 rounded-box overflow-hidden shadow-xl flex flex-col">
+                                <div className="flex-1 min-h-0 overflow-hidden">{treeNavigation}</div>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+                    {isMobile && (
+                        <div className="px-3 pt-3 shrink-0">
+                            <button
+                                aria-label="Open navigation"
+                                className="btn btn-sm btn-ghost gap-2"
+                                onClick={() => setIsMobileNavOpen(true)}
+                            >
+                                <IoMenuOutline className="text-lg" />
+                                Explore
+                            </button>
+                        </div>
                     )}
+                    <div className="flex-1 overflow-auto min-w-0">{detailContent}</div>
                 </div>
+
                 {selectedItem && isDiagramView && (
-                    <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
+                    isMobile ? (
+                        <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true">
+                            <button
+                                aria-label="Close details"
+                                className="absolute inset-0 bg-black/40"
+                                onClick={closeSidebar}
+                            />
+                            <div className="relative h-full w-full max-w-sm">
+                                <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
+                            </div>
+                        </div>
+                    ) : (
+                        <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
+                    )
                 )}
             </div>
         </div>

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { IoChevronForwardOutline, IoMenuOutline } from 'react-icons/io5';
+import { IoChevronForwardOutline } from 'react-icons/io5';
 import { TreeNavigation } from './components/tree-navigation/TreeNavigation.js';
 import { MobileNavMenu } from './components/tree-navigation/MobileNavMenu.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
@@ -99,7 +99,7 @@ export default function Hub() {
 
     return (
         <div className="flex flex-col h-screen overflow-hidden">
-            <Navbar />
+            <Navbar onExploreClick={() => (isMobile ? setIsMobileNavOpen(true) : setIsSidebarOpen((v) => !v))} />
             <div className="relative flex flex-row flex-1 overflow-hidden bg-base-300">
                 {/* Desktop: inline, collapsible tree-navigation column */}
                 {!isMobile && (
@@ -146,16 +146,6 @@ export default function Hub() {
                 )}
 
                 <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-                    {isMobile && (
-                        <button
-                            aria-label="Open navigation"
-                            className="btn btn-xs btn-ghost gap-1 self-start m-2 shrink-0"
-                            onClick={() => setIsMobileNavOpen(true)}
-                        >
-                            <IoMenuOutline className="text-base" />
-                            Explore
-                        </button>
-                    )}
                     <div className="flex-1 overflow-auto min-w-0">{detailContent}</div>
                 </div>
 

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -92,7 +92,7 @@ export default function Hub() {
     ) : adrData ? (
         <AdrRenderer adrDetails={adrData} />
     ) : isDiagramView ? (
-        <DiagramSection data={data} onItemSelect={handleItemSelect} />
+        <DiagramSection data={data} onItemSelect={handleItemSelect} hasDetailsPanel={!!selectedItem} />
     ) : (
         <DocumentDetailSection data={data} />
     );

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ControlDetailSection } from './ControlDetailSection.js';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ControlData } from '../../../model/control.js';
 
 // ── Mocks ─────────────────────────────────────────────────
@@ -33,6 +33,27 @@ vi.mock('../../../service/control-service.js', () => ({
         fetchConfigurationForVersion: (...args: unknown[]) => mockFetchConfigurationForVersion(...args),
     }; }),
 }));
+
+/**
+ * Force `useIsMobile()` (which reads window.matchMedia) to report the given
+ * viewport. Returns a restore function.
+ */
+function mockViewport(isMobile: boolean) {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+        matches: isMobile,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+    return () => {
+        window.matchMedia = original;
+    };
+}
 
 // ── Test data ─────────────────────────────────────────────
 
@@ -445,6 +466,81 @@ describe('ControlDetailSection', () => {
                 expect(document.querySelectorAll('[data-cy="json-renderer-wrapper"]')).toHaveLength(0);
                 expect(screen.getAllByTestId('readable-json-view')).toHaveLength(2);
             });
+        });
+    });
+
+    // ──────────────────────────────────────────────────
+    // Mobile tabbed layout
+    // ──────────────────────────────────────────────────
+    describe('mobile layout', () => {
+        let restore: () => void;
+
+        beforeEach(() => {
+            restore = mockViewport(true);
+        });
+
+        afterEach(() => {
+            restore();
+        });
+
+        it('renders Requirement and Configuration tabs instead of stacked panels', async () => {
+            setupMocks();
+            render(<ControlDetailSection controlData={controlData} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('tab', { name: 'Requirement' })).toBeInTheDocument();
+                expect(screen.getByRole('tab', { name: 'Configuration' })).toBeInTheDocument();
+            });
+
+            // Only the active (requirement) panel is shown, so just one readable view.
+            expect(screen.getAllByTestId('readable-json-view')).toHaveLength(1);
+        });
+
+        it('shows the requirement panel by default', async () => {
+            setupMocks({ reqSchema: requirementSchema });
+            render(<ControlDetailSection controlData={controlData} />);
+
+            await waitFor(() => {
+                const view = screen.getByTestId('readable-json-view');
+                expect(view).toHaveTextContent(JSON.stringify(requirementSchema));
+            });
+        });
+
+        it('omits the Configuration tab when no configurations exist', async () => {
+            setupMocks({ configIds: [] });
+            render(<ControlDetailSection controlData={controlData} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('tab', { name: 'Requirement' })).toBeInTheDocument();
+            });
+            expect(screen.queryByRole('tab', { name: 'Configuration' })).not.toBeInTheDocument();
+        });
+
+        it('switches to the configuration panel and shows its config tabs', async () => {
+            setupMocks({ configIds: [10, 20] });
+            const user = userEvent.setup();
+            render(<ControlDetailSection controlData={controlData} />);
+
+            await user.click(await screen.findByRole('tab', { name: 'Configuration' }));
+
+            expect(screen.getByRole('tab', { name: 'Config 10' })).toBeInTheDocument();
+            expect(screen.getByRole('tab', { name: 'Config 20' })).toBeInTheDocument();
+            // Requirement version pickers are not visible on the configuration panel.
+            expect(screen.queryByText('Requirement /')).not.toBeInTheDocument();
+        });
+
+        it('applies the active style to the selected panel tab', async () => {
+            setupMocks();
+            const user = userEvent.setup();
+            render(<ControlDetailSection controlData={controlData} />);
+
+            const reqTab = await screen.findByRole('tab', { name: 'Requirement' });
+            expect(reqTab).toHaveClass('tab-active');
+
+            await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+
+            expect(screen.getByRole('tab', { name: 'Configuration' })).toHaveClass('tab-active');
+            expect(screen.getByRole('tab', { name: 'Requirement' })).not.toHaveClass('tab-active');
         });
     });
 

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -4,8 +4,10 @@ import { ControlData } from '../../../model/control.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { ReadableJsonView } from './ReadableJsonView.js';
 import { ControlService } from '../../../service/control-service.js';
+import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 
 type ViewMode = 'readable' | 'raw';
+type ControlPanel = 'requirement' | 'configuration';
 
 interface ControlDetailSectionProps {
     controlData: ControlData;
@@ -13,6 +15,7 @@ interface ControlDetailSectionProps {
 
 export function ControlDetailSection({ controlData }: ControlDetailSectionProps) {
     const controlService = useMemo(() => new ControlService(), []);
+    const isMobile = useIsMobile();
 
     // Requirement state
     const [requirementVersions, setRequirementVersions] = useState<string[]>([]);
@@ -29,6 +32,10 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
     // View mode state (readable is the primary/default view)
     const [reqViewMode, setReqViewMode] = useState<ViewMode>('readable');
     const [cfgViewMode, setCfgViewMode] = useState<ViewMode>('readable');
+
+    // On mobile the requirement and configuration panels are shown as tabs
+    // rather than stacked, so we track which one is active.
+    const [activePanel, setActivePanel] = useState<ControlPanel>('requirement');
 
     const handleReqVersionClick = useCallback((version: string) => {
         setSelectedReqVersion(version);
@@ -51,6 +58,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         setConfigVersions([]);
         setSelectedConfigVersion('');
         setConfigJson(undefined);
+        setActivePanel('requirement');
 
         controlService.fetchRequirementVersions(
             controlData.domain,
@@ -93,6 +101,165 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         });
     };
 
+    // ── Shared builders (used by both the desktop stacked layout and the
+    //    mobile tabbed layout) so role/name selectors stay identical. ─────────
+
+    const viewToggle = (mode: ViewMode, setMode: (m: ViewMode) => void) => (
+        <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
+            <button
+                role="tab"
+                className={`tab ${mode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+                onClick={() => setMode('readable')}
+            >
+                Readable
+            </button>
+            <button
+                role="tab"
+                className={`tab ${mode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+                onClick={() => setMode('raw')}
+            >
+                Raw JSON
+            </button>
+        </div>
+    );
+
+    const reqVersionButtons = requirementVersions.map((v) => (
+        <button
+            key={v}
+            role="tab"
+            className={`tab gap-1 rounded-lg ${selectedReqVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+            onClick={() => handleReqVersionClick(v)}
+        >
+            {v}
+        </button>
+    ));
+
+    const configIdButtons = configIds.map((cid) => (
+        <button
+            key={cid}
+            role="tab"
+            className={`tab gap-1 rounded-lg ${selectedConfigId === cid ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+            onClick={() => handleConfigClick(cid)}
+        >
+            Config {cid}
+        </button>
+    ));
+
+    const configVersionButtons = configVersions.map((v) => (
+        <button
+            key={v}
+            role="tab"
+            className={`tab gap-1 rounded-lg ${selectedConfigVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+            onClick={() => handleConfigVersionClick(v)}
+        >
+            {v}
+        </button>
+    ));
+
+    const requirementContent = reqViewMode === 'readable' ? (
+        <ReadableJsonView json={requirementJson} />
+    ) : (
+        <JsonRenderer json={requirementJson} />
+    );
+
+    const configurationContent = cfgViewMode === 'readable' ? (
+        <ReadableJsonView json={configJson} />
+    ) : (
+        <JsonRenderer json={configJson} />
+    );
+
+    // ── Mobile: a single full-bleed pane with Requirement / Configuration
+    //    tabs, stacked headers, and horizontally scrollable version pickers. ──
+    if (isMobile) {
+        const showConfig = configIds.length > 0;
+        const panel = activePanel === 'configuration' && showConfig ? 'configuration' : 'requirement';
+
+        return (
+            <div className="w-full h-full flex flex-col bg-base-100">
+                {/* Control name */}
+                <div className="bg-base-200 px-4 py-3 border-b border-base-300">
+                    <h2 className="text-base font-bold flex items-center gap-2 text-primary min-w-0">
+                        <IoShieldCheckmarkOutline className="text-primary shrink-0" />
+                        <span className="truncate">{controlData.controlName}</span>
+                    </h2>
+                </div>
+
+                {/* Requirement / Configuration tabs */}
+                <div role="tablist" className="tabs tabs-bordered bg-base-100 border-b border-base-200 px-2">
+                    <button
+                        role="tab"
+                        className={`tab flex-1 ${panel === 'requirement' ? 'tab-active text-primary font-semibold' : ''}`}
+                        onClick={() => setActivePanel('requirement')}
+                    >
+                        Requirement
+                    </button>
+                    {showConfig && (
+                        <button
+                            role="tab"
+                            className={`tab flex-1 ${panel === 'configuration' ? 'tab-active text-primary font-semibold' : ''}`}
+                            onClick={() => setActivePanel('configuration')}
+                        >
+                            Configuration
+                        </button>
+                    )}
+                </div>
+
+                {panel === 'requirement' ? (
+                    <div className="flex-1 min-h-0 flex flex-col">
+                        {/* Breadcrumb + view toggle */}
+                        <div className="bg-base-200 px-4 py-2 border-b border-base-300 flex items-center justify-between gap-2">
+                            <h2 className="text-xs font-semibold text-base-content/70 truncate">
+                                Requirement{selectedReqVersion ? ` / ${selectedReqVersion}` : ''}
+                            </h2>
+                            {viewToggle(reqViewMode, setReqViewMode)}
+                        </div>
+                        {requirementVersions.length > 1 && (
+                            <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
+                                <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100 w-max">
+                                    {reqVersionButtons}
+                                </div>
+                            </div>
+                        )}
+                        <div className="flex-1 min-h-0 overflow-auto bg-base-200">
+                            {requirementContent}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex-1 min-h-0 flex flex-col">
+                        {/* Breadcrumb + view toggle */}
+                        <div className="bg-base-200 px-4 py-2 border-b border-base-300 flex items-center justify-between gap-2">
+                            <h2 className="text-xs font-semibold text-base-content/70 truncate">
+                                Configurations
+                                {selectedConfigId !== null ? ` / ${selectedConfigId}` : ''}
+                                {selectedConfigVersion ? ` / ${selectedConfigVersion}` : ''}
+                            </h2>
+                            {viewToggle(cfgViewMode, setCfgViewMode)}
+                        </div>
+                        <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
+                            <div className="flex items-center gap-2 w-max">
+                                <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
+                                    {configIdButtons}
+                                </div>
+                                {selectedConfigId !== null && configVersions.length > 0 && (
+                                    <>
+                                        <span className="text-gray-400">/</span>
+                                        <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
+                                            {configVersionButtons}
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                        <div className="flex-1 min-h-0 overflow-auto bg-base-200">
+                            {configurationContent}
+                        </div>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    // ── Desktop: the original two stacked panels (Requirement / Configurations). ──
     return (
         <div className="w-full h-full py-4 pl-2 pr-4 flex flex-col gap-4">
             {/* Top section: Requirement */}
@@ -112,49 +279,21 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
-                        <button
-                            role="tab"
-                            className={`tab ${reqViewMode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                            onClick={() => setReqViewMode('readable')}
-                        >
-                            Readable
-                        </button>
-                        <button
-                            role="tab"
-                            className={`tab ${reqViewMode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                            onClick={() => setReqViewMode('raw')}
-                        >
-                            Raw JSON
-                        </button>
-                    </div>
+                    {viewToggle(reqViewMode, setReqViewMode)}
                 </div>
 
                 {/* Requirement version tabs */}
                 {requirementVersions.length > 1 && (
                     <div className="bg-base-200 px-6 pb-2 border-b border-base-300">
                         <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
-                            {requirementVersions.map((v) => (
-                                <button
-                                    key={v}
-                                    role="tab"
-                                    className={`tab gap-1 rounded-lg ${selectedReqVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                                    onClick={() => handleReqVersionClick(v)}
-                                >
-                                    {v}
-                                </button>
-                            ))}
+                            {reqVersionButtons}
                         </div>
                     </div>
                 )}
 
                 {/* Requirement content */}
                 <div className="flex-1 min-h-0 overflow-auto bg-base-200">
-                    {reqViewMode === 'readable' ? (
-                        <ReadableJsonView json={requirementJson} />
-                    ) : (
-                        <JsonRenderer json={requirementJson} />
-                    )}
+                    {requirementContent}
                 </div>
             </div>
 
@@ -182,38 +321,14 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
-                        <button
-                            role="tab"
-                            className={`tab ${cfgViewMode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                            onClick={() => setCfgViewMode('readable')}
-                        >
-                            Readable
-                        </button>
-                        <button
-                            role="tab"
-                            className={`tab ${cfgViewMode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                            onClick={() => setCfgViewMode('raw')}
-                        >
-                            Raw JSON
-                        </button>
-                    </div>
+                    {viewToggle(cfgViewMode, setCfgViewMode)}
                 </div>
 
                 {/* Configuration breadcrumb navigation */}
                 <div className="bg-base-200 px-6 pb-2 border-b border-base-300 flex gap-2 flex-wrap">
                     {/* Config ID tabs */}
                     <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
-                        {configIds.map((cid) => (
-                            <button
-                                key={cid}
-                                role="tab"
-                                className={`tab gap-1 rounded-lg ${selectedConfigId === cid ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                                onClick={() => handleConfigClick(cid)}
-                            >
-                                Config {cid}
-                            </button>
-                        ))}
+                        {configIdButtons}
                     </div>
 
                     {/* Config version tabs (shown when a config is selected) */}
@@ -221,16 +336,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         <>
                             <span className="text-gray-400 self-center">/</span>
                             <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
-                                {configVersions.map((v) => (
-                                    <button
-                                        key={v}
-                                        role="tab"
-                                        className={`tab gap-1 rounded-lg ${selectedConfigVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-                                        onClick={() => handleConfigVersionClick(v)}
-                                    >
-                                        {v}
-                                    </button>
-                                ))}
+                                {configVersionButtons}
                             </div>
                         </>
                     )}
@@ -238,11 +344,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
 
                 {/* Configuration content */}
                 <div className="flex-1 min-h-0 overflow-auto bg-base-200">
-                    {cfgViewMode === 'readable' ? (
-                        <ReadableJsonView json={configJson} />
-                    ) : (
-                        <JsonRenderer json={configJson} />
-                    )}
+                    {configurationContent}
                 </div>
                 </div>
             )}

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -526,25 +526,20 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             </div>
 
             {showTimeline && (
-                <div className="fixed inset-0 z-40 flex flex-col justify-end" role="dialog" aria-modal="true">
-                    <button
-                        aria-label="Close timeline"
-                        className="absolute inset-0 bg-black/40"
-                        onClick={() => setShowTimeline(false)}
-                    />
-                    <div className="relative max-h-[75%] overflow-auto bg-base-200 rounded-t-box shadow-xl">
-                        <div className="flex items-center justify-between px-4 py-2 border-b border-base-300 sticky top-0 bg-base-200 z-10">
-                            <span className="font-semibold flex items-center gap-2">
-                                <IoTimeOutline /> Timeline
-                            </span>
-                            <button
-                                aria-label="Close timeline"
-                                className="btn btn-ghost btn-xs btn-circle"
-                                onClick={() => setShowTimeline(false)}
-                            >
-                                <IoCloseOutline size={18} />
-                            </button>
-                        </div>
+                <div className="fixed inset-0 z-40 bg-base-100 flex flex-col animate-slide-in-right" role="dialog" aria-modal="true">
+                    <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center justify-between">
+                        <span className="text-lg font-semibold flex items-center gap-2">
+                            <IoTimeOutline /> Timeline
+                        </span>
+                        <button
+                            aria-label="Close timeline"
+                            className="btn btn-ghost btn-sm btn-circle"
+                            onClick={() => setShowTimeline(false)}
+                        >
+                            <IoCloseOutline size={22} />
+                        </button>
+                    </div>
+                    <div className="flex-1 overflow-auto">
                         <TimelineBar
                             moments={moments}
                             currentVersion={data.version}

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoMenuOutline } from 'react-icons/io5';
+import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline } from 'react-icons/io5';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { Data } from '../../../model/calm.js';
 import { sortVersionsDescending } from '../../../model/version.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { Drawer } from '../../../visualizer/components/drawer/Drawer.js';
+import { SectionHeader } from '../section-header/SectionHeader.js';
 import { DeploymentPanel } from '../../../visualizer/components/reactflow/DeploymentPanel.js';
 import { CompareView } from './compare/CompareView.js';
 import { diffArchitectures, diffPatterns, type NodesAndRelationshipsDiffResult } from '@finos/calm-models/diff';
@@ -27,6 +28,7 @@ import type { DeploymentDecorator, SelectedItem } from '../../../visualizer/cont
 interface DiagramSectionProps {
     data: Data & { calmType: 'Architectures' | 'Patterns' };
     onItemSelect?: (item: SelectedItem) => void;
+    hasDetailsPanel?: boolean;
 }
 
 const iconMap = {
@@ -36,7 +38,7 @@ const iconMap = {
 
 type DiagramTabType = 'diagram' | 'json' | 'deployments';
 
-export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
+export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramSectionProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
     const tabParam = searchParams.get('tab') as DiagramTabType | null;
@@ -286,10 +288,43 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
     const tabButtonClass = (tab: DiagramTabType) =>
         `btn btn-sm justify-start gap-2 ${!comparing && activeTab === tab ? 'tab-active !bg-accent !text-white' : 'btn-ghost'}`;
 
-    // The render pane is full-bleed; the breadcrumb and view-mode switch live in
-    // a menu opened from a hamburger pinned to the top-right of the canvas. On
-    // mobile it opens as a full-screen overlay (like the explorer); on desktop
-    // it's a dropdown.
+    // Desktop: inline tabs in the section header (unchanged).
+    const tabs = (
+        <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
+            <button
+                role="tab"
+                aria-label="Diagram"
+                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
+                onClick={() => setActiveTab('diagram')}
+            >
+                <IoEyeOutline />
+                <span className="hidden sm:inline">Diagram</span>
+            </button>
+            <button
+                role="tab"
+                aria-label="JSON"
+                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
+                onClick={() => setActiveTab('json')}
+            >
+                <IoCodeOutline />
+                <span className="hidden sm:inline">JSON</span>
+            </button>
+            {isArchitecture && (
+                <button
+                    role="tab"
+                    aria-label="Deployments"
+                    className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
+                    onClick={() => setActiveTab('deployments')}
+                >
+                    <IoRocketOutline />
+                    <span className="hidden sm:inline">Deployments</span>
+                </button>
+            )}
+        </div>
+    );
+
+    // Mobile: full-bleed render pane; the view-options menu lives in the navbar
+    // and opens as a full-screen overlay. The trigger shows the active view icon.
     const breadcrumb = (
         <h2 className="text-sm font-semibold flex flex-wrap items-center gap-x-1">
             <Icon className="text-accent shrink-0" />
@@ -322,14 +357,17 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
         </div>
     );
 
-    const viewMenu = isMobile ? (
+    const activeViewIcon =
+        activeTab === 'json' ? <IoCodeOutline size={20} /> : activeTab === 'deployments' ? <IoRocketOutline size={20} /> : <IoEyeOutline size={20} />;
+
+    const viewMenu = (
         <>
             <button
                 aria-label="View options"
                 className="btn btn-ghost btn-circle text-primary"
                 onClick={() => setShowViewMenu(true)}
             >
-                <IoMenuOutline size={20} />
+                {activeViewIcon}
             </button>
             {showViewMenu && (
                 <div className="fixed inset-0 z-40 bg-base-100 flex flex-col animate-slide-in-right" role="dialog" aria-modal="true">
@@ -346,58 +384,81 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
                 </div>
             )}
         </>
+    );
+
+    const content = comparing ? (
+        <CompareView
+            calmType={data.calmType}
+            versionA={compareFrom ?? ''}
+            versionB={compareTo ?? ''}
+            sourceA={compareSourceA}
+            sourceB={compareSourceB}
+            diffResult={diffResult}
+            error={compareError}
+        />
+    ) : activeTab === 'diagram' ? (
+        <div className="w-full h-full">
+            <Drawer data={data} onItemSelect={onItemSelect} decorators={decorators} />
+        </div>
+    ) : activeTab === 'deployments' && isArchitecture ? (
+        <div className="h-full bg-base-200 overflow-auto p-4">
+            <DeploymentPanel decorators={decorators} />
+        </div>
     ) : (
-        <div className="dropdown dropdown-end">
-            <button
-                tabIndex={0}
-                role="button"
-                aria-label="View options"
-                className="btn btn-ghost btn-circle text-primary"
-            >
-                <IoMenuOutline size={20} />
-            </button>
-            <div
-                tabIndex={0}
-                className="dropdown-content z-30 mt-1 w-64 rounded-box border border-base-300 bg-base-100 p-3 shadow-lg"
-            >
-                <div className="mb-2">{breadcrumb}</div>
-                {renderViewModes()}
-            </div>
+        <div className="h-full bg-base-200 overflow-auto">
+            <JsonRenderer json={data} />
         </div>
     );
 
+    const timelineBar = (
+        <TimelineBar
+            moments={moments}
+            currentVersion={data.version}
+            displayName={displayName}
+            timelineCurrentMomentId={timelineCurrentMomentId}
+            timelineIsExplicit={timelineIsExplicit}
+            compareFrom={compareFrom}
+            compareTo={compareTo}
+            diffResult={diffResult}
+            loadChangesForVersion={loadChangesForVersion}
+            onNavigate={handleVersionChange}
+            onCompare={startCompare}
+        />
+    );
+
+    // Desktop keeps the original layout: section header with inline tabs, card
+    // chrome, and an inline timeline bar.
+    if (!isMobile) {
+        return (
+            <div className={`w-full h-full py-4 pl-2 ${hasDetailsPanel ? 'pr-2' : 'pr-4'}`}>
+                <div className="h-full bg-base-100 rounded-box overflow-hidden flex flex-col shadow-xl">
+                    <SectionHeader
+                        icon={<Icon className="text-accent" />}
+                        namespace={data.name}
+                        id={data.id}
+                        version={data.version}
+                        showVersion={false}
+                        displayName={displayName}
+                        typeLabel={typeLabel}
+                        rightContent={tabs}
+                    />
+                    <div className="flex-1 min-h-0 overflow-hidden">{content}</div>
+                    {timelineBar}
+                </div>
+            </div>
+        );
+    }
+
+    // Mobile: full-bleed render pane; view-options menu in the navbar; timeline
+    // tucked behind a floating button.
     return (
         <div className="w-full h-full">
             {navbarSlot ? createPortal(viewMenu, navbarSlot) : viewMenu}
             <div className="h-full bg-base-100 overflow-hidden flex flex-col">
                 <div className="flex-1 min-h-0 overflow-hidden relative">
-                    {comparing ? (
-                        <CompareView
-                            calmType={data.calmType}
-                            versionA={compareFrom ?? ''}
-                            versionB={compareTo ?? ''}
-                            sourceA={compareSourceA}
-                            sourceB={compareSourceB}
-                            diffResult={diffResult}
-                            error={compareError}
-                        />
-                    ) : activeTab === 'diagram' ? (
-                        <div className="w-full h-full">
-                            <Drawer data={data} onItemSelect={onItemSelect} decorators={decorators} />
-                        </div>
-                    ) : activeTab === 'deployments' && isArchitecture ? (
-                        <div className="h-full bg-base-200 overflow-auto p-4">
-                            <DeploymentPanel decorators={decorators} />
-                        </div>
-                    ) : (
-                        <div className="h-full bg-base-200 overflow-auto">
-                            <JsonRenderer json={data} />
-                        </div>
-                    )}
+                    {content}
 
-                    {/* Mobile: timeline is tucked behind a floating button so it
-                        doesn't permanently occupy the short viewport. */}
-                    {isMobile && !showTimeline && (
+                    {!showTimeline && (
                         <button
                             type="button"
                             aria-label="Show timeline"
@@ -408,25 +469,9 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
                         </button>
                     )}
                 </div>
-
-                {!isMobile && (
-                    <TimelineBar
-                        moments={moments}
-                        currentVersion={data.version}
-                        displayName={displayName}
-                        timelineCurrentMomentId={timelineCurrentMomentId}
-                        timelineIsExplicit={timelineIsExplicit}
-                        compareFrom={compareFrom}
-                        compareTo={compareTo}
-                        diffResult={diffResult}
-                        loadChangesForVersion={loadChangesForVersion}
-                        onNavigate={handleVersionChange}
-                        onCompare={startCompare}
-                    />
-                )}
             </div>
 
-            {isMobile && showTimeline && (
+            {showTimeline && (
                 <div className="fixed inset-0 z-40 flex flex-col justify-end" role="dialog" aria-modal="true">
                     <button
                         aria-label="Close timeline"

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline } from 'react-icons/io5';
+import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoCheckmarkOutline } from 'react-icons/io5';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { Data } from '../../../model/calm.js';
 import { sortVersionsDescending } from '../../../model/version.js';
@@ -304,9 +304,6 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     const Icon = iconMap[data.calmType];
     const comparing = compareFrom !== null && compareTo !== null;
 
-    const tabButtonClass = (tab: DiagramTabType) =>
-        `btn btn-sm justify-start gap-2 ${!comparing && activeTab === tab ? 'tab-active !bg-accent !text-white' : 'btn-ghost'}`;
-
     // Desktop: inline tabs in the section header (unchanged).
     const tabs = (
         <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
@@ -343,36 +340,51 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     );
 
     // Mobile: full-bleed render pane; the view-options menu lives in the navbar
-    // and opens as a full-screen overlay. The trigger shows the active view icon.
+    // and opens as a full-screen overlay styled like the explorer. The trigger
+    // shows the active view icon.
     const breadcrumb = (
-        <h2 className="text-sm font-semibold flex flex-wrap items-center gap-x-1">
+        <h2 className="px-4 py-3 text-sm font-medium flex flex-wrap items-center gap-x-1 border-b border-base-200 text-base-content">
             <Icon className="text-accent shrink-0" />
             {data.name}
             {typeLabel && (
                 <>
-                    <span className="text-gray-400">/</span> {typeLabel}
+                    <span className="text-base-content/40">/</span> <span className="text-base-content/70">{typeLabel}</span>
                 </>
             )}
-            <span className="text-gray-400">/</span>
+            <span className="text-base-content/40">/</span>
             <span title={data.id} className="break-all">
                 {displayName || data.id}
             </span>
         </h2>
     );
 
+    const viewModeRow = (tab: DiagramTabType, icon: ReactNode, label: string, onSelect?: () => void) => {
+        const active = !comparing && activeTab === tab;
+        return (
+            <button
+                role="tab"
+                aria-label={label}
+                aria-selected={active}
+                onClick={() => {
+                    setActiveTab(tab);
+                    onSelect?.();
+                }}
+                className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200 ${
+                    active ? 'bg-base-200 text-accent font-semibold' : 'text-base-content'
+                }`}
+            >
+                <span className={active ? 'text-accent' : 'text-base-content/60'}>{icon}</span>
+                <span className="flex-1 min-w-0 truncate">{label}</span>
+                {active && <IoCheckmarkOutline size={18} className="text-accent shrink-0" />}
+            </button>
+        );
+    };
+
     const renderViewModes = (onSelect?: () => void) => (
-        <div role="tablist" className="flex flex-col gap-1">
-            <button role="tab" aria-label="Diagram" className={tabButtonClass('diagram')} onClick={() => { setActiveTab('diagram'); onSelect?.(); }}>
-                <IoEyeOutline /> Diagram
-            </button>
-            <button role="tab" aria-label="JSON" className={tabButtonClass('json')} onClick={() => { setActiveTab('json'); onSelect?.(); }}>
-                <IoCodeOutline /> JSON
-            </button>
-            {isArchitecture && (
-                <button role="tab" aria-label="Deployments" className={tabButtonClass('deployments')} onClick={() => { setActiveTab('deployments'); onSelect?.(); }}>
-                    <IoRocketOutline /> Deployments
-                </button>
-            )}
+        <div role="tablist" className="divide-y divide-base-200 border-b border-base-200">
+            {viewModeRow('diagram', <IoEyeOutline size={18} />, 'Diagram', onSelect)}
+            {viewModeRow('json', <IoCodeOutline size={18} />, 'JSON', onSelect)}
+            {isArchitecture && viewModeRow('deployments', <IoRocketOutline size={18} />, 'Deployments', onSelect)}
         </div>
     );
 
@@ -396,11 +408,27 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                             <IoCloseOutline size={22} />
                         </button>
                     </div>
-                    <div className="p-4 flex flex-col gap-4 overflow-auto">
+                    <div className="flex-1 overflow-auto">
                         {breadcrumb}
                         {renderViewModes(() => setShowViewMenu(false))}
+                        <div className="divide-y divide-base-200 border-b border-base-200">
+                            <button
+                                type="button"
+                                aria-label="Show timeline"
+                                onClick={() => {
+                                    setShowViewMenu(false);
+                                    setShowTimeline(true);
+                                }}
+                                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200 text-base-content"
+                            >
+                                <span className="text-base-content/60">
+                                    <IoTimeOutline size={18} />
+                                </span>
+                                <span className="flex-1 min-w-0 truncate">Timeline</span>
+                            </button>
+                        </div>
                         {!comparing && activeTab === 'diagram' && (
-                            <div>
+                            <div className="p-4">
                                 <div className="text-xs font-semibold text-base-content/50 uppercase tracking-wide mb-2">
                                     Search components
                                 </div>
@@ -483,8 +511,10 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         );
     }
 
-    // Mobile: full-bleed render pane; view-options menu (with component search)
-    // in the navbar; timeline tucked behind a floating button.
+    // Mobile: full-bleed render pane; the view-options menu (which now also
+    // contains the component search and the timeline action) lives in the navbar
+    // right-hand actions — nothing floats over the canvas where iOS chrome would
+    // hide it.
     return (
         <NodeSearchProvider value={nodeSearch}>
         <div className="w-full h-full">
@@ -492,17 +522,6 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             <div className="h-full bg-base-100 overflow-hidden flex flex-col">
                 <div className="flex-1 min-h-0 overflow-hidden relative">
                     {content}
-
-                    {!showTimeline && (
-                        <button
-                            type="button"
-                            aria-label="Show timeline"
-                            className="btn btn-sm btn-circle btn-accent shadow-lg absolute bottom-3 right-3 z-20"
-                            onClick={() => setShowTimeline(true)}
-                        >
-                            <IoTimeOutline size={18} />
-                        </button>
-                    )}
                 </div>
             </div>
 

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -42,6 +42,7 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
     const activeTab: DiagramTabType = tabParam ?? 'diagram';
     const isMobile = useIsMobile();
     const [showTimeline, setShowTimeline] = useState(false);
+    const [showViewMenu, setShowViewMenu] = useState(false);
     const calmService = useMemo(() => new CalmService(), []);
     const [decorators, setDecorators] = useState<DeploymentDecorator[]>([]);
     const [compareFrom, setCompareFrom] = useState<string | null>(null);
@@ -279,8 +280,66 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
         `btn btn-sm justify-start gap-2 ${!comparing && activeTab === tab ? 'tab-active !bg-accent !text-white' : 'btn-ghost'}`;
 
     // The render pane is full-bleed; the breadcrumb and view-mode switch live in
-    // a hamburger menu pinned to the top-right of the canvas.
-    const viewMenu = (
+    // a menu opened from a hamburger pinned to the top-right of the canvas. On
+    // mobile it opens as a full-screen overlay (like the explorer); on desktop
+    // it's a dropdown.
+    const breadcrumb = (
+        <h2 className="text-sm font-semibold flex flex-wrap items-center gap-x-1">
+            <Icon className="text-accent shrink-0" />
+            {data.name}
+            {typeLabel && (
+                <>
+                    <span className="text-gray-400">/</span> {typeLabel}
+                </>
+            )}
+            <span className="text-gray-400">/</span>
+            <span title={data.id} className="break-all">
+                {displayName || data.id}
+            </span>
+        </h2>
+    );
+
+    const renderViewModes = (onSelect?: () => void) => (
+        <div role="tablist" className="flex flex-col gap-1">
+            <button role="tab" aria-label="Diagram" className={tabButtonClass('diagram')} onClick={() => { setActiveTab('diagram'); onSelect?.(); }}>
+                <IoEyeOutline /> Diagram
+            </button>
+            <button role="tab" aria-label="JSON" className={tabButtonClass('json')} onClick={() => { setActiveTab('json'); onSelect?.(); }}>
+                <IoCodeOutline /> JSON
+            </button>
+            {isArchitecture && (
+                <button role="tab" aria-label="Deployments" className={tabButtonClass('deployments')} onClick={() => { setActiveTab('deployments'); onSelect?.(); }}>
+                    <IoRocketOutline /> Deployments
+                </button>
+            )}
+        </div>
+    );
+
+    const viewMenu = isMobile ? (
+        <>
+            <button
+                aria-label="View options"
+                className="btn btn-sm btn-circle bg-base-100 border border-base-300 shadow absolute top-2 right-2 z-20"
+                onClick={() => setShowViewMenu(true)}
+            >
+                <IoMenuOutline size={18} />
+            </button>
+            {showViewMenu && (
+                <div className="fixed inset-0 z-40 bg-base-100 flex flex-col animate-slide-in-right" role="dialog" aria-modal="true">
+                    <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center justify-between">
+                        <span className="text-lg font-semibold">View</span>
+                        <button aria-label="Close view options" className="btn btn-ghost btn-sm btn-circle" onClick={() => setShowViewMenu(false)}>
+                            <IoCloseOutline size={22} />
+                        </button>
+                    </div>
+                    <div className="p-4 flex flex-col gap-4 overflow-auto">
+                        {breadcrumb}
+                        {renderViewModes(() => setShowViewMenu(false))}
+                    </div>
+                </div>
+            )}
+        </>
+    ) : (
         <div className="dropdown dropdown-end absolute top-2 right-2 z-20">
             <button
                 tabIndex={0}
@@ -294,32 +353,8 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
                 tabIndex={0}
                 className="dropdown-content z-30 mt-1 w-64 rounded-box border border-base-300 bg-base-100 p-3 shadow-lg"
             >
-                <h2 className="text-sm font-semibold mb-2 flex flex-wrap items-center gap-x-1">
-                    <Icon className="text-accent shrink-0" />
-                    {data.name}
-                    {typeLabel && (
-                        <>
-                            <span className="text-gray-400">/</span> {typeLabel}
-                        </>
-                    )}
-                    <span className="text-gray-400">/</span>
-                    <span title={data.id} className="break-all">
-                        {displayName || data.id}
-                    </span>
-                </h2>
-                <div role="tablist" className="flex flex-col gap-1">
-                    <button role="tab" aria-label="Diagram" className={tabButtonClass('diagram')} onClick={() => setActiveTab('diagram')}>
-                        <IoEyeOutline /> Diagram
-                    </button>
-                    <button role="tab" aria-label="JSON" className={tabButtonClass('json')} onClick={() => setActiveTab('json')}>
-                        <IoCodeOutline /> JSON
-                    </button>
-                    {isArchitecture && (
-                        <button role="tab" aria-label="Deployments" className={tabButtonClass('deployments')} onClick={() => setActiveTab('deployments')}>
-                            <IoRocketOutline /> Deployments
-                        </button>
-                    )}
-                </div>
+                <div className="mb-2">{breadcrumb}</div>
+                {renderViewModes()}
             </div>
         </div>
     );

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -9,6 +9,8 @@ import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { Drawer } from '../../../visualizer/components/drawer/Drawer.js';
 import { SectionHeader } from '../section-header/SectionHeader.js';
 import { DeploymentPanel } from '../../../visualizer/components/reactflow/DeploymentPanel.js';
+import { SearchBar } from '../../../visualizer/components/reactflow/SearchBar.js';
+import { NodeSearchProvider, type NodeSearchState } from '../../../visualizer/components/reactflow/node-search-context.js';
 import { CompareView } from './compare/CompareView.js';
 import { diffArchitectures, diffPatterns, type NodesAndRelationshipsDiffResult } from '@finos/calm-models/diff';
 import type { CalmArchitectureSchema } from '@finos/calm-models/types';
@@ -52,6 +54,23 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     useLayoutEffect(() => {
         setNavbarSlot(document.getElementById('navbar-actions'));
     }, []);
+    // Node ("component") search state, surfaced inside the mobile view menu and
+    // applied to the graph via NodeSearchProvider.
+    const [nodeSearchTerm, setNodeSearchTerm] = useState('');
+    const [nodeTypeFilter, setNodeTypeFilter] = useState('');
+    const [nodeTypes, setNodeTypes] = useState<string[]>([]);
+    const nodeSearch = useMemo<NodeSearchState>(
+        () => ({
+            searchTerm: nodeSearchTerm,
+            setSearchTerm: setNodeSearchTerm,
+            typeFilter: nodeTypeFilter,
+            setTypeFilter: setNodeTypeFilter,
+            availableNodeTypes: nodeTypes,
+            setAvailableNodeTypes: setNodeTypes,
+            external: true,
+        }),
+        [nodeSearchTerm, nodeTypeFilter, nodeTypes]
+    );
     const calmService = useMemo(() => new CalmService(), []);
     const [decorators, setDecorators] = useState<DeploymentDecorator[]>([]);
     const [compareFrom, setCompareFrom] = useState<string | null>(null);
@@ -380,6 +399,21 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                     <div className="p-4 flex flex-col gap-4 overflow-auto">
                         {breadcrumb}
                         {renderViewModes(() => setShowViewMenu(false))}
+                        {!comparing && activeTab === 'diagram' && (
+                            <div>
+                                <div className="text-xs font-semibold text-base-content/50 uppercase tracking-wide mb-2">
+                                    Search components
+                                </div>
+                                <SearchBar
+                                    searchTerm={nodeSearchTerm}
+                                    onSearchChange={setNodeSearchTerm}
+                                    typeFilter={nodeTypeFilter}
+                                    onTypeFilterChange={setNodeTypeFilter}
+                                    nodeTypes={nodeTypes}
+                                    forceExpanded
+                                />
+                            </div>
+                        )}
                     </div>
                 </div>
             )}
@@ -449,9 +483,10 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         );
     }
 
-    // Mobile: full-bleed render pane; view-options menu in the navbar; timeline
-    // tucked behind a floating button.
+    // Mobile: full-bleed render pane; view-options menu (with component search)
+    // in the navbar; timeline tucked behind a floating button.
     return (
+        <NodeSearchProvider value={nodeSearch}>
         <div className="w-full h-full">
             {navbarSlot ? createPortal(viewMenu, navbarSlot) : viewMenu}
             <div className="h-full bg-base-100 overflow-hidden flex flex-col">
@@ -509,5 +544,6 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                 </div>
             )}
         </div>
+        </NodeSearchProvider>
     );
 }

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoMenuOutline } from 'react-icons/io5';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
@@ -43,6 +44,12 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
     const isMobile = useIsMobile();
     const [showTimeline, setShowTimeline] = useState(false);
     const [showViewMenu, setShowViewMenu] = useState(false);
+    // The view-options menu trigger lives in the navbar (top nav), not floating
+    // over the canvas; resolve the navbar slot after mount.
+    const [navbarSlot, setNavbarSlot] = useState<HTMLElement | null>(null);
+    useLayoutEffect(() => {
+        setNavbarSlot(document.getElementById('navbar-actions'));
+    }, []);
     const calmService = useMemo(() => new CalmService(), []);
     const [decorators, setDecorators] = useState<DeploymentDecorator[]>([]);
     const [compareFrom, setCompareFrom] = useState<string | null>(null);
@@ -319,10 +326,10 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
         <>
             <button
                 aria-label="View options"
-                className="btn btn-sm btn-circle bg-base-100 border border-base-300 shadow absolute top-2 right-2 z-20"
+                className="btn btn-ghost btn-circle text-primary"
                 onClick={() => setShowViewMenu(true)}
             >
-                <IoMenuOutline size={18} />
+                <IoMenuOutline size={20} />
             </button>
             {showViewMenu && (
                 <div className="fixed inset-0 z-40 bg-base-100 flex flex-col animate-slide-in-right" role="dialog" aria-modal="true">
@@ -340,14 +347,14 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
             )}
         </>
     ) : (
-        <div className="dropdown dropdown-end absolute top-2 right-2 z-20">
+        <div className="dropdown dropdown-end">
             <button
                 tabIndex={0}
                 role="button"
                 aria-label="View options"
-                className="btn btn-sm btn-circle bg-base-100 border border-base-300 shadow"
+                className="btn btn-ghost btn-circle text-primary"
             >
-                <IoMenuOutline size={18} />
+                <IoMenuOutline size={20} />
             </button>
             <div
                 tabIndex={0}
@@ -361,9 +368,9 @@ export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
 
     return (
         <div className="w-full h-full">
+            {navbarSlot ? createPortal(viewMenu, navbarSlot) : viewMenu}
             <div className="h-full bg-base-100 overflow-hidden flex flex-col">
                 <div className="flex-1 min-h-0 overflow-hidden relative">
-                    {viewMenu}
                     {comparing ? (
                         <CompareView
                             calmType={data.calmType}

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline } from 'react-icons/io5';
+import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoMenuOutline } from 'react-icons/io5';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { Data } from '../../../model/calm.js';
 import { sortVersionsDescending } from '../../../model/version.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { Drawer } from '../../../visualizer/components/drawer/Drawer.js';
-import { SectionHeader } from '../section-header/SectionHeader.js';
 import { DeploymentPanel } from '../../../visualizer/components/reactflow/DeploymentPanel.js';
 import { CompareView } from './compare/CompareView.js';
 import { diffArchitectures, diffPatterns, type NodesAndRelationshipsDiffResult } from '@finos/calm-models/diff';
@@ -27,7 +26,6 @@ import type { DeploymentDecorator, SelectedItem } from '../../../visualizer/cont
 interface DiagramSectionProps {
     data: Data & { calmType: 'Architectures' | 'Patterns' };
     onItemSelect?: (item: SelectedItem) => void;
-    hasDetailsPanel?: boolean;
 }
 
 const iconMap = {
@@ -37,7 +35,7 @@ const iconMap = {
 
 type DiagramTabType = 'diagram' | 'json' | 'deployments';
 
-export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramSectionProps) {
+export function DiagramSection({ data, onItemSelect }: DiagramSectionProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
     const tabParam = searchParams.get('tab') as DiagramTabType | null;
@@ -277,55 +275,60 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     const Icon = iconMap[data.calmType];
     const comparing = compareFrom !== null && compareTo !== null;
 
-    const tabs = (
-        <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
+    const tabButtonClass = (tab: DiagramTabType) =>
+        `btn btn-sm justify-start gap-2 ${!comparing && activeTab === tab ? 'tab-active !bg-accent !text-white' : 'btn-ghost'}`;
+
+    // The render pane is full-bleed; the breadcrumb and view-mode switch live in
+    // a hamburger menu pinned to the top-right of the canvas.
+    const viewMenu = (
+        <div className="dropdown dropdown-end absolute top-2 right-2 z-20">
             <button
-                role="tab"
-                aria-label="Diagram"
-                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
-                onClick={() => setActiveTab('diagram')}
+                tabIndex={0}
+                role="button"
+                aria-label="View options"
+                className="btn btn-sm btn-circle bg-base-100 border border-base-300 shadow"
             >
-                <IoEyeOutline />
-                <span className="hidden sm:inline">Diagram</span>
+                <IoMenuOutline size={18} />
             </button>
-            <button
-                role="tab"
-                aria-label="JSON"
-                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
-                onClick={() => setActiveTab('json')}
+            <div
+                tabIndex={0}
+                className="dropdown-content z-30 mt-1 w-64 rounded-box border border-base-300 bg-base-100 p-3 shadow-lg"
             >
-                <IoCodeOutline />
-                <span className="hidden sm:inline">JSON</span>
-            </button>
-            {isArchitecture && (
-                <button
-                    role="tab"
-                    aria-label="Deployments"
-                    className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
-                    onClick={() => setActiveTab('deployments')}
-                >
-                    <IoRocketOutline />
-                    <span className="hidden sm:inline">Deployments</span>
-                </button>
-            )}
+                <h2 className="text-sm font-semibold mb-2 flex flex-wrap items-center gap-x-1">
+                    <Icon className="text-accent shrink-0" />
+                    {data.name}
+                    {typeLabel && (
+                        <>
+                            <span className="text-gray-400">/</span> {typeLabel}
+                        </>
+                    )}
+                    <span className="text-gray-400">/</span>
+                    <span title={data.id} className="break-all">
+                        {displayName || data.id}
+                    </span>
+                </h2>
+                <div role="tablist" className="flex flex-col gap-1">
+                    <button role="tab" aria-label="Diagram" className={tabButtonClass('diagram')} onClick={() => setActiveTab('diagram')}>
+                        <IoEyeOutline /> Diagram
+                    </button>
+                    <button role="tab" aria-label="JSON" className={tabButtonClass('json')} onClick={() => setActiveTab('json')}>
+                        <IoCodeOutline /> JSON
+                    </button>
+                    {isArchitecture && (
+                        <button role="tab" aria-label="Deployments" className={tabButtonClass('deployments')} onClick={() => setActiveTab('deployments')}>
+                            <IoRocketOutline /> Deployments
+                        </button>
+                    )}
+                </div>
+            </div>
         </div>
     );
 
     return (
-        <div className={`w-full h-full py-4 pl-2 ${hasDetailsPanel ? 'pr-2' : 'pr-4'}`}>
-            <div className="h-full bg-base-100 rounded-box overflow-hidden flex flex-col shadow-xl">
-                <SectionHeader
-                    icon={<Icon className="text-accent" />}
-                    namespace={data.name}
-                    id={data.id}
-                    version={data.version}
-                    showVersion={false}
-                    displayName={displayName}
-                    typeLabel={typeLabel}
-                    rightContent={tabs}
-                />
-
+        <div className="w-full h-full">
+            <div className="h-full bg-base-100 overflow-hidden flex flex-col">
                 <div className="flex-1 min-h-0 overflow-hidden relative">
+                    {viewMenu}
                     {comparing ? (
                         <CompareView
                             calmType={data.calmType}

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline } from 'react-icons/io5';
+import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline } from 'react-icons/io5';
+import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { Data } from '../../../model/calm.js';
 import { sortVersionsDescending } from '../../../model/version.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
@@ -41,6 +42,8 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     const navigate = useNavigate();
     const tabParam = searchParams.get('tab') as DiagramTabType | null;
     const activeTab: DiagramTabType = tabParam ?? 'diagram';
+    const isMobile = useIsMobile();
+    const [showTimeline, setShowTimeline] = useState(false);
     const calmService = useMemo(() => new CalmService(), []);
     const [decorators, setDecorators] = useState<DeploymentDecorator[]>([]);
     const [compareFrom, setCompareFrom] = useState<string | null>(null);
@@ -278,28 +281,31 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         <div role="tablist" className="tabs tabs-boxed tabs-sm bg-base-100">
             <button
                 role="tab"
+                aria-label="Diagram"
                 className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
                 onClick={() => setActiveTab('diagram')}
             >
                 <IoEyeOutline />
-                Diagram
+                <span className="hidden sm:inline">Diagram</span>
             </button>
             <button
                 role="tab"
+                aria-label="JSON"
                 className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
                 onClick={() => setActiveTab('json')}
             >
                 <IoCodeOutline />
-                JSON
+                <span className="hidden sm:inline">JSON</span>
             </button>
             {isArchitecture && (
                 <button
                     role="tab"
+                    aria-label="Deployments"
                     className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
                     onClick={() => setActiveTab('deployments')}
                 >
                     <IoRocketOutline />
-                    Deployments
+                    <span className="hidden sm:inline">Deployments</span>
                 </button>
             )}
         </div>
@@ -319,7 +325,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                     rightContent={tabs}
                 />
 
-                <div className="flex-1 min-h-0 overflow-hidden">
+                <div className="flex-1 min-h-0 overflow-hidden relative">
                     {comparing ? (
                         <CompareView
                             calmType={data.calmType}
@@ -343,22 +349,75 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                             <JsonRenderer json={data} />
                         </div>
                     )}
+
+                    {/* Mobile: timeline is tucked behind a floating button so it
+                        doesn't permanently occupy the short viewport. */}
+                    {isMobile && !showTimeline && (
+                        <button
+                            type="button"
+                            aria-label="Show timeline"
+                            className="btn btn-sm btn-circle btn-accent shadow-lg absolute bottom-3 right-3 z-20"
+                            onClick={() => setShowTimeline(true)}
+                        >
+                            <IoTimeOutline size={18} />
+                        </button>
+                    )}
                 </div>
 
-                <TimelineBar
-                    moments={moments}
-                    currentVersion={data.version}
-                    displayName={displayName}
-                    timelineCurrentMomentId={timelineCurrentMomentId}
-                    timelineIsExplicit={timelineIsExplicit}
-                    compareFrom={compareFrom}
-                    compareTo={compareTo}
-                    diffResult={diffResult}
-                    loadChangesForVersion={loadChangesForVersion}
-                    onNavigate={handleVersionChange}
-                    onCompare={startCompare}
-                />
+                {!isMobile && (
+                    <TimelineBar
+                        moments={moments}
+                        currentVersion={data.version}
+                        displayName={displayName}
+                        timelineCurrentMomentId={timelineCurrentMomentId}
+                        timelineIsExplicit={timelineIsExplicit}
+                        compareFrom={compareFrom}
+                        compareTo={compareTo}
+                        diffResult={diffResult}
+                        loadChangesForVersion={loadChangesForVersion}
+                        onNavigate={handleVersionChange}
+                        onCompare={startCompare}
+                    />
+                )}
             </div>
+
+            {isMobile && showTimeline && (
+                <div className="fixed inset-0 z-40 flex flex-col justify-end" role="dialog" aria-modal="true">
+                    <button
+                        aria-label="Close timeline"
+                        className="absolute inset-0 bg-black/40"
+                        onClick={() => setShowTimeline(false)}
+                    />
+                    <div className="relative max-h-[75%] overflow-auto bg-base-200 rounded-t-box shadow-xl">
+                        <div className="flex items-center justify-between px-4 py-2 border-b border-base-300 sticky top-0 bg-base-200 z-10">
+                            <span className="font-semibold flex items-center gap-2">
+                                <IoTimeOutline /> Timeline
+                            </span>
+                            <button
+                                aria-label="Close timeline"
+                                className="btn btn-ghost btn-xs btn-circle"
+                                onClick={() => setShowTimeline(false)}
+                            >
+                                <IoCloseOutline size={18} />
+                            </button>
+                        </div>
+                        <TimelineBar
+                            moments={moments}
+                            currentVersion={data.version}
+                            displayName={displayName}
+                            timelineCurrentMomentId={timelineCurrentMomentId}
+                            timelineIsExplicit={timelineIsExplicit}
+                            compareFrom={compareFrom}
+                            compareTo={compareTo}
+                            diffResult={diffResult}
+                            loadChangesForVersion={loadChangesForVersion}
+                            onNavigate={(v) => { handleVersionChange(v); setShowTimeline(false); }}
+                            onCompare={startCompare}
+                            initialExpanded
+                        />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.tsx
@@ -79,6 +79,12 @@ interface TimelineBarProps {
      * exists. Provided by DiagramSection so this component stays service-free.
      */
     loadChangesForVersion?: (prevVersion: string, currVersion: string) => Promise<VersionChange[]>;
+    /**
+     * Force the initial expand state and skip the persisted preference. Used by
+     * the mobile bottom-sheet, which always wants the bar opened to the cards
+     * view (and shouldn't leak that into the desktop inline bar's saved state).
+     */
+    initialExpanded?: boolean;
 }
 
 /**
@@ -103,18 +109,22 @@ export function TimelineBar({
     onNavigate,
     onCompare,
     loadChangesForVersion,
+    initialExpanded,
 }: TimelineBarProps) {
-    const [expanded, setExpanded] = useState<boolean>(readExpanded);
+    const [expanded, setExpanded] = useState<boolean>(() => initialExpanded ?? readExpanded());
     const [hasSeenTimeline, setHasSeenTimeline] = useState<boolean>(readSeen);
 
     // Remember the expand/collapse choice so a refresh keeps the bar as it was.
+    // Skipped when initialExpanded is forced (mobile sheet) so it doesn't leak
+    // into the desktop inline bar's saved preference.
     useEffect(() => {
+        if (initialExpanded !== undefined) return;
         try {
             localStorage.setItem(EXPANDED_STORAGE_KEY, String(expanded));
         } catch {
             /* ignore unavailable storage */
         }
-    }, [expanded]);
+    }, [expanded, initialExpanded]);
 
     const markSeen = useCallback(() => {
         setHasSeenTimeline((prev) => {

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -38,8 +38,8 @@ export function SectionHeader({ icon, namespace, id, version, rightContent, vers
 
     return (
         <div>
-            <div className="bg-base-200 px-6 py-4 flex items-center justify-between border-b border-base-300">
-                <h2 className="text-xl font-semibold flex items-center gap-2 whitespace-nowrap">
+            <div className="bg-base-200 px-4 sm:px-6 py-3 sm:py-4 flex flex-wrap items-center justify-between gap-2 border-b border-base-300">
+                <h2 className="text-base sm:text-xl font-semibold flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0">
                     {icon}
                     {namespace}
                     {typeLabel && (
@@ -77,7 +77,7 @@ export function SectionHeader({ icon, namespace, id, version, rightContent, vers
                 {rightContent}
             </div>
             {showShareBar && (
-                <div className="bg-base-200 px-6 py-2 flex items-center gap-2 border-b border-base-300" data-testid="share-bar">
+                <div className="bg-base-200 px-4 sm:px-6 py-2 flex items-center gap-2 border-b border-base-300" data-testid="share-bar">
                     <IoLinkOutline className="text-base-content/50 shrink-0" />
                     <div className="join shrink-0">
                         <button

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -12,6 +12,12 @@ vi.mock('react-router-dom', async () => {
     };
 });
 
+// Stub the explorer search so it doesn't instantiate real services during these
+// drill-down tests.
+vi.mock('../../../components/navbar/ExplorerSearch.js', () => ({
+    ExplorerSearch: () => <div data-testid="explorer-search" />,
+}));
+
 vi.mock('../../../service/calm-service.js', () => ({
     CalmService: vi.fn().mockImplementation(function () { return ({
         fetchNamespaces: vi.fn().mockResolvedValue(['finos', 'traderx']),

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useNavigate, useParams } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+import { MobileNavMenu } from './MobileNavMenu.js';
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useParams: vi.fn().mockReturnValue({}),
+        useNavigate: vi.fn(),
+    };
+});
+
+vi.mock('../../../service/calm-service.js', () => ({
+    CalmService: vi.fn().mockImplementation(function () { return ({
+        fetchNamespaces: vi.fn().mockResolvedValue(['finos', 'traderx']),
+        fetchArchitectureSummaries: vi.fn().mockResolvedValue([{ id: 1, name: 'Arch One' }]),
+        fetchPatternSummaries: vi.fn().mockResolvedValue([]),
+        fetchFlowSummaries: vi.fn().mockResolvedValue([]),
+        fetchStandardSummaries: vi.fn().mockResolvedValue([]),
+        fetchArchitectureVersions: vi.fn().mockResolvedValue(['1.0.0']),
+        fetchPatternVersions: vi.fn().mockResolvedValue([]),
+        fetchFlowVersions: vi.fn().mockResolvedValue([]),
+        fetchStandardVersions: vi.fn().mockResolvedValue([]),
+        fetchArchitecture: vi.fn().mockResolvedValue({}),
+        fetchVersionsByCustomId: vi.fn().mockResolvedValue([]),
+        fetchResourceByCustomId: vi.fn().mockResolvedValue({}),
+    }); }),
+}));
+
+vi.mock('../../../service/control-service.js', () => ({
+    ControlService: vi.fn().mockImplementation(function () { return ({
+        fetchDomains: vi.fn().mockResolvedValue(['security']),
+        fetchControlsForDomain: vi.fn().mockResolvedValue([{ id: 5, name: 'Encryption', description: 'Encrypt data' }]),
+    }); }),
+}));
+
+vi.mock('../../../service/interface-service.js', () => ({
+    InterfaceService: vi.fn().mockImplementation(function () { return ({
+        fetchInterfacesForNamespace: vi.fn().mockResolvedValue([]),
+    }); }),
+}));
+
+vi.mock('../../../service/adr-service/adr-service.js', () => ({
+    AdrService: vi.fn().mockImplementation(function () { return ({
+        fetchAdrSummaries: vi.fn().mockResolvedValue([]),
+        fetchAdrRevisions: vi.fn().mockResolvedValue([]),
+        fetchAdr: vi.fn().mockResolvedValue({}),
+    }); }),
+}));
+
+const props = {
+    onDataLoad: vi.fn(),
+    onAdrLoad: vi.fn(),
+    onControlLoad: vi.fn(),
+    onInterfaceLoad: vi.fn(),
+    onClose: vi.fn(),
+};
+
+const renderMenu = () =>
+    render(
+        <MemoryRouter>
+            <MobileNavMenu {...props} />
+        </MemoryRouter>
+    );
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    (useParams as Mock).mockReturnValue({});
+    (useNavigate as Mock).mockReturnValue(vi.fn());
+});
+
+describe('MobileNavMenu', () => {
+    it('renders the root level with Namespaces and Control Domains', () => {
+        renderMenu();
+        expect(screen.getByRole('heading', { name: 'Explore' })).toBeInTheDocument();
+        expect(screen.getByText('Namespaces')).toBeInTheDocument();
+        expect(screen.getByText('Control Domains')).toBeInTheDocument();
+        // No back button at the root.
+        expect(screen.queryByLabelText('Back')).not.toBeInTheDocument();
+    });
+
+    it('drills into namespaces and shows resource types', async () => {
+        renderMenu();
+        fireEvent.click(screen.getByText('Namespaces'));
+        expect(await screen.findByText('traderx')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('traderx'));
+        // Resource types level
+        expect(await screen.findByText('Architectures')).toBeInTheDocument();
+        expect(screen.getByText('Interfaces')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'traderx' })).toBeInTheDocument();
+    });
+
+    it('navigates to a resource and closes when a leaf is selected', async () => {
+        const navigate = vi.fn();
+        (useNavigate as Mock).mockReturnValue(navigate);
+        renderMenu();
+
+        fireEvent.click(screen.getByText('Namespaces'));
+        fireEvent.click(await screen.findByText('traderx'));
+        fireEvent.click(await screen.findByText('Architectures'));
+        fireEvent.click(await screen.findByText('Arch One'));
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('/traderx/architectures/1/1.0.0');
+        });
+        expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it('drills into control domains and lists controls', async () => {
+        renderMenu();
+        fireEvent.click(screen.getByText('Control Domains'));
+        fireEvent.click(await screen.findByText('security'));
+        expect(await screen.findByText('Encryption')).toBeInTheDocument();
+    });
+
+    it('goes back up a level with the back button', async () => {
+        renderMenu();
+        fireEvent.click(screen.getByText('Namespaces'));
+        fireEvent.click(await screen.findByText('traderx'));
+        expect(await screen.findByText('Architectures')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Back'));
+        // Back to the namespaces list
+        expect(await screen.findByText('traderx')).toBeInTheDocument();
+        expect(screen.queryByText('Architectures')).not.toBeInTheDocument();
+    });
+
+    it('loads a resource from a deep-link via URL params', async () => {
+        (useParams as Mock).mockReturnValue({
+            namespace: 'traderx',
+            type: 'architectures',
+            id: '1',
+            version: '1.0.0',
+        });
+        renderMenu();
+        await waitFor(() => {
+            expect(props.onDataLoad).toHaveBeenCalled();
+        });
+    });
+});

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -1,0 +1,349 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { IoChevronBackOutline, IoChevronForwardOutline, IoCompassOutline, IoCloseOutline } from 'react-icons/io5';
+import { useNavigate, useParams } from 'react-router-dom';
+import { CalmService } from '../../../service/calm-service.js';
+import { ControlService } from '../../../service/control-service.js';
+import { InterfaceService } from '../../../service/interface-service.js';
+import { AdrService } from '../../../service/adr-service/adr-service.js';
+import { Data, Adr, ResourceSummary, isSlug } from '../../../model/calm.js';
+import { pickLatestVersion } from '../../../model/version.js';
+import { ControlData, ControlDetail } from '../../../model/control.js';
+import { InterfaceData } from '../../../model/interface.js';
+import {
+    type TypeInUrl,
+    type TypeInUI,
+    mapTypeInUrlToTypeInUI,
+    mapTypeInUIToTypeInUrl,
+    loadResource,
+    loadResourceForId,
+    fetchVersionsForResource,
+} from './navigation-loaders.js';
+
+const RESOURCE_TYPES: TypeInUI[] = ['Architectures', 'Patterns', 'Flows', 'Standards', 'ADRs', 'Interfaces'];
+
+interface MobileNavMenuProps {
+    onDataLoad: (data: Data) => void;
+    onAdrLoad: (adr: Adr) => void;
+    onControlLoad: (control: ControlData) => void;
+    onInterfaceLoad: (iface: InterfaceData) => void;
+    /** Dismiss the menu (e.g. after a resource is chosen). */
+    onClose: () => void;
+}
+
+type HubParams = {
+    namespace: string;
+    type: TypeInUrl;
+    id: string;
+    version: string;
+};
+
+/** A single level in the drill-down stack. */
+type View =
+    | { level: 'root' }
+    | { level: 'namespaces' }
+    | { level: 'types'; namespace: string }
+    | { level: 'resources'; namespace: string; type: TypeInUI }
+    | { level: 'domains' }
+    | { level: 'controls'; domain: string };
+
+interface LeafItem {
+    id: string;
+    name: string;
+}
+
+/**
+ * Mobile navigation as an iOS-style drill-down: each tap pushes the next level
+ * as a flat list rather than expanding an inline tree. Leaf taps navigate to the
+ * resource URL; the deep-link effect (below) loads whatever the URL points at,
+ * mirroring the desktop {@link TreeNavigation} loading behaviour.
+ */
+export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfaceLoad, onClose }: MobileNavMenuProps) {
+    const navigate = useNavigate();
+    const params = useParams<HubParams>();
+
+    const calmService = useMemo(() => new CalmService(), []);
+    const controlService = useMemo(() => new ControlService(), []);
+    const interfaceService = useMemo(() => new InterfaceService(), []);
+    const adrService = useMemo(() => new AdrService(), []);
+
+    const onControlLoadRef = useRef(onControlLoad);
+    onControlLoadRef.current = onControlLoad;
+    const onInterfaceLoadRef = useRef(onInterfaceLoad);
+    onInterfaceLoadRef.current = onInterfaceLoad;
+
+    const [view, setView] = useState<View>({ level: 'root' });
+    const [namespaces, setNamespaces] = useState<string[]>([]);
+    const [domains, setDomains] = useState<string[]>([]);
+    const [leafItems, setLeafItems] = useState<LeafItem[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        calmService.fetchNamespaces().then(setNamespaces).catch(() => setNamespaces([]));
+        controlService.fetchDomains().then(setDomains).catch(() => setDomains([]));
+    }, [calmService, controlService]);
+
+    // Deep-link / external navigation loading. Kept here (not just in the desktop
+    // tree) so direct URLs and the global search still load on mobile, where the
+    // tree is not rendered.
+    useEffect(() => {
+        if (!(params.namespace && params.type && params.id && params.version)) return;
+        const uiType = mapTypeInUrlToTypeInUI(params.type);
+        const namespace = params.namespace;
+
+        if (uiType === 'Interfaces') {
+            interfaceService
+                .fetchInterfacesForNamespace(namespace)
+                .then((interfaces) => {
+                    const match = interfaces.find((i) => i.id === Number(params.id));
+                    if (match) {
+                        onInterfaceLoadRef.current({
+                            namespace,
+                            interfaceId: match.id,
+                            interfaceName: match.name,
+                            interfaceDescription: match.description,
+                        });
+                    }
+                })
+                .catch(() => undefined);
+            return;
+        }
+
+        if (uiType === 'Controls') {
+            controlService
+                .fetchControlsForDomain(namespace)
+                .then((controls) => {
+                    const match = controls.find((c) => c.id === Number(params.id));
+                    if (match) {
+                        onControlLoadRef.current({
+                            domain: namespace,
+                            controlId: match.id,
+                            controlName: match.name,
+                            controlDescription: match.description,
+                        });
+                    }
+                })
+                .catch(() => undefined);
+            return;
+        }
+
+        if (isSlug(params.id)) {
+            loadResourceForId(params.version, uiType, namespace, params.id, calmService, onDataLoad);
+        } else {
+            loadResource({
+                version: params.version,
+                type: uiType,
+                namespace,
+                resourceID: params.id,
+                calmService,
+                onDataLoad,
+                onAdrLoad,
+                adrService,
+            });
+        }
+    }, [params, calmService, adrService, interfaceService, controlService, onDataLoad, onAdrLoad]);
+
+    const openType = useCallback(
+        (namespace: string, type: TypeInUI) => {
+            setView({ level: 'resources', namespace, type });
+            setLeafItems([]);
+            setLoading(true);
+            const finish = (items: LeafItem[]) => {
+                setLeafItems(items);
+                setLoading(false);
+            };
+            if (type === 'Interfaces') {
+                interfaceService
+                    .fetchInterfacesForNamespace(namespace)
+                    .then((ifaces) => finish(ifaces.map((i) => ({ id: i.id.toString(), name: i.name }))))
+                    .catch(() => finish([]));
+            } else if (type === 'ADRs') {
+                adrService
+                    .fetchAdrSummaries(namespace)
+                    .then((adrs) => finish(adrs.map((a) => ({ id: a.id.toString(), name: `${a.title} (${a.status})` }))))
+                    .catch(() => finish([]));
+            } else {
+                const fetcher =
+                    type === 'Architectures'
+                        ? calmService.fetchArchitectureSummaries.bind(calmService)
+                        : type === 'Patterns'
+                          ? calmService.fetchPatternSummaries.bind(calmService)
+                          : type === 'Flows'
+                            ? calmService.fetchFlowSummaries.bind(calmService)
+                            : calmService.fetchStandardSummaries.bind(calmService);
+                fetcher(namespace)
+                    .then((sums: ResourceSummary[]) =>
+                        finish(sums.map((s) => ({ id: s.customId ?? s.id.toString(), name: s.name })))
+                    )
+                    .catch(() => finish([]));
+            }
+        },
+        [calmService, interfaceService, adrService]
+    );
+
+    const openDomain = useCallback(
+        (domain: string) => {
+            setView({ level: 'controls', domain });
+            setLeafItems([]);
+            setLoading(true);
+            controlService
+                .fetchControlsForDomain(domain)
+                .then((controls: ControlDetail[]) =>
+                    setLeafItems(controls.map((c) => ({ id: c.id.toString(), name: c.name })))
+                )
+                .catch(() => setLeafItems([]))
+                .finally(() => setLoading(false));
+        },
+        [controlService]
+    );
+
+    const selectResource = useCallback(
+        async (id: string, type: TypeInUI, namespace: string) => {
+            if (type === 'Interfaces') {
+                navigate(`/${namespace}/interfaces/${id}/detail`);
+                onClose();
+                return;
+            }
+            const versions = await fetchVersionsForResource(id, type, namespace, calmService, adrService);
+            const latest = pickLatestVersion(versions);
+            if (!latest) {
+                // arg1 is %s to prevent format string injection from `id`.
+                console.warn('No versions found for resource %s; nothing to load', id);
+                return;
+            }
+            navigate(`/${namespace}/${mapTypeInUIToTypeInUrl(type)}/${id}/${latest}`);
+            onClose();
+        },
+        [navigate, calmService, adrService, onClose]
+    );
+
+    const selectControl = useCallback(
+        (id: string, domain: string) => {
+            navigate(`/${domain}/controls/${id}/detail`);
+            onClose();
+        },
+        [navigate, onClose]
+    );
+
+    const goBack = useCallback(() => {
+        setView((current) => {
+            switch (current.level) {
+                case 'namespaces':
+                case 'domains':
+                    return { level: 'root' };
+                case 'types':
+                    return { level: 'namespaces' };
+                case 'resources':
+                    return { level: 'types', namespace: current.namespace };
+                case 'controls':
+                    return { level: 'domains' };
+                default:
+                    return current;
+            }
+        });
+    }, []);
+
+    const title =
+        view.level === 'root'
+            ? 'Explore'
+            : view.level === 'namespaces'
+              ? 'Namespaces'
+              : view.level === 'types'
+                ? view.namespace
+                : view.level === 'resources'
+                  ? view.type
+                  : view.level === 'domains'
+                    ? 'Control Domains'
+                    : view.domain;
+
+    const rows: { key: string; label: string; isLeaf: boolean; onClick: () => void }[] = (() => {
+        switch (view.level) {
+            case 'root':
+                return [
+                    { key: 'namespaces', label: 'Namespaces', isLeaf: false, onClick: () => setView({ level: 'namespaces' }) },
+                    { key: 'domains', label: 'Control Domains', isLeaf: false, onClick: () => setView({ level: 'domains' }) },
+                ];
+            case 'namespaces':
+                return namespaces.map((ns) => ({
+                    key: ns,
+                    label: ns,
+                    isLeaf: false,
+                    onClick: () => setView({ level: 'types', namespace: ns }),
+                }));
+            case 'types':
+                return RESOURCE_TYPES.map((t) => ({
+                    key: t,
+                    label: t,
+                    isLeaf: false,
+                    onClick: () => openType(view.namespace, t),
+                }));
+            case 'resources':
+                return leafItems.map((item) => ({
+                    key: item.id,
+                    label: item.name,
+                    isLeaf: true,
+                    onClick: () => selectResource(item.id, view.type, view.namespace),
+                }));
+            case 'domains':
+                return domains.map((d) => ({
+                    key: d,
+                    label: d,
+                    isLeaf: false,
+                    onClick: () => openDomain(d),
+                }));
+            case 'controls':
+                return leafItems.map((item) => ({
+                    key: item.id,
+                    label: item.name,
+                    isLeaf: true,
+                    onClick: () => selectControl(item.id, view.domain),
+                }));
+            default:
+                return [];
+        }
+    })();
+
+    const isEmpty = !loading && rows.length === 0;
+
+    return (
+        <div className="h-full w-full flex flex-col">
+            <div className="bg-base-200 px-3 py-3 border-b border-base-300 flex items-center gap-2">
+                {view.level !== 'root' ? (
+                    <button aria-label="Back" className="btn btn-ghost btn-sm btn-circle" onClick={goBack}>
+                        <IoChevronBackOutline size={20} />
+                    </button>
+                ) : (
+                    <IoCompassOutline className="text-accent ml-2" size={20} />
+                )}
+                <h2 className="text-lg font-semibold flex-1 min-w-0 truncate">{title}</h2>
+                <button aria-label="Close navigation" className="btn btn-ghost btn-sm btn-circle" onClick={onClose}>
+                    <IoCloseOutline size={22} />
+                </button>
+            </div>
+
+            <ul className="flex-1 overflow-auto divide-y divide-base-200">
+                {loading && (
+                    <li className="flex items-center justify-center py-8">
+                        <span className="loading loading-spinner loading-md text-base-content/50" />
+                    </li>
+                )}
+                {isEmpty && (
+                    <li className="px-4 py-8 text-center text-base-content/50 text-sm">Nothing here</li>
+                )}
+                {!loading &&
+                    rows.map((row) => (
+                        <li key={row.key}>
+                            <button
+                                className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200"
+                                onClick={row.onClick}
+                            >
+                                <span className="flex-1 min-w-0 truncate">{row.label}</span>
+                                {!row.isLeaf && (
+                                    <IoChevronForwardOutline className="text-base-content/40 shrink-0" size={18} />
+                                )}
+                            </button>
+                        </li>
+                    ))}
+            </ul>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -18,6 +18,7 @@ import {
     loadResourceForId,
     fetchVersionsForResource,
 } from './navigation-loaders.js';
+import { ExplorerSearch } from '../../../components/navbar/ExplorerSearch.js';
 
 const RESOURCE_TYPES: TypeInUI[] = ['Architectures', 'Patterns', 'Flows', 'Standards', 'ADRs', 'Interfaces'];
 
@@ -76,6 +77,7 @@ export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfac
     const [domains, setDomains] = useState<string[]>([]);
     const [leafItems, setLeafItems] = useState<LeafItem[]>([]);
     const [loading, setLoading] = useState(false);
+    const [searching, setSearching] = useState(false);
 
     useEffect(() => {
         calmService.fetchNamespaces().then(setNamespaces).catch(() => setNamespaces([]));
@@ -320,30 +322,34 @@ export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfac
                 </button>
             </div>
 
-            <ul className="flex-1 overflow-auto divide-y divide-base-200">
-                {loading && (
-                    <li className="flex items-center justify-center py-8">
-                        <span className="loading loading-spinner loading-md text-base-content/50" />
-                    </li>
-                )}
-                {isEmpty && (
-                    <li className="px-4 py-8 text-center text-base-content/50 text-sm">Nothing here</li>
-                )}
-                {!loading &&
-                    rows.map((row) => (
-                        <li key={row.key}>
-                            <button
-                                className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200"
-                                onClick={row.onClick}
-                            >
-                                <span className="flex-1 min-w-0 truncate">{row.label}</span>
-                                {!row.isLeaf && (
-                                    <IoChevronForwardOutline className="text-base-content/40 shrink-0" size={18} />
-                                )}
-                            </button>
+            <ExplorerSearch onSearchingChange={setSearching} />
+
+            {!searching && (
+                <ul className="flex-1 overflow-auto divide-y divide-base-200">
+                    {loading && (
+                        <li className="flex items-center justify-center py-8">
+                            <span className="loading loading-spinner loading-md text-base-content/50" />
                         </li>
-                    ))}
-            </ul>
+                    )}
+                    {isEmpty && (
+                        <li className="px-4 py-8 text-center text-base-content/50 text-sm">Nothing here</li>
+                    )}
+                    {!loading &&
+                        rows.map((row) => (
+                            <li key={row.key}>
+                                <button
+                                    className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200"
+                                    onClick={row.onClick}
+                                >
+                                    <span className="flex-1 min-w-0 truncate">{row.label}</span>
+                                    {!row.isLeaf && (
+                                        <IoChevronForwardOutline className="text-base-content/40 shrink-0" size={18} />
+                                    )}
+                                </button>
+                            </li>
+                        ))}
+                </ul>
+            )}
         </div>
     );
 }

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -6,6 +6,15 @@ import { InterfaceService } from '../../../service/interface-service.js';
 import { AdrService } from '../../../service/adr-service/adr-service.js';
 import { Data, Adr, ResourceSummary, AdrSummary, ResourceMapping, isSlug } from '../../../model/calm.js';
 import { pickLatestVersion } from '../../../model/version.js';
+import {
+    type TypeInUrl,
+    type TypeInUI,
+    mapTypeInUrlToTypeInUI,
+    mapTypeInUIToTypeInUrl,
+    loadResource,
+    loadResourceForId,
+    fetchVersionsForResource,
+} from './navigation-loaders.js';
 
 function mapCalmTypeToResourceType(type: string): string {
     switch (type) {
@@ -22,8 +31,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { DomainItem } from './DomainItem.js';
 import { InterfaceItem } from './InterfaceItem.js';
 
-type TypeInUrl = 'architectures' | 'patterns' | 'flows' | 'adrs' | 'standards' | 'interfaces' | 'controls';
-type TypeInUI = 'Architectures' | 'Patterns' | 'Flows' | 'ADRs' | 'Standards' | 'Interfaces' | 'Controls';
 type HubParams = {
     namespace: string;
     type: TypeInUrl;
@@ -41,17 +48,6 @@ interface LoadResourceIdsOptions {
     setStandardSummaries: (summaries: ResourceSummary[]) => void;
     adrService: AdrService;
     setAdrSummaries: (summaries: AdrSummary[]) => void;
-}
-
-interface LoadResourceOptions {
-    version: string;
-    type: string;
-    namespace: string;
-    resourceID: string;
-    calmService: CalmService;
-    onDataLoad: (data: Data) => void;
-    onAdrLoad: (adr: Adr) => void;
-    adrService: AdrService;
 }
 
 const basePath = '';
@@ -146,48 +142,6 @@ export function buildNamespaceTree(namespaces: string[]): NamespaceNode[] {
         }
     }
     return collapseToTree(root, '');
-}
-
-function mapTypeInUrlToTypeInUI(urlType: TypeInUrl): TypeInUI {
-    switch (urlType) {
-        case 'architectures':
-            return 'Architectures';
-        case 'patterns':
-            return 'Patterns';
-        case 'flows':
-            return 'Flows';
-        case 'adrs':
-            return 'ADRs';
-        case 'standards':
-            return 'Standards';
-        case 'interfaces':
-            return 'Interfaces';
-        case 'controls':
-            return 'Controls';
-        default:
-            throw new Error(`Unhandled type: ${urlType}`);
-    }
-}
-
-function mapTypeInUIToTypeInUrl(uiType: TypeInUI): TypeInUrl {
-    switch (uiType) {
-        case 'Architectures':
-            return 'architectures';
-        case 'Patterns':
-            return 'patterns';
-        case 'Flows':
-            return 'flows';
-        case 'ADRs':
-            return 'adrs';
-        case 'Standards':
-            return 'standards';
-        case 'Interfaces':
-            return 'interfaces';
-        case 'Controls':
-            return 'controls';
-        default:
-            throw new Error(`Unhandled type: ${uiType}`);
-    }
 }
 
 function ResourceItem({
@@ -385,67 +339,6 @@ function loadResourceIds({
     }
 }
 
-function loadResourceForId(
-    version: string,
-    type: string,
-    namespace: string,
-    resourceID: string,
-    calmService: CalmService,
-    onDataLoad: (data: Data) => void,
-) {
-    if (isSlug(resourceID)) {
-        calmService.fetchResourceByCustomId(namespace, resourceID, version, type).then(onDataLoad);
-    }
-}
-
-async function fetchVersionsForResource(
-    resourceID: string,
-    type: string,
-    namespace: string,
-    calmService: CalmService,
-    adrService: AdrService,
-): Promise<string[]> {
-    if (isSlug(resourceID) && type !== 'ADRs') {
-        return calmService.fetchVersionsByCustomId(namespace, resourceID, type);
-    }
-    switch (type) {
-        case 'Architectures':
-            return calmService.fetchArchitectureVersions(namespace, resourceID);
-        case 'Patterns':
-            return calmService.fetchPatternVersions(namespace, resourceID);
-        case 'Flows':
-            return calmService.fetchFlowVersions(namespace, resourceID);
-        case 'Standards':
-            return calmService.fetchStandardVersions(namespace, resourceID);
-        case 'ADRs':
-            return (await adrService.fetchAdrRevisions(namespace, resourceID)).map((rev) => rev.toString());
-        default:
-            return [];
-    }
-}
-
-function loadResource({ 
-    version, 
-    type, 
-    namespace, 
-    resourceID,
-    calmService,
-    onDataLoad,
-    onAdrLoad,
-    adrService
-}: LoadResourceOptions) {
-    if (type === 'Architectures') {
-        calmService.fetchArchitecture(namespace, resourceID, version).then(onDataLoad);
-    } else if (type === 'Patterns') {
-        calmService.fetchPattern(namespace, resourceID, version).then(onDataLoad);
-    } else if (type === 'Flows') {
-        calmService.fetchFlow(namespace, resourceID, version).then(onDataLoad);
-    } else if (type === 'Standards') {
-        calmService.fetchStandard(namespace, resourceID, version).then(onDataLoad);
-    } else if (type === 'ADRs') {
-        adrService.fetchAdr(namespace, resourceID, version).then(onAdrLoad);
-    }
-}
 
 export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfaceLoad, onCollapse }: TreeNavigationProps) {
     const navigate = useNavigate();

--- a/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.ts
+++ b/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.ts
@@ -1,0 +1,121 @@
+import { CalmService } from '../../../service/calm-service.js';
+import { AdrService } from '../../../service/adr-service/adr-service.js';
+import { Data, Adr, isSlug } from '../../../model/calm.js';
+
+export type TypeInUrl = 'architectures' | 'patterns' | 'flows' | 'adrs' | 'standards' | 'interfaces' | 'controls';
+export type TypeInUI = 'Architectures' | 'Patterns' | 'Flows' | 'ADRs' | 'Standards' | 'Interfaces' | 'Controls';
+
+export interface LoadResourceOptions {
+    version: string;
+    type: string;
+    namespace: string;
+    resourceID: string;
+    calmService: CalmService;
+    onDataLoad: (data: Data) => void;
+    onAdrLoad: (adr: Adr) => void;
+    adrService: AdrService;
+}
+
+export function mapTypeInUrlToTypeInUI(urlType: TypeInUrl): TypeInUI {
+    switch (urlType) {
+        case 'architectures':
+            return 'Architectures';
+        case 'patterns':
+            return 'Patterns';
+        case 'flows':
+            return 'Flows';
+        case 'adrs':
+            return 'ADRs';
+        case 'standards':
+            return 'Standards';
+        case 'interfaces':
+            return 'Interfaces';
+        case 'controls':
+            return 'Controls';
+        default:
+            throw new Error(`Unhandled type: ${urlType}`);
+    }
+}
+
+export function mapTypeInUIToTypeInUrl(uiType: TypeInUI): TypeInUrl {
+    switch (uiType) {
+        case 'Architectures':
+            return 'architectures';
+        case 'Patterns':
+            return 'patterns';
+        case 'Flows':
+            return 'flows';
+        case 'ADRs':
+            return 'adrs';
+        case 'Standards':
+            return 'standards';
+        case 'Interfaces':
+            return 'interfaces';
+        case 'Controls':
+            return 'controls';
+        default:
+            throw new Error(`Unhandled type: ${uiType}`);
+    }
+}
+
+export function loadResourceForId(
+    version: string,
+    type: string,
+    namespace: string,
+    resourceID: string,
+    calmService: CalmService,
+    onDataLoad: (data: Data) => void,
+) {
+    if (isSlug(resourceID)) {
+        calmService.fetchResourceByCustomId(namespace, resourceID, version, type).then(onDataLoad);
+    }
+}
+
+export async function fetchVersionsForResource(
+    resourceID: string,
+    type: string,
+    namespace: string,
+    calmService: CalmService,
+    adrService: AdrService,
+): Promise<string[]> {
+    if (isSlug(resourceID) && type !== 'ADRs') {
+        return calmService.fetchVersionsByCustomId(namespace, resourceID, type);
+    }
+    switch (type) {
+        case 'Architectures':
+            return calmService.fetchArchitectureVersions(namespace, resourceID);
+        case 'Patterns':
+            return calmService.fetchPatternVersions(namespace, resourceID);
+        case 'Flows':
+            return calmService.fetchFlowVersions(namespace, resourceID);
+        case 'Standards':
+            return calmService.fetchStandardVersions(namespace, resourceID);
+        case 'ADRs':
+            return (await adrService.fetchAdrRevisions(namespace, resourceID)).map((rev) => rev.toString());
+        default:
+            return [];
+    }
+}
+
+export function loadResource({
+    version,
+    type,
+    namespace,
+    resourceID,
+    calmService,
+    onDataLoad,
+    onAdrLoad,
+    adrService,
+}: LoadResourceOptions) {
+    if (type === 'Architectures') {
+        calmService.fetchArchitecture(namespace, resourceID, version).then(onDataLoad);
+    } else if (type === 'Patterns') {
+        calmService.fetchPattern(namespace, resourceID, version).then(onDataLoad);
+    } else if (type === 'Flows') {
+        calmService.fetchFlow(namespace, resourceID, version).then(onDataLoad);
+    } else if (type === 'Standards') {
+        calmService.fetchStandard(namespace, resourceID, version).then(onDataLoad);
+    } else if (type === 'ADRs') {
+        adrService.fetchAdr(namespace, resourceID, version).then(onAdrLoad);
+    }
+}

--- a/calm-hub-ui/src/index.css
+++ b/calm-hub-ui/src/index.css
@@ -37,6 +37,21 @@ code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
+/* Full-screen detail panel slide-in (mobile push overlay) */
+@keyframes slide-in-right {
+    from {
+        transform: translateX(100%);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+.animate-slide-in-right {
+    animation: slide-in-right 0.25s ease-out;
+}
+
 /* ReactFlow style overrides */
 .react-flow__background {
     background-color: #ffffff;

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import ReactFlow, {
     Node,
     Background,
@@ -22,6 +22,7 @@ import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/s
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
 import { applyStoredPositions } from '../../services/node-position-service.js';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
+import { useNodeSearch } from './node-search-context.js';
 import type { ArchitectureGraphProps } from '../../contracts/contracts.js';
 
 const edgeTypes = { custom: FloatingEdge };
@@ -38,15 +39,14 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
 
     const [nodes, setNodes, onNodesChangeBase] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-    const [searchTerm, setSearchTerm] = useState('');
-    const [typeFilter, setTypeFilter] = useState('');
+    const { searchTerm, setSearchTerm, typeFilter, setTypeFilter, availableNodeTypes, setAvailableNodeTypes, external: externalSearch } =
+        useNodeSearch();
 
     // Ref holds the structural node data from parsing.
     // Filter effect reads from this instead of reactive state to avoid
     // re-triggering when setNodes/setEdges update styles.
     const sourceNodesRef = useRef<Node[]>([]);
 
-    const [availableNodeTypes, setAvailableNodeTypes] = useState<string[]>([]);
     const isMobile = useIsMobile();
 
     const {
@@ -72,7 +72,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
         setNodes(viewportKey ? applyStoredPositions(viewportKey, parsedNodes) : parsedNodes);
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
-    }, [jsonData, setNodes, setEdges, onNodeClick, viewportKey]);
+    }, [jsonData, setNodes, setEdges, setAvailableNodeTypes, onNodeClick, viewportKey]);
 
     // Search & filter
     const isSearchActive = searchTerm !== '' || typeFilter !== '';
@@ -149,16 +149,17 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         maskColor={`${THEME.colors.background}cc`}
                     />
                 )}
-                {/* Offset left so it clears the diagram's top-right view-options menu. */}
-                <Panel position="top-right" style={{ marginRight: '2.75rem' }}>
-                    <SearchBar
-                        searchTerm={searchTerm}
-                        onSearchChange={setSearchTerm}
-                        typeFilter={typeFilter}
-                        onTypeFilterChange={setTypeFilter}
-                        nodeTypes={availableNodeTypes}
-                    />
-                </Panel>
+                {!externalSearch && (
+                    <Panel position="top-right">
+                        <SearchBar
+                            searchTerm={searchTerm}
+                            onSearchChange={setSearchTerm}
+                            typeFilter={typeFilter}
+                            onTypeFilterChange={setTypeFilter}
+                            nodeTypes={availableNodeTypes}
+                        />
+                    </Panel>
+                )}
             </ReactFlow>
         </div>
     );

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -149,7 +149,8 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         maskColor={`${THEME.colors.background}cc`}
                     />
                 )}
-                <Panel position="top-right">
+                {/* Offset left so it clears the diagram's top-right view-options menu. */}
+                <Panel position="top-right" style={{ marginRight: '2.75rem' }}>
                     <SearchBar
                         searchTerm={searchTerm}
                         onSearchChange={setSearchTerm}

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -21,6 +21,7 @@ import { parseCALMData } from './utils/calmTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
 import { applyStoredPositions } from '../../services/node-position-service.js';
+import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import type { ArchitectureGraphProps } from '../../contracts/contracts.js';
 
 const edgeTypes = { custom: FloatingEdge };
@@ -46,6 +47,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
     const sourceNodesRef = useRef<Node[]>([]);
 
     const [availableNodeTypes, setAvailableNodeTypes] = useState<string[]>([]);
+    const isMobile = useIsMobile();
 
     const {
         onNodesChange,
@@ -135,14 +137,16 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         borderRadius: '8px',
                     }}
                 />
-                <MiniMap
-                    style={{
-                        background: THEME.colors.backgroundSecondary,
-                        border: `1px solid ${THEME.colors.border}`,
-                    }}
-                    nodeColor={THEME.colors.accent}
-                    maskColor={`${THEME.colors.background}cc`}
-                />
+                {!isMobile && (
+                    <MiniMap
+                        style={{
+                            background: THEME.colors.backgroundSecondary,
+                            border: `1px solid ${THEME.colors.border}`,
+                        }}
+                        nodeColor={THEME.colors.accent}
+                        maskColor={`${THEME.colors.background}cc`}
+                    />
+                )}
                 <Panel position="top-right">
                     <SearchBar
                         searchTerm={searchTerm}

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -130,13 +130,15 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                 style={{ background: THEME.colors.background }}
             >
                 <Background color={THEME.colors.border} gap={16} />
-                <Controls
-                    style={{
-                        background: THEME.colors.card,
-                        border: `1px solid ${THEME.colors.border}`,
-                        borderRadius: '8px',
-                    }}
-                />
+                {!isMobile && (
+                    <Controls
+                        style={{
+                            background: THEME.colors.card,
+                            border: `1px solid ${THEME.colors.border}`,
+                            borderRadius: '8px',
+                        }}
+                    />
+                )}
                 {!isMobile && (
                     <MiniMap
                         style={{

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -194,13 +194,15 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                 style={{ background: THEME.colors.background }}
             >
                 <Background color={THEME.colors.border} gap={16} />
-                <Controls
-                    style={{
-                        background: THEME.colors.card,
-                        border: `1px solid ${THEME.colors.border}`,
-                        borderRadius: '8px',
-                    }}
-                />
+                {!isMobile && (
+                    <Controls
+                        style={{
+                            background: THEME.colors.card,
+                            border: `1px solid ${THEME.colors.border}`,
+                            borderRadius: '8px',
+                        }}
+                    />
+                )}
                 {!isMobile && (
                     <MiniMap
                         style={{

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -221,7 +221,8 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         onReset={handleDecisionReset}
                     />
                 </Panel>
-                <Panel position="top-right">
+                {/* Offset left so it clears the diagram's top-right view-options menu. */}
+                <Panel position="top-right" style={{ marginRight: '2.75rem' }}>
                     <SearchBar
                         searchTerm={searchTerm}
                         onSearchChange={setSearchTerm}

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -23,6 +23,7 @@ import { parsePatternData } from './utils/patternTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
 import { applyStoredPositions } from '../../services/node-position-service.js';
+import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { DecisionSelectorPanel } from './DecisionSelectorPanel.js';
 import {
     extractDecisionPoints,
@@ -67,6 +68,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
 
     const [availableNodeTypes, setAvailableNodeTypes] = useState<string[]>([]);
     const [decisionPoints, setDecisionPoints] = useState<ReturnType<typeof extractDecisionPoints>>([]);
+    const isMobile = useIsMobile();
 
     const {
         onNodesChange,
@@ -199,14 +201,16 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         borderRadius: '8px',
                     }}
                 />
-                <MiniMap
-                    style={{
-                        background: THEME.colors.backgroundSecondary,
-                        border: `1px solid ${THEME.colors.border}`,
-                    }}
-                    nodeColor={THEME.colors.accent}
-                    maskColor={`${THEME.colors.background}cc`}
-                />
+                {!isMobile && (
+                    <MiniMap
+                        style={{
+                            background: THEME.colors.backgroundSecondary,
+                            border: `1px solid ${THEME.colors.border}`,
+                        }}
+                        nodeColor={THEME.colors.accent}
+                        maskColor={`${THEME.colors.background}cc`}
+                    />
+                )}
                 <Panel position="top-left">
                     <DecisionSelectorPanel
                         decisionPoints={decisionPoints}

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -24,6 +24,7 @@ import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/s
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
 import { applyStoredPositions } from '../../services/node-position-service.js';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
+import { useNodeSearch } from './node-search-context.js';
 import { DecisionSelectorPanel } from './DecisionSelectorPanel.js';
 import {
     extractDecisionPoints,
@@ -56,8 +57,8 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
 
     const [nodes, setNodes, onNodesChangeBase] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-    const [searchTerm, setSearchTerm] = useState('');
-    const [typeFilter, setTypeFilter] = useState('');
+    const { searchTerm, setSearchTerm, typeFilter, setTypeFilter, availableNodeTypes, setAvailableNodeTypes, external: externalSearch } =
+        useNodeSearch();
     const [decisionSelections, setDecisionSelections] = useState<DecisionSelections>(new Map());
 
     // Refs hold the structural node/edge data from parsing.
@@ -66,7 +67,6 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
     const sourceNodesRef = useRef<Node[]>([]);
     const sourceEdgesRef = useRef<Edge[]>([]);
 
-    const [availableNodeTypes, setAvailableNodeTypes] = useState<string[]>([]);
     const [decisionPoints, setDecisionPoints] = useState<ReturnType<typeof extractDecisionPoints>>([]);
     const isMobile = useIsMobile();
 
@@ -95,7 +95,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
         setDecisionPoints(extractDecisionPoints(parsedNodes));
-    }, [patternData, setNodes, setEdges, viewportKey]);
+    }, [patternData, setNodes, setEdges, setAvailableNodeTypes, viewportKey]);
 
     // Search & filter
     const isSearchActive = searchTerm !== '' || typeFilter !== '';
@@ -221,8 +221,8 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         onReset={handleDecisionReset}
                     />
                 </Panel>
-                {/* Offset left so it clears the diagram's top-right view-options menu. */}
-                <Panel position="top-right" style={{ marginRight: '2.75rem' }}>
+                {!externalSearch && (
+                <Panel position="top-right">
                     <SearchBar
                         searchTerm={searchTerm}
                         onSearchChange={setSearchTerm}
@@ -231,6 +231,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         nodeTypes={availableNodeTypes}
                     />
                 </Panel>
+                )}
             </ReactFlow>
         </div>
     );

--- a/calm-hub-ui/src/visualizer/components/reactflow/SearchBar.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/SearchBar.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Search, X } from 'lucide-react';
 import { THEME } from './theme';
+import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 
 interface SearchBarProps {
     searchTerm: string;
@@ -9,6 +11,20 @@ interface SearchBarProps {
     nodeTypes: string[];
 }
 
+const iconButtonStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: THEME.colors.card,
+    border: `1px solid ${THEME.colors.border}`,
+    borderRadius: '8px',
+    boxShadow: THEME.shadows.md,
+    width: '34px',
+    height: '34px',
+    cursor: 'pointer',
+    color: THEME.colors.muted,
+};
+
 export function SearchBar({
     searchTerm,
     onSearchChange,
@@ -16,6 +32,27 @@ export function SearchBar({
     onTypeFilterChange,
     nodeTypes,
 }: SearchBarProps) {
+    const isMobile = useIsMobile();
+    const [expanded, setExpanded] = useState(false);
+
+    // On small screens the full search/filter bar steals too much canvas, so it
+    // collapses to a single icon button until tapped. An active search/filter
+    // keeps it expanded so the user can see and clear what's applied.
+    const showCompact = isMobile && !expanded && !searchTerm && !typeFilter;
+
+    if (showCompact) {
+        return (
+            <button
+                type="button"
+                aria-label="Search nodes"
+                onClick={() => setExpanded(true)}
+                style={iconButtonStyle}
+            >
+                <Search style={{ width: '16px', height: '16px' }} />
+            </button>
+        );
+    }
+
     return (
         <div
             style={{
@@ -35,13 +72,14 @@ export function SearchBar({
                 placeholder="Search nodes..."
                 value={searchTerm}
                 onChange={(e) => onSearchChange(e.target.value)}
+                autoFocus={isMobile && expanded}
                 style={{
                     border: 'none',
                     outline: 'none',
                     background: 'transparent',
                     color: THEME.colors.foreground,
                     fontSize: '12px',
-                    width: '140px',
+                    width: isMobile ? '110px' : '140px',
                 }}
             />
             {searchTerm && (
@@ -83,6 +121,28 @@ export function SearchBar({
                         </option>
                     ))}
                 </select>
+            )}
+            {isMobile && (
+                <button
+                    type="button"
+                    onClick={() => {
+                        onSearchChange('');
+                        onTypeFilterChange('');
+                        setExpanded(false);
+                    }}
+                    aria-label="Collapse search"
+                    style={{
+                        border: 'none',
+                        background: 'transparent',
+                        cursor: 'pointer',
+                        padding: '2px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        color: THEME.colors.muted,
+                    }}
+                >
+                    <X style={{ width: '14px', height: '14px' }} />
+                </button>
             )}
         </div>
     );

--- a/calm-hub-ui/src/visualizer/components/reactflow/SearchBar.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/SearchBar.tsx
@@ -9,6 +9,8 @@ interface SearchBarProps {
     typeFilter: string;
     onTypeFilterChange: (type: string) => void;
     nodeTypes: string[];
+    /** Render the full bar (no collapse-to-icon), e.g. inside the mobile view menu. */
+    forceExpanded?: boolean;
 }
 
 const iconButtonStyle: React.CSSProperties = {
@@ -31,14 +33,16 @@ export function SearchBar({
     typeFilter,
     onTypeFilterChange,
     nodeTypes,
+    forceExpanded = false,
 }: SearchBarProps) {
     const isMobile = useIsMobile();
     const [expanded, setExpanded] = useState(false);
 
-    // On small screens the full search/filter bar steals too much canvas, so it
+    // On small screens the floating canvas bar steals too much room, so it
     // collapses to a single icon button until tapped. An active search/filter
     // keeps it expanded so the user can see and clear what's applied.
-    const showCompact = isMobile && !expanded && !searchTerm && !typeFilter;
+    // forceExpanded (e.g. inside the view menu) always shows the full bar.
+    const showCompact = isMobile && !expanded && !searchTerm && !typeFilter && !forceExpanded;
 
     if (showCompact) {
         return (
@@ -63,7 +67,8 @@ export function SearchBar({
                 border: `1px solid ${THEME.colors.border}`,
                 borderRadius: '8px',
                 padding: '6px 10px',
-                boxShadow: THEME.shadows.md,
+                boxShadow: forceExpanded ? 'none' : THEME.shadows.md,
+                width: forceExpanded ? '100%' : undefined,
             }}
         >
             <Search style={{ width: '14px', height: '14px', color: THEME.colors.muted, flexShrink: 0 }} />
@@ -78,8 +83,10 @@ export function SearchBar({
                     outline: 'none',
                     background: 'transparent',
                     color: THEME.colors.foreground,
-                    fontSize: '12px',
-                    width: isMobile ? '110px' : '140px',
+                    fontSize: forceExpanded ? '14px' : '12px',
+                    minWidth: 0,
+                    flex: forceExpanded ? 1 : undefined,
+                    width: forceExpanded ? 'auto' : isMobile ? '110px' : '140px',
                 }}
             />
             {searchTerm && (
@@ -122,7 +129,7 @@ export function SearchBar({
                     ))}
                 </select>
             )}
-            {isMobile && (
+            {isMobile && !forceExpanded && (
                 <button
                     type="button"
                     onClick={() => {

--- a/calm-hub-ui/src/visualizer/components/reactflow/node-search-context.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/node-search-context.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState } from 'react';
+
+/**
+ * Shared node ("component") search state for a diagram. By default each graph
+ * owns its own state and renders the in-canvas search bar. When a parent
+ * provides this context (e.g. the mobile diagram, which surfaces the search
+ * inside its view-options menu), the graph uses the external state instead and
+ * hides its in-canvas search bar.
+ */
+export interface NodeSearchState {
+    searchTerm: string;
+    setSearchTerm: (value: string) => void;
+    typeFilter: string;
+    setTypeFilter: (value: string) => void;
+    availableNodeTypes: string[];
+    setAvailableNodeTypes: (value: string[]) => void;
+    /** True when the search UI is rendered outside the canvas (hide the in-canvas bar). */
+    external: boolean;
+}
+
+const NodeSearchContext = createContext<NodeSearchState | null>(null);
+
+export const NodeSearchProvider = NodeSearchContext.Provider;
+
+/**
+ * Returns the externally-provided node-search state when a {@link NodeSearchProvider}
+ * is present, otherwise falls back to graph-local state.
+ */
+export function useNodeSearch(): NodeSearchState {
+    const ctx = useContext(NodeSearchContext);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [typeFilter, setTypeFilter] = useState('');
+    const [availableNodeTypes, setAvailableNodeTypes] = useState<string[]>([]);
+
+    if (ctx) return ctx;
+    return {
+        searchTerm,
+        setSearchTerm,
+        typeFilter,
+        setTypeFilter,
+        availableNodeTypes,
+        setAvailableNodeTypes,
+        external: false,
+    };
+}

--- a/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
@@ -20,7 +20,7 @@ export function Sidebar({ selectedData, closeSidebar }: SidebarProps) {
     const isRelationship = isCALMRelationship(selectedData);
 
     return (
-        <div className="p-4 pl-2 h-full w-96 shrink-0">
+        <div className="p-4 lg:pl-2 h-full w-full lg:w-96 shrink-0">
             <div className="h-full bg-base-100 rounded-box shadow-xl flex flex-col overflow-hidden">
                 <div className="bg-base-200 px-6 py-4 border-b border-base-300 flex items-center justify-between">
                     <h2 className="text-xl font-semibold flex items-center gap-2">

--- a/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/Sidebar.tsx
@@ -20,8 +20,8 @@ export function Sidebar({ selectedData, closeSidebar }: SidebarProps) {
     const isRelationship = isCALMRelationship(selectedData);
 
     return (
-        <div className="p-4 lg:pl-2 h-full w-full lg:w-96 shrink-0">
-            <div className="h-full bg-base-100 rounded-box shadow-xl flex flex-col overflow-hidden">
+        <div className="h-full w-full lg:w-96 shrink-0 lg:p-4 lg:pl-2">
+            <div className="h-full bg-base-100 lg:rounded-box lg:shadow-xl flex flex-col overflow-hidden">
                 <div className="bg-base-200 px-6 py-4 border-b border-base-300 flex items-center justify-between">
                     <h2 className="text-xl font-semibold flex items-center gap-2">
                         {isNode ? (

--- a/calm-hub-ui/vitest.setup.ts
+++ b/calm-hub-ui/vitest.setup.ts
@@ -9,6 +9,23 @@ global.ResizeObserver = class ResizeObserver {
     disconnect() {}
 };
 
+// Polyfill matchMedia (not implemented in jsdom). Defaults to non-matching so
+// components fall back to their desktop layout in tests. Individual tests can
+// override window.matchMedia to exercise mobile/responsive behaviour.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+    window.matchMedia = (query: string) =>
+        ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            addListener: () => {},
+            removeListener: () => {},
+            dispatchEvent: () => false,
+        }) as unknown as MediaQueryList;
+}
+
 // runs a clean after each test case (e.g. clearing jsdom)
 afterEach(() => {
     cleanup();


### PR DESCRIPTION
## Description
Implements a responsive layout for CALM Hub UI so the Hub, the architecture/pattern diagram, the detail panels, and the version timeline/compare views are usable on phones and tablet-portrait screens. Desktop (`lg+`) behaviour is unchanged — every change gates on a mobile breakpoint.

Closes #2698

**Highlights**
- New `useMediaQuery` / `useIsMobile` hook (test-safe; guards `window.matchMedia`), keyed to Tailwind's `lg` (1024px) breakpoint.
- **Hub**: tree navigation becomes an off-canvas drawer (slide-in + dimmed backdrop, opened from an "Explore" button); the details panel becomes a full-screen overlay.
- **Diagram**: minimap hidden on mobile (single and compare views); node search/type-filter collapses to a single expandable icon; tabs become icon-only.
- **Timeline**: tucked behind a floating clock button that opens it as a bottom sheet, instead of permanently occupying the short viewport.
- **Compare view**: the two version graphs stack vertically on mobile so each is legible.
- **Header / search**: breadcrumb + tabs wrap instead of overflowing; the global search input and dropdown are viewport-bounded.
- **Fix**: kept the tree mounted (slid off-canvas) on mobile so URL deep-links and global-search navigation still load data.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified at ~390px, tablet-portrait, and desktop across Hub browse, architecture diagram (incl. a 14-node example), node/relationship detail, JSON tab, timeline, and compare view. `npm test --workspace calm-hub-ui` -> 757 passing; lint and build clean.

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

## Screenshots
### Desktop — unchanged (`lg+`)
<img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/desktop.png" width="760" />

### Mobile (~390px)
| Off-canvas drawer | Diagram (no minimap, collapsed search) |
|---|---|
| <img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/mobile-drawer.png" width="240" /> | <img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/mobile-diagram.png" width="240" /> |

| Node detail overlay | Timeline bottom sheet |
|---|---|
| <img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/mobile-detail.png" width="240" /> | <img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/mobile-timeline.png" width="240" /> |

### Compare view — graphs stack vertically
<img src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/docs/mobile-responsive-screenshots/docs/assets/mobile-responsive/mobile-compare.png" width="240" />

<sub>Screenshots hosted on the `docs/mobile-responsive-screenshots` branch of the fork to keep the diff focused on code.</sub>