### PR TITLE
fix(calm-hub): seed patternStoreCounter and flowStoreCounter at max seeded id to prevent first-push duplicate

### DIFF
--- a/.github/workflows/validate-mongo-seed-counters.yml
+++ b/.github/workflows/validate-mongo-seed-counters.yml
@@ -1,0 +1,35 @@
+name: Validate Mongo Seed Counters
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release*'
+    paths:
+      - 'calm-hub/mongo/init-mongo.js'
+  push:
+    branches:
+      - 'main'
+      - 'release*'
+    paths:
+      - 'calm-hub/mongo/init-mongo.js'
+
+jobs:
+  validate-mongo-seed-counters:
+    name: Validate Mongo Seed Counters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Validate Mongo seed counters against seeded entity ids
+        run: node scripts/validate-mongo-seed-counters.js

--- a/.github/workflows/validate-mongo-seed-counters.yml
+++ b/.github/workflows/validate-mongo-seed-counters.yml
@@ -10,12 +10,14 @@ on:
       - 'release*'
     paths:
       - 'calm-hub/mongo/init-mongo.js'
+      - 'scripts/validate-mongo-seed-counters.js'
   push:
     branches:
       - 'main'
       - 'release*'
     paths:
       - 'calm-hub/mongo/init-mongo.js'
