### PR TITLE
ci: guard CVE/license scanning workflows to canonical repo

### DIFF
--- a/.github/workflows/cve-scanning-maven.yml
+++ b/.github/workflows/cve-scanning-maven.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
     depchecktest:
+        if: github.repository == 'finos/architecture-as-code'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/cve-scanning-node.yml
+++ b/.github/workflows/cve-scanning-node.yml
@@ -24,6 +24,7 @@ on:
 jobs:
     node-modules-scan:
         name: ${{ matrix.module-folder }}-node-scan
+        if: github.repository == 'finos/architecture-as-code'
         runs-on: ubuntu-latest
         environment:
             name: code-scan

--- a/.github/workflows/license-scanning-maven.yml
+++ b/.github/workflows/license-scanning-maven.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
     scan:
+        if: github.repository == 'finos/architecture-as-code'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/license-scanning-node.yml
+++ b/.github/workflows/license-scanning-node.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
     scan:
+        if: github.repository == 'finos/architecture-as-code'
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## Description

Adds `if: github.repository == 'finos/architecture-as-code'` at the job level in all four secret-dependent scanning workflows. Fork repos skip the jobs cleanly (neutral) instead of failing twice daily on missing secrets.

Fixes #2752.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Testing
- [x] YAML validated with `python3 yaml.safe_load`

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] My changes follow the project's coding standards