### PR TITLE
fix(calm-hub-ui): render childless system nodes as regular nodes

### DIFF
--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmTransformer.test.ts
@@ -31,7 +31,7 @@ describe('parseCALMData', () => {
         expect(result.nodes[1].id).toBe('node-2');
     });
 
-    it('creates system nodes for system type', () => {
+    it('renders a childless system node as a regular node', () => {
         const data: CalmArchitectureSchema = {
             nodes: [
                 { 'unique-id': 'system-1', name: 'My System', 'node-type': 'system' },
@@ -39,8 +39,28 @@ describe('parseCALMData', () => {
         };
         const result = parseCALMData(data);
         expect(result.nodes).toHaveLength(1);
-        expect(result.nodes[0].type).toBe('group');
+        expect(result.nodes[0].type).toBe('custom');
         expect(result.nodes[0].data['node-type']).toBe('system');
+    });
+
+    it('renders a system node that contains children as a group node', () => {
+        const data: CalmArchitectureSchema = {
+            nodes: [
+                { 'unique-id': 'system-1', name: 'My System', 'node-type': 'system' },
+                { 'unique-id': 'child-1', name: 'Child Service', 'node-type': 'service' },
+            ],
+            relationships: [
+                {
+                    'unique-id': 'rel-1',
+                    'relationship-type': {
+                        'composed-of': { container: 'system-1', nodes: ['child-1'] },
+                    },
+                },
+            ],
+        };
+        const result = parseCALMData(data);
+        const systemNode = result.nodes.find((n) => n.id === 'system-1');
+        expect(systemNode?.type).toBe('group');
     });
 
     it('creates edges from connects relationships', () => {

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/nodeParser.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/nodeParser.ts
@@ -112,15 +112,13 @@ export function parseNodes(
 
     nodes.forEach((node) => {
         const id = node['unique-id'];
-        const nodeType = node['node-type'];
 
         if (!id) return;
 
         const isContainer = containerNodeIds.has(id);
-        const isSystemNode = nodeType === 'system' || isContainer;
         const parentId = parentMap.get(id);
 
-        if (isSystemNode) {
+        if (isContainer) {
             systemNodes.push(createSystemNode(node, parentId));
         } else {
             regularNodes.push(createRegularNode(node, parentId, onShowDetailsCallback));


### PR DESCRIPTION
## Description

Fixes #2744. A CALM node with `node-type: "system"` but no container relationships rendered as an empty dashed-border box (`SystemGroupNode`) — visually indistinguishable from a Kubernetes cluster container — instead of as a labeled leaf node.

Root cause: `nodeParser.ts` used `nodeType === 'system'` as a proxy for containment. Containment is already derived from `deployed-in` / `composed-of` relationships in `identifyContainerNodes`; the type string was irrelevant. Removed the `nodeType === 'system'` clause so the `isContainer` signal (relationship-derived) is the sole determinant.

A system node that genuinely contains children still appears in `containerNodeIds` and renders as `type: 'group'` unchanged.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test additions or updates

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Changes

- `nodeParser.ts` — remove `nodeType === 'system'` from container check; inline `isContainer` directly into the branch condition
- `calmTransformer.test.ts` — update existing test (was asserting the buggy `type: 'group'`); add test confirming a system node with a `composed-of` child still renders as `type: 'group'`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

`npm test --workspace calm-hub-ui`: 20 tests pass (including nested-container regression suite from #2567)

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards