### PR TITLE
feat(calm-hub): add /coffee endpoint returning 418 I'm a Teapot

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/resources/CoffeeResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CoffeeResource.java
@@ -1,0 +1,34 @@
+package org.finos.calm.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Tag(name = "Teapot API", description = "Critical caffeination infrastructure")
+@Path("/coffee")
+public class CoffeeResource {
+
+    static final String TEAPOT_MESSAGE =
+            "{\"status\":418," +
+            "\"title\":\"I'm a Teapot\"," +
+            "\"type\":\"https://www.rfc-editor.org/rfc/rfc2324\"," +
+            "\"detail\":\"This service is a TEApot — a Topology-Expressed Architecture — and is CALMly declining your request. " +
+            "No 'CoffeeMachine' node exists in the architecture model, and brewing coffee falls outside the defined interface contract. " +
+            "Please update your CALM pattern to include an appropriate caffeination service before retrying.\"}";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Brew Coffee",
+            description = "Attempts to brew coffee. This endpoint will always fail — CALM Hub is a TEApot (Topology-Expressed Architecture), not a coffee machine."
+    )
+    @APIResponse(responseCode = "418", description = "I'm a Teapot")
+    public Response brewCoffee() {
+        return Response.status(418).entity(TEAPOT_MESSAGE).build();
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCoffeeResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCoffeeResourceShould.java
@@ -1,0 +1,32 @@
+package org.finos.calm.resources;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class TestCoffeeResourceShould {
+
+    @Test
+    void return_418_when_asked_to_brew_coffee() {
+        given()
+                .when()
+                .get("/coffee")
+                .then()
+                .statusCode(418);
+    }
+
+    /* Pun-testing */
+    @Test
+    void return_teapot_message_when_asked_to_brew_coffee() {
+        given()
+                .when()
+                .get("/coffee")
+                .then()
+                .body(containsString("TEApot"))
+                .body(containsString("Topology-Expressed Architecture"))
+                .body(containsString("CALMly"));
+    }
+}


### PR DESCRIPTION
## Description

Adds a whimsical \`GET /coffee\` endpoint to CALM Hub that CALMly declines all requests with HTTP 418 I'm a Teapot.

CALM — the **C**ommon **A**rchitecture **L**anguage **M**odel — is a declarative, schema-driven language for modelling software architectures. Coffee is not a topology. Coffee is not a node. Coffee has no interface contract. Serving coffee is fundamentally outside the CALM specification, and attempting to brew it via a CALM Hub is a category error.

There is also a deeper physiological truth at work here. Tea contains L-theanine, an amino acid that works with caffeine to produce a state of **calm alertness**. Coffee, by contrast, delivers a potent, fast-acting caffeine hit that leads to an energetic spike followed by a crash — the architectural equivalent of a Big Ball of Mud. CALM Hub is, by its very nature, a TEA system: measured, structured, and conducive to calm. It cannot, in good conscience, serve coffee.

Therefore, CALM Hub must identify itself as a **TEApot** — a **T**opology-**E**xpressed **A**rchitecture — and return HTTP 418, as required by [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324). No \`CoffeeMachine\` node exists in the architecture model, and no amount of schema extensions will change that.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components

- [x] CALM Hub (\`calm-hub/\`)

## Commit Message Format ✅

\`feat(calm-hub): add /coffee endpoint returning 418 I'm a Teapot\`

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Tests added in \`TestCoffeeResourceShould\`: verifies HTTP 418 status and that the response body contains the TEApot puns (\`TEApot\`, \`Topology-Expressed Architecture\`, \`CALMly\`).

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards