### PR TITLE
chore(calm-hub): curate read-only seed data for hosted CALM Hub demo

### DIFF
--- a/calm-hub/build-readonly-image.sh
+++ b/calm-hub/build-readonly-image.sh
@@ -15,6 +15,8 @@
 #   --no-docker    Run steps 1 and 2 only; skip the docker build step.
 #                  CI uses this flag and performs its own multi-arch buildx push.
 #   --no-maven     Skip the Maven build (assumes target/quarkus-app/ already exists).
+#   --smoke        After the docker build, run the readonly smoke test (start container,
+#                  run smoke-test.sh readonly, stop container).  Mirrors what CI does.
 #   --help         Show this message.
 #
 # IMAGE_TAG:
@@ -33,11 +35,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 IMAGE_TAG="calm-hub:read-only-static"
 RUN_DOCKER=true
 RUN_MAVEN=true
+RUN_SMOKE=false
 
 for arg in "$@"; do
     case "${arg}" in
         --no-docker) RUN_DOCKER=false ;;
         --no-maven)  RUN_MAVEN=false  ;;
+        --smoke)     RUN_SMOKE=true   ;;
         --help)
             sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | grep '^#' | sed 's/^# \{0,1\}//'
             exit 0
@@ -74,4 +78,27 @@ if [[ "${RUN_DOCKER}" == true ]]; then
     echo ""
     echo "[build] Done. Run the image with:"
     echo "  docker run --rm -p 8080:8080 ${IMAGE_TAG}"
+fi
+
+# ── Step 4: Smoke test (optional, --smoke flag) ────────────────────────────────
+if [[ "${RUN_SMOKE}" == true ]]; then
+    if [[ "${RUN_DOCKER}" != true ]]; then
+        echo "[build] WARNING: --smoke requires a docker build; skipping smoke test." >&2
+    else
+        SMOKE_PORT=18080
+        SMOKE_CONTAINER="calm-hub-readonly-smoke-$$"
+        cleanup_smoke() { docker stop "${SMOKE_CONTAINER}" > /dev/null 2>&1 || true; }
+        trap cleanup_smoke EXIT
+
+        echo "[build] Starting smoke container on port ${SMOKE_PORT}..."
+        docker run --rm -d -p "${SMOKE_PORT}:8080" --name "${SMOKE_CONTAINER}" "${IMAGE_TAG}"
+
+        echo "[build] Running readonly smoke test..."
+        bash "${SCRIPT_DIR}/smoke-test.sh" "http://localhost:${SMOKE_PORT}" readonly
+
+        echo "[build] Stopping smoke container..."
+        docker stop "${SMOKE_CONTAINER}" > /dev/null 2>&1 || true
+        trap - EXIT
+        echo "[build] Smoke test passed."
+    fi
 fi

--- a/calm-hub/nitrite/init-nitrite.sh
+++ b/calm-hub/nitrite/init-nitrite.sh
@@ -121,27 +121,33 @@ load_schemas_from_dir() {
     done
 }
 
+# Resolve CALM_SCHEMA_BASE_PATH once (falling back to the calm/ dir beside this
+# script when unset) so every schema-reading function — create_core_schemas,
+# create_standards, create_interfaces — sees the same path.  Without this a bare
+# `bash init-nitrite.sh` (no env var) leaves the var empty, which causes those
+# functions to build absolute paths from '/' that don't exist and silently
+# [WARN]-skip content.  seed-readonly.sh always exports CALM_SCHEMA_BASE_PATH,
+# so the Docker build masks the issue; this fix makes the bare run equally safe.
+resolve_schema_base_path() {
+    if [[ -z "$CALM_SCHEMA_BASE_PATH" ]]; then
+        local script_dir
+        script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+        CALM_SCHEMA_BASE_PATH=$(realpath "$script_dir/../../calm" 2>/dev/null || echo "")
+    fi
+}
+
 # Function to create core schemas
 create_core_schemas() {
     print_status "Creating core schemas..."
 
-    local base_path="$CALM_SCHEMA_BASE_PATH"
-
-    if [[ -z "$base_path" ]]; then
-        # Try to find the calm directory relative to this script's location
-        local script_dir
-        script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-        base_path=$(realpath "$script_dir/../../calm" 2>/dev/null || echo "")
-    fi
-
-    if [[ -z "$base_path" || ! -d "$base_path" ]]; then
+    if [[ -z "$CALM_SCHEMA_BASE_PATH" || ! -d "$CALM_SCHEMA_BASE_PATH" ]]; then
         print_error "CALM schema base path not found. Set CALM_SCHEMA_BASE_PATH to the calm/ directory."
         return 1
     fi
 
-    print_status "Loading schemas from: $base_path"
-    load_schemas_from_dir "${base_path}/release" "release"
-    load_schemas_from_dir "${base_path}/draft" "draft"
+    print_status "Loading schemas from: $CALM_SCHEMA_BASE_PATH"
+    load_schemas_from_dir "${CALM_SCHEMA_BASE_PATH}/release" "release"
+    load_schemas_from_dir "${CALM_SCHEMA_BASE_PATH}/draft" "draft"
 }
 
 # Function to POST a CALM document using the request envelope expected by the API.