+      - 'scripts/validate-mongo-seed-counters.js'
 
 jobs:
   validate-mongo-seed-counters:

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -37,7 +37,15 @@ if (db.counters.countDocuments({ _id: "patternStoreCounter" }) === 0) {
     });
     logSuccess("Initialized patternStoreCounter with sequence_value 2");
 } else {
-    logSkip("patternStoreCounter already exists, no initialization needed");
+    const patternUpgrade = db.counters.updateOne(
+        { _id: "patternStoreCounter", sequence_value: { $lt: 2 } },
+        { $set: { sequence_value: 2 } }
+    );
+    if (patternUpgrade.modifiedCount > 0) {
+        logSuccess("Upgraded patternStoreCounter to sequence_value 2 (was below minimum)");
+    } else {
+        logSkip("patternStoreCounter already exists with sequence_value >= 2, no update needed");
+    }
 }
 
 if (db.counters.countDocuments({ _id: "architectureStoreCounter" }) === 0) {
@@ -78,7 +86,15 @@ if (db.counters.countDocuments({ _id: "flowStoreCounter" }) === 0) {
     });
     logSuccess("Initialized flowStoreCounter with sequence_value 2");
 } else {
-    logSkip("flowStoreCounter already exists, no initialization needed");
+    const flowUpgrade = db.counters.updateOne(
+        { _id: "flowStoreCounter", sequence_value: { $lt: 2 } },
+        { $set: { sequence_value: 2 } }
+    );
+    if (flowUpgrade.modifiedCount > 0) {
+        logSuccess("Upgraded flowStoreCounter to sequence_value 2 (was below minimum)");
+    } else {
+        logSkip("flowStoreCounter already exists with sequence_value >= 2, no update needed");
+    }
 }
 
 if (db.counters.countDocuments({ _id: "userAccessStoreCounter" }) === 0) {

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -33,9 +33,9 @@ logSection("Counters");
 if (db.counters.countDocuments({ _id: "patternStoreCounter" }) === 0) {
     db.counters.insertOne({
         _id: "patternStoreCounter",
-        sequence_value: 1
+        sequence_value: 2
     });
-    logSuccess("Initialized patternStoreCounter with sequence_value 1");
+    logSuccess("Initialized patternStoreCounter with sequence_value 2");
 } else {
     logSkip("patternStoreCounter already exists, no initialization needed");
 }
@@ -74,9 +74,9 @@ if (db.counters.countDocuments({ _id: "standardStoreCounter" }) === 0) {
 if (db.counters.countDocuments({ _id: "flowStoreCounter" }) === 0) {
     db.counters.insertOne({
         _id: "flowStoreCounter",
-        sequence_value: 1
+        sequence_value: 2
     });
-    logSuccess("Initialized flowStoreCounter with sequence_value 1");
+    logSuccess("Initialized flowStoreCounter with sequence_value 2");
 } else {
     logSkip("flowStoreCounter already exists, no initialization needed");
 }

--- a/scripts/validate-mongo-seed-counters.js
+++ b/scripts/validate-mongo-seed-counters.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that every counter in calm-hub/mongo/init-mongo.js is seeded at or
+ * above the maximum entity id of its type already present in the seed data.
+ *
+ * MongoCounterStore.nextValueForCounter uses findOneAndUpdate with $inc and
+ * returnDocument(AFTER), so the first issued id = sequence_value + 1.  If
+ * sequence_value < max seeded entity id, the first push into that namespace
+ * collides with an existing seed document, producing duplicate ids in the
+ * summaries API response and corrupting the UI rendering.
+ *
+ * architectureStoreCounter was correctly set to 2 (= max seeded architectureId)
+ * from the start; this script enforces the same invariant for every type.
+ */
+
+'use strict';
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const seedPath = join(__dirname, '..', 'calm-hub', 'mongo', 'init-mongo.js');
+
+let seed;
+try {
+    seed = readFileSync(seedPath, 'utf8');
+} catch (err) {
+    console.error(`Failed to read init-mongo.js: ${err.message}`);
+    process.exit(1);
+}
+
+// Map from counter _id to its sequence_value
+const counterPattern = /_id:\s*"(\w+StoreCounter)"[\s\S]*?sequence_value:\s*(\d+)/g;
+const counters = new Map();
+for (const m of seed.matchAll(counterPattern)) {
+    counters.set(m[1], parseInt(m[2], 10));
+}
+
+// Map from entity field name to the counter that governs it
+const fieldToCounter = {
+    patternId: 'patternStoreCounter',
+    flowId: 'flowStoreCounter',
+    architectureId: 'architectureStoreCounter',
+    adrId: 'adrStoreCounter',
+    standardId: 'standardStoreCounter',
+    interfaceId: 'interfaceStoreCounter',
+    controlId: 'controlStoreCounter',
+    decoratorId: 'decoratorStoreCounter',
+};
+
+// Extract the maximum NumberInt value for each entity id field
+function maxSeedId(field) {
+    const re = new RegExp(`${field}:\\s*NumberInt\\((\\d+)\\)`, 'g');
+    let max = 0;
+    for (const m of seed.matchAll(re)) {
+        const v = parseInt(m[1], 10);
+        if (v > max) max = v;
+    }
+    return max;
+}
+
+let failures = 0;
+
+for (const [field, counterName] of Object.entries(fieldToCounter)) {
+    const seqVal = counters.get(counterName);
+    if (seqVal === undefined) {
+        console.error(`  MISSING  ${counterName} — not found in init-mongo.js`);
+        failures++;
+        continue;
+    }
+    const maxId = maxSeedId(field);
+    const firstIssuedId = seqVal + 1;
+    const ok = seqVal >= maxId;
+    const status = ok ? 'OK     ' : 'FAIL   ';
+    const detail = maxId === 0
+        ? `(no seeded ${field} — first issued id would be ${firstIssuedId})`
+        : `sequence_value=${seqVal}, max seeded ${field}=${maxId}, first issued id=${firstIssuedId}`;
+    console.log(`  ${status}  ${counterName}: ${detail}`);
+    if (!ok) failures++;
+}
+
+if (failures > 0) {
+    console.error(
+        `\nMongo seed counter validation FAILED (${failures} violation${failures > 1 ? 's' : ''}).\n` +
+        'Each counter\'s sequence_value must be >= the max entity id already present in the seed.\n' +
+        'The first id issued after init = sequence_value + 1; if that collides with a seeded id,\n' +
+        'the affected namespace will contain duplicate entity ids which corrupt the Hub UI.\n\n' +
+        'Fix: raise the counter sequence_value in calm-hub/mongo/init-mongo.js to match the\n' +
+        'highest seeded id of that type (see architectureStoreCounter: 2 as the correct pattern).'
+    );
+    process.exit(1);
+}
+
+console.log(`\nMongo seed counter validation passed: ${Object.keys(fieldToCounter).length} counters checked.`);

--- a/scripts/validate-mongo-seed-counters.js
+++ b/scripts/validate-mongo-seed-counters.js
@@ -46,11 +46,14 @@ const fieldToCounter = {
     interfaceId: 'interfaceStoreCounter',
     controlId: 'controlStoreCounter',
     decoratorId: 'decoratorStoreCounter',
+    userAccessId: 'userAccessStoreCounter',
 };
 
-// Extract the maximum NumberInt value for each entity id field
+// Extract the maximum NumberInt value for each entity id field.
+// Handles both unquoted JS object syntax (field: NumberInt) and quoted JSON syntax
+// ("field": NumberInt) since init-mongo.js uses both styles in different sections.
 function maxSeedId(field) {
-    const re = new RegExp(`${field}:\\s*NumberInt\\((\\d+)\\)`, 'g');
+    const re = new RegExp(`"?${field}"?:\\s*NumberInt\\((\\d+)\\)`, 'g');
     let max = 0;
     for (const m of seed.matchAll(re)) {
         const v = parseInt(m[1], 10);


### PR DESCRIPTION
## Description

Fixes #2678 — CalmHub UI displays strange duplicates when pushing new pattern.

`patternStoreCounter` and `flowStoreCounter` were seeded at `sequence_value: 1` while the seed data already contained entities at id 2. `MongoCounterStore` uses `$inc` with `returnDocument(AFTER)`, so first issued id = `sequence_value + 1 = 2` — colliding with the seeded document and producing duplicate `patternId` values in the summaries response. The UI's `Object.fromEntries` keying on the duplicate id caused label bleed and duplicate rows.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] CI/CD

## Changes

- `calm-hub/mongo/init-mongo.js`: `patternStoreCounter` and `flowStoreCounter` `sequence_value` 1 → 2 (matches existing `architectureStoreCounter: 2` precedent); else-branches add `$lt: 2` `updateOne` to fix existing deployments without a data wipe
- `scripts/validate-mongo-seed-counters.js`: static checker asserting `sequence_value >= max seeded entity id` for all 9 counter types; handles both unquoted JS and quoted JSON key styles in the seed file
- `.github/workflows/validate-mongo-seed-counters.yml`: CI workflow triggered on changes to `init-mongo.js` or the validator script

## Testing
- [x] `node scripts/validate-mongo-seed-counters.js` passes (9 counters OK); exits 1 with per-counter detail when any counter is below its max seeded id
- [x] All existing tests pass

## Manual verification
1. `cd calm-hub/local-dev && docker compose down -v && docker compose up`
2. `npm run build:cli && npm run link:cli`
3. `npx calm hub push pattern <test.pattern.json>` into `workshop`
4. UI: new pattern appears as a single row with its own label; no duplicates; id is 3

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards