### PR TITLE
fix(calm-hub): sanitize user input in user-access error responses

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -157,6 +157,42 @@ Security: `@PermissionsAllowed` on resource methods is resolved by
 `CalmHubPermissionChecker`, which consults `UserAccessValidator` against the
 caller's grants. See [PERMISSIONS.md](./PERMISSIONS.md) for the full model.
 
+#### Preventing Cross-Site Scripting (XSS) in Responses
+
+**CRITICAL — never echo user-controlled input into a response body unsanitized.** CodeQL's
+`java/xss` rule (CWE-79) flags any path where a request value (`@PathParam`, `@QueryParam`,
+request-body field, or `exception.getMessage()` derived from one) reaches a `Response` entity
+or a log line. `@Pattern` bean-validation on the parameter is **not** a recognised barrier — CodeQL
+still flags it, and content negotiation can serve the error body as `text/html`, making reflected
+XSS exploitable.
+
+**The barrier:** wrap every user-derived value with the shared OWASP sanitizer before
+concatenating it into a body or log message:
+
+```java
+import static org.finos.calm.resources.ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
+
+return Response.status(Response.Status.NOT_FOUND)
+        .entity("Invalid namespace provided: " + STRICT_SANITIZATION_POLICY.sanitize(namespace))
+        .build();
+
+logger.error("Cannot parse JSON for namespace [{}]: [{}]",
+        namespace, STRICT_SANITIZATION_POLICY.sanitize(request.getJson()), e);
+```
+
+Rules:
+- **Sanitize in the helper, not the call site.** Fix shared/private error-response helpers
+  (e.g. `invalidNamespaceResponse`, `invalidDomainResponse`) so every caller is covered — not just
+  the one method CodeQL happened to flag.
+- **Prefer not echoing input at all.** When the value adds no diagnostic value to the *client*,
+  return a generic message (see `CalmResourceErrorResponses.invalidJsonResponse`, which deliberately
+  does not echo the payload). Sanitize only when the echoed value genuinely helps the caller.
+- **Always set `@Produces`.** Every endpoint should declare `@Produces(MediaType.APPLICATION_JSON)`
+  (mutating endpoints with no return body included). A missing `@Produces` lets the entity be
+  content-negotiated to `text/html`, which is what turns an echoed string into an XSS sink.
+- The reference implementations are `ControlResource`, `MappingControllerResource`, and
+  `CalmResourceErrorResponses` — match how they sanitize.
+
 There are **four auth modes**, each selected by a separate property file:
 
 **Default** (secure, no mechanism configured) — `application.properties`:
@@ -501,6 +537,9 @@ private static final int PATTERN_ID = 42;
 4. Write unit tests in `test/`
 5. Add integration test in `integration-test/`
 6. Document with OpenAPI annotations
+7. Declare `@Produces(MediaType.APPLICATION_JSON)` on every method, and sanitize any
+   user-derived value echoed into a response body or log with `STRICT_SANITIZATION_POLICY.sanitize(...)`
+   (see [Preventing Cross-Site Scripting (XSS) in Responses](#preventing-cross-site-scripting-xss-in-responses))
 
 ### Adding a New Storage Backend
 1. Create package: `org.finos.calm.store.mybackend`
@@ -552,6 +591,10 @@ CALM Hub is largely independent - it's a standalone REST API server.
      `quarkus.profile=standalone` via the plugin's own `systemProperties` configuration.
 4. **Certificate Issues**: Use exact CN in URLs when using self-signed certs
 5. **Profile Selection**: Remember to pass `-Dquarkus.profile=secure` for secure mode
+6. **Reflected XSS in error bodies/logs**: Concatenating a raw `@PathParam`/`@QueryParam`/request
+   field into a `Response` entity or log message triggers CodeQL `java/xss`. `@Pattern` validation
+   is not a barrier — wrap the value in `STRICT_SANITIZATION_POLICY.sanitize(...)`. See
+   [Preventing Cross-Site Scripting (XSS) in Responses](#preventing-cross-site-scripting-xss-in-responses).
 
 ## Known Issues
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainUserAccessResource.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 
 import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
+import static org.finos.calm.resources.ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
 
 @Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
 @Path("/api/calm/domains")
@@ -130,7 +131,7 @@ public class DomainUserAccessResource {
 
     private Response invalidDomainResponse(String domain) {
         return Response.status(Response.Status.NOT_FOUND)
-                .entity("Invalid domain provided: " + domain)
+                .entity("Invalid domain provided: " + STRICT_SANITIZATION_POLICY.sanitize(domain))
                 .build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/UserAccessResource.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
+import static org.finos.calm.resources.ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
 
 @Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
 @Path("/api/calm/namespaces")
@@ -139,7 +140,7 @@ public class UserAccessResource {
 
     private Response invalidNamespaceResponse(String namespace) {
         return Response.status(Response.Status.NOT_FOUND)
-                .entity("Invalid namespace provided: " + namespace)
+                .entity("Invalid namespace provided: " + STRICT_SANITIZATION_POLICY.sanitize(namespace))
                 .build();
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestSanitizationSecurityShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestSanitizationSecurityShould.java
@@ -32,12 +32,36 @@ public class TestSanitizationSecurityShould {
     @Test
     void act_as_strict_policy() {
         PolicyFactory policy = ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
-        
+
         String input = "<div><b>bold</b><script>alert('xss')</script></div>";
         String output = policy.sanitize(input);
-        
+
         // Default builder().toFactory() allows NO elements.
         // So it should strip all tags.
         Assertions.assertEquals("bold", output, "Strict policy should strip all tags");
+    }
+
+    @Test
+    void neutralise_script_tags_in_domain_error_message() {
+        // Mirrors DomainUserAccessResource#invalidDomainResponse, which echoes the path param
+        // into the 404 body. The @Pattern guard 400s malicious values before they reach the
+        // helper, so this is defence-in-depth against any future caller that bypasses validation.
+        String maliciousDomain = "<script>alert('xss')</script>";
+        String body = "Invalid domain provided: "
+                + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(maliciousDomain);
+
+        Assertions.assertEquals("Invalid domain provided: ", body,
+                "Domain error body should contain no executable markup");
+    }
+
+    @Test
+    void neutralise_script_tags_in_namespace_error_message() {
+        // Mirrors UserAccessResource#invalidNamespaceResponse — see the domain test above.
+        String maliciousNamespace = "<script>alert('xss')</script>";
+        String body = "Invalid namespace provided: "
+                + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(maliciousNamespace);
+
+        Assertions.assertEquals("Invalid namespace provided: ", body,
+                "Namespace error body should contain no executable markup");
     }
 }


### PR DESCRIPTION
## Description
Fixes CodeQL `java/xss` (CWE-79) alerts **#71** and **#72**. Both flagged a user-controlled path parameter being echoed into a `Response` body:

- `DomainUserAccessResource#invalidDomainResponse` — `"Invalid domain provided: " + domain`
- `UserAccessResource#invalidNamespaceResponse` — `"Invalid namespace provided: " + namespace`

Both helpers now route the value through the codebase's existing OWASP sanitizer (`ResourceValidationConstants.STRICT_SANITIZATION_POLICY`), matching the established pattern in `ControlResource`, `MappingControllerResource`, and `CalmResourceErrorResponses#invalidDomainResponse`. The fix is applied in the **shared private helpers**, so every caller is covered — not only the DELETE endpoints CodeQL happened to flag.

**Note on behaviour:** the path params carry `@Pattern` bean-validation (`^[A-Za-z0-9-]+...$`), which rejects any payload containing XSS characters with a `400` *before* these helpers run. So for every reachable input the sanitizer is a no-op; its value is (a) satisfying CodeQL's recognised XSS barrier and (b) defence-in-depth against any future caller that bypasses `@Pattern`. CodeQL does not model `@Pattern` as a sanitizer, hence the alerts.

Also documents the XSS-prevention pattern in `calm-hub/AGENTS.md` (new "Preventing Cross-Site Scripting (XSS) in Responses" subsection, plus cross-links from the "Adding a New REST Endpoint" checklist and "Common Pitfalls") to stop the pattern recurring.

**Follow-up (out of scope):** `CalmResourceErrorResponses#invalidNamespaceResponse` still concatenates `namespace` raw while its `invalidDomainResponse` sibling sanitizes — the same class of latent sink, not currently flagged by CodeQL (its callers all set `@Produces(APPLICATION_JSON)`). Left for a separate change to keep this PR scoped to the two alerts.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] Documentation (`docs/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added two assertions to `TestSanitizationSecurityShould` covering the exact error-body construction used by both helpers. Verified with `./mvnw clean verify -Ddependency-check.skip=true` from `calm-hub/` — **BUILD SUCCESS**, 2032 tests pass, JaCoCo per-class 90% gate clears. (A resource-layer HTTP test cannot exercise a pre/post difference because `@Pattern` 400s any malicious value before the helper, so the assertions are placed at the policy level.)

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
