### PR TITLE
fix(calm-hub-ui): render object property values as JSON in node sidebar

### DIFF
--- a/calm-hub-ui/src/visualizer/components/sidebar/detail-components.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/detail-components.test.tsx
@@ -44,6 +44,29 @@ describe('PropertiesSection', () => {
         expect(screen.getByText('My Field')).toBeInTheDocument();
         expect(screen.getByText('my-value')).toBeInTheDocument();
     });
+
+    it('renders nested object values as pretty-printed JSON, not [object Object]', () => {
+        render(
+            <PropertiesSection properties={[['config', { retries: 3, egg: 'beans' }]]} />
+        );
+
+        expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+        expect(screen.getByText(/"egg": "beans"/)).toBeInTheDocument();
+    });
+
+    it('renders array values as JSON, not [object Object]', () => {
+        render(
+            <PropertiesSection properties={[['tags', ['alpha', 'beta']]]} />
+        );
+
+        expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+        expect(screen.getByText(/"alpha"/)).toBeInTheDocument();
+    });
+
+    it('renders null values as the string null', () => {
+        render(<PropertiesSection properties={[['optional', null]]} />);
+        expect(screen.getByText('null')).toBeInTheDocument();
+    });
 });
 
 describe('ControlsSection', () => {
@@ -144,6 +167,19 @@ describe('InterfacesSection', () => {
     it('generates fallback id when unique-id is missing', () => {
         render(<InterfacesSection interfaces={[{ host: 'example.com' }]} />);
         expect(screen.getByText('interface-0')).toBeInTheDocument();
+    });
+
+    it('renders nested object interface field as pretty-printed JSON, not [object Object]', () => {
+        // Reproduces issue #2745: rate-limit interface with a properties object
+        render(
+            <InterfacesSection interfaces={[
+                { 'unique-id': 'rate-limit', properties: { key: 'IP', calls: 100, egg: 'beans' } },
+            ]} />
+        );
+
+        expect(screen.getByText('rate-limit')).toBeInTheDocument();
+        expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+        expect(screen.getByText(/"egg": "beans"/)).toBeInTheDocument();
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/sidebar/detail-components.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/detail-components.tsx
@@ -32,6 +32,17 @@ export function RiskLevelBadge({ level }: { level: string }) {
     return <Badge icon={AlertTriangle} label={level} color={getRiskLevelColor(level)} />;
 }
 
+function PropertyValue({ value, className }: { value: unknown; className?: string }) {
+    if (value !== null && typeof value === 'object') {
+        return (
+            <pre className={`${className ?? ''} whitespace-pre-wrap break-all m-0 font-mono`}>
+                {JSON.stringify(value, null, 2)}
+            </pre>
+        );
+    }
+    return <span className={className}>{String(value)}</span>;
+}
+
 export function PropertiesSection({ properties }: { properties: [string, unknown][] }) {
     if (properties.length === 0) return null;
     return (
@@ -40,7 +51,7 @@ export function PropertiesSection({ properties }: { properties: [string, unknown
                 {properties.map(([key, value]) => (
                     <div key={key} className="contents">
                         <span className="text-xs text-base-content/50 font-medium">{formatFieldName(key)}</span>
-                        <span className="text-xs text-base-content font-medium">{String(value)}</span>
+                        <PropertyValue value={value} className="text-xs text-base-content font-medium" />
                     </div>
                 ))}
             </div>
@@ -131,7 +142,7 @@ export function InterfacesSection({ interfaces }: { interfaces: Record<string, u
                             {otherFields.map(([k, v]) => (
                                 <div key={k} className="flex justify-between text-xs">
                                     <span className="text-base-content/50">{formatFieldName(k)}</span>
-                                    <span className="text-base-content font-mono">{String(v)}</span>
+                                    <PropertyValue value={v} className="text-base-content font-mono" />
                                 </div>
                             ))}
                         </div>


### PR DESCRIPTION
## Description

Fixes #2745. Interface `properties` fields whose values are nested objects rendered as `[object Object]` in the visualizer node/interface sidebar because `String({...})` was used to coerce all values to a display string.

Introduces a `PropertyValue` component that pretty-prints objects and arrays as indented JSON in a `<pre>` block, while preserving existing `String()` behaviour for primitives and `null`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test additions or updates

## Affected Components

- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅

`fix(calm-hub-ui): render object property values as JSON in node sidebar`

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Regression tests added to `detail-components.test.tsx`:
- `PropertiesSection` — nested object renders as JSON (not `[object Object]`)
- `PropertiesSection` — array value renders as JSON
- `PropertiesSection` — `null` value still renders as `"null"`
- `InterfacesSection` — exact `rate-limit` shape from the issue renders as JSON

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

### Code review notes

Two findings from pre-PR review worth tracking:
- `JSON.stringify` has no try/catch — circular refs would crash the sidebar; CALM data from the REST API is always JSON-safe but a defensive guard could be added as follow-up.
- `<pre>` blocks in the `flex justify-between` interface card rows will expand the row height for object values — intentional given the chosen pretty-print style, but worth a visual check on narrow viewports.