@@ -223,9 +229,8 @@ post_architecture_version() {
 }
 
 # POST an additional version of an existing pattern (mutable version store).
-# Unlike the architecture version endpoint (which takes a name/description/architectureJson
-# envelope), the pattern version endpoint consumes the raw pattern document as the request
-# body, so the document JSON is sent directly.
+# PatternResource.createVersionedPattern requires a {name, description, patternJson}
+# envelope — the document JSON must be stringified into patternJson, not sent raw.
 # Usage: post_pattern_version <namespace> <pattern-id> <version> <name> <description> <document-json>
 post_pattern_version() {
     local namespace="$1"
@@ -235,11 +240,18 @@ post_pattern_version() {
     local description="$5"
     local doc="$6"
 
+    local payload
+    payload=$(jq -n \
+        --arg n "$name" \
+        --arg d "$description" \
+        --argjson doc "$doc" \
+        '{name: $n, description: $d, patternJson: ($doc | tojson)}')
+
     local http_code
     http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         "$CALM_HUB_URL/api/calm/namespaces/$namespace/patterns/$pattern_id/versions/$version" \
         -H "$CONTENT_TYPE" \
-        -d "$doc")
+        -d "$payload")
 
     if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
         print_status "Created pattern '$name' version $version in namespace $namespace"
@@ -3072,32 +3084,10 @@ create_timeline_demo() {
     local pattern_id
     pattern_id=$(get_resource_id_by_name "workshop" "patterns" "Demo Pattern (implied timeline)")
     if [[ -n "$pattern_id" ]]; then
-        # Post extra pattern versions with the {name, description, patternJson}
-        # envelope (the shared post_pattern_version helper still sends the raw
-        # doc, which the current endpoint rejects with 400 — see calm-hub
-        # PatternResource.createVersionedPattern).
-        post_demo_pattern_version() {
-            local version="$1" desc="$2" doc="$3"
-            local payload
-            payload=$(jq -n \
-                --arg n "Demo Pattern (implied timeline)" \
-                --arg d "$desc" \
-                --argjson doc "$doc" \
-                '{name: $n, description: $d, patternJson: ($doc | tojson)}')
-            local code
-            code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-                "$CALM_HUB_URL/api/calm/namespaces/workshop/patterns/$pattern_id/versions/$version" \
-                -H "$CONTENT_TYPE" -d "$payload")
-            if [[ "$code" == "200" || "$code" == "201" ]]; then
-                print_status "Created Demo Pattern version $version in workshop"
-            elif [[ "$code" == "409" ]]; then
-                print_warning "Demo Pattern version $version already exists, skipping"
-            else
-                print_warning "Failed to create Demo Pattern version $version (HTTP $code)"
-            fi
-        }
-        post_demo_pattern_version "1.1.0" "Added downstream service node." "$pattern_v2"
-        post_demo_pattern_version "2.0.0" "Added gateway→service interacts relationship." "$pattern_v3"
+        post_pattern_version "workshop" "$pattern_id" "1.1.0" \
+            "Demo Pattern (implied timeline)" "Added downstream service node." "$pattern_v2"
+        post_pattern_version "workshop" "$pattern_id" "2.0.0" \
+            "Demo Pattern (implied timeline)" "Added gateway→service interacts relationship." "$pattern_v3"
     else
         print_warning "Could not resolve Demo Pattern id; skipping additional versions"
     fi
@@ -3111,6 +3101,7 @@ main() {
     check_calmhub_status
 
     # Initialize data in order
+    resolve_schema_base_path
     create_namespaces
     create_core_schemas
     create_domains_and_controls

--- a/calm-hub/nitrite/init-nitrite.sh
+++ b/calm-hub/nitrite/init-nitrite.sh
@@ -49,7 +49,7 @@ create_namespaces() {
     print_status "Creating namespaces..."
     
     # Create required namespaces (the API requires both a name and a description)
-    for namespace in finos workshop traderx ai-governance-v2 timeline-demo; do
+    for namespace in finos finos.calm finos.traderx workshop; do
         print_status "Creating namespace: $namespace"
         local http_code
         http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$CALM_HUB_URL/api/calm/namespaces" \
@@ -504,7 +504,7 @@ create_patterns() {
         }
 CALMDOC
 )
-    post_document "finos" "patterns" "patternJson" "API Gateway Pattern" "API Gateway pattern for verifying authorization and access to downstream systems" "$doc"
+    post_document "workshop" "patterns" "patternJson" "API Gateway Pattern" "API Gateway pattern for verifying authorization and access to downstream systems" "$doc"
 
     # Workshop Conference Signup Pattern (Pattern 1) - Exact MongoDB content
     print_status "Creating Workshop Conference Signup Pattern..."
@@ -1311,34 +1311,6 @@ CALMDOC
 create_flows() {
     print_status "Creating flows..."
     
-    # FINOS Flow 1
-    print_status "Creating FINOS flow 1..."
-    local doc
-    doc=$(cat <<'CALMDOC'
-{
-            "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
-            "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow/flow-1",
-            "title": "Flow 1",
-            "description": "This is a non-compliant flow document. Just creating something to simulate"
-        }
-CALMDOC
-)
-    post_document "finos" "flows" "flowJson" "Flow 1" "This is a non-compliant flow document. Just creating something to simulate" "$doc"
-
-    # FINOS Flow 2
-    print_status "Creating FINOS flow 2..."
-    local doc
-    doc=$(cat <<'CALMDOC'
-{
-            "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
-            "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow/flow-2",
-            "title": "Flow 2",
-            "description": "This is a non-compliant flow document. Just creating something to simulate"
-        }
-CALMDOC
-)
-    post_document "finos" "flows" "flowJson" "Flow 2" "This is a non-compliant flow document. Just creating something to simulate" "$doc"
-
     # TraderX Flow 1 - Add or Update Account
     print_status "Creating TraderX flow 1..."
     local doc
@@ -1381,7 +1353,7 @@ CALMDOC
         }
 CALMDOC
 )
-    post_document "traderx" "flows" "flowJson" "Add or Update Account" "Flow for adding or updating account information in the database." "$doc"
+    post_document "finos.traderx" "flows" "flowJson" "Add or Update Account" "Flow for adding or updating account information in the database." "$doc"
 
     # TraderX Flow 2 - Load List of Accounts
     print_status "Creating TraderX flow 2..."
@@ -1420,27 +1392,13 @@ CALMDOC
         }
 CALMDOC
 )
-    post_document "traderx" "flows" "flowJson" "Load List of Accounts" "Flow for loading a list of accounts from the database to populate the GUI drop-down for user account selection." "$doc"
+    post_document "finos.traderx" "flows" "flowJson" "Load List of Accounts" "Flow for loading a list of accounts from the database to populate the GUI drop-down for user account selection." "$doc"
 }
 
 # Function to create architectures
 create_architectures() {
     print_status "Creating architectures..."
     
-    # FINOS Architecture
-    print_status "Creating FINOS architecture..."
-    local doc
-    doc=$(cat <<'CALMDOC'
-{
-            "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
-            "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/arch-1",
-            "title": "Architecture 1",
-            "description": "This is a non-compliant arch document. Just creating something to simulate"
-        }
-CALMDOC
-)
-    post_document "finos" "architectures" "architectureJson" "Architecture 1" "This is a non-compliant arch document. Just creating something to simulate" "$doc"
-
     # Workshop Architecture
     print_status "Creating Workshop architecture..."
     local doc
@@ -2152,7 +2110,7 @@ CALMDOC
         }
 CALMDOC
 )
-    post_document "traderx" "architectures" "architectureJson" "TraderX Architecture" "TraderX simple trading system architecture" "$doc"
+    post_document "finos.traderx" "architectures" "architectureJson" "TraderX Architecture" "TraderX simple trading system architecture" "$doc"
 }
 
 # Function to create user access (if endpoint exists)
@@ -2160,7 +2118,7 @@ create_user_access() {
     print_status "Creating user access entries..."
     
     # Create sample user access for different namespaces
-    for namespace in finos workshop traderx ai-governance-v2; do
+    for namespace in finos finos.calm finos.traderx workshop; do
         print_status "Creating user access for namespace: $namespace"
         curl -s -X POST "$CALM_HUB_URL/api/calm/namespaces/$namespace/user-access" \
             -H "$CONTENT_TYPE" \
@@ -2173,19 +2131,71 @@ create_user_access() {
     done
 }
 
-# Function to create standards (if implemented)
+# Function to create standards
 create_standards() {
     print_status "Creating standards..."
-    
-    # Create a sample NIST standard
-    print_status "Creating NIST standard..."
-    curl -s -X POST "$CALM_HUB_URL/api/calm/namespaces/finos/standards" \
-        -H "$CONTENT_TYPE" \
-        -d '{
-            "name": "NIST Cybersecurity Framework",
-            "description": "NIST Cybersecurity Framework standard",
-            "standardJson": "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"NIST Cybersecurity Framework\",\"type\":\"object\",\"properties\":{\"identify\":{\"type\":\"object\",\"description\":\"Identify function\"},\"protect\":{\"type\":\"object\",\"description\":\"Protect function\"}}}"
-        }' || print_warning "Failed to create NIST standard"
+
+    # Create the CALM Deployment Decorator Standard in finos.calm
+    local f="${CALM_SCHEMA_BASE_PATH}/draft/2026-03/standards/deployment/deployment.decorator.standard.json"
+    if [[ -f "$f" ]]; then
+        local doc payload
+        doc=$(cat "$f")
+        payload=$(jq -n \
+            --arg name "CALM Deployment Decorator Standard" \
+            --arg description "Deployment decorator standard for architectures" \
+            --argjson doc "$doc" \
+            '{name: $name, description: $description, standardJson: ($doc | tojson)}')
+        local http_code
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            "$CALM_HUB_URL/api/calm/namespaces/finos.calm/standards" \
+            -H "$CONTENT_TYPE" -d "$payload")
+        if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+            print_status "Created deployment standard in finos.calm"
+        elif [[ "$http_code" == "409" ]]; then
+            print_warning "Deployment standard already exists, skipping"
+        else
+            print_warning "Failed to create deployment standard (HTTP $http_code)"
+        fi
+    else
+        print_warning "Deployment standard not found at $f"
+    fi
+}
+
+# Function to seed CALM interface examples into finos.calm
+create_interfaces() {
+    print_status "Creating interfaces in finos.calm..."
+
+    local interfaces_dir="${CALM_SCHEMA_BASE_PATH}/interfaces/example"
+    if [[ ! -d "$interfaces_dir" ]]; then
+        print_warning "Interfaces example directory not found at $interfaces_dir, skipping"
+        return
+    fi
+
+    for f in "$interfaces_dir"/*.json; do
+        [[ -f "$f" ]] || continue
+        local name doc payload http_code
+        # Derive name from the .title field; fall back to the basename without extension
+        name=$(jq -r '.title // empty' "$f")
+        if [[ -z "$name" ]]; then
+            name=$(basename "$f" .json)
+        fi
+        doc=$(cat "$f")
+        payload=$(jq -n \
+            --arg name "$name" \
+            --arg description "CALM interface example: $name" \
+            --argjson doc "$doc" \
+            '{name: $name, description: $description, interfaceJson: ($doc | tojson)}')
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            "$CALM_HUB_URL/api/calm/namespaces/finos.calm/interfaces" \
+            -H "$CONTENT_TYPE" -d "$payload")
+        if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+            print_status "Created interface '$name' in finos.calm"
+        elif [[ "$http_code" == "409" ]]; then
+            print_warning "Interface '$name' already exists, skipping"
+        else
+            print_warning "Failed to create interface '$name' (HTTP $http_code)"
+        fi
+    done
 }
 
 # Map of ai-governance control IDs (as referenced in source documents) to the IDs
@@ -2220,17 +2230,24 @@ create_domains_and_controls() {
         local domain
         domain=$(basename "$domain_dir")
 
-        print_status "Creating domain: $domain"
+        # Skip the security domain
+        [[ "$domain" == "security" ]] && continue
+
+        # Rename ai-governance → finos-ai-governance (domain regex forbids dots)
+        local api_domain="$domain"
+        [[ "$domain" == "ai-governance" ]] && api_domain="finos-ai-governance"
+
+        print_status "Creating domain: $api_domain"
         local domain_code
         domain_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$CALM_HUB_URL/api/calm/domains" \
             -H "$CONTENT_TYPE" \
-            -d "{\"name\": \"$domain\"}")
+            -d "{\"name\": \"$api_domain\"}")
         if [[ "$domain_code" == "200" || "$domain_code" == "201" ]]; then
-            print_status "Created domain $domain"
+            print_status "Created domain $api_domain"
         elif [[ "$domain_code" == "409" ]]; then
-            print_warning "Domain $domain already exists, skipping"
+            print_warning "Domain $api_domain already exists, skipping"
         else
-            print_warning "Failed to create domain $domain (HTTP $domain_code)"
+            print_warning "Failed to create domain $api_domain (HTTP $domain_code)"
         fi
 
         # Create controls in ascending controlId order so assignment is deterministic.
@@ -2250,19 +2267,19 @@ create_domains_and_controls() {
                 '{name: $name, description: $description, requirementJson: $requirementJson}')
 
             local location new_id
-            location=$(curl -s -D - -o /dev/null -X POST "$CALM_HUB_URL/api/calm/domains/$domain/controls" \
+            location=$(curl -s -D - -o /dev/null -X POST "$CALM_HUB_URL/api/calm/domains/$api_domain/controls" \
                 -H "$CONTENT_TYPE" \
                 -d "$payload" | grep -i '^location:' | tr -d '\r')
             new_id=$(echo "$location" | sed -E 's#.*/controls/([0-9]+).*#\1#')
 
             if [[ -n "$new_id" && "$new_id" =~ ^[0-9]+$ ]]; then
-                print_status "Created control '$name' in domain $domain (id $new_id)"
+                print_status "Created control '$name' in domain $api_domain (id $new_id)"
                 if [[ "$domain" == "ai-governance" ]]; then
                     AI_GOVERNANCE_CONTROL_MAP=$(echo "$AI_GOVERNANCE_CONTROL_MAP" \
                         | jq --arg k "$orig_id" --arg v "$new_id" '. + {($k): $v}')
                 fi
             else
-                print_warning "Failed to create control '$name' in domain $domain"
+                print_warning "Failed to create control '$name' in domain $api_domain"
             fi
         done < <(find "$domain_dir" -maxdepth 1 -name '*.json' | sort)
     done
@@ -2741,7 +2758,7 @@ CALMDOC
 
 # Main execution
 create_timeline_demo() {
-    print_status "Creating timeline-demo architectures + explicit timeline..."
+    print_status "Creating workshop timeline demo architectures + explicit timeline..."
 
     # --- Payments Service (implied timeline) ---------------------------------
     # No stored timeline; the timeline bar projects one from the version list.
@@ -2788,17 +2805,17 @@ create_timeline_demo() {
         ]
     }'
 
-    post_document "timeline-demo" "architectures" "architectureJson" \
+    post_document "workshop" "architectures" "architectureJson" \
         "Payments Service (implied timeline)" \
         "Demo architecture with no curated timeline — the bar projects one from the version list." \
         "$payments_v1"
 
     local payments_id
-    payments_id=$(get_resource_id_by_name "timeline-demo" "architectures" "Payments Service (implied timeline)")
+    payments_id=$(get_resource_id_by_name "workshop" "architectures" "Payments Service (implied timeline)")
     if [[ -n "$payments_id" ]]; then
-        post_architecture_version "timeline-demo" "$payments_id" "1.1.0" \
+        post_architecture_version "workshop" "$payments_id" "1.1.0" \
             "Payments Service (implied timeline)" "Added idempotency cache." "$payments_v2"
-        post_architecture_version "timeline-demo" "$payments_id" "1.2.0" \
+        post_architecture_version "workshop" "$payments_id" "1.2.0" \
             "Payments Service (implied timeline)" "Added async settlement worker." "$payments_v3"
     else
         print_warning "Could not resolve Payments Service id; skipping additional versions"
@@ -2871,23 +2888,23 @@ create_timeline_demo() {
         ]
     }'
 
-    post_document "timeline-demo" "architectures" "architectureJson" \
+    post_document "workshop" "architectures" "architectureJson" \
         "Trading Platform (explicit timeline)" \
         "Demo architecture with a curated timeline. Has four versions; the explicit timeline marks the third as current." \
         "$trading_v1"
 
     local trading_id
-    trading_id=$(get_resource_id_by_name "timeline-demo" "architectures" "Trading Platform (explicit timeline)")
+    trading_id=$(get_resource_id_by_name "workshop" "architectures" "Trading Platform (explicit timeline)")
     if [[ -z "$trading_id" ]]; then
         print_warning "Could not resolve Trading Platform id; skipping additional versions + timeline"
         return
     fi
 
-    post_architecture_version "timeline-demo" "$trading_id" "1.1.0" \
+    post_architecture_version "workshop" "$trading_id" "1.1.0" \
         "Trading Platform (explicit timeline)" "Added centralised order book." "$trading_v2"
-    post_architecture_version "timeline-demo" "$trading_id" "2.0.0" \
+    post_architecture_version "workshop" "$trading_id" "2.0.0" \
         "Trading Platform (explicit timeline)" "Added pre-trade risk engine." "$trading_v3"
-    post_architecture_version "timeline-demo" "$trading_id" "3.0.0" \
+    post_architecture_version "workshop" "$trading_id" "3.0.0" \
         "Trading Platform (explicit timeline)" "Added post-trade settlement." "$trading_v4"
 
     # Explicit stored timeline: 4 curated moments referencing the 4 versions
