### PR TITLE
fix(calm-hub-ui): render nested containers at 3+ levels (parent-before-child node ordering)

### DIFF
--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
@@ -360,4 +360,35 @@ describe('parseCALMData', () => {
         expect(result.edges[0].target).toBe('node-1');
         expect(result.edges[1].target).toBe('node-2');
     });
+
+    describe('nested container ordering', () => {
+        // 4-level deployed-in stack A > B > C > system, with the nested containers
+        // listed out of parent-first order (A, C, B, system) — the case that drops C.
+        const data: CalmArchitectureSchema = {
+            nodes: [
+                { 'unique-id': 'A', name: 'A', 'node-type': 'system' },
+                { 'unique-id': 'C', name: 'C', 'node-type': 'system' },
+                { 'unique-id': 'B', name: 'B', 'node-type': 'system' },
+                { 'unique-id': 'system', name: 'system', 'node-type': 'service' },
+            ],
+            relationships: [
+                { 'unique-id': 'b-in-a', 'relationship-type': { 'deployed-in': { container: 'A', nodes: ['B'] } } },
+                { 'unique-id': 'c-in-b', 'relationship-type': { 'deployed-in': { container: 'B', nodes: ['C'] } } },
+                { 'unique-id': 's-in-c', 'relationship-type': { 'deployed-in': { container: 'C', nodes: ['system'] } } },
+            ],
+        };
+
+        it('emits every parent before its children', () => {
+            const order = parseCALMData(data).nodes.map((n) => n.id);
+            const parentOf: Record<string, string> = { B: 'A', C: 'B', system: 'C' };
+            for (const [child, parent] of Object.entries(parentOf)) {
+                expect(order.indexOf(parent)).toBeLessThan(order.indexOf(child));
+            }
+        });
+
+        it('keeps all four nodes (no container dropped)', () => {
+            const ids = parseCALMData(data).nodes.map((n) => n.id).sort();
+            expect(ids).toEqual(['A', 'B', 'C', 'system']);
+        });
+    });
 });

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.ts
@@ -5,6 +5,7 @@ import {
     createTopLevelLayout,
     calculateChildBounds,
     sortContainersDeepestFirst,
+    sortNodesParentsBeforeChildren,
 } from './layoutUtils';
 import { identifyContainerNodes, parseNodes } from './nodeParser';
 import { extractFlowTransitions, parseRelationships } from './relationshipParser';
