### PR TITLE
fix(calm-hub): display control/config titles and use slug-based URLs

### DIFF
--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
@@ -169,7 +169,7 @@ export function ExplorerSearch({
             setResults(null);
 
             if (type === 'controls') {
-                navigate(`/${result.namespace}/controls/${result.id}/detail`);
+                navigate(`/${result.namespace}/controls/${result.name}/detail`);
                 return;
             }
 

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
@@ -153,7 +153,7 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
             setResults(null);
 
             if (type === 'controls') {
-                navigate(`/${result.namespace}/controls/${result.id}/detail`);
+                navigate(`/${result.namespace}/controls/${result.name}/detail`);
                 return;
             }
 

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ControlDetailSection } from './ControlDetailSection.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ControlData } from '../../../model/control.js';
+import { ControlConfigDetail, ControlData } from '../../../model/control.js';
 
 // ── Mocks ─────────────────────────────────────────────────
 
@@ -80,19 +80,19 @@ const configJson = { minKeyLength: 256, algorithm: 'AES' };
 function setupMocks({
     reqVersions = ['0.1.0'],
     reqSchema = requirementSchema,
-    configIds = [10],
+    configs = [{ id: 10 }] as ControlConfigDetail[],
     cfgVersions = ['1.0.0'],
     cfgJson = configJson,
 }: {
     reqVersions?: string[];
     reqSchema?: object;
-    configIds?: number[];
+    configs?: ControlConfigDetail[];
     cfgVersions?: string[];
     cfgJson?: object;
 } = {}) {
     mockFetchRequirementVersions.mockResolvedValue(reqVersions);
     mockFetchRequirementForVersion.mockResolvedValue(reqSchema);
-    mockFetchConfigurationsForControl.mockResolvedValue(configIds);
+    mockFetchConfigurationsForControl.mockResolvedValue(configs);
     mockFetchConfigurationVersions.mockResolvedValue(cfgVersions);
     mockFetchConfigurationForVersion.mockResolvedValue(cfgJson);
 }
@@ -135,7 +135,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('hides the configurations panel when no config IDs exist', async () => {
-            setupMocks({ configIds: [] });
+            setupMocks({ configs: [] });
             render(<ControlDetailSection controlData={controlData} />);
 
             // Wait for requirement panel to render, then assert configurations heading is absent
@@ -270,7 +270,7 @@ describe('ControlDetailSection', () => {
     // ──────────────────────────────────────────────────
     describe('configuration tabs', () => {
         it('renders config ID tabs', async () => {
-            setupMocks({ configIds: [10, 20] });
+            setupMocks({ configs: [{ id: 10 }, { id: 20 }] });
             render(<ControlDetailSection controlData={controlData} />);
 
             await waitFor(() => {
@@ -280,7 +280,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('clicking a config ID tab fetches its versions', async () => {
-            setupMocks({ configIds: [10, 20] });
+            setupMocks({ configs: [{ id: 10 }, { id: 20 }] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -294,7 +294,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('applies active style to the selected config tab', async () => {
-            setupMocks({ configIds: [10, 20] });
+            setupMocks({ configs: [{ id: 10 }, { id: 20 }] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -305,7 +305,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('shows the selected config ID in the breadcrumb header', async () => {
-            setupMocks({ configIds: [10] });
+            setupMocks({ configs: [{ id: 10 }] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -316,7 +316,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('renders config version tabs after selecting a config ID', async () => {
-            setupMocks({ configIds: [10], cfgVersions: ['1.0.0', '1.1.0'] });
+            setupMocks({ configs: [{ id: 10 }], cfgVersions: ['1.0.0', '1.1.0'] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -329,7 +329,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('clicking a config version tab fetches the configuration JSON', async () => {
-            setupMocks({ configIds: [10], cfgVersions: ['1.0.0'] });
+            setupMocks({ configs: [{ id: 10 }], cfgVersions: ['1.0.0'] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -350,7 +350,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('applies active style to the selected config version tab', async () => {
-            setupMocks({ configIds: [10], cfgVersions: ['1.0.0', '1.1.0'] });
+            setupMocks({ configs: [{ id: 10 }], cfgVersions: ['1.0.0', '1.1.0'] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -366,7 +366,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('shows the selected config version in the breadcrumb header', async () => {
-            setupMocks({ configIds: [10], cfgVersions: ['1.0.0'] });
+            setupMocks({ configs: [{ id: 10 }], cfgVersions: ['1.0.0'] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -381,7 +381,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('does not show config version tabs until a config ID is selected', async () => {
-            setupMocks({ configIds: [10], cfgVersions: ['1.0.0'] });
+            setupMocks({ configs: [{ id: 10 }], cfgVersions: ['1.0.0'] });
             render(<ControlDetailSection controlData={controlData} />);
 
             await waitFor(() => {
@@ -425,7 +425,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('switches configuration panel to Raw JSON view independently', async () => {
-            setupMocks();
+            setupMocks({ configs: [{ id: 10 }] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 
@@ -507,7 +507,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('omits the Configuration tab when no configurations exist', async () => {
-            setupMocks({ configIds: [] });
+            setupMocks({ configs: [] });
             render(<ControlDetailSection controlData={controlData} />);
 
             await waitFor(() => {
@@ -517,7 +517,7 @@ describe('ControlDetailSection', () => {
         });
 
         it('switches to the configuration panel and shows its config tabs', async () => {
-            setupMocks({ configIds: [10, 20] });
+            setupMocks({ configs: [{ id: 10 }, { id: 20 }] });
             const user = userEvent.setup();
             render(<ControlDetailSection controlData={controlData} />);
 

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.test.tsx
@@ -121,6 +121,17 @@ describe('ControlDetailSection', () => {
             });
         });
 
+        it('renders the requirement breadcrumb header with control title when present', async () => {
+            setupMocks();
+            render(<ControlDetailSection controlData={{ ...controlData, controlTitle: 'Pretty Title' }} />);
+
+            await waitFor(() => {
+                const headings = screen.getAllByRole('heading');
+                expect(headings[0]).toHaveTextContent('Pretty Title');
+                expect(headings[0]).not.toHaveTextContent('Access Control');
+            });
+        });
+
         it('renders the configuration breadcrumb header with control name', async () => {
             setupMocks();
             render(<ControlDetailSection controlData={controlData} />);
@@ -269,6 +280,21 @@ describe('ControlDetailSection', () => {
     // Configuration tabs
     // ──────────────────────────────────────────────────
     describe('configuration tabs', () => {
+        it('renders config tab labels using title then name then fallback', async () => {
+            setupMocks({ configs: [
+                { id: 10, title: 'Rate Limit Config' },
+                { id: 20, name: 'config-b' },
+                { id: 30 },
+            ]});
+            render(<ControlDetailSection controlData={controlData} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('tab', { name: 'Rate Limit Config' })).toBeInTheDocument();
+                expect(screen.getByRole('tab', { name: 'config-b' })).toBeInTheDocument();
+                expect(screen.getByRole('tab', { name: 'Config 30' })).toBeInTheDocument();
+            });
+        });
+
         it('renders config ID tabs', async () => {
             setupMocks({ configs: [{ id: 10 }, { id: 20 }] });
             render(<ControlDetailSection controlData={controlData} />);

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { IoShieldCheckmarkOutline } from 'react-icons/io5';
-import { ControlData } from '../../../model/control.js';
+import { ControlConfigDetail, ControlData } from '../../../model/control.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { ReadableJsonView } from './ReadableJsonView.js';
 import { ControlService } from '../../../service/control-service.js';
@@ -23,7 +23,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
     const [requirementJson, setRequirementJson] = useState<object | undefined>();
 
     // Configuration state
-    const [configIds, setConfigIds] = useState<number[]>([]);
+    const [configs, setConfigs] = useState<ControlConfigDetail[]>([]);
     const [selectedConfigId, setSelectedConfigId] = useState<number | null>(null);
     const [configVersions, setConfigVersions] = useState<string[]>([]);
     const [selectedConfigVersion, setSelectedConfigVersion] = useState<string>('');
@@ -53,7 +53,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         setRequirementVersions([]);
         setSelectedReqVersion('');
         setRequirementJson(undefined);
-        setConfigIds([]);
+        setConfigs([]);
         setSelectedConfigId(null);
         setConfigVersions([]);
         setSelectedConfigVersion('');
@@ -67,7 +67,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         controlService.fetchConfigurationsForControl(
             controlData.domain,
             controlData.controlId,
-        ).then(setConfigIds);
+        ).then(setConfigs);
     }, [controlService, controlData.domain, controlData.controlId]);
 
     // Auto-select first requirement version when versions load
@@ -134,14 +134,14 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         </button>
     ));
 
-    const configIdButtons = configIds.map((cid) => (
+    const configIdButtons = configs.map((cfg) => (
         <button
-            key={cid}
+            key={cfg.id}
             role="tab"
-            className={`tab gap-1 rounded-lg ${selectedConfigId === cid ? 'tab-active !bg-primary !text-primary-content' : ''}`}
-            onClick={() => handleConfigClick(cid)}
+            className={`tab gap-1 rounded-lg ${selectedConfigId === cfg.id ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+            onClick={() => handleConfigClick(cfg.id)}
         >
-            Config {cid}
+            {cfg.title ?? cfg.name ?? `Config ${cfg.id}`}
         </button>
     ));
 
@@ -171,7 +171,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
     // ── Mobile: a single full-bleed pane with Requirement / Configuration
     //    tabs, stacked headers, and horizontally scrollable version pickers. ──
     if (isMobile) {
-        const showConfig = configIds.length > 0;
+        const showConfig = configs.length > 0;
         const panel = activePanel === 'configuration' && showConfig ? 'configuration' : 'requirement';
 
         return (
@@ -230,7 +230,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         <div className="bg-base-200 px-4 py-2 border-b border-base-300 flex items-center justify-between gap-2">
                             <h2 className="text-xs font-semibold text-base-content/70 truncate">
                                 Configurations
-                                {selectedConfigId !== null ? ` / ${selectedConfigId}` : ''}
+                                {selectedConfigId !== null ? ` / ${configs.find(c => c.id === selectedConfigId)?.title ?? configs.find(c => c.id === selectedConfigId)?.name ?? `Config ${selectedConfigId}`}` : ''}
                                 {selectedConfigVersion ? ` / ${selectedConfigVersion}` : ''}
                             </h2>
                             {viewToggle(cfgViewMode, setCfgViewMode)}
@@ -298,7 +298,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
             </div>
 
             {/* Bottom section: Configurations (only shown if any exist) */}
-            {configIds.length > 0 && (
+            {configs.length > 0 && (
                 <div className="flex-1 min-h-0 bg-base-100 rounded-2xl overflow-hidden flex flex-col shadow-xl">
                 {/* Configuration breadcrumb header */}
                 <div className="bg-base-200 px-6 py-2 flex items-center justify-between border-b border-base-300">
@@ -310,7 +310,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         {selectedConfigId !== null && (
                             <>
                                 <span className="text-gray-400">/</span>
-                                <span>{selectedConfigId}</span>
+                                <span>{configs.find(c => c.id === selectedConfigId)?.title ?? configs.find(c => c.id === selectedConfigId)?.name ?? `Config ${selectedConfigId}`}</span>
                             </>
                         )}
                         {selectedConfigVersion && (

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -168,6 +168,12 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         <JsonRenderer json={configJson} />
     );
 
+    const controlLabel = controlData.controlTitle ?? controlData.controlName;
+    const selectedCfg = configs.find((c) => c.id === selectedConfigId);
+    const selectedCfgLabel = selectedCfg
+        ? (selectedCfg.title ?? selectedCfg.name ?? `Config ${selectedCfg.id}`)
+        : selectedConfigId !== null ? `Config ${selectedConfigId}` : null;
+
     // ── Mobile: a single full-bleed pane with Requirement / Configuration
     //    tabs, stacked headers, and horizontally scrollable version pickers. ──
     if (isMobile) {
@@ -180,7 +186,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                 <div className="bg-base-200 px-4 py-3 border-b border-base-300">
                     <h2 className="text-base font-bold flex items-center gap-2 text-primary min-w-0">
                         <IoShieldCheckmarkOutline className="text-primary shrink-0" />
-                        <span className="truncate">{controlData.controlName}</span>
+                        <span className="truncate">{controlLabel}</span>
                     </h2>
                 </div>
 
@@ -230,7 +236,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         <div className="bg-base-200 px-4 py-2 border-b border-base-300 flex items-center justify-between gap-2">
                             <h2 className="text-xs font-semibold text-base-content/70 truncate">
                                 Configurations
-                                {selectedConfigId !== null ? ` / ${configs.find(c => c.id === selectedConfigId)?.title ?? configs.find(c => c.id === selectedConfigId)?.name ?? `Config ${selectedConfigId}`}` : ''}
+                                {selectedCfgLabel ? ` / ${selectedCfgLabel}` : ''}
                                 {selectedConfigVersion ? ` / ${selectedConfigVersion}` : ''}
                             </h2>
                             {viewToggle(cfgViewMode, setCfgViewMode)}
@@ -268,7 +274,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                 <div className="bg-base-200 px-6 py-2 flex items-center justify-between border-b border-base-300">
                     <h2 className="text-sm font-bold flex items-center gap-2 text-primary">
                         <IoShieldCheckmarkOutline className="text-primary" />
-                        <span>{controlData.controlName}</span>
+                        <span>{controlLabel}</span>
                         <span className="text-gray-400">/</span>
                         <span>Requirement</span>
                         {selectedReqVersion && (
@@ -304,13 +310,13 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                 <div className="bg-base-200 px-6 py-2 flex items-center justify-between border-b border-base-300">
                     <h2 className="text-sm font-bold flex items-center gap-2">
                         <IoShieldCheckmarkOutline className="text-accent" />
-                        <span>{controlData.controlName}</span>
+                        <span>{controlLabel}</span>
                         <span className="text-gray-400">/</span>
                         <span>Configurations</span>
-                        {selectedConfigId !== null && (
+                        {selectedCfgLabel && (
                             <>
                                 <span className="text-gray-400">/</span>
-                                <span>{configs.find(c => c.id === selectedConfigId)?.title ?? configs.find(c => c.id === selectedConfigId)?.name ?? `Config ${selectedConfigId}`}</span>
+                                <span>{selectedCfgLabel}</span>
                             </>
                         )}
                         {selectedConfigVersion && (

--- a/calm-hub-ui/src/hub/components/tree-navigation/ControlItem.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/ControlItem.tsx
@@ -11,7 +11,7 @@ export function ControlItem({ control, isSelected, onControlClick }: ControlItem
     return (
         <li>
             <a className={isSelected ? 'active' : ''} onClick={() => onControlClick(control)}>
-                {control.name}
+                {control.title ?? control.name}
             </a>
         </li>
     );

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -114,13 +114,15 @@ export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfac
             controlService
                 .fetchControlsForDomain(namespace)
                 .then((controls) => {
-                    const match = controls.find((c) => c.name === params.id);
+                    const match = controls.find((c) => c.name === params.id)
+                        ?? controls.find((c) => c.id === Number(params.id));
                     if (match) {
                         onControlLoadRef.current({
                             domain: namespace,
                             controlId: match.id,
                             controlName: match.name,
                             controlDescription: match.description,
+                            controlTitle: match.title,
                         });
                     }
                 })

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -114,7 +114,7 @@ export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfac
             controlService
                 .fetchControlsForDomain(namespace)
                 .then((controls) => {
-                    const match = controls.find((c) => c.id === Number(params.id));
+                    const match = controls.find((c) => c.name === params.id);
                     if (match) {
                         onControlLoadRef.current({
                             domain: namespace,
@@ -190,7 +190,7 @@ export function MobileNavMenu({ onDataLoad, onAdrLoad, onControlLoad, onInterfac
             controlService
                 .fetchControlsForDomain(domain)
                 .then((controls: ControlDetail[]) =>
-                    setLeafItems(controls.map((c) => ({ id: c.id.toString(), name: c.name })))
+                    setLeafItems(controls.map((c) => ({ id: c.name, name: c.title ?? c.name })))
                 )
                 .catch(() => setLeafItems([]))
                 .finally(() => setLoading(false));

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
@@ -289,12 +289,12 @@ describe('TreeNavigation', () => {
         });
     });
 
-    it('loads data based on deeplink route - control', async () => {
+    it('loads data based on deeplink route - control (slug match)', async () => {
         vi.mocked(ControlService).mockImplementation(function () {
             controlServiceInstance = {
                 fetchDomains: vi.fn().mockResolvedValue(['test-domain']),
                 fetchControlsForDomain: vi.fn().mockResolvedValue([
-                    { id: 401, name: 'test-control', description: 'A control' },
+                    { id: 401, name: 'test-control', description: 'A control', title: 'Test Control Title' },
                 ]),
             };
             return controlServiceInstance as unknown as InstanceType<typeof ControlService>;
@@ -318,6 +318,40 @@ describe('TreeNavigation', () => {
                 controlId: 401,
                 controlName: 'test-control',
                 controlDescription: 'A control',
+                controlTitle: 'Test Control Title',
+            });
+        });
+    });
+
+    it('loads data based on deeplink route - control (numeric id fallback)', async () => {
+        vi.mocked(ControlService).mockImplementation(function () {
+            controlServiceInstance = {
+                fetchDomains: vi.fn().mockResolvedValue(['test-domain']),
+                fetchControlsForDomain: vi.fn().mockResolvedValue([
+                    { id: 401, name: 'test-control', description: 'A control', title: 'Test Control Title' },
+                ]),
+            };
+            return controlServiceInstance as unknown as InstanceType<typeof ControlService>;
+        });
+
+        vi.mocked(useParams).mockReturnValue({
+            namespace: 'test-domain',
+            type: 'controls',
+            id: '401',
+            version: 'detail',
+        });
+
+        render(<MemoryRouter initialEntries={["/"]}>
+            <TreeNavigation {...mockProps} />
+        </MemoryRouter>);
+
+        await waitFor(() => {
+            expect(mockProps.onControlLoad).toHaveBeenCalledWith({
+                domain: 'test-domain',
+                controlId: 401,
+                controlName: 'test-control',
+                controlDescription: 'A control',
+                controlTitle: 'Test Control Title',
             });
         });
     });

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.test.tsx
@@ -294,7 +294,7 @@ describe('TreeNavigation', () => {
             controlServiceInstance = {
                 fetchDomains: vi.fn().mockResolvedValue(['test-domain']),
                 fetchControlsForDomain: vi.fn().mockResolvedValue([
-                    { id: 401, name: 'Test Control', description: 'A control' },
+                    { id: 401, name: 'test-control', description: 'A control' },
                 ]),
             };
             return controlServiceInstance as unknown as InstanceType<typeof ControlService>;
@@ -303,7 +303,7 @@ describe('TreeNavigation', () => {
         vi.mocked(useParams).mockReturnValue({
             namespace: 'test-domain',
             type: 'controls',
-            id: '401',
+            id: 'test-control',
             version: 'detail',
         });
 
@@ -316,7 +316,7 @@ describe('TreeNavigation', () => {
             expect(mockProps.onControlLoad).toHaveBeenCalledWith({
                 domain: 'test-domain',
                 controlId: 401,
-                controlName: 'Test Control',
+                controlName: 'test-control',
                 controlDescription: 'A control',
             });
         });

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -465,13 +465,13 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
             }
 
             if (uiType === 'Controls') {
-                const controlId = Number(params.id);
+                const controlSlug = params.id;
                 const domain = params.namespace;
                 controlService.fetchControlsForDomain(domain)
                     .then((controls) => {
                         setDomainControls(controls);
                         setSelectedDomain(domain);
-                        const match = controls.find((c) => c.id === controlId);
+                        const match = controls.find((c) => c.name === controlSlug);
                         if (match) {
                             setSelectedControlId(match.id);
                             onControlLoadRef.current({

--- a/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/TreeNavigation.tsx
@@ -471,7 +471,8 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
                     .then((controls) => {
                         setDomainControls(controls);
                         setSelectedDomain(domain);
-                        const match = controls.find((c) => c.name === controlSlug);
+                        const match = controls.find((c) => c.name === controlSlug)
+                            ?? controls.find((c) => c.id === Number(controlSlug));
                         if (match) {
                             setSelectedControlId(match.id);
                             onControlLoadRef.current({
@@ -479,6 +480,7 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
                                 controlId: match.id,
                                 controlName: match.name,
                                 controlDescription: match.description,
+                                controlTitle: match.title,
                             });
                         }
                     })
@@ -558,6 +560,7 @@ export function TreeNavigation({ onDataLoad, onAdrLoad, onControlLoad, onInterfa
             controlId: control.id,
             controlName: control.name,
             controlDescription: control.description,
+            controlTitle: control.title,
         });
     };
 

--- a/calm-hub-ui/src/model/control.ts
+++ b/calm-hub-ui/src/model/control.ts
@@ -16,4 +16,5 @@ export interface ControlData {
     controlId: number;
     controlName: string;
     controlDescription: string;
+    controlTitle?: string;
 }

--- a/calm-hub-ui/src/model/control.ts
+++ b/calm-hub-ui/src/model/control.ts
@@ -1,15 +1,16 @@
-/**
- * Represents a control detail returned from the API.
- */
 export interface ControlDetail {
     id: number;
     name: string;
     description: string;
+    title?: string;
 }
 
-/**
- * Represents the data loaded when a user selects a control in the tree.
- */
+export interface ControlConfigDetail {
+    id: number;
+    name?: string;
+    title?: string;
+}
+
 export interface ControlData {
     domain: string;
     controlId: number;

--- a/calm-hub-ui/src/service/control-service.test.ts
+++ b/calm-hub-ui/src/service/control-service.test.ts
@@ -152,8 +152,12 @@ describe('ControlService', () => {
     // fetchConfigurationsForControl
     // ──────────────────────────────────────────────────
     describe('fetchConfigurationsForControl', () => {
-        it('should call the correct endpoint and return config IDs', async () => {
-            const expected = [10, 20, 30];
+        it('should call the correct endpoint and return config details', async () => {
+            const expected = [
+                { id: 10, name: 'config-a', title: 'Config A' },
+                { id: 20, name: 'config-b', title: null },
+                { id: 30 },
+            ];
             mock.onGet(`/api/calm/domains/${domain}/controls/${controlId}/configurations`).reply(200, { values: expected });
 
             const result = await controlService.fetchConfigurationsForControl(domain, controlId);

--- a/calm-hub-ui/src/service/control-service.ts
+++ b/calm-hub-ui/src/service/control-service.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { getAuthHeaders } from '../authService.js';
-import { ControlDetail } from '../model/control.js';
+import { ControlConfigDetail, ControlDetail } from '../model/control.js';
 import { apiClient } from './utils/api-client.js';
 
 export class ControlService {
@@ -69,7 +69,7 @@ export class ControlService {
             });
     }
 
-    public async fetchConfigurationsForControl(domain: string, controlId: number): Promise<number[]> {
+    public async fetchConfigurationsForControl(domain: string, controlId: number): Promise<ControlConfigDetail[]> {
         const headers = await getAuthHeaders();
         return this.ax
             .get(`/api/calm/domains/${encodeURIComponent(domain)}/controls/${controlId}/configurations`, { headers })

--- a/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
@@ -268,7 +268,7 @@ public class MongoControlIntegration {
                 .then()
                 .statusCode(200)
                 .body("values", hasSize(1))
-                .body("values[0]", equalTo(100));
+                .body("values[0].id", equalTo(100));
     }
 
     @Test

--- a/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlConfigDetail.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlConfigDetail.java
@@ -10,12 +10,19 @@ public class ControlConfigDetail {
 
     private Integer id;
     private String name;
+    private String title;
 
     public ControlConfigDetail() {}
 
     public ControlConfigDetail(Integer id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public ControlConfigDetail(Integer id, String name, String title) {
+        this.id = id;
+        this.name = name;
+        this.title = title;
     }
 
     public Integer getId() {
@@ -34,15 +41,23 @@ public class ControlConfigDetail {
         this.name = name;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         ControlConfigDetail that = (ControlConfigDetail) o;
-        return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(title, that.title);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name);
+        return Objects.hash(id, name, title);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlDetail.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlDetail.java
@@ -6,6 +6,7 @@ public class ControlDetail {
     private Integer id;
     private String name;
     private String description;
+    private String title;
 
     public ControlDetail() {
 
@@ -15,6 +16,13 @@ public class ControlDetail {
         this.id = id;
         this.name = name;
         this.description = description;
+    }
+
+    public ControlDetail(Integer id, String name, String description, String title) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.title = title;
     }
 
     public Integer getId() {
@@ -41,15 +49,23 @@ public class ControlDetail {
         this.description = description;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         ControlDetail that = (ControlDetail) o;
-        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(description, that.description);
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(title, that.title);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description);
+        return Objects.hash(id, name, description, title);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
@@ -179,7 +179,7 @@ public class ControlResource {
     @Path("{domain}/controls/{controlId}/configurations")
     @Operation(
             summary = "Retrieve configurations for a control",
-            description = "Returns the list of configuration IDs for a given control"
+            description = "Returns the list of configurations (id, name, title) for a given control"
     )
     @PermissionsAllowed(CalmHubScopes.DOMAIN_READ)
     public Response getConfigurationsForControl(
@@ -188,7 +188,7 @@ public class ControlResource {
             String domain,
             @PathParam("controlId") int controlId) {
         try {
-            return Response.ok(new ValueWrapper<>(store.getConfigurationsForControl(domain, controlId))).build();
+            return Response.ok(new ValueWrapper<>(store.getConfigurationDetailsForControl(domain, controlId))).build();
         } catch (DomainNotFoundException e) {
             logger.error("Invalid domain [{}] when retrieving configurations", domain, e);
             return invalidDomainResponse(domain);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -24,6 +24,7 @@ import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.store.ControlStore;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -90,10 +91,13 @@ public class MongoControlStore implements ControlStore {
 
         List<ControlDetail> result = new ArrayList<>();
         for (Document control : controls) {
+            Document requirement = (Document) control.get("requirement");
+            String title = titleFromRequirementDoc(requirement);
             result.add(new ControlDetail(
                     control.getInteger("controlId"),
                     control.getString("name"),
-                    control.getString("description")
+                    control.getString("description"),
+                    title
             ));
         }
         return result;
@@ -185,9 +189,12 @@ public class MongoControlStore implements ControlStore {
 
         List<ControlConfigDetail> details = new ArrayList<>();
         for (Document config : configurations) {
+            Document versions = (Document) config.get("versions");
+            String title = titleFromVersionsDoc(versions);
             details.add(new ControlConfigDetail(
                     config.getInteger("configurationId"),
-                    config.getString("name")));
+                    config.getString("name"),
+                    title));
         }
         return details;
     }
@@ -357,6 +364,38 @@ public class MongoControlStore implements ControlStore {
         }
 
         throw new ControlConfigurationNotFoundException();
+    }
+
+    private String latestVersionKey(Set<String> keys) {
+        return keys.stream()
+                .max(Comparator.comparingInt(k -> {
+                    String[] parts = k.split("-");
+                    if (parts.length != 3) return 0;
+                    try {
+                        return Integer.parseInt(parts[0]) * 1_000_000
+                                + Integer.parseInt(parts[1]) * 1_000
+                                + Integer.parseInt(parts[2]);
+                    } catch (NumberFormatException e) {
+                        return 0;
+                    }
+                }))
+                .orElse(null);
+    }
+
+    private String titleFromRequirementDoc(Document requirement) {
+        if (requirement == null || requirement.isEmpty()) return null;
+        String latestKey = latestVersionKey(requirement.keySet());
+        if (latestKey == null) return null;
+        Document versionDoc = (Document) requirement.get(latestKey);
+        return versionDoc != null ? versionDoc.getString("title") : null;
+    }
+
+    private String titleFromVersionsDoc(Document versions) {
+        if (versions == null || versions.isEmpty()) return null;
+        String latestKey = latestVersionKey(versions.keySet());
+        if (latestKey == null) return null;
+        Document versionDoc = (Document) versions.get(latestKey);
+        return versionDoc != null ? versionDoc.getString("title") : null;
     }
 
     private void validateDomain(String domain) throws DomainNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -24,10 +24,10 @@ import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.store.ControlStore;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
+import org.finos.calm.store.util.VersionKeySelector;
 
 /**
  * MongoDB-backed implementation of {@link ControlStore}.
@@ -366,25 +366,9 @@ public class MongoControlStore implements ControlStore {
         throw new ControlConfigurationNotFoundException();
     }
 
-    private String latestVersionKey(Set<String> keys) {
-        return keys.stream()
-                .max(Comparator.comparingInt(k -> {
-                    String[] parts = k.split("-");
-                    if (parts.length != 3) return 0;
-                    try {
-                        return Integer.parseInt(parts[0]) * 1_000_000
-                                + Integer.parseInt(parts[1]) * 1_000
-                                + Integer.parseInt(parts[2]);
-                    } catch (NumberFormatException e) {
-                        return 0;
-                    }
-                }))
-                .orElse(null);
-    }
-
     private String titleFromRequirementDoc(Document requirement) {
         if (requirement == null || requirement.isEmpty()) return null;
-        String latestKey = latestVersionKey(requirement.keySet());
+        String latestKey = VersionKeySelector.latestVersionKey(requirement.keySet());
         if (latestKey == null) return null;
         Document versionDoc = (Document) requirement.get(latestKey);
         return versionDoc != null ? versionDoc.getString("title") : null;
@@ -392,7 +376,7 @@ public class MongoControlStore implements ControlStore {
 
     private String titleFromVersionsDoc(Document versions) {
         if (versions == null || versions.isEmpty()) return null;
-        String latestKey = latestVersionKey(versions.keySet());
+        String latestKey = VersionKeySelector.latestVersionKey(versions.keySet());
         if (latestKey == null) return null;
         Document versionDoc = (Document) versions.get(latestKey);
         return versionDoc != null ? versionDoc.getString("title") : null;

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -22,7 +22,10 @@ import org.finos.calm.store.ControlStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -50,6 +53,8 @@ public class NitriteControlStore implements ControlStore {
     private static final String CONFIGURATION_ID_FIELD = "configurationId";
     private static final String VERSIONS_FIELD = "versions";
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final NitriteCollection controlCollection;
     private final NitriteDomainStore domainStore;
     private final NitriteCounterStore counterStore;
@@ -75,10 +80,13 @@ public class NitriteControlStore implements ControlStore {
                 continue;
             }
             for (Document control : controls) {
+                Document requirement = control.get(REQUIREMENT_FIELD, Document.class);
+                String title = titleFromRequirementNitriteDoc(requirement);
                 result.add(new ControlDetail(
                         control.get(CONTROL_ID_FIELD, Integer.class),
                         control.get("name", String.class),
-                        control.get("description", String.class)
+                        control.get("description", String.class),
+                        title
                 ));
             }
         }
@@ -196,9 +204,12 @@ public class NitriteControlStore implements ControlStore {
 
         List<ControlConfigDetail> details = new ArrayList<>();
         for (Document config : configurations) {
+            Document versions = config.get(VERSIONS_FIELD, Document.class);
+            String title = titleFromVersionsNitriteDoc(versions);
             details.add(new ControlConfigDetail(
                     config.get(CONFIGURATION_ID_FIELD, Integer.class),
-                    config.get("name", String.class)));
+                    config.get("name", String.class),
+                    title));
         }
         return details;
     }
@@ -398,6 +409,48 @@ public class NitriteControlStore implements ControlStore {
         }
 
         throw new ControlConfigurationNotFoundException();
+    }
+
+    private String latestVersionKey(Set<String> keys) {
+        return keys.stream()
+                .max(Comparator.comparingInt(k -> {
+                    String[] parts = k.split("-");
+                    if (parts.length != 3) return 0;
+                    try {
+                        return Integer.parseInt(parts[0]) * 1_000_000
+                                + Integer.parseInt(parts[1]) * 1_000
+                                + Integer.parseInt(parts[2]);
+                    } catch (NumberFormatException e) {
+                        return 0;
+                    }
+                }))
+                .orElse(null);
+    }
+
+    private String titleFromJsonString(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(json);
+            JsonNode titleNode = node.get("title");
+            return (titleNode != null && titleNode.isTextual()) ? titleNode.asText() : null;
+        } catch (Exception e) {
+            LOG.debug("Could not parse version JSON to extract title", e);
+            return null;
+        }
+    }
+
+    private String titleFromRequirementNitriteDoc(Document requirement) {
+        if (requirement == null || requirement.getFields().isEmpty()) return null;
+        String latestKey = latestVersionKey(requirement.getFields());
+        if (latestKey == null) return null;
+        return titleFromJsonString(requirement.get(latestKey, String.class));
+    }
+
+    private String titleFromVersionsNitriteDoc(Document versions) {
+        if (versions == null || versions.getFields().isEmpty()) return null;
+        String latestKey = latestVersionKey(versions.getFields());
+        if (latestKey == null) return null;
+        return titleFromJsonString(versions.get(latestKey, String.class));
     }
 
     private void validateDomain(String domain) throws DomainNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -25,11 +25,11 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.finos.calm.store.util.VersionKeySelector;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -411,22 +411,6 @@ public class NitriteControlStore implements ControlStore {
         throw new ControlConfigurationNotFoundException();
     }
 
-    private String latestVersionKey(Set<String> keys) {
-        return keys.stream()
-                .max(Comparator.comparingInt(k -> {
-                    String[] parts = k.split("-");
-                    if (parts.length != 3) return 0;
-                    try {
-                        return Integer.parseInt(parts[0]) * 1_000_000
-                                + Integer.parseInt(parts[1]) * 1_000
-                                + Integer.parseInt(parts[2]);
-                    } catch (NumberFormatException e) {
-                        return 0;
-                    }
-                }))
-                .orElse(null);
-    }
-
     private String titleFromJsonString(String json) {
         if (json == null || json.isBlank()) return null;
         try {
@@ -441,14 +425,14 @@ public class NitriteControlStore implements ControlStore {
 
     private String titleFromRequirementNitriteDoc(Document requirement) {
         if (requirement == null || requirement.getFields().isEmpty()) return null;
-        String latestKey = latestVersionKey(requirement.getFields());
+        String latestKey = VersionKeySelector.latestVersionKey(requirement.getFields());
         if (latestKey == null) return null;
         return titleFromJsonString(requirement.get(latestKey, String.class));
     }
 
     private String titleFromVersionsNitriteDoc(Document versions) {
         if (versions == null || versions.getFields().isEmpty()) return null;
-        String latestKey = latestVersionKey(versions.getFields());
+        String latestKey = VersionKeySelector.latestVersionKey(versions.getFields());
         if (latestKey == null) return null;
         return titleFromJsonString(versions.get(latestKey, String.class));
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/VersionKeySelector.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/VersionKeySelector.java
@@ -1,0 +1,26 @@
+package org.finos.calm.store.util;
+
+import java.util.Comparator;
+import java.util.Set;
+
+public final class VersionKeySelector {
+
+    private VersionKeySelector() {
+    }
+
+    public static String latestVersionKey(Set<String> keys) {
+        return keys.stream()
+                .max(Comparator.comparingInt(k -> {
+                    String[] parts = k.split("-");
+                    if (parts.length != 3) return 0;
+                    try {
+                        return Integer.parseInt(parts[0]) * 1_000_000
+                                + Integer.parseInt(parts[1]) * 1_000
+                                + Integer.parseInt(parts[2]);
+                    } catch (NumberFormatException e) {
+                        return 0;
+                    }
+                }))
+                .orElse(null);
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
@@ -4,6 +4,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.bson.json.JsonParseException;
+import org.finos.calm.domain.controls.ControlConfigDetail;
 import org.finos.calm.domain.controls.ControlDetail;
 import org.finos.calm.domain.controls.CreateControlConfiguration;
 import org.finos.calm.domain.controls.CreateControlRequirement;
@@ -266,9 +267,12 @@ public class TestControlResourceShould {
     @MethodSource("provideParametersForGetConfigurationsTests")
     void respond_correctly_to_get_configurations(String domain, Throwable exceptionToThrow, int expectedStatusCode) throws Exception {
         if (exceptionToThrow != null) {
-            when(mockControlStore.getConfigurationsForControl(anyString(), anyInt())).thenThrow(exceptionToThrow);
+            when(mockControlStore.getConfigurationDetailsForControl(anyString(), anyInt())).thenThrow(exceptionToThrow);
         } else {
-            when(mockControlStore.getConfigurationsForControl(anyString(), anyInt())).thenReturn(List.of(10, 20));
+            when(mockControlStore.getConfigurationDetailsForControl(anyString(), anyInt()))
+                    .thenReturn(List.of(
+                            new ControlConfigDetail(10, "config-a", "Config A Title"),
+                            new ControlConfigDetail(20, "config-b", null)));
         }
 
         if (expectedStatusCode == 200) {
@@ -278,8 +282,11 @@ public class TestControlResourceShould {
                     .then()
                     .statusCode(expectedStatusCode)
                     .body("values", hasSize(2))
-                    .body("values[0]", equalTo(10))
-                    .body("values[1]", equalTo(20));
+                    .body("values[0].id", equalTo(10))
+                    .body("values[0].name", equalTo("config-a"))
+                    .body("values[0].title", equalTo("Config A Title"))
+                    .body("values[1].id", equalTo(20))
+                    .body("values[1].name", equalTo("config-b"));
         } else {
             given()
                     .when()
@@ -288,12 +295,12 @@ public class TestControlResourceShould {
                     .statusCode(expectedStatusCode);
         }
 
-        verify(mockControlStore).getConfigurationsForControl(domain, 1);
+        verify(mockControlStore).getConfigurationDetailsForControl(domain, 1);
     }
 
     @Test
     void return_empty_configurations_for_control_with_none() throws Exception {
-        when(mockControlStore.getConfigurationsForControl(VALID_DOMAIN, 1)).thenReturn(List.of());
+        when(mockControlStore.getConfigurationDetailsForControl(VALID_DOMAIN, 1)).thenReturn(List.of());
 
         given()
                 .when()
@@ -302,7 +309,7 @@ public class TestControlResourceShould {
                 .statusCode(200)
                 .body("values", is(empty()));
 
-        verify(mockControlStore).getConfigurationsForControl(VALID_DOMAIN, 1);
+        verify(mockControlStore).getConfigurationDetailsForControl(VALID_DOMAIN, 1);
     }
 
     // --- Configuration Version Endpoints ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestVersionKeySelectorShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestVersionKeySelectorShould.java
@@ -1,0 +1,38 @@
+package org.finos.calm.store.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TestVersionKeySelectorShould {
+
+    @Test
+    void return_the_highest_semver_from_multiple_valid_keys() {
+        assertEquals("2-0-0", VersionKeySelector.latestVersionKey(Set.of("1-0-0", "2-0-0", "1-5-0")));
+    }
+
+    @Test
+    void return_the_single_key_when_set_has_one_entry() {
+        assertEquals("3-2-1", VersionKeySelector.latestVersionKey(Set.of("3-2-1")));
+    }
+
+    @Test
+    void return_valid_key_when_set_contains_malformed_non_three_part_key() {
+        // "abc" has fewer than 3 parts → score 0; "1-0-0" wins
+        assertEquals("1-0-0", VersionKeySelector.latestVersionKey(Set.of("1-0-0", "abc")));
+    }
+
+    @Test
+    void return_valid_key_when_set_contains_non_numeric_three_part_key() {
+        // "a-b-c" triggers NumberFormatException → score 0; "1-0-0" wins
+        assertEquals("1-0-0", VersionKeySelector.latestVersionKey(Set.of("1-0-0", "a-b-c")));
+    }
+
+    @Test
+    void return_null_for_empty_set() {
+        assertNull(VersionKeySelector.latestVersionKey(Set.of()));
+    }
+}


### PR DESCRIPTION
## Description

Fixes #2680. CalmHub UI was showing "Control 1" / "Config 1" instead of human-readable titles, and deep-link URLs used numeric storage IDs instead of slugs.

**Backend (calm-hub):**
- `ControlDetail` and `ControlConfigDetail` gain a `title` field extracted from the latest version JSON at request time (no DB migration)
- `latestVersionKey` extracted to `VersionKeySelector` shared util (replaces duplicate in Mongo and Nitrite stores)
- Nitrite and Mongo stores both populate `title` — Nitrite parses the version value as a JSON string; Mongo reads a nested `Document`
- `ControlResource` wired to `getConfigurationDetailsForControl` (already existed) instead of bare `getConfigurationsForControl`

**Frontend (calm-hub-ui):**
- Control tree navigation renders `title ?? name`; config tabs render `title ?? name ?? Config {id}`
- Deep-link URL now uses the control slug (`name`) instead of the numeric ID
- Both `TreeNavigation` and `MobileNavMenu` deep-link handlers add a numeric-ID fallback so existing bookmarked URLs (`/security/controls/1/detail`) still resolve
- `ControlData` carries `controlTitle`; breadcrumbs show `controlTitle ?? controlName`
- `GlobalSearchBar` and `ExplorerSearch` build control URLs with the slug
- `selectedCfg` computed once before render, eliminating duplicate `configs.find()` calls

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅

All commits follow conventional format (`fix(calm-hub): ...`).

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Backend: 2073 tests pass (`./mvnw -pl calm-hub test`)
Frontend: 964 tests pass (`npm test --workspace calm-hub-ui`)
Lint: 0 errors (`npm run lint --workspace calm-hub-ui`)

New tests cover: title display in breadcrumbs and tabs, numeric-ID fallback in deep-link handlers, `title ?? name ?? Config N` fallback chain in config tab labels.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards