### PR TITLE
docs(calm-widgets): document alphabetical ordering requirement for widgets and helpers

### DIFF
--- a/calm-widgets/AGENTS.md
+++ b/calm-widgets/AGENTS.md
@@ -277,7 +277,7 @@ npm run build --workspace calm-widgets
 6. **Register the widget** in `widget-engine.ts` `registerDefaultWidgets()` —
    add `{ widget: MyWidget, folder: __dirname + '/widgets/my-widget' }`.
    A widget is not usable until it is registered here.
-   **The registration list must stay in alphabetical order by widget name** (e.g. `block-architecture` before `table`).
+   **The registration list must stay in alphabetical order by widget id** (e.g. `block-architecture` before `table`).
    Likewise, the helper registrations in `widget-helpers.ts` must stay alphabetical.
    Both orderings are enforced by tests in `widget-engine.spec.ts` and `widget-helpers.spec.ts` — CI will fail if a new entry is added out of order.
 7. Add test fixtures in `test-fixtures/my-widget/`

--- a/calm-widgets/AGENTS.md
+++ b/calm-widgets/AGENTS.md
@@ -277,6 +277,9 @@ npm run build --workspace calm-widgets
 6. **Register the widget** in `widget-engine.ts` `registerDefaultWidgets()` —
    add `{ widget: MyWidget, folder: __dirname + '/widgets/my-widget' }`.
    A widget is not usable until it is registered here.
+   **The registration list must stay in alphabetical order by widget name** (e.g. `block-architecture` before `table`).
+   Likewise, the helper registrations in `widget-helpers.ts` must stay alphabetical.
+   Both orderings are enforced by tests in `widget-engine.spec.ts` and `widget-helpers.spec.ts` — CI will fail if a new entry is added out of order.
 7. Add test fixtures in `test-fixtures/my-widget/`
 8. Document in `README.md`
 

--- a/calm-widgets/src/widget-engine.ts
+++ b/calm-widgets/src/widget-engine.ts
@@ -86,6 +86,7 @@ export class WidgetEngine {
     }
 
     registerDefaultWidgets() {
+        // Entries must stay in alphabetical order by widget name — enforced by widget-engine.spec.ts.
         const widgets: { widget: CalmWidget<unknown, object, unknown>, folder: string }[] = [
             {
                 widget: BlockArchitectureWidget as CalmWidget<unknown, object, unknown>,

--- a/calm-widgets/src/widget-engine.ts
+++ b/calm-widgets/src/widget-engine.ts
@@ -86,7 +86,7 @@ export class WidgetEngine {
     }
 
     registerDefaultWidgets() {
-        // Entries must stay in alphabetical order by widget name — enforced by widget-engine.spec.ts.
+        // Entries must stay in alphabetical order by widget id — enforced by widget-engine.spec.ts.
         const widgets: { widget: CalmWidget<unknown, object, unknown>, folder: string }[] = [
             {
                 widget: BlockArchitectureWidget as CalmWidget<unknown, object, unknown>,

--- a/calm-widgets/src/widget-helpers.ts
+++ b/calm-widgets/src/widget-helpers.ts
@@ -1,6 +1,7 @@
 import { buildThemeClassDefsString, buildThemeFrontMatter } from './widgets/block-architecture/core/themes/theme-builder';
 import { ThemeColors } from './widgets/block-architecture/types';
 
+// Helper keys must stay in alphabetical order — enforced by widget-helpers.spec.ts.
 export function registerGlobalTemplateHelpers(): Record<string, (...args: unknown[]) => unknown> {
     return {
         currentDate: (): string => new Date().toISOString().split('T')[0],


### PR DESCRIPTION
## Summary

- Adds a note to `calm-widgets/AGENTS.md` in the **Adding a New Widget** section documenting that both the `registerDefaultWidgets()` list in `widget-engine.ts` and the helper registrations in `widget-helpers.ts` must be kept in alphabetical order
- Notes that this ordering is enforced by `widget-engine.spec.ts` and `widget-helpers.spec.ts`, so CI will fail if a new entry is added out of order

This closes the follow-up requested in the review of #2697, which noted that issue #1501's acceptance criteria included updating contributing guidelines with the ordering requirement.

## Test plan

- [ ] No code changes — documentation only
- [ ] Verify the updated section reads clearly in `calm-widgets/AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)