@@ -206,9 +207,9 @@ function combineNodes(
     nodesWithParents: Node[],
     systemNodes: Node[]
 ): Node[] {
-    return [
+    return sortNodesParentsBeforeChildren([
         ...topLevelSystemNodes,
         ...nodesWithoutParents.filter((n) => !systemNodes.includes(n)),
         ...nodesWithParents,
-    ];
+    ]);
 }

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.test.ts
@@ -5,6 +5,7 @@ import {
     createTopLevelLayout,
     calculateChildBounds,
     sortContainersDeepestFirst,
+    sortNodesParentsBeforeChildren,
     getNodeWidth,
     getNodeHeight,
     reflowContainersToFitChildren,
@@ -162,6 +163,55 @@ describe('sortContainersDeepestFirst', () => {
         const before = containers.map((n) => n.id);
         sortContainersDeepestFirst(containers);
         expect(containers.map((n) => n.id)).toEqual(before);
+    });
+});
+
+describe('sortNodesParentsBeforeChildren', () => {
+    it('orders every parent before its children regardless of input order', () => {
+        // Deliberately out-of-order: a nested container (C) before its parent (B),
+        // and the leaf (system) before all of them.
+        const nodes: Node[] = [
+            { id: 'A', position: { x: 0, y: 0 }, data: {} },
+            { id: 'system', parentId: 'C', position: { x: 0, y: 0 }, data: {} },
+            { id: 'C', parentId: 'B', position: { x: 0, y: 0 }, data: {} },
+            { id: 'B', parentId: 'A', position: { x: 0, y: 0 }, data: {} },
+        ];
+
+        const order = sortNodesParentsBeforeChildren(nodes).map((n) => n.id);
+
+        expect(order.indexOf('A')).toBeLessThan(order.indexOf('B'));
+        expect(order.indexOf('B')).toBeLessThan(order.indexOf('C'));
+        expect(order.indexOf('C')).toBeLessThan(order.indexOf('system'));
+    });
+
+    it('does not mutate the input array', () => {
+        const nodes: Node[] = [
+            { id: 'child', parentId: 'parent', position: { x: 0, y: 0 }, data: {} },
+            { id: 'parent', position: { x: 0, y: 0 }, data: {} },
+        ];
+        const before = nodes.map((n) => n.id);
+        sortNodesParentsBeforeChildren(nodes);
+        expect(nodes.map((n) => n.id)).toEqual(before);
+    });
+
+    it('is stable for nodes at the same depth', () => {
+        const nodes: Node[] = [
+            { id: 'p', position: { x: 0, y: 0 }, data: {} },
+            { id: 'c1', parentId: 'p', position: { x: 0, y: 0 }, data: {} },
+            { id: 'c2', parentId: 'p', position: { x: 0, y: 0 }, data: {} },
+            { id: 'c3', parentId: 'p', position: { x: 0, y: 0 }, data: {} },
+        ];
+        const order = sortNodesParentsBeforeChildren(nodes).map((n) => n.id);
+        expect(order).toEqual(['p', 'c1', 'c2', 'c3']);
+    });
+
+    it('does not loop forever on a parent cycle', () => {
+        const nodes: Node[] = [
+            { id: 'x', parentId: 'y', position: { x: 0, y: 0 }, data: {} },
+            { id: 'y', parentId: 'x', position: { x: 0, y: 0 }, data: {} },
+        ];
+        const order = sortNodesParentsBeforeChildren(nodes).map((n) => n.id);
+        expect(order).toHaveLength(2);
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/layoutUtils.ts
@@ -20,6 +20,23 @@ export function getNodeHeight(node: Node): number {
 }
 
 /**
+ * Containment depth of a node: how many parents are crossed walking up the
+ * `parentId` chain (0 for a top-level node). `byId` must map every id that can
+ * appear in a chain. Cycle-safe via the `seen` guard.
+ */
+function nodeDepth(node: Node, byId: Map<string, Node>): number {
+    let d = 0;
+    let current: Node | undefined = node;
+    const seen = new Set<string>();
+    while (current?.parentId && byId.has(current.parentId) && !seen.has(current.id)) {
+        seen.add(current.id);
+        d++;
+        current = byId.get(current.parentId);
+    }
+    return d;
+}
+
+/**
  * Orders container nodes so that the most deeply nested containers come first.
  * Containers must be laid out (and therefore sized) bottom-up: an outer
  * container can only be sized correctly once its inner container children
@@ -27,20 +44,18 @@ export function getNodeHeight(node: Node): number {
  */
 export function sortContainersDeepestFirst(containers: Node[]): Node[] {
     const byId = new Map(containers.map((c) => [c.id, c]));
+    return [...containers].sort((a, b) => nodeDepth(b, byId) - nodeDepth(a, byId));
+}
 
-    const depth = (node: Node): number => {
-        let d = 0;
-        let current: Node | undefined = node;
-        const seen = new Set<string>();
-        while (current?.parentId && byId.has(current.parentId) && !seen.has(current.id)) {
-            seen.add(current.id);
-            d++;
-            current = byId.get(current.parentId);
-        }
-        return d;
-    };
-
-    return [...containers].sort((a, b) => depth(b) - depth(a));
+/**
+ * Orders nodes so that every parent appears before its children (shallowest
+ * depth first). React Flow requires a parent node to precede its child nodes in
+ * the array, otherwise nested group children are dropped or mispositioned.
+ * Returns a new array; the input is not mutated. Stable for equal depths.
+ */
+export function sortNodesParentsBeforeChildren(nodes: Node[]): Node[] {
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    return [...nodes].sort((a, b) => nodeDepth(a, byId) - nodeDepth(b, byId));
 }
 
 /**

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.test.ts
@@ -452,3 +452,50 @@ describe('parsePatternData', () => {
         expect(result.edges).toHaveLength(0);
     });
 });
+
+describe('nested container ordering', () => {
+    function deployedInRel(uniqueId: string, container: string, child: string) {
+        return {
+            properties: {
+                'unique-id': { const: uniqueId },
+                'relationship-type': {
+                    const: { 'deployed-in': { container, nodes: [child] } },
+                },
+            },
+        };
+    }
+
+    // A > B > C > system, nested containers listed out of order (A, C, B, system).
+    const pattern = {
+        properties: {
+            nodes: {
+                prefixItems: [
+                    schemaNode('A', 'A', 'system'),
+                    schemaNode('C', 'C', 'system'),
+                    schemaNode('B', 'B', 'system'),
+                    schemaNode('system', 'system', 'service'),
+                ],
+            },
+            relationships: {
+                prefixItems: [
+                    deployedInRel('b-in-a', 'A', 'B'),
+                    deployedInRel('c-in-b', 'B', 'C'),
+                    deployedInRel('s-in-c', 'C', 'system'),
+                ],
+            },
+        },
+    };
+
+    it('emits every parent before its children', () => {
+        const order = parsePatternData(pattern).nodes.map((n) => n.id);
+        const parentOf: Record<string, string> = { B: 'A', C: 'B', system: 'C' };
+        for (const [child, parent] of Object.entries(parentOf)) {
+            expect(order.indexOf(parent)).toBeLessThan(order.indexOf(child));
+        }
+    });
+
+    it('keeps all four nodes', () => {
+        const ids = parsePatternData(pattern).nodes.map((n) => n.id).sort();
+        expect(ids).toEqual(['A', 'B', 'C', 'system']);
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
@@ -4,6 +4,7 @@ import {
     createTopLevelLayout,
     calculateChildBounds,
     sortContainersDeepestFirst,
+    sortNodesParentsBeforeChildren,
 } from './layoutUtils';
 import { createEdge } from './edgeFactory';
 import { GRAPH_LAYOUT } from './constants';
@@ -600,11 +601,11 @@ function applyPatternLayout(regularNodes: Node[], groupNodes: Node[], edges: Edg
         if (pos) node.position = pos;
     });
 
-    const allNodes = [
+    const allNodes = sortNodesParentsBeforeChildren([
         ...topLevelGroupNodes,
         ...nodesWithoutParents.filter((n) => !groupNodes.includes(n)),
         ...nodesWithParents,
-    ];
+    ]);
 
     return { nodes: allNodes, edges };
 }


### PR DESCRIPTION
## Description

Fixes a bug in the CALM Hub UI architecture visualizer where **nested container nodes were silently dropped** at 3+ levels of `deployed-in` / `composed-of` containment (boxes-within-boxes).

**Root cause:** both transformers handed React Flow (v11) a node array that was not ordered parent-before-child. React Flow requires a parent node to appear before its children in the `nodes` array; when a nested container appeared before its parent container, React Flow could not resolve the parent and dropped the container. The transformers already computed correct positions/sizes for any depth (via `sortContainersDeepestFirst`), but the final array order was not depth-sorted. A 4-level stack listed out of order (`A, C, B, system`) rendered as `A > B > [leaf]` with `C` missing.

**Fix:**
- Add a pure helper `sortNodesParentsBeforeChildren()` to `layoutUtils.ts` that sorts nodes shallowest-first so every parent precedes its descendants (stable, non-mutating, cycle-safe), refactoring the depth walk into a shared `nodeDepth()` used by both sorts.
- Apply it at the single return point of `combineNodes()` (architecture path) and `applyPatternLayout()` (pattern path).

Only the final node-array ordering changes — no layout math (positions, sizes, padding) is touched, and there is no public API change. Verified that reordering does not affect stacking (z-index is set explicitly) or any consumer (all are id-keyed). The diff view inherits the fix for free via the `*WithDiff` wrappers.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
Added regression tests driving a 4-level out-of-order `deployed-in` stack through `parseCALMData` and `parsePatternData`, asserting parent-before-child for every link (genuine RED→GREEN). Helper unit tests cover ordering, non-mutation, stability, and cycle-safety.

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

> Note: the visualizer `utils/` suite passes 169/169 locally (run via vitest with the `node` environment). The full jsdom suite and eslint could not be run on this machine due to a pre-existing local `node_modules`/transitive-dependency issue unrelated to this change; CI validates lint + the full jsdom suite on Node 22.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
