### PR TITLE
fix(calm-hub-ui): always show pinned version URL in resource share bar

### DIFF
--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -500,6 +500,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                         namespace={data.name}
                         id={data.id}
                         version={data.version}
+                        typeSegment={urlType}
                         showVersion={false}
                         displayName={displayName}
                         typeLabel={typeLabel}

--- a/calm-hub-ui/src/hub/components/document-detail-section/DocumentDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/document-detail-section/DocumentDetailSection.tsx
@@ -70,6 +70,7 @@ export function DocumentDetailSection({ data }: DocumentDetailSectionProps) {
                     namespace={data.name}
                     id={data.id}
                     version={data.version}
+                    typeSegment={calmTypeToUrlSegment(data.calmType)}
                     versions={versions}
                     onVersionChange={handleVersionChange}
                 />

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { SectionHeader } from './SectionHeader.js';
 import { describe, it, expect } from 'vitest';
 
@@ -11,6 +11,7 @@ describe('SectionHeader', () => {
                 namespace="my-namespace"
                 id="my-id"
                 version="1.0.0"
+                typeSegment="architectures"
             />
         );
 
@@ -29,6 +30,7 @@ describe('SectionHeader', () => {
                 namespace="my-namespace"
                 id="42"
                 version="1.0.0"
+                typeSegment="architectures"
                 showVersion={false}
                 typeLabel="Architecture"
                 displayName="Trading System"
@@ -53,6 +55,7 @@ describe('SectionHeader', () => {
                 namespace="namespace"
                 id="id"
                 version="1.0"
+                typeSegment="architectures"
                 rightContent={rightContent}
             />
         );
@@ -70,6 +73,7 @@ describe('SectionHeader', () => {
                 namespace="namespace"
                 id="id"
                 version="1.0"
+                typeSegment="architectures"
             />
         );
 
@@ -86,6 +90,7 @@ describe('SectionHeader', () => {
                 namespace="namespace"
                 id="id"
                 version="1.0"
+                typeSegment="architectures"
             />
         );
 
@@ -95,7 +100,7 @@ describe('SectionHeader', () => {
         expect(graySpans[1]).toHaveTextContent('/');
     });
 
-    it('shows share bar defaulting to latest (unversioned) URL when id is a slug', () => {
+    it('shows share bar with pinned versioned URL when id is a slug', () => {
         const icon = <span>Icon</span>;
 
         render(
@@ -104,6 +109,7 @@ describe('SectionHeader', () => {
                 namespace="finos"
                 id="api-gateway"
                 version="1.0.0"
+                typeSegment="architectures"
             />
         );
 
@@ -112,49 +118,14 @@ describe('SectionHeader', () => {
 
         const urlInput = screen.getByRole('textbox', { name: 'Shareable URL' });
         expect(urlInput).toBeInTheDocument();
-        expect(urlInput).toHaveValue('http://localhost:3000/calm/namespaces/finos/api-gateway');
+        expect(urlInput).toHaveValue(
+            'http://localhost:3000/calm/namespaces/finos/architectures/api-gateway/versions/1.0.0'
+        );
         expect(urlInput).toHaveAttribute('readOnly');
 
-        expect(screen.getByTitle('Link to latest version')).toBeInTheDocument();
-        expect(screen.getByTitle('Link to this specific version')).toBeInTheDocument();
         expect(screen.getByTitle('Copy URL')).toBeInTheDocument();
-    });
-
-    it('switches to pinned (versioned) URL when Pinned is clicked', () => {
-        const icon = <span>Icon</span>;
-
-        render(
-            <SectionHeader
-                icon={icon}
-                namespace="finos"
-                id="api-gateway"
-                version="1.0.0"
-            />
-        );
-
-        fireEvent.click(screen.getByTitle('Link to this specific version'));
-
-        const urlInput = screen.getByRole('textbox', { name: 'Shareable URL' });
-        expect(urlInput).toHaveValue('http://localhost:3000/calm/namespaces/finos/api-gateway/versions/1.0.0');
-    });
-
-    it('switches back to latest URL when Latest is clicked after Pinned', () => {
-        const icon = <span>Icon</span>;
-
-        render(
-            <SectionHeader
-                icon={icon}
-                namespace="finos"
-                id="api-gateway"
-                version="1.0.0"
-            />
-        );
-
-        fireEvent.click(screen.getByTitle('Link to this specific version'));
-        fireEvent.click(screen.getByTitle('Link to latest version'));
-
-        const urlInput = screen.getByRole('textbox', { name: 'Shareable URL' });
-        expect(urlInput).toHaveValue('http://localhost:3000/calm/namespaces/finos/api-gateway');
+        expect(screen.queryByTitle('Link to latest version')).not.toBeInTheDocument();
+        expect(screen.queryByTitle('Link to this specific version')).not.toBeInTheDocument();
     });
 
     it('does not show share bar when id is numeric', () => {
@@ -166,6 +137,7 @@ describe('SectionHeader', () => {
                 namespace="finos"
                 id="42"
                 version="1.0.0"
+                typeSegment="architectures"
             />
         );
 

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -7,6 +7,8 @@ interface SectionHeaderProps {
     namespace: string;
     id: string;
     version: string;
+    /** URL path segment for the resource type (e.g. "architectures", "flows"). Distinct from the display-only `typeLabel`. */
+    typeSegment: string;
     rightContent?: ReactNode;
     /** When provided (and non-empty), the version renders as a selectable dropdown. */
     versions?: string[];
@@ -21,13 +23,10 @@ interface SectionHeaderProps {
     typeLabel?: string;
 }
 
-export function SectionHeader({ icon, namespace, id, version, rightContent, versions, onVersionChange, titleActions, showVersion = true, displayName, typeLabel }: SectionHeaderProps) {
+export function SectionHeader({ icon, namespace, id, version, typeSegment, rightContent, versions, onVersionChange, titleActions, showVersion = true, displayName, typeLabel }: SectionHeaderProps) {
     const [copied, setCopied] = useState(false);
-    const [pinned, setPinned] = useState(false);
     const showShareBar = isSlug(id);
-    const latestUrl = `${window.location.origin}/calm/namespaces/${namespace}/${id}`;
-    const pinnedUrl = `${latestUrl}/versions/${version}`;
-    const shareUrl = pinned ? pinnedUrl : latestUrl;
+    const shareUrl = `${window.location.origin}/calm/namespaces/${encodeURIComponent(namespace)}/${typeSegment}/${encodeURIComponent(id)}/versions/${encodeURIComponent(version)}`;
 
     const handleCopy = () => {
         navigator.clipboard.writeText(shareUrl).then(() => {
@@ -79,22 +78,6 @@ export function SectionHeader({ icon, namespace, id, version, rightContent, vers
             {showShareBar && (
                 <div className="bg-base-200 px-4 sm:px-6 py-2 flex items-center gap-2 border-b border-base-300" data-testid="share-bar">
                     <IoLinkOutline className="text-base-content/50 shrink-0" />
-                    <div className="join shrink-0">
-                        <button
-                            className={`join-item btn btn-xs ${!pinned ? 'btn-active' : 'btn-ghost'}`}
-                            onClick={() => setPinned(false)}
-                            title="Link to latest version"
-                        >
-                            Latest
-                        </button>
-                        <button
-                            className={`join-item btn btn-xs ${pinned ? 'btn-active' : 'btn-ghost'}`}
-                            onClick={() => setPinned(true)}
-                            title="Link to this specific version"
-                        >
-                            Pinned
-                        </button>
-                    </div>
                     <div className="join flex-1">
                         <input
                             className="input input-sm input-bordered join-item w-full font-mono text-xs"


### PR DESCRIPTION
## Description

The share bar in CalmHub UI defaulted to a versionless "Latest" URL and offered a Latest/Pinned toggle. The "latest" concept no longer exists in CalmHub, so this fix removes the toggle and always shows the canonical pinned URL matching the resource's `$id`.

- Before: `{origin}/calm/namespaces/{ns}/{id}` (missing type segment and version)
- After: `{origin}/calm/namespaces/{ns}/{type}/{id}/versions/{version}`

Closes #2746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components

- [x] CALM Hub UI (`calm-hub-ui/`)

## Changes

- `SectionHeader.tsx` — adds required `typeSegment` prop; removes `pinned` state and Latest/Pinned toggle; always builds one versioned URL with `encodeURIComponent` on namespace/id/version
- `DocumentDetailSection.tsx` — passes `typeSegment={calmTypeToUrlSegment(data.calmType)}` (reuses existing helper)
- `DiagramSection.tsx` — passes `typeSegment={urlType}` (already computed for navigation)
- `SectionHeader.test.tsx` — updates assertions to expect full pinned URL; removes three now-obsolete toggle tests

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

All 957 calm-hub-ui tests pass. Manually verified against running CalmHub instance.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

## Code Review Notes

One non-blocking cleanup opportunity identified: `calmTypeToUrlSegment` in `DocumentDetailSection.tsx` duplicates `mapTypeInUIToTypeInUrl` from `navigation-loaders.ts`. Consolidating to the shared function is a separate refactor and out of scope for this bug fix.