@@ -2902,19 +2919,19 @@ create_timeline_demo() {
         "moments": [
             { "unique-id": "initial-launch", "node-type": "moment", "name": "Initial launch",
               "description": "Order gateway + matching engine", "valid-from": "2024-01-15",
-              "details": { "detailed-architecture": ("/calm/namespaces/timeline-demo/architectures/" + $id + "/versions/1.0.0") },
+              "details": { "detailed-architecture": ("/calm/namespaces/workshop/architectures/" + $id + "/versions/1.0.0") },
               "adrs": ["https://example.com/adr/0001-initial-trading-architecture"] },
             { "unique-id": "order-book-rollout", "node-type": "moment", "name": "Order book rollout",
               "description": "Centralised order book", "valid-from": "2024-04-01",
-              "details": { "detailed-architecture": ("/calm/namespaces/timeline-demo/architectures/" + $id + "/versions/1.1.0") },
+              "details": { "detailed-architecture": ("/calm/namespaces/workshop/architectures/" + $id + "/versions/1.1.0") },
               "adrs": ["https://example.com/adr/0002-order-book"] },
             { "unique-id": "risk-controls", "node-type": "moment", "name": "Risk controls go-live",
               "description": "Added pre-trade risk engine", "valid-from": "2024-09-01",
-              "details": { "detailed-architecture": ("/calm/namespaces/timeline-demo/architectures/" + $id + "/versions/2.0.0") },
+              "details": { "detailed-architecture": ("/calm/namespaces/workshop/architectures/" + $id + "/versions/2.0.0") },
               "adrs": ["https://example.com/adr/0003-pre-trade-risk"] },
             { "unique-id": "settlement-go-live", "node-type": "moment", "name": "Settlement go-live",
               "description": "Added post-trade settlement", "valid-from": "2025-02-01",
-              "details": { "detailed-architecture": ("/calm/namespaces/timeline-demo/architectures/" + $id + "/versions/3.0.0") },
+              "details": { "detailed-architecture": ("/calm/namespaces/workshop/architectures/" + $id + "/versions/3.0.0") },
               "adrs": ["https://example.com/adr/0004-settlement"] }
         ]
     }')
