### PR TITLE
fix(calm-hub-ui): keep parent namespace open when collapsing a child

### DIFF
--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
@@ -111,6 +111,29 @@ const mockProps = {
     onInterfaceLoad: vi.fn()
 };
 
+// Override the next CalmService instance so fetchNamespaces returns a specific set;
+// all other methods resolve empty so the tree renders without further fetches.
+function mockCalmServiceWithNamespaces(namespaces: string[]) {
+    vi.mocked(CalmService).mockImplementationOnce(function () { return {
+        fetchNamespaces: vi.fn().mockResolvedValue(namespaces),
+        fetchPatternSummaries: vi.fn().mockResolvedValue([]),
+        fetchFlowSummaries: vi.fn().mockResolvedValue([]),
+        fetchStandardSummaries: vi.fn().mockResolvedValue([]),
+        fetchArchitectureSummaries: vi.fn().mockResolvedValue([]),
+        fetchPatternVersions: vi.fn().mockResolvedValue([]),
+        fetchFlowVersions: vi.fn().mockResolvedValue([]),
+        fetchStandardVersions: vi.fn().mockResolvedValue([]),
+        fetchArchitectureVersions: vi.fn().mockResolvedValue([]),
+        fetchPattern: vi.fn().mockResolvedValue({}),
+        fetchFlow: vi.fn().mockResolvedValue({}),
+        fetchStandard: vi.fn().mockResolvedValue({}),
+        fetchArchitecture: vi.fn().mockResolvedValue({}),
+        fetchMappings: vi.fn().mockResolvedValue([]),
+        fetchVersionsByCustomId: vi.fn().mockResolvedValue([]),
+        fetchResourceByCustomId: vi.fn().mockResolvedValue({}),
+    }; } as unknown as InstanceType<typeof CalmService>);
+}
+
 describe('TreeNavigation', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -333,6 +356,50 @@ describe('TreeNavigation', () => {
         await waitFor(() => {
             expect(navigate).toHaveBeenCalledWith('/test-namespace/architectures/201/2.0.0');
         });
+    });
+
+    it('keeps the parent namespace open when a child sub-namespace is collapsed', async () => {
+        vi.mocked(useParams).mockReturnValue({});
+        // 'a' is a real namespace that also contains the sub-namespaces 'a.b' and 'a.c'
+        mockCalmServiceWithNamespaces(['a', 'a.b', 'a.c']);
+
+        render(<MemoryRouter initialEntries={['/']}>
+            <TreeNavigation {...mockProps} />
+        </MemoryRouter>);
+
+        // Open the parent namespace 'a'
+        fireEvent.click(await screen.findByText('a'));
+
+        // Its sub-namespaces are now visible
+        await screen.findByText('a.b');
+        expect(screen.getByText('a.c')).toBeInTheDocument();
+
+        // Open then collapse the child sub-namespace 'a.b'
+        fireEvent.click(screen.getByText('a.b'));
+        fireEvent.click(screen.getByText('a.b'));
+
+        // Collapsing the child must NOT collapse the parent — its other child is still shown
+        expect(screen.getByText('a.c')).toBeInTheDocument();
+    });
+
+    it('collapses a deselected childless namespace instead of leaving an empty expander', async () => {
+        vi.mocked(useParams).mockReturnValue({});
+        mockCalmServiceWithNamespaces(['a', 'a.b', 'a.c']);
+
+        render(<MemoryRouter initialEntries={['/']}>
+            <TreeNavigation {...mockProps} />
+        </MemoryRouter>);
+
+        // Open parent 'a', then select the childless sub-namespace 'a.b'
+        fireEvent.click(await screen.findByText('a'));
+        fireEvent.click(await screen.findByText('a.b'));
+        expect(screen.getByText('a.b').closest('details')).toHaveAttribute('open');
+
+        // Select sibling 'a.c' — 'a.b' is deselected and has no children, so it collapses
+        fireEvent.click(screen.getByText('a.c'));
+        expect(screen.getByText('a.b').closest('details')).not.toHaveAttribute('open');
+        // Parent 'a' has children, so it stays open and both children remain visible
+        expect(screen.getByText('a.c')).toBeInTheDocument();
     });
 
     it('clears the selected type and resource list when authStore emits a 403', async () => {

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -220,23 +220,32 @@ function NamespaceItem({
     const resourceTypes = ['Architectures', 'Patterns', 'Flows', 'Standards', 'ADRs', 'Interfaces'];
     const isThisSelected = node.namespace !== null && node.namespace === selectedNamespace;
     const hasSelectedDescendant = selectedNamespace.startsWith(node.label + '.');
+    const hasChildren = node.children.length > 0;
+    const shouldAutoOpen = isThisSelected || hasSelectedDescendant;
 
-    // Grouping nodes (no real namespace) track their own open state so users can toggle them
-    const [groupingOpen, setGroupingOpen] = useState(hasSelectedDescendant);
+    // Every node (real namespace or grouping-only) tracks its own expanded state. Selection
+    // expands it (one-directional, never auto-collapses) so deep-links and ancestor expansion
+    // work, while collapsing a child no longer forces its ancestors closed.
+    const [expanded, setExpanded] = useState(shouldAutoOpen);
     useEffect(() => {
-        if (hasSelectedDescendant) setGroupingOpen(true);
-    }, [hasSelectedDescendant]);
+        if (shouldAutoOpen) setExpanded(true);
+    }, [shouldAutoOpen]);
 
-    const isOpen = node.namespace !== null
-        ? (isThisSelected || hasSelectedDescendant)
-        : groupingOpen;
+    // An expanded node only has something to render when it is selected (its resource types)
+    // or it has child namespaces. Keeping a childless, deselected node expanded would draw an
+    // empty expander, so it appears collapsed.
+    const isOpen = expanded && (isThisSelected || hasChildren);
 
     const handleSummaryClick = (e: React.MouseEvent) => {
         e.preventDefault();
         if (node.namespace) {
+            // Clicking a real namespace toggles its selection. Selecting it always expands it;
+            // deselecting it (clicking it while selected) collapses just this node.
+            const willSelect = node.namespace !== selectedNamespace;
             onNamespaceClick(node.namespace);
+            setExpanded(willSelect);
         } else {
-            setGroupingOpen((prev) => !prev);
+            setExpanded((prev) => !prev);
         }
     };
 


### PR DESCRIPTION
## Description

Fixes #2727 — in the CALM Hub UI namespace tree, collapsing a sub-namespace collapsed the **entire** parent tree instead of just that one node.

A real namespace node derived its open state purely from the current selection (`isThisSelected || hasSelectedDescendant`). Collapsing a child calls `handleNamespaceClick`, which clears `selectedNamespace`, so every ancestor lost `hasSelectedDescendant` and collapsed too.

**Fix:** every tree node now tracks its own `expanded` state. Selection only ever *opens* a node (one-directional, never auto-collapses), so deep-links and ancestor expansion still work, but collapsing a child no longer forces its ancestors closed. Clicking a real namespace toggles its own expansion explicitly. A node renders open only when it is selected or has child namespaces, so a deselected childless node never leaves an empty expander.

### Behaviour

Steps: expand `repro-2727`, expand `repro-2727.sub-a`, then click `repro-2727.sub-a` again to collapse it.

| Before (bug): whole tree collapses | After (fix): only `sub-a` collapses |
|---|---|
| ![before](https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/issue-2727-tree-collapse-screenshots/issue-2727-after.png) | ![after](https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/issue-2727-tree-collapse-screenshots/issue-2727-fix-after.png) |

### Notes for reviewers

- **Deliberate behaviour change:** a namespace you expanded now stays expanded until you explicitly collapse it (e.g. selecting a sibling no longer auto-collapses a previously-opened namespace). This is standard file-tree behaviour and a direct consequence of "selection opens, never auto-closes".
- **Desktop tree only.** Mobile uses the separate `MobileNavMenu` drill-down, which does not share this logic and is unaffected. Verified at both viewports.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added two `TreeNavigation` tests: collapsing a child sub-namespace keeps the real-namespace parent open, and a deselected childless namespace collapses rather than leaving an empty expander. Verified live against a local CALM Hub with nested namespaces in both hierarchical and flat views. `npm run lint` (0 errors), `npm test` (956 pass), and `npm run build` for `calm-hub-ui` all pass.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
