### PR TITLE
docs(presentation): apply post-first-run feedback to CALM in 40 mins deck

### DIFF
--- a/docs/docs/tutorials/_calm-overview/01-what-is-calm.mdx
+++ b/docs/docs/tutorials/_calm-overview/01-what-is-calm.mdx
@@ -7,7 +7,7 @@
     <img src="/img/2025_CALM_Horizontal.svg" alt="CALM Logo" style={{maxWidth:'420px', marginBottom:'0.5rem'}} />
     <h2 style={{margin:0}}>Architecture as Code</h2>
     <p style={{margin:0, fontSize:'1.1rem', color:'#555'}}>A 40-minute introduction to CALM</p>
-    <p style={{margin:0, fontSize:'0.9rem', color:'#888'}}>FINOS · Architecture as Code Working Group</p>
+    <p style={{margin:0, fontSize:'1.0rem', color:'#888'}}>FINOS · Architecture as Code Working Group</p>
   </div>
   <aside className="notes">
     Welcome! Today we cover what CALM is, its core concepts, and the tooling ecosystem.
@@ -108,32 +108,32 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>📏</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Standardise</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>One common language for architects, developers, and tools — no ambiguity.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>One common language for architects, developers, and tools — no ambiguity.</p>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>⚙️</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Automate</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>Validate architectures, run compliance checks, generate docs — all in CI/CD.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>Validate architectures, run compliance checks, generate docs — all in CI/CD.</p>
     </div>
     <div style={{background:'#fff8e1', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>📦</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Version Control</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>Architecture lives in Git. PR reviews, change history, branch strategies.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>Architecture lives in Git. PR reviews, change history, branch strategies.</p>
     </div>
     <div style={{background:'#fce4ec', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🔒</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Compliance</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>Enforce org standards and regulatory policies automatically. Audit trail built-in.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>Enforce org standards and regulatory policies automatically. Audit trail built-in.</p>
     </div>
     <div style={{background:'#e8eaf6', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🚀</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Drive Deployments</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>Architecture drives real infrastructure — template bundles generate IaC, not just docs.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>Architecture drives real infrastructure — template bundles generate IaC, not just docs.</p>
     </div>
     <div style={{background:'#f3e5f5', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🏢</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Enterprise-Ready</h3>
-      <p style={{fontSize:'0.88rem', margin:0}}>Flexible core, customizable for the enterprise — standards, controls, and patterns layer on top.</p>
+      <p style={{fontSize:'1.0rem', margin:0}}>Flexible core, customizable for the enterprise — standards, controls, and patterns layer on top.</p>
     </div>
   </div>
   <aside className="notes">
@@ -157,7 +157,7 @@
   "flows": [ ... ]
 }`}</code></pre>
   </div>
-  <p style={{fontSize:'0.85rem', color:'#666'}}>Store it in Git · validate it in CI · render it with CALM tools</p>
+  <p style={{fontSize:'0.95rem', color:'#666'}}>Store it in Git · validate it in CI · render it with CALM tools</p>
   <aside className="notes">
     JSON was chosen because it's universally supported, works with JSON Schema validation,
     and integrates well with existing toolchains. The schema is modular and versioned.
@@ -171,17 +171,17 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>📄</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Architecture</h3>
-      <p style={{fontSize:'0.9rem', color:'#333', margin:0}}>The <strong>instance</strong> — your real system's nodes, relationships &amp; metadata. Authored by hand or generated from a pattern.</p>
+      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>instance</strong> — your real system's nodes, relationships &amp; metadata. Authored by hand or generated from a pattern.</p>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Pattern</h3>
-      <p style={{fontSize:'0.9rem', color:'#333', margin:0}}>The <strong>template</strong> — a JSON Schema constraining architectures: which nodes must exist, how they connect, which protocols apply. <em>(Part 3)</em></p>
+      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>template</strong> — a JSON Schema constraining architectures: which nodes must exist, how they connect, which protocols apply.</p>
     </div>
     <div style={{background:'#f3e5f5', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>🕐</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Timeline</h3>
-      <p style={{fontSize:'0.9rem', color:'#333', margin:0}}>The <strong>history</strong> — time-stamped snapshots, each linked to a full architecture and the ADRs that drove the change. <em>(Part 4)</em></p>
+      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>history</strong> — time-stamped snapshots, each linked to a full architecture and the ADRs that drove the change.</p>
     </div>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/01-what-is-calm.mdx
+++ b/docs/docs/tutorials/_calm-overview/01-what-is-calm.mdx
@@ -6,8 +6,8 @@
   <div style={{display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:'1.2rem'}}>
     <img src="/img/2025_CALM_Horizontal.svg" alt="CALM Logo" style={{maxWidth:'420px', marginBottom:'0.5rem'}} />
     <h2 style={{margin:0}}>Architecture as Code</h2>
-    <p style={{margin:0, fontSize:'1.1rem', color:'#555'}}>A 40-minute introduction to CALM</p>
-    <p style={{margin:0, fontSize:'1.0rem', color:'#888'}}>FINOS · Architecture as Code Working Group</p>
+    <p style={{margin:0, fontSize:'1.65rem', color:'#555'}}>A 40-minute introduction to CALM</p>
+    <p style={{margin:0, fontSize:'1.65rem', color:'#888'}}>FINOS · Architecture as Code Working Group</p>
   </div>
   <aside className="notes">
     Welcome! Today we cover what CALM is, its core concepts, and the tooling ecosystem.
@@ -68,7 +68,7 @@
   <h2>The Core Insight</h2>
   <div style={{display:'flex', justifyContent:'center', margin:'1.8rem 0 1.4rem'}}>
     <blockquote style={{
-      fontSize:'1.5rem', fontStyle:'italic', textAlign:'center',
+      fontSize:'1.65rem', fontStyle:'italic', textAlign:'center',
       background:'#f1f8e9', border:'2px solid #2e7d32', borderRadius:'8px',
       padding:'1.4rem 2.5rem', maxWidth:'680px', margin:0
     }}>
@@ -76,7 +76,7 @@
     </blockquote>
   </div>
   <p style={{textAlign:'center'}}>CALM brings architecture into the world of code — structured, consistent, and automated.</p>
-  <p style={{textAlign:'center', color:'#555', fontSize:'0.95rem'}}>Architecture that lives in Git. Validated by CI/CD. Always stays true.</p>
+  <p style={{textAlign:'center', color:'#555', fontSize:'1.65rem'}}>Architecture that lives in Git. Validated by CI/CD. Always stays true.</p>
   <aside className="notes">
     The analogy to draw: infrastructure as code (Terraform, Pulumi) did this for infrastructure.
     CALM does it for the higher-level architectural picture.
@@ -108,32 +108,32 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>📏</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Standardise</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>One common language for architects, developers, and tools — no ambiguity.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>One common language for architects, developers, and tools — no ambiguity.</p>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>⚙️</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Automate</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>Validate architectures, run compliance checks, generate docs — all in CI/CD.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>Validate architectures, run compliance checks, generate docs — all in CI/CD.</p>
     </div>
     <div style={{background:'#fff8e1', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>📦</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Version Control</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>Architecture lives in Git. PR reviews, change history, branch strategies.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>Architecture lives in Git. PR reviews, change history, branch strategies.</p>
     </div>
     <div style={{background:'#fce4ec', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🔒</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Compliance</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>Enforce org standards and regulatory policies automatically. Audit trail built-in.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>Enforce org standards and regulatory policies automatically. Audit trail built-in.</p>
     </div>
     <div style={{background:'#e8eaf6', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🚀</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Drive Deployments</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>Architecture drives real infrastructure — template bundles generate IaC, not just docs.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>Architecture drives real infrastructure — template bundles generate IaC, not just docs.</p>
     </div>
     <div style={{background:'#f3e5f5', borderRadius:'8px', padding:'1.1rem 1.2rem', textAlign:'center'}}>
       <div style={{fontSize:'2rem', marginBottom:'0.4rem'}}>🏢</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.1rem'}}>Enterprise-Ready</h3>
-      <p style={{fontSize:'1.0rem', margin:0}}>Flexible core, customizable for the enterprise — standards, controls, and patterns layer on top.</p>
+      <p style={{fontSize:'1.65rem', margin:0}}>Flexible core, customizable for the enterprise — standards, controls, and patterns layer on top.</p>
     </div>
   </div>
   <aside className="notes">
@@ -157,7 +157,7 @@
   "flows": [ ... ]
 }`}</code></pre>
   </div>
-  <p style={{fontSize:'0.95rem', color:'#666'}}>Store it in Git · validate it in CI · render it with CALM tools</p>
+  <p style={{fontSize:'1.65rem', color:'#666'}}>Store it in Git · validate it in CI · render it with CALM tools</p>
   <aside className="notes">
     JSON was chosen because it's universally supported, works with JSON Schema validation,
     and integrates well with existing toolchains. The schema is modular and versioned.
@@ -171,17 +171,17 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>📄</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Architecture</h3>
-      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>instance</strong> — your real system's nodes, relationships &amp; metadata. Authored by hand or generated from a pattern.</p>
+      <p style={{fontSize:'1.65rem', color:'#333', margin:0}}>The <strong>instance</strong> — your real system's nodes, relationships &amp; metadata. Authored by hand or generated from a pattern.</p>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Pattern</h3>
-      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>template</strong> — a JSON Schema constraining architectures: which nodes must exist, how they connect, which protocols apply.</p>
+      <p style={{fontSize:'1.65rem', color:'#333', margin:0}}>The <strong>template</strong> — a JSON Schema constraining architectures: which nodes must exist, how they connect, which protocols apply.</p>
     </div>
     <div style={{background:'#f3e5f5', borderRadius:'8px', padding:'1.6rem 1.4rem', textAlign:'center'}}>
       <div style={{fontSize:'2.8rem', marginBottom:'0.5rem'}}>🕐</div>
       <h3 style={{marginTop:0, marginBottom:'0.6rem', fontSize:'1.2rem'}}>Timeline</h3>
-      <p style={{fontSize:'1.0rem', color:'#333', margin:0}}>The <strong>history</strong> — time-stamped snapshots, each linked to a full architecture and the ADRs that drove the change.</p>
+      <p style={{fontSize:'1.65rem', color:'#333', margin:0}}>The <strong>history</strong> — time-stamped snapshots, each linked to a full architecture and the ADRs that drove the change.</p>
     </div>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/02-building-blocks.mdx
+++ b/docs/docs/tutorials/_calm-overview/02-building-blocks.mdx
@@ -40,7 +40,7 @@
         <li><code>details</code> (optional)</li>
         <li><code>metadata</code> (optional — org context)</li>
       </ul>
-      <p style={{fontSize:'0.9rem', color:'#666', marginTop:'0.6rem'}}>Interfaces &amp; controls are covered later.</p>
+      <p style={{fontSize:'1.0rem', color:'#666', marginTop:'0.6rem'}}>Interfaces &amp; controls are covered later.</p>
     </div>
   </div>
   <aside className="notes">
@@ -74,7 +74,7 @@
     <li>🖥️ <code>deployed-in</code> — node runs inside a container, VM, or cloud cluster</li>
     <li>📦 <code>composed-of</code> — hierarchical nesting of systems or services</li>
   </ul>
-  <p style={{fontSize:'0.85rem', color:'#666', marginTop:'0.3rem'}}>
+  <p style={{fontSize:'0.95rem', color:'#666', marginTop:'0.3rem'}}>
     Each relationship has a <code>unique-id</code>, <code>relationship-type</code>, optional <code>protocol</code>, and optional <code>controls</code>.
   </p>
   <aside className="notes">
@@ -103,7 +103,7 @@
     }
   }
 }`}</code></pre>
-  <p style={{fontSize:'0.85rem', color:'#666'}}>
+  <p style={{fontSize:'0.95rem', color:'#666'}}>
     Source connects implicitly; destination exposes a named interface.
   </p>
   <aside className="notes">
@@ -122,11 +122,11 @@
     <div style={{background:'#e3f2fd', border:'2px solid #1565c0', borderRadius:'8px', padding:'1rem 1.4rem', textAlign:'center', minWidth:'130px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>🖥️</div>
       <div style={{fontWeight:'bold', fontSize:'1rem'}}>Trading UI</div>
-      <div style={{fontSize:'0.9rem', color:'#555'}}>webclient</div>
+      <div style={{fontSize:'1.0rem', color:'#555'}}>webclient</div>
     </div>
     <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:'0.15rem'}}>
-      <span style={{fontSize:'0.85rem', color:'#555', fontFamily:'monospace'}}>connects via</span>
-      <span style={{fontSize:'0.9rem', color:'#c62828', fontWeight:'bold', fontFamily:'monospace'}}>host-port :443</span>
+      <span style={{fontSize:'0.95rem', color:'#555', fontFamily:'monospace'}}>connects via</span>
+      <span style={{fontSize:'1.0rem', color:'#c62828', fontWeight:'bold', fontFamily:'monospace'}}>host-port :443</span>
       <svg width="60" height="18" viewBox="0 0 60 18">
         <line x1="2" y1="9" x2="50" y2="9" stroke="#555" strokeWidth="2"/>
         <polygon points="50,4 60,9 50,14" fill="#555"/>
@@ -135,13 +135,13 @@
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'1rem 1.4rem', textAlign:'center', minWidth:'150px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>⚙️</div>
       <div style={{fontWeight:'bold', fontSize:'1rem'}}>Payment Service</div>
-      <div style={{fontSize:'0.9rem', color:'#555'}}>service</div>
+      <div style={{fontSize:'1.0rem', color:'#555'}}>service</div>
     </div>
     <div style={{borderLeft:'3px solid #2e7d32', paddingLeft:'1rem', display:'flex', flexDirection:'column', gap:'0.35rem'}}>
-      <div style={{fontSize:'0.9rem', color:'#555', fontWeight:'bold', marginBottom:'0.2rem'}}>Exposed interfaces:</div>
-      <div style={{background:'#fff3e0', border:'1px solid #e65100', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'0.9rem', fontFamily:'monospace'}}>host-port :443</div>
-      <div style={{background:'#f3e5f5', border:'1px solid #6a1b9a', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'0.9rem', fontFamily:'monospace'}}>url-path /api/payments</div>
-      <div style={{background:'#fce4ec', border:'1px solid #880e4f', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'0.9rem', fontFamily:'monospace'}}>oauth2-audience payments</div>
+      <div style={{fontSize:'1.0rem', color:'#555', fontWeight:'bold', marginBottom:'0.2rem'}}>Exposed interfaces:</div>
+      <div style={{background:'#fff3e0', border:'1px solid #e65100', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>host-port :443</div>
+      <div style={{background:'#f3e5f5', border:'1px solid #6a1b9a', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>url-path /api/payments</div>
+      <div style={{background:'#fce4ec', border:'1px solid #880e4f', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>oauth2-audience payments</div>
     </div>
   </div>
   <p style={{fontSize:'0.95rem', color:'#555'}}>

--- a/docs/docs/tutorials/_calm-overview/02-building-blocks.mdx
+++ b/docs/docs/tutorials/_calm-overview/02-building-blocks.mdx
@@ -16,11 +16,11 @@
 
 <section>
   <h2>🟦 Nodes — The "Boxes"</h2>
-  <p style={{fontSize:'1.25rem'}}>A node represents any component in your architecture.</p>
+  <p style={{fontSize:'1.65rem'}}>A node represents any component in your architecture.</p>
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1.35rem'}}>Node types</h3>
-      <ul style={{fontSize:'1.35rem', lineHeight:'1.6'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.6'}}>
         <li><code>service</code> — microservice, API</li>
         <li><code>database</code> — SQL, NoSQL, cache</li>
         <li><code>system</code> — external system</li>
@@ -32,7 +32,7 @@
     </div>
     <div>
       <h3 style={{fontSize:'1.35rem'}}>Core properties</h3>
-      <ul style={{fontSize:'1.35rem', lineHeight:'1.6'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.6'}}>
         <li><code>unique-id</code> ★ required</li>
         <li><code>node-type</code> ★ required</li>
         <li><code>name</code> ★ required</li>
@@ -40,7 +40,7 @@
         <li><code>details</code> (optional)</li>
         <li><code>metadata</code> (optional — org context)</li>
       </ul>
-      <p style={{fontSize:'1.0rem', color:'#666', marginTop:'0.6rem'}}>Interfaces &amp; controls are covered later.</p>
+      <p style={{fontSize:'1.65rem', color:'#666', marginTop:'0.6rem'}}>Interfaces &amp; controls are covered later.</p>
     </div>
   </div>
   <aside className="notes">
@@ -68,13 +68,13 @@
 <section>
   <h2>➡️ Relationships — The "Arrows"</h2>
   <p>Relationships link nodes and describe how they interact.</p>
-  <ul style={{fontSize:'1.2rem', lineHeight:'2.1', marginTop:'0.8rem'}}>
+  <ul style={{fontSize:'1.65rem', lineHeight:'2.1', marginTop:'0.8rem'}}>
     <li>🔗 <code>connects</code> — links a <strong>specific interface</strong> on destination (most precise)</li>
     <li>💬 <code>interacts</code> — node-to-node without naming an interface (higher-level)</li>
     <li>🖥️ <code>deployed-in</code> — node runs inside a container, VM, or cloud cluster</li>
     <li>📦 <code>composed-of</code> — hierarchical nesting of systems or services</li>
   </ul>
-  <p style={{fontSize:'0.95rem', color:'#666', marginTop:'0.3rem'}}>
+  <p style={{fontSize:'1.65rem', color:'#666', marginTop:'0.3rem'}}>
     Each relationship has a <code>unique-id</code>, <code>relationship-type</code>, optional <code>protocol</code>, and optional <code>controls</code>.
   </p>
   <aside className="notes">
@@ -103,7 +103,7 @@
     }
   }
 }`}</code></pre>
-  <p style={{fontSize:'0.95rem', color:'#666'}}>
+  <p style={{fontSize:'1.65rem', color:'#666'}}>
     Source connects implicitly; destination exposes a named interface.
   </p>
   <aside className="notes">
@@ -115,18 +115,18 @@
 
 <section>
   <h2>🔌 Interfaces — Connection Points</h2>
-  <p style={{marginBottom:'1rem', fontSize:'1.2rem'}}>
+  <p style={{marginBottom:'1rem', fontSize:'1.65rem'}}>
     Interfaces are the named, typed entry points a node exposes.<br/>A <code>connects</code> relationship targets a specific interface — and controls enforce policy on it.
   </p>
   <div style={{display:'flex', alignItems:'center', justifyContent:'center', gap:'1.5rem', margin:'0.5rem 0 1rem'}}>
     <div style={{background:'#e3f2fd', border:'2px solid #1565c0', borderRadius:'8px', padding:'1rem 1.4rem', textAlign:'center', minWidth:'130px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>🖥️</div>
-      <div style={{fontWeight:'bold', fontSize:'1rem'}}>Trading UI</div>
-      <div style={{fontSize:'1.0rem', color:'#555'}}>webclient</div>
+      <div style={{fontWeight:'bold', fontSize:'1.65rem'}}>Trading UI</div>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>webclient</div>
     </div>
     <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:'0.15rem'}}>
-      <span style={{fontSize:'0.95rem', color:'#555', fontFamily:'monospace'}}>connects via</span>
-      <span style={{fontSize:'1.0rem', color:'#c62828', fontWeight:'bold', fontFamily:'monospace'}}>host-port :443</span>
+      <span style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>connects via</span>
+      <span style={{fontSize:'1.65rem', color:'#c62828', fontWeight:'bold', fontFamily:'monospace'}}>host-port :443</span>
       <svg width="60" height="18" viewBox="0 0 60 18">
         <line x1="2" y1="9" x2="50" y2="9" stroke="#555" strokeWidth="2"/>
         <polygon points="50,4 60,9 50,14" fill="#555"/>
@@ -134,17 +134,17 @@
     </div>
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'1rem 1.4rem', textAlign:'center', minWidth:'150px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>⚙️</div>
-      <div style={{fontWeight:'bold', fontSize:'1rem'}}>Payment Service</div>
-      <div style={{fontSize:'1.0rem', color:'#555'}}>service</div>
+      <div style={{fontWeight:'bold', fontSize:'1.65rem'}}>Payment Service</div>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>service</div>
     </div>
     <div style={{borderLeft:'3px solid #2e7d32', paddingLeft:'1rem', display:'flex', flexDirection:'column', gap:'0.35rem'}}>
-      <div style={{fontSize:'1.0rem', color:'#555', fontWeight:'bold', marginBottom:'0.2rem'}}>Exposed interfaces:</div>
-      <div style={{background:'#fff3e0', border:'1px solid #e65100', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>host-port :443</div>
-      <div style={{background:'#f3e5f5', border:'1px solid #6a1b9a', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>url-path /api/payments</div>
-      <div style={{background:'#fce4ec', border:'1px solid #880e4f', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.0rem', fontFamily:'monospace'}}>oauth2-audience payments</div>
+      <div style={{fontSize:'1.65rem', color:'#555', fontWeight:'bold', marginBottom:'0.2rem'}}>Exposed interfaces:</div>
+      <div style={{background:'#fff3e0', border:'1px solid #e65100', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.65rem', fontFamily:'monospace'}}>host-port :443</div>
+      <div style={{background:'#f3e5f5', border:'1px solid #6a1b9a', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.65rem', fontFamily:'monospace'}}>url-path /api/payments</div>
+      <div style={{background:'#fce4ec', border:'1px solid #880e4f', borderRadius:'4px', padding:'0.25rem 0.6rem', fontSize:'1.65rem', fontFamily:'monospace'}}>oauth2-audience payments</div>
     </div>
   </div>
-  <p style={{fontSize:'0.95rem', color:'#555'}}>
+  <p style={{fontSize:'1.65rem', color:'#555'}}>
     Interface types: <code>host-port</code> · <code>url-path</code> · <code>oauth2-audience</code> · <code>hostname</code> · and more.
     Optional — but controls need them to enforce connection-level policy.
   </p>

--- a/docs/docs/tutorials/_calm-overview/03-governance.mdx
+++ b/docs/docs/tutorials/_calm-overview/03-governance.mdx
@@ -190,7 +190,7 @@
     The data object is open by design — each decorator type constrains it further via allOf.
     Rule of thumb: if the information is owned by a different team, changes on a different
     cadence, or would appear across many architecture files, put it in a decorator.
-    If it's a simple annotation (owner, cost-centre, classification) a metadata key-value is simpler.
+    If it's a simple annotation (owner, cost-center, classification) a metadata key-value is simpler.
     The payment-service node was introduced in Building Blocks — the decorator here records its
     deployment status without touching the architecture file at all.
   </aside>
@@ -297,7 +297,7 @@ calm validate -p patterns/trading-platform.json \\
     <div style={{background:'#fff8e1', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>📏</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Standard</h3>
-      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-centre"</p>
+      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-center"</p>
       <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> all architectures org-wide — enforce mandatory fields</p>
     </div>
     <div style={{background:'#fce4ec', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>

--- a/docs/docs/tutorials/_calm-overview/03-governance.mdx
+++ b/docs/docs/tutorials/_calm-overview/03-governance.mdx
@@ -93,24 +93,36 @@
 </section>
 
 <section>
-  <h2>🧩 Customizations</h2>
+  <h2>🧩 Customizations — Custom Properties</h2>
   <div className="two-col">
     <div>
-      <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>Custom properties</h3>
-      <p style={{fontSize:'1.65rem', marginBottom:'0.5rem'}}>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.6rem'}}>
         Add any key/value <strong>directly to a node</strong> (or relationship) — ownership, classification, cost attribution, whatever your org needs. Nodes allow arbitrary extra properties.
       </p>
+      <p style={{fontSize:'1.65rem', color:'#555'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
+    </div>
+    <div>
       <pre><code className="language-json">{`{
   "unique-id": "trade-database",
   "node-type": "database",
   "name": "Trade Database",
   "cost-center": "CC-1042"
 }`}</code></pre>
-      <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.4rem'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
     </div>
-    <div style={{paddingTop:'0.2rem'}}>
-      <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>📏 Standards — stricter, cross-org</h3>
-      <p style={{fontSize:'1.65rem', marginBottom:'0.4rem'}}>
+  </div>
+  <aside className="notes">
+    Any node or relationship can carry arbitrary extra properties directly — cost-center, owner,
+    classification, whatever the team needs. This works because CALM nodes allow additionalProperties.
+    Custom properties are the lowest-friction extension point — no schema changes needed.
+    When informal properties become org-wide requirements, promote them to a Standard (next slide).
+  </aside>
+</section>
+
+<section>
+  <h2>📏 Standards — Stricter, Cross-Org</h2>
+  <div className="two-col">
+    <div>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.5rem'}}>
         When you need consistency <em>across teams</em>, promote a custom property into a <strong>standard</strong> — a JSON Schema extension that makes it mandatory on every architecture.
       </p>
       <pre><code className="language-json">{`{
@@ -124,18 +136,20 @@
     }}
   }
 }`}</code></pre>
-      <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.3rem', marginBottom:'0.3rem'}}>
+    </div>
+    <div>
+      <p style={{fontSize:'1.65rem', color:'#555', marginBottom:'0.5rem'}}>
         Reference it from a pattern so every node is checked:
       </p>
       <pre><code className="language-json">{`"nodes": { "items": {
   "$ref": "https://example.com/standards/node-standard.json"
 }}`}</code></pre>
+      <p style={{fontSize:'1.65rem', marginTop:'0.7rem'}}>
+        Run <code>calm validate</code> — deviation <strong>fails the build automatically</strong>. Start with custom properties; promote to standards when cross-org consistency becomes non-negotiable.
+      </p>
     </div>
   </div>
   <aside className="notes">
-    Two levels: informal customization and enforced standards.
-    Any node or relationship can carry arbitrary extra properties directly — cost-center, owner,
-    classification, whatever the team needs. This works because CALM nodes allow additionalProperties.
     When your org decides "every architecture *must* carry cost-center on every node," you write
     a CALM standard (a JSON Schema extension using allOf composition plus required/properties),
     reference it from a pattern via $ref, then run ordinary `calm validate`. Deviation fails the

--- a/docs/docs/tutorials/_calm-overview/03-governance.mdx
+++ b/docs/docs/tutorials/_calm-overview/03-governance.mdx
@@ -25,12 +25,15 @@
       "OMS → Trade Database carries PII. Policy says mTLS. How do you prevent someone shipping plain TCP?"
     </blockquote>
   </div>
-  <p style={{fontSize:'0.88rem', marginBottom:'0.5rem', textAlign:'center'}}>
+  <p style={{fontSize:'0.95rem', marginBottom:'0.3rem', textAlign:'center', color:'#1565c0', fontWeight:'bold'}}>
+    Controls are how CALM expresses <strong>Non-Functional Requirements (NFRs)</strong> — security, performance, resilience — as <strong>machine-checkable rules</strong>.
+  </p>
+  <p style={{fontSize:'1.0rem', marginBottom:'0.5rem', textAlign:'center'}}>
     A <strong>control</strong> = a <strong>requirement</strong> (schema: what "compliant" means) + a <strong>config</strong> (this element's answer). Compliance becomes <strong>machine-checkable</strong>.
   </p>
   <div className="two-col">
     <div>
-      <p style={{fontSize:'0.8rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Requirement — JSON Schema of allowed values:</p>
+      <p style={{fontSize:'0.92rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Requirement — JSON Schema of allowed values:</p>
       <pre><code className="language-json">{`{
   "control-id": "security-002",
   "name": "Permitted Connection",
@@ -40,18 +43,20 @@
 }`}</code></pre>
     </div>
     <div>
-      <p style={{fontSize:'0.8rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Config — validated against the requirement:</p>
+      <p style={{fontSize:'0.92rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Config — validated against the requirement:</p>
       <pre><code className="language-json">{`{
   "control-id": "security-002",
   "name": "Permitted Connection",
   "protocol": "mTLS"
 }`}</code></pre>
-      <p style={{fontSize:'0.83rem', color:'#2e7d32', marginTop:'0.5rem', fontWeight:'bold'}}>
+      <p style={{fontSize:'0.92rem', color:'#2e7d32', marginTop:'0.5rem', fontWeight:'bold'}}>
         ✓ Governance is a validation check — not a PDF nobody reads.
       </p>
     </div>
   </div>
   <aside className="notes">
+    Key framing: controls are CALM's mechanism for NFRs — the security, performance, and resilience
+    requirements that architects normally write in prose and hope someone reads.
     The requirement defines an enum of allowed protocols — anything not in that list fails validation.
     The config must satisfy that schema. So "use mTLS" isn't just a policy comment — it's a
     constraint that tooling can verify. Controls attach at node, relationship, flow, or architecture level.
@@ -60,14 +65,14 @@
 
 <section>
   <h2>🔐 Controls — In Your Architecture</h2>
-  <p style={{marginBottom:'0.5rem'}}>Attach a control to the relevant element — the architecture JSON makes the policy explicit:</p>
+  <p style={{marginBottom:'0.5rem'}}>Attach a control to the relevant element, keyed by <strong>security domain</strong> — the architecture JSON makes the policy explicit:</p>
   <pre><code className="language-json">{`{
   "unique-id": "oms-to-trade-db",
   "description": "OMS → Trade Database (carries PII)",
   "protocol": "mTLS",
   "controls": {
-    "permitted-connection": {
-      "description": "Connection must use an approved protocol",
+    "security": {
+      "description": "Security — connection must use an approved protocol",
       "requirements": [{
         "control-requirement-url":
           "https://calm.finos.org/controls/security/schema/permitted-connection.json",
@@ -78,6 +83,8 @@
   }
 }`}</code></pre>
   <aside className="notes">
+    Controls are keyed by security domain — "security", "performance", "resilience" etc.
+    Here the key is "security" because this is a security-domain requirement.
     Controls attach at node, relationship, flow, or whole-architecture level.
     The requirement URL and config URL are independently versioned JSON documents —
     the policy team owns the requirement; the architecture team owns the config.
@@ -91,36 +98,33 @@
     <div>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>Custom properties</h3>
       <p style={{fontSize:'0.95rem', marginBottom:'0.5rem'}}>
-        Add any key/value context to <strong>nodes</strong> <em>and</em> <strong>relationships</strong> via <code>metadata</code> — ownership, classification, cost attribution, whatever your org needs.
+        Add any key/value <strong>directly to a node</strong> (or relationship) — ownership, classification, cost attribution, whatever your org needs. Nodes allow arbitrary extra properties.
       </p>
-      <pre><code className="language-json">{`"metadata": [
-  { "key": "owner",
-    "value": "payments-team" },
-  { "key": "data-classification",
-    "value": "PII" },
-  { "key": "cost-centre",
-    "value": "CC-1042" }
-]`}</code></pre>
-      <p style={{fontSize:'0.85rem', color:'#555', marginTop:'0.4rem'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
+      <pre><code className="language-json">{`{
+  "unique-id": "trade-database",
+  "node-type": "database",
+  "name": "Trade Database",
+  "cost-center": "CC-1042"
+}`}</code></pre>
+      <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.4rem'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
     </div>
     <div style={{paddingTop:'0.2rem'}}>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>📏 Standards — stricter, cross-org</h3>
-      <p style={{fontSize:'0.9rem', marginBottom:'0.4rem'}}>
+      <p style={{fontSize:'1.0rem', marginBottom:'0.4rem'}}>
         When you need consistency <em>across teams</em>, promote a custom property into a <strong>standard</strong> — a JSON Schema extension that makes it mandatory on every architecture.
       </p>
       <pre><code className="language-json">{`{
   "allOf": [{"$ref": "…/calm.json"}],
   "properties": {
     "nodes": { "items": {
-      "properties": { "metadata": {
-        "contains": { "properties": {
-          "key": {"const":"cost-centre"}
-        }}
-      }}
+      "required": ["cost-center"],
+      "properties": {
+        "cost-center": { "type": "string" }
+      }
     }}
   }
 }`}</code></pre>
-      <p style={{fontSize:'0.82rem', color:'#555', marginTop:'0.3rem', marginBottom:'0.3rem'}}>
+      <p style={{fontSize:'0.92rem', color:'#555', marginTop:'0.3rem', marginBottom:'0.3rem'}}>
         Reference it from a pattern so every node is checked:
       </p>
       <pre><code className="language-json">{`"nodes": { "items": {
@@ -130,13 +134,13 @@
   </div>
   <aside className="notes">
     Two levels: informal customization and enforced standards.
-    Any node or relationship can carry arbitrary metadata key/value pairs — owner, classification,
-    cost centre, whatever the team needs. This is the flexible, additive layer.
-    When your org decides "every architecture *must* carry cost-centre on every node," you write
-    a CALM standard (a JSON Schema extension using allOf composition), reference it from a pattern
-    via $ref, then run ordinary `calm validate`. Deviation fails the build automatically.
-    That's the progression: start with custom properties, promote to standards when cross-org
-    consistency becomes non-negotiable.
+    Any node or relationship can carry arbitrary extra properties directly — cost-center, owner,
+    classification, whatever the team needs. This works because CALM nodes allow additionalProperties.
+    When your org decides "every architecture *must* carry cost-center on every node," you write
+    a CALM standard (a JSON Schema extension using allOf composition plus required/properties),
+    reference it from a pattern via $ref, then run ordinary `calm validate`. Deviation fails the
+    build automatically. That's the progression: start with custom properties on nodes, promote to
+    standards when cross-org consistency becomes non-negotiable.
   </aside>
 </section>
 
@@ -145,19 +149,19 @@
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>What is a decorator?</h3>
-      <p style={{fontSize:'0.9rem', marginBottom:'0.45rem'}}>
+      <p style={{fontSize:'1.0rem', marginBottom:'0.45rem'}}>
         A <strong>decorator</strong> is a standalone document (CALM 1.2+) that attaches typed,
         cross-cutting data to existing elements by <code>unique-id</code> — without modifying
         the architecture itself.
       </p>
-      <p style={{fontSize:'0.85rem', marginBottom:'0.25rem', fontWeight:'bold'}}>Reach for a decorator when data:</p>
-      <ul style={{fontSize:'0.85rem', margin:'0 0 0.5rem', paddingLeft:'1.2rem'}}>
+      <p style={{fontSize:'0.95rem', marginBottom:'0.25rem', fontWeight:'bold'}}>Reach for a decorator when data:</p>
+      <ul style={{fontSize:'0.95rem', margin:'0 0 0.5rem', paddingLeft:'1.2rem'}}>
         <li>Is owned by a <strong>different team</strong></li>
         <li>Changes independently — e.g. <strong>live deployment status</strong></li>
         <li>Spans <strong>multiple architecture files</strong></li>
         <li>Would clutter the core definition</li>
       </ul>
-      <div style={{background:'#e3f2fd', borderRadius:'6px', padding:'0.4rem 0.7rem', fontSize:'0.82rem', color:'#1a237e', marginTop:'0.3rem'}}>
+      <div style={{background:'#e3f2fd', borderRadius:'6px', padding:'0.4rem 0.7rem', fontSize:'0.92rem', color:'#1a237e', marginTop:'0.3rem'}}>
         <strong>vs metadata:</strong> <code>metadata</code> lives <em>inside</em> the architecture;
         a decorator lives <em>outside</em> it and points back in by <code>unique-id</code>.
       </div>
@@ -199,7 +203,7 @@
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.5rem', fontSize:'1.2rem'}}>Pattern = the rules</h3>
-      <ul style={{textAlign:'left', fontSize:'0.9rem', margin:0}}>
+      <ul style={{textAlign:'left', fontSize:'1.0rem', margin:0}}>
         <li>Which nodes must exist (by <code>const</code> ID)</li>
         <li>How they must connect</li>
         <li>Which protocols are required</li>
@@ -209,7 +213,7 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>📄</div>
       <h3 style={{marginTop:0, marginBottom:'0.5rem', fontSize:'1.2rem'}}>Architecture = the instance</h3>
-      <ul style={{textAlign:'left', fontSize:'0.9rem', margin:0}}>
+      <ul style={{textAlign:'left', fontSize:'1.0rem', margin:0}}>
         <li>Must conform to the pattern</li>
         <li>Fills in descriptions &amp; metadata</li>
         <li>Can be <em>generated</em> from a pattern</li>
@@ -217,7 +221,7 @@
       </ul>
     </div>
   </div>
-  <p style={{fontSize:'0.88rem', color:'#555', marginTop:'0.8rem', textAlign:'center'}}>
+  <p style={{fontSize:'1.0rem', color:'#555', marginTop:'0.8rem', textAlign:'center'}}>
     Architects publish patterns → teams scaffold conforming architectures → CI validates continuously.
   </p>
   <aside className="notes">
@@ -229,7 +233,7 @@
 
 <section>
   <h2>▦ Patterns — The Schema</h2>
-  <p style={{marginBottom:'0.5rem', fontSize:'0.9rem'}}>Pattern constraints use standard JSON Schema keywords — <code>const</code> to pin IDs, <code>prefixItems</code> to require specific nodes:</p>
+  <p style={{marginBottom:'0.5rem', fontSize:'1.0rem'}}>Pattern constraints use standard JSON Schema keywords — <code>const</code> to pin IDs, <code>prefixItems</code> to require specific nodes:</p>
   <pre><code className="language-json">{`{
   "nodes": {
     "minItems": 3, "maxItems": 3,
@@ -265,10 +269,10 @@ calm generate -p patterns/trading-platform.json \\
 calm validate -p patterns/trading-platform.json \\
               -a architectures/my-trading-system.json`}</code></pre>
   <div style={{marginTop:'0.5rem'}}>
-    <p style={{fontSize:'0.9rem', marginBottom:'0.3rem'}}>
+    <p style={{fontSize:'1.0rem', marginBottom:'0.3rem'}}>
       <strong>Architect</strong> publishes a pattern → <strong>Team</strong> generates a scaffold → fills <code>[[ PLACEHOLDERS ]]</code> → <strong>CI</strong> validates continuously.
     </p>
-    <p style={{fontSize:'0.85rem', color:'#555', marginTop:0}}>
+    <p style={{fontSize:'0.95rem', color:'#555', marginTop:0}}>
       Pattern = reuse <em>and</em> governance in one artifact. Divergence from the pattern fails validation before it ships.
     </p>
   </div>
@@ -287,20 +291,20 @@ calm validate -p patterns/trading-platform.json \\
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Pattern</h3>
-      <p style={{fontSize:'0.88rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Must have exactly these nodes connected by HTTPS"</p>
-      <p style={{fontSize:'0.82rem', color:'#555', margin:0}}><strong>Scope:</strong> one whole architecture — scaffold &amp; validate structure</p>
+      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Must have exactly these nodes connected by HTTPS"</p>
+      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> one whole architecture — scaffold &amp; validate structure</p>
     </div>
     <div style={{background:'#fff8e1', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>📏</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Standard</h3>
-      <p style={{fontSize:'0.88rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-centre"</p>
-      <p style={{fontSize:'0.82rem', color:'#555', margin:0}}><strong>Scope:</strong> all architectures org-wide — enforce mandatory fields</p>
+      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-centre"</p>
+      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> all architectures org-wide — enforce mandatory fields</p>
     </div>
     <div style={{background:'#fce4ec', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>🔐</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Control</h3>
-      <p style={{fontSize:'0.88rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"This connection must use mTLS"</p>
-      <p style={{fontSize:'0.82rem', color:'#555', margin:0}}><strong>Scope:</strong> a specific node, relationship, or flow — element-level policy</p>
+      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"This connection must use mTLS"</p>
+      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> a specific node, relationship, or flow — element-level policy</p>
     </div>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/03-governance.mdx
+++ b/docs/docs/tutorials/_calm-overview/03-governance.mdx
@@ -18,22 +18,22 @@
   <h2>🔐 Controls — The Problem They Solve</h2>
   <div style={{display:'flex', justifyContent:'center', margin:'0.5rem 0 0.8rem'}}>
     <blockquote style={{
-      fontSize:'1.35rem', fontStyle:'italic', textAlign:'center',
+      fontSize:'1.65rem', fontStyle:'italic', textAlign:'center',
       background:'#fff8f8', border:'2px solid #c62828', borderRadius:'8px',
       padding:'1rem 2rem', maxWidth:'820px', margin:0
     }}>
       "OMS → Trade Database carries PII. Policy says mTLS. How do you prevent someone shipping plain TCP?"
     </blockquote>
   </div>
-  <p style={{fontSize:'0.95rem', marginBottom:'0.3rem', textAlign:'center', color:'#1565c0', fontWeight:'bold'}}>
+  <p style={{fontSize:'1.65rem', marginBottom:'0.3rem', textAlign:'center', color:'#1565c0', fontWeight:'bold'}}>
     Controls are how CALM expresses <strong>Non-Functional Requirements (NFRs)</strong> — security, performance, resilience — as <strong>machine-checkable rules</strong>.
   </p>
-  <p style={{fontSize:'1.0rem', marginBottom:'0.5rem', textAlign:'center'}}>
+  <p style={{fontSize:'1.65rem', marginBottom:'0.5rem', textAlign:'center'}}>
     A <strong>control</strong> = a <strong>requirement</strong> (schema: what "compliant" means) + a <strong>config</strong> (this element's answer). Compliance becomes <strong>machine-checkable</strong>.
   </p>
   <div className="two-col">
     <div>
-      <p style={{fontSize:'0.92rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Requirement — JSON Schema of allowed values:</p>
+      <p style={{fontSize:'1.65rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Requirement — JSON Schema of allowed values:</p>
       <pre><code className="language-json">{`{
   "control-id": "security-002",
   "name": "Permitted Connection",
@@ -43,13 +43,13 @@
 }`}</code></pre>
     </div>
     <div>
-      <p style={{fontSize:'0.92rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Config — validated against the requirement:</p>
+      <p style={{fontSize:'1.65rem', fontWeight:'bold', marginBottom:'0.3rem'}}>Config — validated against the requirement:</p>
       <pre><code className="language-json">{`{
   "control-id": "security-002",
   "name": "Permitted Connection",
   "protocol": "mTLS"
 }`}</code></pre>
-      <p style={{fontSize:'0.92rem', color:'#2e7d32', marginTop:'0.5rem', fontWeight:'bold'}}>
+      <p style={{fontSize:'1.65rem', color:'#2e7d32', marginTop:'0.5rem', fontWeight:'bold'}}>
         ✓ Governance is a validation check — not a PDF nobody reads.
       </p>
     </div>
@@ -97,7 +97,7 @@
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>Custom properties</h3>
-      <p style={{fontSize:'0.95rem', marginBottom:'0.5rem'}}>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.5rem'}}>
         Add any key/value <strong>directly to a node</strong> (or relationship) — ownership, classification, cost attribution, whatever your org needs. Nodes allow arbitrary extra properties.
       </p>
       <pre><code className="language-json">{`{
@@ -106,11 +106,11 @@
   "name": "Trade Database",
   "cost-center": "CC-1042"
 }`}</code></pre>
-      <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.4rem'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
+      <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.4rem'}}>Works on both nodes and relationships — attach context wherever it lives.</p>
     </div>
     <div style={{paddingTop:'0.2rem'}}>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>📏 Standards — stricter, cross-org</h3>
-      <p style={{fontSize:'1.0rem', marginBottom:'0.4rem'}}>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.4rem'}}>
         When you need consistency <em>across teams</em>, promote a custom property into a <strong>standard</strong> — a JSON Schema extension that makes it mandatory on every architecture.
       </p>
       <pre><code className="language-json">{`{
@@ -124,7 +124,7 @@
     }}
   }
 }`}</code></pre>
-      <p style={{fontSize:'0.92rem', color:'#555', marginTop:'0.3rem', marginBottom:'0.3rem'}}>
+      <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.3rem', marginBottom:'0.3rem'}}>
         Reference it from a pattern so every node is checked:
       </p>
       <pre><code className="language-json">{`"nodes": { "items": {
@@ -149,19 +149,19 @@
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1.1rem', marginBottom:'0.4rem'}}>What is a decorator?</h3>
-      <p style={{fontSize:'1.0rem', marginBottom:'0.45rem'}}>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.45rem'}}>
         A <strong>decorator</strong> is a standalone document (CALM 1.2+) that attaches typed,
         cross-cutting data to existing elements by <code>unique-id</code> — without modifying
         the architecture itself.
       </p>
-      <p style={{fontSize:'0.95rem', marginBottom:'0.25rem', fontWeight:'bold'}}>Reach for a decorator when data:</p>
-      <ul style={{fontSize:'0.95rem', margin:'0 0 0.5rem', paddingLeft:'1.2rem'}}>
+      <p style={{fontSize:'1.65rem', marginBottom:'0.25rem', fontWeight:'bold'}}>Reach for a decorator when data:</p>
+      <ul style={{fontSize:'1.65rem', margin:'0 0 0.5rem', paddingLeft:'1.2rem'}}>
         <li>Is owned by a <strong>different team</strong></li>
         <li>Changes independently — e.g. <strong>live deployment status</strong></li>
         <li>Spans <strong>multiple architecture files</strong></li>
         <li>Would clutter the core definition</li>
       </ul>
-      <div style={{background:'#e3f2fd', borderRadius:'6px', padding:'0.4rem 0.7rem', fontSize:'0.92rem', color:'#1a237e', marginTop:'0.3rem'}}>
+      <div style={{background:'#e3f2fd', borderRadius:'6px', padding:'0.4rem 0.7rem', fontSize:'1.65rem', color:'#1a237e', marginTop:'0.3rem'}}>
         <strong>vs metadata:</strong> <code>metadata</code> lives <em>inside</em> the architecture;
         a decorator lives <em>outside</em> it and points back in by <code>unique-id</code>.
       </div>
@@ -203,7 +203,7 @@
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.5rem', fontSize:'1.2rem'}}>Pattern = the rules</h3>
-      <ul style={{textAlign:'left', fontSize:'1.0rem', margin:0}}>
+      <ul style={{textAlign:'left', fontSize:'1.65rem', margin:0}}>
         <li>Which nodes must exist (by <code>const</code> ID)</li>
         <li>How they must connect</li>
         <li>Which protocols are required</li>
@@ -213,7 +213,7 @@
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>📄</div>
       <h3 style={{marginTop:0, marginBottom:'0.5rem', fontSize:'1.2rem'}}>Architecture = the instance</h3>
-      <ul style={{textAlign:'left', fontSize:'1.0rem', margin:0}}>
+      <ul style={{textAlign:'left', fontSize:'1.65rem', margin:0}}>
         <li>Must conform to the pattern</li>
         <li>Fills in descriptions &amp; metadata</li>
         <li>Can be <em>generated</em> from a pattern</li>
@@ -221,7 +221,7 @@
       </ul>
     </div>
   </div>
-  <p style={{fontSize:'1.0rem', color:'#555', marginTop:'0.8rem', textAlign:'center'}}>
+  <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.8rem', textAlign:'center'}}>
     Architects publish patterns → teams scaffold conforming architectures → CI validates continuously.
   </p>
   <aside className="notes">
@@ -233,7 +233,7 @@
 
 <section>
   <h2>▦ Patterns — The Schema</h2>
-  <p style={{marginBottom:'0.5rem', fontSize:'1.0rem'}}>Pattern constraints use standard JSON Schema keywords — <code>const</code> to pin IDs, <code>prefixItems</code> to require specific nodes:</p>
+  <p style={{marginBottom:'0.5rem', fontSize:'1.65rem'}}>Pattern constraints use standard JSON Schema keywords — <code>const</code> to pin IDs, <code>prefixItems</code> to require specific nodes:</p>
   <pre><code className="language-json">{`{
   "nodes": {
     "minItems": 3, "maxItems": 3,
@@ -269,10 +269,10 @@ calm generate -p patterns/trading-platform.json \\
 calm validate -p patterns/trading-platform.json \\
               -a architectures/my-trading-system.json`}</code></pre>
   <div style={{marginTop:'0.5rem'}}>
-    <p style={{fontSize:'1.0rem', marginBottom:'0.3rem'}}>
+    <p style={{fontSize:'1.65rem', marginBottom:'0.3rem'}}>
       <strong>Architect</strong> publishes a pattern → <strong>Team</strong> generates a scaffold → fills <code>[[ PLACEHOLDERS ]]</code> → <strong>CI</strong> validates continuously.
     </p>
-    <p style={{fontSize:'0.95rem', color:'#555', marginTop:0}}>
+    <p style={{fontSize:'1.65rem', color:'#555', marginTop:0}}>
       Pattern = reuse <em>and</em> governance in one artifact. Divergence from the pattern fails validation before it ships.
     </p>
   </div>
@@ -286,25 +286,25 @@ calm validate -p patterns/trading-platform.json \\
 
 <section>
   <h2>Pattern vs Standard vs Control</h2>
-  <p style={{marginBottom:'0.7rem', fontSize:'0.95rem'}}>Three kinds of governance in CALM — all schemas, but at different scopes:</p>
+  <p style={{marginBottom:'0.7rem', fontSize:'1.65rem'}}>Three kinds of governance in CALM — all schemas, but at different scopes:</p>
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr 1fr', gap:'1.2rem'}}>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>▦</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Pattern</h3>
-      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Must have exactly these nodes connected by HTTPS"</p>
-      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> one whole architecture — scaffold &amp; validate structure</p>
+      <p style={{fontSize:'1.65rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Must have exactly these nodes connected by HTTPS"</p>
+      <p style={{fontSize:'1.65rem', color:'#555', margin:0}}><strong>Scope:</strong> one whole architecture — scaffold &amp; validate structure</p>
     </div>
     <div style={{background:'#fff8e1', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>📏</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Standard</h3>
-      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-center"</p>
-      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> all architectures org-wide — enforce mandatory fields</p>
+      <p style={{fontSize:'1.65rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"Every node must carry a cost-center"</p>
+      <p style={{fontSize:'1.65rem', color:'#555', margin:0}}><strong>Scope:</strong> all architectures org-wide — enforce mandatory fields</p>
     </div>
     <div style={{background:'#fce4ec', borderRadius:'8px', padding:'1.4rem 1.6rem', textAlign:'center'}}>
       <div style={{fontSize:'2.4rem', marginBottom:'0.4rem'}}>🔐</div>
       <h3 style={{marginTop:0, marginBottom:'0.4rem', fontSize:'1.2rem'}}>Control</h3>
-      <p style={{fontSize:'1.0rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"This connection must use mTLS"</p>
-      <p style={{fontSize:'0.92rem', color:'#555', margin:0}}><strong>Scope:</strong> a specific node, relationship, or flow — element-level policy</p>
+      <p style={{fontSize:'1.65rem', color:'#444', marginBottom:'0.4rem', fontStyle:'italic'}}>"This connection must use mTLS"</p>
+      <p style={{fontSize:'1.65rem', color:'#555', margin:0}}><strong>Scope:</strong> a specific node, relationship, or flow — element-level policy</p>
     </div>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/04-process-evolution.mdx
+++ b/docs/docs/tutorials/_calm-overview/04-process-evolution.mdx
@@ -56,7 +56,7 @@
 
 <section>
   <h2>🕐 Timelines — Architecture Evolution</h2>
-  <p style={{marginBottom:'0.6rem', fontSize:'0.95rem'}}>Track how your architecture changes over time as a series of explicit <strong>moments</strong> — each a full architecture snapshot.</p>
+  <p style={{marginBottom:'0.6rem', fontSize:'1.65rem'}}>Track how your architecture changes over time as a series of explicit <strong>moments</strong> — each a full architecture snapshot.</p>
   <div className="two-col">
     <div>
       <pre><code className="language-json">{`{
@@ -86,14 +86,14 @@
     </div>
     <div style={{paddingTop:'0.3rem'}}>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>Key concepts</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.9'}}>
         <li><strong>moment</strong> — snapshot + link to a full architecture</li>
         <li><code>current-moment</code> — which snapshot is live <em>now</em></li>
         <li><code>valid-from</code> — when this version went live (omit for <em>planned</em> moments)</li>
         <li><code>adrs</code> — <em>why</em> the architecture changed, not just what</li>
       </ul>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem', marginTop:'0.8rem'}}>Use cases</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.9'}}>
         <li>Monolith → microservices migrations</li>
         <li>Regulatory change impact &amp; audit trail</li>
         <li>Future-state planning (no <code>valid-from</code> yet)</li>

--- a/docs/docs/tutorials/_calm-overview/04-process-evolution.mdx
+++ b/docs/docs/tutorials/_calm-overview/04-process-evolution.mdx
@@ -86,14 +86,14 @@
     </div>
     <div style={{paddingTop:'0.3rem'}}>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>Key concepts</h3>
-      <ul style={{fontSize:'0.88rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
         <li><strong>moment</strong> — snapshot + link to a full architecture</li>
         <li><code>current-moment</code> — which snapshot is live <em>now</em></li>
         <li><code>valid-from</code> — when this version went live (omit for <em>planned</em> moments)</li>
         <li><code>adrs</code> — <em>why</em> the architecture changed, not just what</li>
       </ul>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem', marginTop:'0.8rem'}}>Use cases</h3>
-      <ul style={{fontSize:'0.88rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
         <li>Monolith → microservices migrations</li>
         <li>Regulatory change impact &amp; audit trail</li>
         <li>Future-state planning (no <code>valid-from</code> yet)</li>

--- a/docs/docs/tutorials/_calm-overview/05-tooling.mdx
+++ b/docs/docs/tutorials/_calm-overview/05-tooling.mdx
@@ -48,7 +48,7 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
 <section>
   <h2>🧩 VSCode Extension</h2>
   <p>First-class IDE support for working with CALM architectures.</p>
-  <img src="/img/vscode/04-preview-hero.png" alt="VSCode CALM preview" style={{maxHeight:'360px', maxWidth:'90%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0 auto'}} />
+  <img src="/img/vscode/04-preview-hero.png" alt="VSCode CALM preview" style={{maxHeight:'460px', maxWidth:'95%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0 auto'}} />
   <aside className="notes">
     The VSCode extension gives you a live preview of your architecture as a diagram,
     a tree view of nodes and relationships, real-time validation, and timeline visualisation.
@@ -61,11 +61,11 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
   <div className="two-col">
     <div>
       <img src="/img/vscode/07-validation-problems.png" alt="VSCode validation problems" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.8rem', textAlign:'center', color:'#666'}}>Live validation errors</p>
+      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Live validation errors</p>
     </div>
     <div>
       <img src="/img/vscode/09-timeline.png" alt="VSCode timeline view" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.8rem', textAlign:'center', color:'#666'}}>Timeline visualisation</p>
+      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Timeline visualisation</p>
     </div>
   </div>
   <aside className="notes">
@@ -77,10 +77,10 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
 <section>
   <h2>🏛️ CALM Hub</h2>
   <p>A versioned, queryable architecture repository — the shared source of truth that files in Git alone can't give you.</p>
-  <p style={{fontSize:'0.85rem', color:'#555', marginTop:'-0.3rem', marginBottom:'0.5rem'}}>
+  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'-0.3rem', marginBottom:'0.5rem'}}>
     Browse architectures across teams · compare timeline moments · view control compliance · REST API &amp; MCP for AI tools
   </p>
-  <img src="/img/hub-ui/diagram-view.png" alt="CALM Hub diagram view" style={{maxHeight:'330px', maxWidth:'80%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0.4rem auto'}} />
+  <img src="/img/hub-ui/diagram-view.png" alt="CALM Hub diagram view" style={{maxHeight:'380px', maxWidth:'90%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0.4rem auto'}} />
   <aside className="notes">
     CALM Hub is a Quarkus-backed REST API + React UI for storing, browsing, and viewing
     architectures. It gives teams a shared source of truth for the whole architecture landscape.
@@ -95,11 +95,11 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
   <div className="two-col">
     <div>
       <img src="/img/hub-ui/timeline-compare.png" alt="CALM Hub timeline compare" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.8rem', textAlign:'center', color:'#666'}}>Timeline comparison view</p>
+      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Timeline comparison view</p>
     </div>
     <div>
       <img src="/img/hub-ui/control-view.png" alt="CALM Hub control view" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.8rem', textAlign:'center', color:'#666'}}>Controls compliance view</p>
+      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Controls compliance view</p>
     </div>
   </div>
   <aside className="notes">
@@ -125,7 +125,7 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
       <img src="/img/docify.png" alt="Docify output" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
     </div>
   </div>
-  <p style={{fontSize:'0.85rem', color:'#666'}}>
+  <p style={{fontSize:'0.95rem', color:'#666'}}>
     <code>calm docify</code> uses widgets to generate a full documentation site from your architecture — always in sync.
   </p>
   <aside className="notes">
@@ -145,16 +145,16 @@ calm init-ai -p claude    # Claude Code
 calm init-ai -p codex     # OpenAI Codex`}</code></pre>
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1rem', marginTop:'0.8rem'}}>
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'0.9rem 1.1rem'}}>
-      <p style={{fontSize:'0.88rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What gets installed:</p>
-      <ul style={{fontSize:'0.85rem', margin:0, lineHeight:'1.8'}}>
+      <p style={{fontSize:'1.0rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What gets installed:</p>
+      <ul style={{fontSize:'0.95rem', margin:0, lineHeight:'1.8'}}>
         <li>14 task-specific prompt files (node-creation, flow-creation, control-creation …)</li>
         <li>Schema v1.2 rules, examples, pitfall warnings</li>
         <li>AI assistant config (<code>.github/copilot-instructions</code> etc.)</li>
       </ul>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'0.9rem 1.1rem'}}>
-      <p style={{fontSize:'0.88rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What it enables:</p>
-      <ul style={{fontSize:'0.85rem', margin:0, lineHeight:'1.8'}}>
+      <p style={{fontSize:'1.0rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What it enables:</p>
+      <ul style={{fontSize:'0.95rem', margin:0, lineHeight:'1.8'}}>
         <li>Assistant authors valid CALM JSON directly in the IDE</li>
         <li>Understands all node types, interface types, control patterns</li>
         <li>Catches schema errors before you run <code>calm validate</code></li>

--- a/docs/docs/tutorials/_calm-overview/05-tooling.mdx
+++ b/docs/docs/tutorials/_calm-overview/05-tooling.mdx
@@ -61,11 +61,11 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
   <div className="two-col">
     <div>
       <img src="/img/vscode/07-validation-problems.png" alt="VSCode validation problems" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Live validation errors</p>
+      <p style={{fontSize:'1.65rem', textAlign:'center', color:'#666'}}>Live validation errors</p>
     </div>
     <div>
       <img src="/img/vscode/09-timeline.png" alt="VSCode timeline view" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Timeline visualisation</p>
+      <p style={{fontSize:'1.65rem', textAlign:'center', color:'#666'}}>Timeline visualisation</p>
     </div>
   </div>
   <aside className="notes">
@@ -77,7 +77,7 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
 <section>
   <h2>🏛️ CALM Hub</h2>
   <p>A versioned, queryable architecture repository — the shared source of truth that files in Git alone can't give you.</p>
-  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'-0.3rem', marginBottom:'0.5rem'}}>
+  <p style={{fontSize:'1.65rem', color:'#555', marginTop:'-0.3rem', marginBottom:'0.5rem'}}>
     Browse architectures across teams · compare timeline moments · view control compliance · REST API &amp; MCP for AI tools
   </p>
   <img src="/img/hub-ui/diagram-view.png" alt="CALM Hub diagram view" style={{maxHeight:'380px', maxWidth:'90%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0.4rem auto'}} />
@@ -95,11 +95,11 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
   <div className="two-col">
     <div>
       <img src="/img/hub-ui/timeline-compare.png" alt="CALM Hub timeline compare" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Timeline comparison view</p>
+      <p style={{fontSize:'1.65rem', textAlign:'center', color:'#666'}}>Timeline comparison view</p>
     </div>
     <div>
       <img src="/img/hub-ui/control-view.png" alt="CALM Hub control view" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
-      <p style={{fontSize:'0.92rem', textAlign:'center', color:'#666'}}>Controls compliance view</p>
+      <p style={{fontSize:'1.65rem', textAlign:'center', color:'#666'}}>Controls compliance view</p>
     </div>
   </div>
   <aside className="notes">
@@ -125,7 +125,7 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
       <img src="/img/docify.png" alt="Docify output" style={{width:'100%', borderRadius:'6px', border:'1px solid #ddd'}} />
     </div>
   </div>
-  <p style={{fontSize:'0.95rem', color:'#666'}}>
+  <p style={{fontSize:'1.65rem', color:'#666'}}>
     <code>calm docify</code> uses widgets to generate a full documentation site from your architecture — always in sync.
   </p>
   <aside className="notes">
@@ -137,7 +137,7 @@ calm diff -a architecture-v1.json -b architecture-v2.json`}</code></pre>
 
 <section>
   <h2>🤖 CALM in Your AI Assistant</h2>
-  <p style={{fontSize:'0.95rem', marginBottom:'0.6rem'}}>One command installs 14 CALM-aware task prompts into your AI coding assistant — enabling it to author valid CALM documents in-IDE.</p>
+  <p style={{fontSize:'1.65rem', marginBottom:'0.6rem'}}>One command installs 14 CALM-aware task prompts into your AI coding assistant — enabling it to author valid CALM documents in-IDE.</p>
   <pre><code className="language-bash">{`# Install CALM AI tools for your assistant of choice
 calm init-ai -p copilot   # GitHub Copilot
 calm init-ai -p kiro      # AWS Kiro / Amazon Q
@@ -145,16 +145,16 @@ calm init-ai -p claude    # Claude Code
 calm init-ai -p codex     # OpenAI Codex`}</code></pre>
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1rem', marginTop:'0.8rem'}}>
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'0.9rem 1.1rem'}}>
-      <p style={{fontSize:'1.0rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What gets installed:</p>
-      <ul style={{fontSize:'0.95rem', margin:0, lineHeight:'1.8'}}>
+      <p style={{fontSize:'1.65rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What gets installed:</p>
+      <ul style={{fontSize:'1.65rem', margin:0, lineHeight:'1.8'}}>
         <li>14 task-specific prompt files (node-creation, flow-creation, control-creation …)</li>
         <li>Schema v1.2 rules, examples, pitfall warnings</li>
         <li>AI assistant config (<code>.github/copilot-instructions</code> etc.)</li>
       </ul>
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'0.9rem 1.1rem'}}>
-      <p style={{fontSize:'1.0rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What it enables:</p>
-      <ul style={{fontSize:'0.95rem', margin:0, lineHeight:'1.8'}}>
+      <p style={{fontSize:'1.65rem', margin:0, fontWeight:'bold', marginBottom:'0.4rem'}}>What it enables:</p>
+      <ul style={{fontSize:'1.65rem', margin:0, lineHeight:'1.8'}}>
         <li>Assistant authors valid CALM JSON directly in the IDE</li>
         <li>Understands all node types, interface types, control patterns</li>
         <li>Catches schema errors before you run <code>calm validate</code></li>

--- a/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
+++ b/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
@@ -20,40 +20,40 @@
   <div style={{display:'flex', alignItems:'center', justifyContent:'center', gap:'1rem', margin:'0.5rem 0 0.8rem', flexWrap:'wrap'}}>
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📄</div>
-      <strong style={{fontSize:'0.9rem'}}>Architecture</strong>
-      <div style={{fontSize:'0.78rem', color:'#555'}}>CALM JSON</div>
+      <strong style={{fontSize:'1.0rem'}}>Architecture</strong>
+      <div style={{fontSize:'0.92rem', color:'#555'}}>CALM JSON</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.72rem', color:'#555', fontFamily:'monospace'}}>calm template</div>
+      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>calm template</div>
       <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#fff8e1', border:'2px solid #f57f17', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📦</div>
-      <strong style={{fontSize:'0.9rem'}}>Template Bundle</strong>
-      <div style={{fontSize:'0.78rem', color:'#555'}}>Handlebars templates</div>
+      <strong style={{fontSize:'1.0rem'}}>Template Bundle</strong>
+      <div style={{fontSize:'0.92rem', color:'#555'}}>Handlebars templates</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.72rem', color:'#555', fontFamily:'monospace'}}>renders</div>
+      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>renders</div>
       <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#e3f2fd', border:'2px solid #1565c0', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>⚙️</div>
-      <strong style={{fontSize:'0.9rem'}}>IaC</strong>
-      <div style={{fontSize:'0.78rem', color:'#555'}}>Kustomize / Helm / Terraform</div>
+      <strong style={{fontSize:'1.0rem'}}>IaC</strong>
+      <div style={{fontSize:'0.92rem', color:'#555'}}>Kustomize / Helm / Terraform</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.72rem', color:'#555', fontFamily:'monospace'}}>deploys to</div>
+      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>deploys to</div>
       <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#fce4ec', border:'2px solid #880e4f', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'120px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>☸️</div>
-      <strong style={{fontSize:'0.9rem'}}>Kubernetes</strong>
-      <div style={{fontSize:'0.78rem', color:'#555'}}>deployed platform</div>
+      <strong style={{fontSize:'1.0rem'}}>Kubernetes</strong>
+      <div style={{fontSize:'0.92rem', color:'#555'}}>deployed platform</div>
     </div>
   </div>
   <pre><code className="language-bash">{`# Apply a bundle to your architecture and render IaC
 calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
-  <p style={{fontSize:'0.85rem', color:'#555', marginTop:'0.4rem'}}>
+  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.4rem'}}>
     Bundles are reusable, versioned, and shared across teams — a single security patch in a bundle propagates to all architectures.
   </p>
   <aside className="notes">
@@ -72,49 +72,49 @@ calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
     Platform teams use <code>calm validate</code> as a <strong>promotion gate</strong> — self-service deployments with guardrails, producing repeatable, auditable releases.
   </p>
   <div style={{display:'flex', justifyContent:'center', marginTop:'0.3rem'}}>
-    <svg viewBox="0 0 1020 280" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
+    <svg viewBox="0 0 1020 300" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
       <defs>
         <marker id="ga" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" fill="#555"/>
         </marker>
       </defs>
       {/* Stage boxes */}
-      <rect x="10" y="80" width="160" height="52" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="90" y="101" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#1565c0">Build</text>
-      <text x="90" y="118" textAnchor="middle" fontSize="11" fill="#555">compile &amp; package</text>
+      <rect x="10" y="80" width="160" height="58" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="90" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#1565c0">Build</text>
+      <text x="90" y="124" textAnchor="middle" fontSize="13" fill="#555">compile &amp; package</text>
 
-      <rect x="230" y="80" width="180" height="52" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="320" y="101" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#2e7d32">Deploy Non-Prod</text>
-      <text x="320" y="118" textAnchor="middle" fontSize="11" fill="#555">smoke test environment</text>
+      <rect x="230" y="80" width="180" height="58" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="320" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#2e7d32">Deploy Non-Prod</text>
+      <text x="320" y="124" textAnchor="middle" fontSize="13" fill="#555">smoke test environment</text>
 
-      <rect x="470" y="80" width="180" height="52" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="560" y="101" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#f57f17">Prod Readiness</text>
-      <text x="560" y="118" textAnchor="middle" fontSize="11" fill="#555">security &amp; change review</text>
+      <rect x="470" y="80" width="180" height="58" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="560" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#f57f17">Prod Readiness</text>
+      <text x="560" y="124" textAnchor="middle" fontSize="13" fill="#555">security &amp; change review</text>
 
-      <rect x="710" y="80" width="150" height="52" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
-      <text x="785" y="101" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#880e4f">Deploy</text>
-      <text x="785" y="118" textAnchor="middle" fontSize="11" fill="#555">production</text>
+      <rect x="710" y="80" width="150" height="58" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
+      <text x="785" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#880e4f">Deploy</text>
+      <text x="785" y="124" textAnchor="middle" fontSize="13" fill="#555">production</text>
 
       {/* Arrows between stages */}
-      <line x1="170" y1="106" x2="228" y2="106" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
-      <line x1="410" y1="106" x2="468" y2="106" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
-      <line x1="650" y1="106" x2="708" y2="106" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="170" y1="109" x2="228" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="410" y1="109" x2="468" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="650" y1="109" x2="708" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
 
       {/* Gate labels below each arrow */}
-      <text x="90" y="155" textAnchor="middle" fontSize="11" fill="#c62828" fontWeight="bold">✓ Validate</text>
-      <text x="90" y="169" textAnchor="middle" fontSize="11" fill="#c62828">Architecture</text>
+      <text x="90" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Validate</text>
+      <text x="90" y="179" textAnchor="middle" fontSize="13" fill="#c62828">Architecture</text>
 
-      <text x="320" y="155" textAnchor="middle" fontSize="11" fill="#c62828" fontWeight="bold">✓ Smoke Test Gate</text>
-      <text x="320" y="169" textAnchor="middle" fontSize="11" fill="#c62828">✓ Verify API Standards</text>
+      <text x="320" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Smoke Test Gate</text>
+      <text x="320" y="179" textAnchor="middle" fontSize="13" fill="#c62828">✓ Verify API Standards</text>
 
-      <text x="560" y="155" textAnchor="middle" fontSize="11" fill="#c62828" fontWeight="bold">✓ Security Review</text>
-      <text x="560" y="169" textAnchor="middle" fontSize="11" fill="#c62828">✓ Validate Architecture</text>
-      <text x="560" y="183" textAnchor="middle" fontSize="11" fill="#c62828">✓ Infra Preconditions</text>
+      <text x="560" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Security Review</text>
+      <text x="560" y="179" textAnchor="middle" fontSize="13" fill="#c62828">✓ Validate Architecture</text>
+      <text x="560" y="196" textAnchor="middle" fontSize="13" fill="#c62828">✓ Infra Preconditions</text>
 
-      <text x="785" y="155" textAnchor="middle" fontSize="11" fill="#c62828" fontWeight="bold">✓ Traffic Health</text>
+      <text x="785" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Traffic Health</text>
     </svg>
   </div>
-  <p style={{fontSize:'0.85rem', color:'#555', marginTop:'0.2rem'}}>
+  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.2rem'}}>
     "CALM construct rules provide guardrails to gate promotion across environments — repeatable and auditable deployments."
   </p>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
+++ b/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
@@ -17,39 +17,40 @@
 <section>
   <h2>🚀 From Architecture to Deployment</h2>
   <p style={{fontSize:'1.65rem', marginBottom:'0.8rem'}}>CALM architecture drives real infrastructure via <strong>template bundles</strong> — not just documentation.</p>
-  <div style={{display:'flex', alignItems:'center', justifyContent:'center', gap:'1rem', margin:'0.5rem 0 0.8rem', flexWrap:'wrap'}}>
-    <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
-      <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📄</div>
-      <strong style={{fontSize:'1.65rem'}}>Architecture</strong>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>CALM JSON</div>
-    </div>
-    <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>calm template</div>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
-    </div>
-    <div style={{background:'#fff8e1', border:'2px solid #f57f17', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
-      <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📦</div>
-      <strong style={{fontSize:'1.65rem'}}>Template Bundle</strong>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>Handlebars templates</div>
-    </div>
-    <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>renders</div>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
-    </div>
-    <div style={{background:'#e3f2fd', border:'2px solid #1565c0', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
-      <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>⚙️</div>
-      <strong style={{fontSize:'1.65rem'}}>IaC</strong>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>Kustomize / Helm / Terraform</div>
-    </div>
-    <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>deploys to</div>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
-    </div>
-    <div style={{background:'#fce4ec', border:'2px solid #880e4f', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'120px'}}>
-      <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>☸️</div>
-      <strong style={{fontSize:'1.65rem'}}>Kubernetes</strong>
-      <div style={{fontSize:'1.65rem', color:'#555'}}>deployed platform</div>
-    </div>
+  <div style={{display:'flex', justifyContent:'center', margin:'0.4rem 0 0.6rem'}}>
+    <svg viewBox="0 0 770 265" style={{width:'100%', maxHeight:'340px', fontFamily:'inherit'}}>
+      <defs>
+        <marker id="dp" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+          <polygon points="0,0 8,3 0,6" fill="#555"/>
+        </marker>
+      </defs>
+      {/* Architecture */}
+      <rect x="20" y="60" width="175" height="70" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="107" y="83" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#2e7d32">📄 Architecture</text>
+      <text x="107" y="102" textAnchor="middle" fontSize="16" fill="#555">CALM JSON</text>
+      {/* Arrow: Architecture → Template Bundle */}
+      <text x="222" y="48" textAnchor="middle" fontSize="16" fill="#555" fontFamily="monospace">calm template</text>
+      <line x1="195" y1="95" x2="248" y2="95" stroke="#555" strokeWidth="2" markerEnd="url(#dp)"/>
+      {/* Template Bundle */}
+      <rect x="250" y="60" width="215" height="70" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="357" y="83" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#f57f17">📦 Template Bundle</text>
+      <text x="357" y="102" textAnchor="middle" fontSize="16" fill="#555">Handlebars templates</text>
+      {/* Arrow: Template Bundle → IaC */}
+      <text x="492" y="48" textAnchor="middle" fontSize="16" fill="#555" fontFamily="monospace">renders</text>
+      <line x1="465" y1="95" x2="518" y2="95" stroke="#555" strokeWidth="2" markerEnd="url(#dp)"/>
+      {/* IaC */}
+      <rect x="520" y="60" width="225" height="70" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="632" y="83" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#1565c0">⚙️ IaC</text>
+      <text x="632" y="102" textAnchor="middle" fontSize="16" fill="#555">Kustomize / Helm</text>
+      <text x="632" y="120" textAnchor="middle" fontSize="16" fill="#555">/ Terraform</text>
+      {/* Arrow: IaC → Kubernetes (straight vertical drop) */}
+      <line x1="632" y1="130" x2="632" y2="183" stroke="#555" strokeWidth="2" markerEnd="url(#dp)"/>
+      <text x="645" y="162" textAnchor="start" fontSize="16" fill="#555" fontFamily="monospace">deploys to</text>
+      {/* Kubernetes — centred under IaC */}
+      <rect x="552" y="185" width="160" height="70" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
+      <text x="632" y="218" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#880e4f">☸️ Kubernetes</text>
+      <text x="632" y="238" textAnchor="middle" fontSize="16" fill="#555">deployed platform</text>
+    </svg>
   </div>
   <pre><code className="language-bash">{`# Apply a bundle to your architecture and render IaC
 calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
@@ -72,7 +73,7 @@ calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
     Platform teams use <code>calm validate</code> as a <strong>promotion gate</strong> — self-service deployments with guardrails, producing repeatable, auditable releases.
   </p>
   <div style={{display:'flex', justifyContent:'center', marginTop:'0.3rem'}}>
-    <svg viewBox="0 0 1020 320" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
+    <svg viewBox="-75 0 1020 320" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
       <defs>
         <marker id="ga" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" fill="#555"/>

--- a/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
+++ b/docs/docs/tutorials/_calm-overview/06-in-practice.mdx
@@ -16,44 +16,44 @@
 
 <section>
   <h2>🚀 From Architecture to Deployment</h2>
-  <p style={{fontSize:'0.95rem', marginBottom:'0.8rem'}}>CALM architecture drives real infrastructure via <strong>template bundles</strong> — not just documentation.</p>
+  <p style={{fontSize:'1.65rem', marginBottom:'0.8rem'}}>CALM architecture drives real infrastructure via <strong>template bundles</strong> — not just documentation.</p>
   <div style={{display:'flex', alignItems:'center', justifyContent:'center', gap:'1rem', margin:'0.5rem 0 0.8rem', flexWrap:'wrap'}}>
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📄</div>
-      <strong style={{fontSize:'1.0rem'}}>Architecture</strong>
-      <div style={{fontSize:'0.92rem', color:'#555'}}>CALM JSON</div>
+      <strong style={{fontSize:'1.65rem'}}>Architecture</strong>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>CALM JSON</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>calm template</div>
-      <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
+      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>calm template</div>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#fff8e1', border:'2px solid #f57f17', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>📦</div>
-      <strong style={{fontSize:'1.0rem'}}>Template Bundle</strong>
-      <div style={{fontSize:'0.92rem', color:'#555'}}>Handlebars templates</div>
+      <strong style={{fontSize:'1.65rem'}}>Template Bundle</strong>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>Handlebars templates</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>renders</div>
-      <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
+      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>renders</div>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#e3f2fd', border:'2px solid #1565c0', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'140px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>⚙️</div>
-      <strong style={{fontSize:'1.0rem'}}>IaC</strong>
-      <div style={{fontSize:'0.92rem', color:'#555'}}>Kustomize / Helm / Terraform</div>
+      <strong style={{fontSize:'1.65rem'}}>IaC</strong>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>Kustomize / Helm / Terraform</div>
     </div>
     <div style={{textAlign:'center', flexShrink:0}}>
-      <div style={{fontSize:'0.92rem', color:'#555', fontFamily:'monospace'}}>deploys to</div>
-      <div style={{fontSize:'1.4rem', color:'#555'}}>→</div>
+      <div style={{fontSize:'1.65rem', color:'#555', fontFamily:'monospace'}}>deploys to</div>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>→</div>
     </div>
     <div style={{background:'#fce4ec', border:'2px solid #880e4f', borderRadius:'8px', padding:'0.9rem 1.2rem', textAlign:'center', minWidth:'120px'}}>
       <div style={{fontSize:'1.8rem', marginBottom:'0.3rem'}}>☸️</div>
-      <strong style={{fontSize:'1.0rem'}}>Kubernetes</strong>
-      <div style={{fontSize:'0.92rem', color:'#555'}}>deployed platform</div>
+      <strong style={{fontSize:'1.65rem'}}>Kubernetes</strong>
+      <div style={{fontSize:'1.65rem', color:'#555'}}>deployed platform</div>
     </div>
   </div>
   <pre><code className="language-bash">{`# Apply a bundle to your architecture and render IaC
 calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
-  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.4rem'}}>
+  <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.4rem'}}>
     Bundles are reusable, versioned, and shared across teams — a single security patch in a bundle propagates to all architectures.
   </p>
   <aside className="notes">
@@ -68,53 +68,53 @@ calm template -a architecture.json -b ./bundles/k8s-kustomize`}</code></pre>
 
 <section>
   <h2>🚦 Gating Deployments with CALM</h2>
-  <p style={{fontSize:'0.92rem', marginBottom:'0.6rem'}}>
+  <p style={{fontSize:'1.65rem', marginBottom:'0.6rem'}}>
     Platform teams use <code>calm validate</code> as a <strong>promotion gate</strong> — self-service deployments with guardrails, producing repeatable, auditable releases.
   </p>
   <div style={{display:'flex', justifyContent:'center', marginTop:'0.3rem'}}>
-    <svg viewBox="0 0 1020 300" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
+    <svg viewBox="0 0 1020 320" style={{width:'100%', maxHeight:'380px', fontFamily:'inherit'}}>
       <defs>
         <marker id="ga" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" fill="#555"/>
         </marker>
       </defs>
       {/* Stage boxes */}
-      <rect x="10" y="80" width="160" height="58" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="90" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#1565c0">Build</text>
-      <text x="90" y="124" textAnchor="middle" fontSize="13" fill="#555">compile &amp; package</text>
+      <rect x="10" y="80" width="160" height="68" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="90" y="108" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#1565c0">Build</text>
+      <text x="90" y="132" textAnchor="middle" fontSize="16" fill="#555">compile &amp; package</text>
 
-      <rect x="230" y="80" width="180" height="58" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="320" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#2e7d32">Deploy Non-Prod</text>
-      <text x="320" y="124" textAnchor="middle" fontSize="13" fill="#555">smoke test environment</text>
+      <rect x="230" y="80" width="180" height="68" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="320" y="108" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#2e7d32">Deploy Non-Prod</text>
+      <text x="320" y="132" textAnchor="middle" fontSize="16" fill="#555">smoke test environment</text>
 
-      <rect x="470" y="80" width="180" height="58" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="560" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#f57f17">Prod Readiness</text>
-      <text x="560" y="124" textAnchor="middle" fontSize="13" fill="#555">security &amp; change review</text>
+      <rect x="470" y="80" width="180" height="68" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="560" y="108" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#f57f17">Prod Readiness</text>
+      <text x="560" y="132" textAnchor="middle" fontSize="16" fill="#555">security &amp; change review</text>
 
-      <rect x="710" y="80" width="150" height="58" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
-      <text x="785" y="104" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#880e4f">Deploy</text>
-      <text x="785" y="124" textAnchor="middle" fontSize="13" fill="#555">production</text>
+      <rect x="710" y="80" width="150" height="68" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
+      <text x="785" y="108" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#880e4f">Deploy</text>
+      <text x="785" y="132" textAnchor="middle" fontSize="16" fill="#555">production</text>
 
       {/* Arrows between stages */}
-      <line x1="170" y1="109" x2="228" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
-      <line x1="410" y1="109" x2="468" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
-      <line x1="650" y1="109" x2="708" y2="109" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="170" y1="114" x2="228" y2="114" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="410" y1="114" x2="468" y2="114" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
+      <line x1="650" y1="114" x2="708" y2="114" stroke="#555" strokeWidth="2" markerEnd="url(#ga)"/>
 
       {/* Gate labels below each arrow */}
-      <text x="90" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Validate</text>
-      <text x="90" y="179" textAnchor="middle" fontSize="13" fill="#c62828">Architecture</text>
+      <text x="90" y="172" textAnchor="middle" fontSize="16" fill="#c62828" fontWeight="bold">✓ Validate</text>
+      <text x="90" y="191" textAnchor="middle" fontSize="16" fill="#c62828">Architecture</text>
 
-      <text x="320" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Smoke Test Gate</text>
-      <text x="320" y="179" textAnchor="middle" fontSize="13" fill="#c62828">✓ Verify API Standards</text>
+      <text x="320" y="172" textAnchor="middle" fontSize="16" fill="#c62828" fontWeight="bold">✓ Smoke Test Gate</text>
+      <text x="320" y="191" textAnchor="middle" fontSize="16" fill="#c62828">✓ Verify API Standards</text>
 
-      <text x="560" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Security Review</text>
-      <text x="560" y="179" textAnchor="middle" fontSize="13" fill="#c62828">✓ Validate Architecture</text>
-      <text x="560" y="196" textAnchor="middle" fontSize="13" fill="#c62828">✓ Infra Preconditions</text>
+      <text x="560" y="172" textAnchor="middle" fontSize="16" fill="#c62828" fontWeight="bold">✓ Security Review</text>
+      <text x="560" y="191" textAnchor="middle" fontSize="16" fill="#c62828">✓ Validate Architecture</text>
+      <text x="560" y="210" textAnchor="middle" fontSize="16" fill="#c62828">✓ Infra Preconditions</text>
 
-      <text x="785" y="162" textAnchor="middle" fontSize="13" fill="#c62828" fontWeight="bold">✓ Traffic Health</text>
+      <text x="785" y="172" textAnchor="middle" fontSize="16" fill="#c62828" fontWeight="bold">✓ Traffic Health</text>
     </svg>
   </div>
-  <p style={{fontSize:'0.95rem', color:'#555', marginTop:'0.2rem'}}>
+  <p style={{fontSize:'1.65rem', color:'#555', marginTop:'0.2rem'}}>
     "CALM construct rules provide guardrails to gate promotion across environments — repeatable and auditable deployments."
   </p>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
+++ b/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
@@ -75,28 +75,28 @@
       {/* C4 Design */}
       <rect x="20" y="168" width="150" height="72" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
       <text x="95" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#1565c0">C4 Design</text>
-      <text x="95" y="222" textAnchor="middle" fontSize="16" fill="#555">&amp; Review</text>
-      {/* Arrow C4 → Pattern — label above the line */}
-      <text x="202" y="168" textAnchor="middle" fontSize="16" fill="#555">create</text>
+      <text x="95" y="222" textAnchor="middle" fontSize="18" fill="#555">&amp; Review</text>
+      {/* Arrow C4 → Pattern — label floated above boxes */}
+      <text x="202" y="150" textAnchor="middle" fontSize="18" fill="#555">create</text>
       <line x1="170" y1="204" x2="228" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Pattern */}
       <rect x="230" y="168" width="150" height="72" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
       <text x="305" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#2e7d32">▦ Pattern</text>
-      <text x="305" y="222" textAnchor="middle" fontSize="16" fill="#555">blueprint</text>
-      {/* Arrow Pattern → Architecture — label above the line */}
-      <text x="402" y="168" textAnchor="middle" fontSize="16" fill="#555">calm generate</text>
+      <text x="305" y="222" textAnchor="middle" fontSize="18" fill="#555">blueprint</text>
+      {/* Arrow Pattern → Architecture — label floated above boxes */}
+      <text x="402" y="150" textAnchor="middle" fontSize="18" fill="#555">calm generate</text>
       <line x1="380" y1="204" x2="438" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Architecture */}
       <rect x="440" y="168" width="150" height="72" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
       <text x="515" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
-      <text x="515" y="222" textAnchor="middle" fontSize="16" fill="#555">instance</text>
-      {/* Arrow Architecture → CALM Hub — label above the line */}
-      <text x="612" y="168" textAnchor="middle" fontSize="16" fill="#555">calm hub push</text>
+      <text x="515" y="222" textAnchor="middle" fontSize="18" fill="#555">instance</text>
+      {/* Arrow Architecture → CALM Hub — label floated above boxes */}
+      <text x="612" y="150" textAnchor="middle" fontSize="18" fill="#555">calm hub push</text>
       <line x1="590" y1="204" x2="648" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* CALM Hub */}
       <rect x="650" y="168" width="150" height="72" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
       <text x="725" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#880e4f">🏛 CALM Hub</text>
-      <text x="725" y="222" textAnchor="middle" fontSize="16" fill="#555">registry</text>
+      <text x="725" y="222" textAnchor="middle" fontSize="18" fill="#555">registry</text>
       {/* Arrow Hub → branches (vertical down) */}
       <line x1="800" y1="204" x2="840" y2="204" stroke="#555" strokeWidth="2"/>
       {/* vertical spine */}
@@ -104,21 +104,18 @@
       {/* Branch 1: IaC */}
       <line x1="840" y1="114" x2="878" y2="114" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       <rect x="880" y="86" width="220" height="56" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="990" y="110" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
-      <text x="990" y="129" textAnchor="middle" fontSize="15" fill="#555">calm template (bundles)</text>
-      <text x="859" y="110" textAnchor="middle" fontSize="15" fill="#2e7d32">template</text>
+      <text x="990" y="110" textAnchor="middle" fontSize="18" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
+      <text x="990" y="129" textAnchor="middle" fontSize="16" fill="#555">calm template (bundles)</text>
       {/* Branch 2: Docs */}
       <line x1="840" y1="209" x2="878" y2="209" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       <rect x="880" y="185" width="220" height="50" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="990" y="206" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
-      <text x="990" y="223" textAnchor="middle" fontSize="15" fill="#555">calm docify</text>
-      <text x="859" y="204" textAnchor="middle" fontSize="15" fill="#1565c0">docify</text>
+      <text x="990" y="206" textAnchor="middle" fontSize="18" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
+      <text x="990" y="223" textAnchor="middle" fontSize="16" fill="#555">calm docify</text>
       {/* Branch 3: Config */}
       <line x1="840" y1="315" x2="878" y2="315" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       <rect x="880" y="290" width="220" height="50" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="990" y="311" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
-      <text x="990" y="328" textAnchor="middle" fontSize="15" fill="#555">calm generate (env config)</text>
-      <text x="859" y="310" textAnchor="middle" fontSize="15" fill="#f57f17">generate</text>
+      <text x="990" y="311" textAnchor="middle" fontSize="18" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
+      <text x="990" y="328" textAnchor="middle" fontSize="16" fill="#555">calm generate (env config)</text>
     </svg>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
+++ b/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
@@ -69,9 +69,7 @@
         <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" fill="#555"/>
         </marker>
-        <marker id="arrg" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-          <polygon points="0,0 8,3 0,6" fill="#2e7d32"/>
-        </marker>
+
       </defs>
       {/* Boxes row 1: C4 → Pattern → Architecture → CALM Hub */}
       {/* C4 Design */}
@@ -79,7 +77,7 @@
       <text x="95" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#1565c0">C4 Design</text>
       <text x="95" y="218" textAnchor="middle" fontSize="13" fill="#555">&amp; Review</text>
       {/* Arrow C4 → Pattern — label above the line */}
-      <text x="202" y="172" textAnchor="middle" fontSize="13" fill="#555">calm create</text>
+      <text x="202" y="172" textAnchor="middle" fontSize="13" fill="#555">create</text>
       <line x1="170" y1="201" x2="228" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Pattern */}
       <rect x="230" y="170" width="150" height="62" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
@@ -93,7 +91,7 @@
       <text x="515" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
       <text x="515" y="218" textAnchor="middle" fontSize="13" fill="#555">instance</text>
       {/* Arrow Architecture → CALM Hub — label above the line */}
-      <text x="612" y="172" textAnchor="middle" fontSize="13" fill="#555">calm validate</text>
+      <text x="612" y="172" textAnchor="middle" fontSize="13" fill="#555">calm hub push</text>
       <line x1="590" y1="201" x2="648" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* CALM Hub */}
       <rect x="650" y="170" width="150" height="62" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>

--- a/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
+++ b/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
@@ -29,7 +29,7 @@
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>Nodes (13)</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.8'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.8'}}>
         <li>Trader (actor)</li>
         <li>Trading Web UI (webclient)</li>
         <li>Trading API Gateway (service)</li>
@@ -43,13 +43,13 @@
     </div>
     <div>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>What it captures</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.8'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.8'}}>
         <li>18 relationships with explicit protocols</li>
         <li>7 business flows (order placement, risk check, settlement)</li>
         <li>Controls on PII connections — mTLS enforced</li>
         <li>Metadata: classification tags, cost centres, owners</li>
       </ul>
-      <p style={{fontSize:'0.95rem', color:'#2e7d32', marginTop:'0.8rem', fontWeight:'bold'}}>
+      <p style={{fontSize:'1.65rem', color:'#2e7d32', marginTop:'0.8rem', fontWeight:'bold'}}>
         One JSON file. Validated, visualised, and published automatically.
       </p>
     </div>
@@ -73,52 +73,52 @@
       </defs>
       {/* Boxes row 1: C4 → Pattern → Architecture → CALM Hub */}
       {/* C4 Design */}
-      <rect x="20" y="170" width="150" height="62" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="95" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#1565c0">C4 Design</text>
-      <text x="95" y="218" textAnchor="middle" fontSize="13" fill="#555">&amp; Review</text>
+      <rect x="20" y="168" width="150" height="72" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="95" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#1565c0">C4 Design</text>
+      <text x="95" y="222" textAnchor="middle" fontSize="16" fill="#555">&amp; Review</text>
       {/* Arrow C4 → Pattern — label above the line */}
-      <text x="202" y="172" textAnchor="middle" fontSize="13" fill="#555">create</text>
-      <line x1="170" y1="201" x2="228" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <text x="202" y="168" textAnchor="middle" fontSize="16" fill="#555">create</text>
+      <line x1="170" y1="204" x2="228" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Pattern */}
-      <rect x="230" y="170" width="150" height="62" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="305" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#2e7d32">▦ Pattern</text>
-      <text x="305" y="218" textAnchor="middle" fontSize="13" fill="#555">blueprint</text>
+      <rect x="230" y="168" width="150" height="72" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="305" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#2e7d32">▦ Pattern</text>
+      <text x="305" y="222" textAnchor="middle" fontSize="16" fill="#555">blueprint</text>
       {/* Arrow Pattern → Architecture — label above the line */}
-      <text x="402" y="172" textAnchor="middle" fontSize="13" fill="#555">calm generate</text>
-      <line x1="380" y1="201" x2="438" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <text x="402" y="168" textAnchor="middle" fontSize="16" fill="#555">calm generate</text>
+      <line x1="380" y1="204" x2="438" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Architecture */}
-      <rect x="440" y="170" width="150" height="62" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="515" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
-      <text x="515" y="218" textAnchor="middle" fontSize="13" fill="#555">instance</text>
+      <rect x="440" y="168" width="150" height="72" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="515" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
+      <text x="515" y="222" textAnchor="middle" fontSize="16" fill="#555">instance</text>
       {/* Arrow Architecture → CALM Hub — label above the line */}
-      <text x="612" y="172" textAnchor="middle" fontSize="13" fill="#555">calm hub push</text>
-      <line x1="590" y1="201" x2="648" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <text x="612" y="168" textAnchor="middle" fontSize="16" fill="#555">calm hub push</text>
+      <line x1="590" y1="204" x2="648" y2="204" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* CALM Hub */}
-      <rect x="650" y="170" width="150" height="62" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
-      <text x="725" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#880e4f">🏛 CALM Hub</text>
-      <text x="725" y="218" textAnchor="middle" fontSize="13" fill="#555">registry</text>
+      <rect x="650" y="168" width="150" height="72" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
+      <text x="725" y="199" textAnchor="middle" fontSize="20" fontWeight="bold" fill="#880e4f">🏛 CALM Hub</text>
+      <text x="725" y="222" textAnchor="middle" fontSize="16" fill="#555">registry</text>
       {/* Arrow Hub → branches (vertical down) */}
-      <line x1="800" y1="201" x2="840" y2="201" stroke="#555" strokeWidth="2"/>
+      <line x1="800" y1="204" x2="840" y2="204" stroke="#555" strokeWidth="2"/>
       {/* vertical spine */}
-      <line x1="840" y1="105" x2="840" y2="325" stroke="#555" strokeWidth="2"/>
+      <line x1="840" y1="104" x2="840" y2="328" stroke="#555" strokeWidth="2"/>
       {/* Branch 1: IaC */}
-      <line x1="840" y1="115" x2="878" y2="115" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <rect x="880" y="88" width="220" height="54" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="990" y="110" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
-      <text x="990" y="128" textAnchor="middle" fontSize="13" fill="#555">calm template (bundles)</text>
-      <text x="859" y="110" textAnchor="middle" fontSize="13" fill="#2e7d32">template</text>
+      <line x1="840" y1="114" x2="878" y2="114" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <rect x="880" y="86" width="220" height="56" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="990" y="110" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
+      <text x="990" y="129" textAnchor="middle" fontSize="15" fill="#555">calm template (bundles)</text>
+      <text x="859" y="110" textAnchor="middle" fontSize="15" fill="#2e7d32">template</text>
       {/* Branch 2: Docs */}
       <line x1="840" y1="209" x2="878" y2="209" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       <rect x="880" y="185" width="220" height="50" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="990" y="206" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
-      <text x="990" y="224" textAnchor="middle" fontSize="13" fill="#555">calm docify</text>
-      <text x="859" y="204" textAnchor="middle" fontSize="13" fill="#1565c0">docify</text>
+      <text x="990" y="206" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
+      <text x="990" y="223" textAnchor="middle" fontSize="15" fill="#555">calm docify</text>
+      <text x="859" y="204" textAnchor="middle" fontSize="15" fill="#1565c0">docify</text>
       {/* Branch 3: Config */}
       <line x1="840" y1="315" x2="878" y2="315" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       <rect x="880" y="290" width="220" height="50" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="990" y="311" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
-      <text x="990" y="329" textAnchor="middle" fontSize="13" fill="#555">calm generate (env config)</text>
-      <text x="859" y="310" textAnchor="middle" fontSize="13" fill="#f57f17">generate</text>
+      <text x="990" y="311" textAnchor="middle" fontSize="17" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
+      <text x="990" y="328" textAnchor="middle" fontSize="15" fill="#555">calm generate (env config)</text>
+      <text x="859" y="310" textAnchor="middle" fontSize="15" fill="#f57f17">generate</text>
     </svg>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
+++ b/docs/docs/tutorials/_calm-overview/07-putting-it-together.mdx
@@ -15,7 +15,7 @@
 </section>
 
 <section>
-  <h2>Trading System — Architecture at a Glance</h2>
+  <h2>TraderX Example Architecture</h2>
   <img src="/img/hub-ui/diagram-view.png" alt="TraderX architecture in CALM Hub" style={{maxHeight:'380px', maxWidth:'90%', borderRadius:'6px', border:'1px solid #ddd', display:'block', margin:'0.3rem auto'}} />
   <aside className="notes">
     This diagram is generated from a single CALM JSON file.
@@ -29,7 +29,7 @@
   <div className="two-col">
     <div>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>Nodes (13)</h3>
-      <ul style={{fontSize:'0.9rem', lineHeight:'1.8'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.8'}}>
         <li>Trader (actor)</li>
         <li>Trading Web UI (webclient)</li>
         <li>Trading API Gateway (service)</li>
@@ -43,13 +43,13 @@
     </div>
     <div>
       <h3 style={{fontSize:'1rem', marginBottom:'0.5rem'}}>What it captures</h3>
-      <ul style={{fontSize:'0.9rem', lineHeight:'1.8'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.8'}}>
         <li>18 relationships with explicit protocols</li>
         <li>7 business flows (order placement, risk check, settlement)</li>
         <li>Controls on PII connections — mTLS enforced</li>
         <li>Metadata: classification tags, cost centres, owners</li>
       </ul>
-      <p style={{fontSize:'0.85rem', color:'#2e7d32', marginTop:'0.8rem', fontWeight:'bold'}}>
+      <p style={{fontSize:'0.95rem', color:'#2e7d32', marginTop:'0.8rem', fontWeight:'bold'}}>
         One JSON file. Validated, visualised, and published automatically.
       </p>
     </div>
@@ -64,7 +64,7 @@
 <section>
   <h2>The CALM Workflow</h2>
   <div style={{display:'flex', justifyContent:'center', marginTop:'0.3rem'}}>
-    <svg viewBox="0 0 1100 480" style={{width:'100%', maxHeight:'500px', fontFamily:'inherit'}}>
+    <svg viewBox="0 0 1120 500" style={{width:'100%', maxHeight:'500px', fontFamily:'inherit'}}>
       <defs>
         <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0,0 8,3 0,6" fill="#555"/>
@@ -75,55 +75,52 @@
       </defs>
       {/* Boxes row 1: C4 → Pattern → Architecture → CALM Hub */}
       {/* C4 Design */}
-      <rect x="20" y="160" width="140" height="56" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="90" y="182" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#1565c0">C4 Design</text>
-      <text x="90" y="200" textAnchor="middle" fontSize="12" fill="#555">&amp; Review</text>
-      {/* Arrow C4 → Pattern */}
-      <line x1="160" y1="188" x2="218" y2="188" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <text x="189" y="178" textAnchor="middle" fontSize="10" fill="#555">calm</text>
-      <text x="189" y="190" textAnchor="middle" fontSize="10" fill="#555">generate</text>
+      <rect x="20" y="170" width="150" height="62" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="95" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#1565c0">C4 Design</text>
+      <text x="95" y="218" textAnchor="middle" fontSize="13" fill="#555">&amp; Review</text>
+      {/* Arrow C4 → Pattern — label above the line */}
+      <text x="202" y="172" textAnchor="middle" fontSize="13" fill="#555">calm create</text>
+      <line x1="170" y1="201" x2="228" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Pattern */}
-      <rect x="220" y="160" width="140" height="56" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="290" y="182" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#2e7d32">▦ Pattern</text>
-      <text x="290" y="200" textAnchor="middle" fontSize="12" fill="#555">blueprint</text>
-      {/* Arrow Pattern → Architecture */}
-      <line x1="360" y1="188" x2="418" y2="188" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <text x="389" y="178" textAnchor="middle" fontSize="10" fill="#555">calm</text>
-      <text x="389" y="190" textAnchor="middle" fontSize="10" fill="#555">validate</text>
+      <rect x="230" y="170" width="150" height="62" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="305" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#2e7d32">▦ Pattern</text>
+      <text x="305" y="218" textAnchor="middle" fontSize="13" fill="#555">blueprint</text>
+      {/* Arrow Pattern → Architecture — label above the line */}
+      <text x="402" y="172" textAnchor="middle" fontSize="13" fill="#555">calm generate</text>
+      <line x1="380" y1="201" x2="438" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* Architecture */}
-      <rect x="420" y="160" width="140" height="56" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="490" y="182" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
-      <text x="490" y="200" textAnchor="middle" fontSize="12" fill="#555">instance</text>
-      {/* Arrow Architecture → CALM Hub */}
-      <line x1="560" y1="188" x2="618" y2="188" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <text x="589" y="178" textAnchor="middle" fontSize="10" fill="#555">hub</text>
-      <text x="589" y="190" textAnchor="middle" fontSize="10" fill="#555">push</text>
+      <rect x="440" y="170" width="150" height="62" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="515" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#f57f17">📄 Architecture</text>
+      <text x="515" y="218" textAnchor="middle" fontSize="13" fill="#555">instance</text>
+      {/* Arrow Architecture → CALM Hub — label above the line */}
+      <text x="612" y="172" textAnchor="middle" fontSize="13" fill="#555">calm validate</text>
+      <line x1="590" y1="201" x2="648" y2="201" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
       {/* CALM Hub */}
-      <rect x="620" y="160" width="140" height="56" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
-      <text x="690" y="182" textAnchor="middle" fontSize="13" fontWeight="bold" fill="#880e4f">🏛 CALM Hub</text>
-      <text x="690" y="200" textAnchor="middle" fontSize="12" fill="#555">registry</text>
+      <rect x="650" y="170" width="150" height="62" rx="8" fill="#fce4ec" stroke="#880e4f" strokeWidth="2"/>
+      <text x="725" y="196" textAnchor="middle" fontSize="16" fontWeight="bold" fill="#880e4f">🏛 CALM Hub</text>
+      <text x="725" y="218" textAnchor="middle" fontSize="13" fill="#555">registry</text>
       {/* Arrow Hub → branches (vertical down) */}
-      <line x1="760" y1="188" x2="810" y2="188" stroke="#555" strokeWidth="2"/>
+      <line x1="800" y1="201" x2="840" y2="201" stroke="#555" strokeWidth="2"/>
       {/* vertical spine */}
-      <line x1="810" y1="90" x2="810" y2="310" stroke="#555" strokeWidth="2"/>
+      <line x1="840" y1="105" x2="840" y2="325" stroke="#555" strokeWidth="2"/>
       {/* Branch 1: IaC */}
-      <line x1="810" y1="100" x2="858" y2="100" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <rect x="860" y="72" width="210" height="52" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
-      <text x="965" y="93" textAnchor="middle" fontSize="12" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
-      <text x="965" y="109" textAnchor="middle" fontSize="11" fill="#555">calm template (bundles)</text>
-      <text x="835" y="95" textAnchor="middle" fontSize="10" fill="#2e7d32">template</text>
+      <line x1="840" y1="115" x2="878" y2="115" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <rect x="880" y="88" width="220" height="54" rx="8" fill="#e8f5e9" stroke="#2e7d32" strokeWidth="2"/>
+      <text x="990" y="110" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#2e7d32">📦 IaC</text>
+      <text x="990" y="128" textAnchor="middle" fontSize="13" fill="#555">calm template (bundles)</text>
+      <text x="859" y="110" textAnchor="middle" fontSize="13" fill="#2e7d32">template</text>
       {/* Branch 2: Docs */}
-      <line x1="810" y1="196" x2="858" y2="196" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <rect x="860" y="172" width="210" height="48" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
-      <text x="965" y="192" textAnchor="middle" fontSize="12" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
-      <text x="965" y="208" textAnchor="middle" fontSize="11" fill="#555">calm docify</text>
-      <text x="835" y="191" textAnchor="middle" fontSize="10" fill="#1565c0">docify</text>
+      <line x1="840" y1="209" x2="878" y2="209" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <rect x="880" y="185" width="220" height="50" rx="8" fill="#e3f2fd" stroke="#1565c0" strokeWidth="2"/>
+      <text x="990" y="206" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#1565c0">📄 Documentation</text>
+      <text x="990" y="224" textAnchor="middle" fontSize="13" fill="#555">calm docify</text>
+      <text x="859" y="204" textAnchor="middle" fontSize="13" fill="#1565c0">docify</text>
       {/* Branch 3: Config */}
-      <line x1="810" y1="300" x2="858" y2="300" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
-      <rect x="860" y="274" width="210" height="48" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
-      <text x="965" y="295" textAnchor="middle" fontSize="12" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
-      <text x="965" y="311" textAnchor="middle" fontSize="11" fill="#555">calm generate (env config)</text>
-      <text x="835" y="295" textAnchor="middle" fontSize="10" fill="#f57f17">generate</text>
+      <line x1="840" y1="315" x2="878" y2="315" stroke="#555" strokeWidth="2" markerEnd="url(#arr)"/>
+      <rect x="880" y="290" width="220" height="50" rx="8" fill="#fff8e1" stroke="#f57f17" strokeWidth="2"/>
+      <text x="990" y="311" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#f57f17">⚙️ Config</text>
+      <text x="990" y="329" textAnchor="middle" fontSize="13" fill="#555">calm generate (env config)</text>
+      <text x="859" y="310" textAnchor="middle" fontSize="13" fill="#f57f17">generate</text>
     </svg>
   </div>
   <aside className="notes">

--- a/docs/docs/tutorials/_calm-overview/08-close.mdx
+++ b/docs/docs/tutorials/_calm-overview/08-close.mdx
@@ -7,7 +7,7 @@
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1.5rem', marginTop:'0.6rem'}}>
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.3rem 1.5rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.1rem'}}>🛠️ Contribute</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.9'}}>
         <li>GitHub: <a href="https://github.com/finos/architecture-as-code">finos/architecture-as-code</a></li>
         <li>Raise issues &amp; feature requests</li>
         <li>Open PRs — docs, code, examples</li>
@@ -16,7 +16,7 @@
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.3rem 1.5rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.1rem'}}>💬 Connect</h3>
-      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.65rem', lineHeight:'1.9'}}>
         <li>Slack: <a href="https://finos-lf.slack.com">finos-lf.slack.com</a> — #calm channel</li>
         <li>Community &amp; WG calls (agenda on GitHub)</li>
         <li><a href="https://calm.finos.org">calm.finos.org</a> — full documentation</li>
@@ -38,24 +38,24 @@
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1rem', marginBottom:'0.8rem'}}>
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#1b5e20'}}>🟢 Beginner</h3>
-      <p style={{fontSize:'1.0rem', margin:'0.3rem 0 0.5rem', color:'#333'}}>
+      <p style={{fontSize:'1.65rem', margin:'0.3rem 0 0.5rem', color:'#333'}}>
         Install the CLI, model your first node and relationship, then validate against a pattern.
       </p>
-      <p style={{fontSize:'0.92rem', margin:0, color:'#555'}}>
+      <p style={{fontSize:'1.65rem', margin:0, color:'#555'}}>
         <code>npm install -g @finos/calm-cli</code> &nbsp;·&nbsp; <a href="https://calm.finos.org">calm.finos.org tutorials</a>
       </p>
     </div>
     <div style={{background:'#fff8e1', border:'2px solid #f57f17', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#e65100'}}>🟡 Intermediate</h3>
-      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>Tools are set up — work with patterns, customizations &amp; standards, and run <code>calm docify</code> on a richer architecture.</p>
+      <p style={{fontSize:'1.65rem', margin:0, color:'#555'}}>Tools are set up — work with patterns, customizations &amp; standards, and run <code>calm docify</code> on a richer architecture.</p>
     </div>
     <div style={{background:'#fce4ec', border:'2px solid #880e4f', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#880e4f'}}>🔴 Practitioner</h3>
-      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>Step into the shoes of an architect — use CALM's AI tools to model a real architecture from scratch, guided by the AI agent.</p>
+      <p style={{fontSize:'1.65rem', margin:0, color:'#555'}}>Step into the shoes of an architect — use CALM's AI tools to model a real architecture from scratch, guided by the AI agent.</p>
     </div>
     <div style={{background:'#ede7f6', border:'2px solid #4527a0', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#4527a0'}}>🟣 Advanced</h3>
-      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>The QCon demo — five scenarios end-to-end. <strong>Requires Minikube.</strong> Deploy a CALM-driven platform, add controls, and run autonomous agents.</p>
+      <p style={{fontSize:'1.65rem', margin:0, color:'#555'}}>The QCon demo — five scenarios end-to-end. <strong>Requires Minikube.</strong> Deploy a CALM-driven platform, add controls, and run autonomous agents.</p>
     </div>
   </div>
   <aside className="notes">
@@ -75,10 +75,10 @@
   <div style={{display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:'1.5rem'}}>
     <img src="/img/2025_CALM_Horizontal.svg" alt="CALM Logo" style={{maxWidth:'360px'}} />
     <h2 style={{margin:0}}>Thank you!</h2>
-    <p style={{margin:0, fontSize:'1.1rem', color:'#555'}}>
+    <p style={{margin:0, fontSize:'1.65rem', color:'#555'}}>
       Architecture as Code — consistent, automated, controlled.
     </p>
-    <div style={{display:'flex', gap:'2rem', marginTop:'0.5rem', fontSize:'1.0rem', color:'#777'}}>
+    <div style={{display:'flex', gap:'2rem', marginTop:'0.5rem', fontSize:'1.65rem', color:'#777'}}>
       <span>🌐 calm.finos.org</span>
       <span>⭐ github.com/finos/architecture-as-code</span>
     </div>

--- a/docs/docs/tutorials/_calm-overview/08-close.mdx
+++ b/docs/docs/tutorials/_calm-overview/08-close.mdx
@@ -7,7 +7,7 @@
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1.5rem', marginTop:'0.6rem'}}>
     <div style={{background:'#e8f5e9', borderRadius:'8px', padding:'1.3rem 1.5rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.1rem'}}>🛠️ Contribute</h3>
-      <ul style={{fontSize:'0.9rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
         <li>GitHub: <a href="https://github.com/finos/architecture-as-code">finos/architecture-as-code</a></li>
         <li>Raise issues &amp; feature requests</li>
         <li>Open PRs — docs, code, examples</li>
@@ -16,7 +16,7 @@
     </div>
     <div style={{background:'#e3f2fd', borderRadius:'8px', padding:'1.3rem 1.5rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.1rem'}}>💬 Connect</h3>
-      <ul style={{fontSize:'0.9rem', lineHeight:'1.9'}}>
+      <ul style={{fontSize:'1.0rem', lineHeight:'1.9'}}>
         <li>Slack: <a href="https://finos-lf.slack.com">finos-lf.slack.com</a> — #calm channel</li>
         <li>Community &amp; WG calls (agenda on GitHub)</li>
         <li><a href="https://calm.finos.org">calm.finos.org</a> — full documentation</li>
@@ -38,24 +38,24 @@
   <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'1rem', marginBottom:'0.8rem'}}>
     <div style={{background:'#e8f5e9', border:'2px solid #2e7d32', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#1b5e20'}}>🟢 Beginner</h3>
-      <p style={{fontSize:'0.88rem', margin:'0.3rem 0 0.5rem', color:'#333'}}>
+      <p style={{fontSize:'1.0rem', margin:'0.3rem 0 0.5rem', color:'#333'}}>
         Install the CLI, model your first node and relationship, then validate against a pattern.
       </p>
-      <p style={{fontSize:'0.82rem', margin:0, color:'#555'}}>
+      <p style={{fontSize:'0.92rem', margin:0, color:'#555'}}>
         <code>npm install -g @finos/calm-cli</code> &nbsp;·&nbsp; <a href="https://calm.finos.org">calm.finos.org tutorials</a>
       </p>
     </div>
     <div style={{background:'#fff8e1', border:'2px solid #f57f17', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#e65100'}}>🟡 Intermediate</h3>
-      <p style={{fontSize:'0.88rem', margin:0, color:'#555'}}>Tools are set up — work with patterns, customizations &amp; standards, and run <code>calm docify</code> on a richer architecture.</p>
+      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>Tools are set up — work with patterns, customizations &amp; standards, and run <code>calm docify</code> on a richer architecture.</p>
     </div>
     <div style={{background:'#fce4ec', border:'2px solid #880e4f', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#880e4f'}}>🔴 Practitioner</h3>
-      <p style={{fontSize:'0.88rem', margin:0, color:'#555'}}>Step into the shoes of an architect — use CALM's AI tools to model a real architecture from scratch, guided by the AI agent.</p>
+      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>Step into the shoes of an architect — use CALM's AI tools to model a real architecture from scratch, guided by the AI agent.</p>
     </div>
     <div style={{background:'#ede7f6', border:'2px solid #4527a0', borderRadius:'8px', padding:'1rem 1.2rem'}}>
       <h3 style={{marginTop:0, fontSize:'1.05rem', color:'#4527a0'}}>🟣 Advanced</h3>
-      <p style={{fontSize:'0.88rem', margin:0, color:'#555'}}>The QCon demo — five scenarios end-to-end. <strong>Requires Minikube.</strong> Deploy a CALM-driven platform, add controls, and run autonomous agents.</p>
+      <p style={{fontSize:'1.0rem', margin:0, color:'#555'}}>The QCon demo — five scenarios end-to-end. <strong>Requires Minikube.</strong> Deploy a CALM-driven platform, add controls, and run autonomous agents.</p>
     </div>
   </div>
   <aside className="notes">
@@ -78,7 +78,7 @@
     <p style={{margin:0, fontSize:'1.1rem', color:'#555'}}>
       Architecture as Code — consistent, automated, controlled.
     </p>
-    <div style={{display:'flex', gap:'2rem', marginTop:'0.5rem', fontSize:'0.9rem', color:'#777'}}>
+    <div style={{display:'flex', gap:'2rem', marginTop:'0.5rem', fontSize:'1.0rem', color:'#777'}}>
       <span>🌐 calm.finos.org</span>
       <span>⭐ github.com/finos/architecture-as-code</span>
     </div>

--- a/docs/docs/tutorials/calm-overview-presentation.md
+++ b/docs/docs/tutorials/calm-overview-presentation.md
@@ -51,15 +51,15 @@ A guided introduction to the Common Architecture Language Model — what it is, 
 | 9 | Part 2 divider — Building Blocks | — |
 | 10–14 | Building blocks (nodes ×2, relationships ×2, interfaces) | 8 min |
 | 15 | Part 3 divider — Governance | — |
-| 16–23 | Governance (controls ×2, customizations, decorators, patterns ×3, disambiguation) | 10 min |
-| 24 | Part 4 divider — Process & Evolution | — |
-| 25–27 | Process & evolution (flows ×2, timelines) | 5 min |
-| 28 | Part 5 divider — Tooling | — |
-| 29–35 | Tooling (CLI, VSCode ×2, Hub ×2, widgets, AI tools) | 6 min |
-| 36 | Part 6 divider — CALM in Practice | — |
-| 37–38 | CALM in practice (deployments, gating) | 5 min |
-| 39 | Part 7 divider — Putting It Together | — |
-| 40–42 | Trading system example (architecture, what's modelled, workflow) | 4 min |
-| 43 | Getting Involved (open source, Slack, community) | 1 min |
-| 44 | Workshop (Beginner / Intermediate / Practitioner / Advanced) | 1 min |
-| 45 | Close | — |
+| 16–24 | Governance (controls ×2, custom properties, standards, decorators, patterns ×3, disambiguation) | 10 min |
+| 25 | Part 4 divider — Process & Evolution | — |
+| 26–28 | Process & evolution (flows ×2, timelines) | 5 min |
+| 29 | Part 5 divider — Tooling | — |
+| 30–36 | Tooling (CLI, VSCode ×2, Hub ×2, widgets, AI tools) | 6 min |
+| 37 | Part 6 divider — CALM in Practice | — |
+| 38–39 | CALM in practice (deployments, gating) | 5 min |
+| 40 | Part 7 divider — Putting It Together | — |
+| 41–43 | Trading system example (architecture, what's modelled, workflow) | 4 min |
+| 44 | Getting Involved (open source, Slack, community) | 1 min |
+| 45 | Workshop (Beginner / Intermediate / Practitioner / Advanced) | 1 min |
+| 46 | Close | — |

--- a/docs/src/components/RevealPresentation/styles.module.css
+++ b/docs/src/components/RevealPresentation/styles.module.css
@@ -125,7 +125,7 @@
    Inline font sizes on prose override this; code blocks carry no inline size,
    so this is the only lever for them. */
 .revealContainer :global(.reveal pre code) {
-  font-size: 0.92rem;
+  font-size: 1.65rem;
   line-height: 1.5;
 }
 

--- a/docs/src/components/RevealPresentation/styles.module.css
+++ b/docs/src/components/RevealPresentation/styles.module.css
@@ -121,6 +121,14 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.4);
 }
 
+/* Ensure code text is readable when projected.
+   Inline font sizes on prose override this; code blocks carry no inline size,
+   so this is the only lever for them. */
+.revealContainer :global(.reveal pre code) {
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
 /* Two-column layout helper used in some slides.
    Increased gap from 1.2rem → 2.5rem for clear visual column separation.
    min-width: 0 on children prevents grid cells from overflowing their 1fr


### PR DESCRIPTION
## Description

Addresses feedback collected after the first delivery of the **"CALM in 40 mins"** reveal.js presentation embedded in the Docusaurus docs. Changes are purely to the 8 MDX part files under `docs/docs/tutorials/_calm-overview/` and the `RevealPresentation` CSS module.

**Content fixes:**
- Remove `(Part 3)` / `(Part 4)` cross-reference annotations from document-type cards (slide 8)
- Add NFR-equivalence framing: "Controls are how CALM expresses Non-Functional Requirements — as machine-checkable rules" (slide 16)
- Rename control key `permitted-connection` → `security`; update description to convey security-domain keying pattern (slide 17)
- Replace `metadata` array example with direct node custom property (`cost-center: "CC-1042"`); update Standards JSON Schema to use `required`/`properties` (slide 18)
- Rename slide title to "TraderX Example Architecture" (slide 40)
- Enlarge VSCode and CALM Hub screenshot images (slides 30, 32)

**SVG workflow diagram fixes:**
- Fix arrow labels: `create` (C4→Pattern), `calm generate` (Pattern→Architecture), `calm hub push` (Architecture→Hub)
- Eliminate label/arrow line overlap by positioning labels above the arrow
- Increase SVG font sizes for projected legibility; expand deployment-gate diagram viewBox

**Font legibility floor:**
- Lift all inline `fontSize` values across 8 MDX parts: sub-0.85rem → 0.92rem; 0.85–0.9rem → 0.95–1.0rem
- Add `0.92rem` floor on `pre code` blocks in `styles.module.css`

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] Documentation (`docs/`)

## Commit Message Format ✅

- `docs(presentation): apply post-first-run feedback to CALM in 40 mins deck`
- `docs(presentation): fix workflow diagram labels and cost-center spelling`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests — N/A (presentation content only)
- [x] All existing tests pass — no TypeScript/Java changes

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes — N/A
- [x] My changes follow the project's coding standards