@@ -2928,10 +2945,10 @@ create_timeline_demo() {
 
     local http_code
     http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-        "$CALM_HUB_URL/api/calm/namespaces/timeline-demo/timelines" \
+        "$CALM_HUB_URL/api/calm/namespaces/workshop/timelines" \
         -H "$CONTENT_TYPE" -d "$tl_payload")
     if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
-        print_status "Created explicit timeline for Trading Platform in timeline-demo"
+        print_status "Created explicit timeline for Trading Platform in workshop"
     elif [[ "$http_code" == "409" ]]; then
         print_warning "Trading Platform timeline already exists, skipping"
     else
@@ -3047,13 +3064,13 @@ create_timeline_demo() {
         }
     }'
 
-    post_document "timeline-demo" "patterns" "patternJson" \
+    post_document "workshop" "patterns" "patternJson" \
         "Demo Pattern (implied timeline)" \
         "Demo pattern with three versions to exercise the pattern path of the timeline bar." \
         "$pattern_v1"
 
     local pattern_id
-    pattern_id=$(get_resource_id_by_name "timeline-demo" "patterns" "Demo Pattern (implied timeline)")
+    pattern_id=$(get_resource_id_by_name "workshop" "patterns" "Demo Pattern (implied timeline)")
     if [[ -n "$pattern_id" ]]; then
         # Post extra pattern versions with the {name, description, patternJson}
         # envelope (the shared post_pattern_version helper still sends the raw
@@ -3069,10 +3086,10 @@ create_timeline_demo() {
                 '{name: $n, description: $d, patternJson: ($doc | tojson)}')
             local code
             code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-                "$CALM_HUB_URL/api/calm/namespaces/timeline-demo/patterns/$pattern_id/versions/$version" \
+                "$CALM_HUB_URL/api/calm/namespaces/workshop/patterns/$pattern_id/versions/$version" \
                 -H "$CONTENT_TYPE" -d "$payload")
             if [[ "$code" == "200" || "$code" == "201" ]]; then
-                print_status "Created Demo Pattern version $version in timeline-demo"
+                print_status "Created Demo Pattern version $version in workshop"
             elif [[ "$code" == "409" ]]; then
                 print_warning "Demo Pattern version $version already exists, skipping"
             else
@@ -3100,9 +3117,9 @@ main() {
     create_patterns
     create_flows
     create_architectures
-    create_ai_governance_architecture
     create_user_access
     create_standards
+    create_interfaces
     create_timeline_demo
 
     print_status "CalmHub NitriteDB initialization completed!"

--- a/calm-hub/smoke-test.sh
+++ b/calm-hub/smoke-test.sh
@@ -18,13 +18,15 @@
 #   GET  /calm/namespaces/{ns}/{type}
 #   PUT  /calm  → 403 when allow.put.operations=false (default)
 #
-# Readonly mode assertions:
+# Readonly mode assertions (curated hosted-hub dataset):
 #   GET    /api/calm/namespaces                              -> 200  (reads work)
-#   GET    /api/calm/namespaces/finos/architectures          -> 200  (seeded namespace)
-#   GET    /api/calm/namespaces/finos/patterns               -> 200
-#   GET    /api/calm/namespaces/traderx/architectures        -> 200
-#   GET    /api/calm/namespaces/finos/architectures          body contains "name","description"
-#   GET    /api/calm/namespaces/finos/patterns               body contains "name"
+#   GET    /api/calm/namespaces                              body contains "finos.calm","finos.traderx","workshop"
+#   GET    /api/calm/namespaces/finos.calm/standards         -> 200 + body contains "name"
+#   GET    /api/calm/namespaces/finos.calm/interfaces        -> 200 + body contains "name"
+#   GET    /api/calm/namespaces/workshop/patterns            -> 200 + body contains "Conference Signup Pattern"
+#   GET    /api/calm/namespaces/workshop/architectures       -> 200 + body contains "name","description"
+#   GET    /api/calm/namespaces/finos.traderx/architectures  -> 200 + body contains "name"
+#   Conference Signup Pattern: versions list contains "1.0.0" and "2.0.0" (uses jq)
 #   POST   /api/calm/namespaces                             -> 405  (blocked by ReadOnlyRequestFilter)
 #   PUT    /api/calm/namespaces/smoke                       -> 405
 #   DELETE /api/calm/namespaces/smoke                       -> 405
@@ -106,16 +108,42 @@ assert_body_contains() {
 echo "[smoke] Running assertions (mode: ${MODE})..."
 
 if [[ "${MODE}" == "readonly" ]]; then
-    # Read access to pre-seeded namespaces (numeric-ID storage API)
+    # Read access and curated namespace list
     assert GET /api/calm/namespaces 200
-    assert GET /api/calm/namespaces/finos/architectures 200
-    assert GET /api/calm/namespaces/finos/patterns 200
-    assert GET /api/calm/namespaces/traderx/architectures 200
-    # Summary payloads must be populated, not empty objects (native serialization
-    # regression guard): a seeded summary must carry name and description fields.
-    assert_body_contains GET /api/calm/namespaces/finos/architectures '"name"'
-    assert_body_contains GET /api/calm/namespaces/finos/architectures '"description"'
-    assert_body_contains GET /api/calm/namespaces/finos/patterns '"name"'
+    assert_body_contains GET /api/calm/namespaces '"finos.calm"'
+    assert_body_contains GET /api/calm/namespaces '"finos.traderx"'
+    assert_body_contains GET /api/calm/namespaces '"workshop"'
+
+    # finos.calm — deployment standard and interfaces must be present
+    assert GET /api/calm/namespaces/finos.calm/standards 200
+    assert_body_contains GET /api/calm/namespaces/finos.calm/standards '"name"'
+    assert GET /api/calm/namespaces/finos.calm/interfaces 200
+    assert_body_contains GET /api/calm/namespaces/finos.calm/interfaces '"name"'
+
+    # workshop — patterns and architectures must be present with populated payloads
+    # (native-image serialization regression guard: non-empty name/description fields)
+    assert GET /api/calm/namespaces/workshop/patterns 200
+    assert_body_contains GET /api/calm/namespaces/workshop/patterns '"Conference Signup Pattern"'
+    assert GET /api/calm/namespaces/workshop/architectures 200
+    assert_body_contains GET /api/calm/namespaces/workshop/architectures '"name"'
+    assert_body_contains GET /api/calm/namespaces/workshop/architectures '"description"'
+
+    # finos.traderx — TraderX architecture must be present
+    assert GET /api/calm/namespaces/finos.traderx/architectures 200
+    assert_body_contains GET /api/calm/namespaces/finos.traderx/architectures '"name"'
+
+    # Conference Signup Pattern must have both v1.0.0 (always seeded) and v2.0.0
+    # (only seeds when post_pattern_version sends the correct {name,patternJson} envelope).
+    # Requires jq to extract the numeric pattern id from the summary response.
+    conf_pattern_id=$(curl -s "${BASE_URL}/api/calm/namespaces/workshop/patterns" \
+        | jq -r '.values[] | select(.name == "Conference Signup Pattern") | .id // empty' 2>/dev/null || true)
+    if [[ -z "$conf_pattern_id" ]]; then
+        echo "[smoke] FAIL could not resolve Conference Signup Pattern id from workshop/patterns" >&2
+        exit 1
+    fi
+    assert_body_contains GET "/api/calm/namespaces/workshop/patterns/${conf_pattern_id}/versions" '"1.0.0"'
+    assert_body_contains GET "/api/calm/namespaces/workshop/patterns/${conf_pattern_id}/versions" '"2.0.0"'
+
     # All mutating methods must be blocked on both API surfaces
     assert POST   /api/calm/namespaces       405 -H 'Content-Type: application/json' -d '{"name":"smoke-test","description":"smoke test namespace"}'
     assert PUT    /api/calm/namespaces/smoke  405


### PR DESCRIPTION
Restructures init-nitrite.sh to produce a clean demo dataset (contributes to #2534) :
- Namespaces: finos (parent), finos.calm, finos.traderx, workshop
- finos.calm: CALM Deployment Decorator Standard + 4 interface examples
- finos.traderx: TraderX flows and architecture
- workshop: API Gateway pattern, Conference patterns/architecture, timeline demo content
- Removed: Architecture 1, Flow 1/2, NIST standard, ai-governance-v2 namespace, security domain
- Domain ai-governance renamed to finos-ai-governance
- Timeline demo detailed-architecture refs updated to workshop namespace

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
