### PR TITLE
feat(cli): add --fail-if-modified to hub push

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -59,6 +59,7 @@ npm run copy-ai-tools         # Copy AI agent files from ../calm-ai/
 9. **hub** - Command **group** for interacting with CALM Hub. Subcommands:
    - `hub push <resource> <file>` / `hub pull <resource>` / `hub list <resources>` / `hub create <resource>`
    - Resources span architectures, patterns, standards, control-requirements, control-configurations, namespaces, and domains (which subcommands exist varies per verb).
+   - `hub push architecture|pattern|standard` auto-bumps by default (creates a new version off the latest). The `--fail-if-modified` flag switches to a strict, non-bumping mode: a brand-new mapping is still created at `1.0.0`, an unchanged document is skipped, and a document that differs from the latest published version fails the push. Content comparison uses `canonicalEqual` from `@finos/calm-shared` (key-order-insensitive).
 
 ### Important Directories
 ```

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -59,7 +59,7 @@ npm run copy-ai-tools         # Copy AI agent files from ../calm-ai/
 9. **hub** - Command **group** for interacting with CALM Hub. Subcommands:
    - `hub push <resource> <file>` / `hub pull <resource>` / `hub list <resources>` / `hub create <resource>`
    - Resources span architectures, patterns, standards, control-requirements, control-configurations, namespaces, and domains (which subcommands exist varies per verb).
-   - `hub push architecture|pattern|standard` auto-bumps by default (creates a new version off the latest). The `--fail-if-modified` flag switches to a strict, non-bumping mode: a brand-new mapping is still created at `1.0.0`, an unchanged document is skipped, and a document that differs from the latest published version fails the push. Content comparison uses `canonicalEqual` from `@finos/calm-shared` (key-order-insensitive).
+   - `hub push` auto-bumps by default (creates a new version off the latest). The `--fail-if-modified` flag (supported on `architecture`, `pattern`, `standard`, `control-requirement` and `control-configuration`) switches to a strict, non-bumping mode: a brand-new mapping is still created at `1.0.0`, an unchanged document is skipped, and a document that differs from the latest published version fails the push. The local document is normalised the same way Hub stores it (via `updateDocumentMetadata`/`updateControlDocumentMetadata`) before comparing with `canonicalEqual` from `@finos/calm-shared`, so a version-only or defaulted-field difference is not mistaken for a content change.
 
 ### Important Directories
 ```

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -784,6 +784,31 @@ describe('CLI Commands', () => {
             }));
         });
 
+        it('passes --fail-if-modified through to the architecture handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'architecture',
+                'arch.json',
+                '--calm-hub-url', 'http://hub',
+                '--fail-if-modified',
+            ]);
+
+            expect(hubCommandsModule.runPushArchitecture).toHaveBeenCalledWith(expect.objectContaining({
+                failIfModified: true,
+            }));
+        });
+
+        it('defaults --fail-if-modified to false when not provided', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'architecture',
+                'arch.json',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPushArchitecture).toHaveBeenCalledWith(expect.objectContaining({
+                failIfModified: false,
+            }));
+        });
+
         it('passes --format pretty through to the handler', async () => {
             await program.parseAsync([
                 'node', 'cli.js', 'hub', 'push', 'architecture',
@@ -1085,6 +1110,18 @@ describe('CLI Commands', () => {
             expect(hubCommandsModule.runPushControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
                 file: 'req.json',
                 changeType: 'PATCH',
+            }));
+        });
+
+        it('passes --fail-if-modified through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'control-requirement', 'req.json',
+                '--calm-hub-url', 'http://hub',
+                '--fail-if-modified',
+            ]);
+
+            expect(hubCommandsModule.runPushControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                failIfModified: true,
             }));
         });
     });

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -463,6 +463,9 @@ Example:
         .choices(['patch', 'minor', 'major'])
         .default('patch');
 
+    const hubFailIfModifiedOption = new Option('--fail-if-modified', 'Strict mode: do not auto-bump. Skip if the document is unchanged from the latest published version; fail if it has changed. A brand-new mapping is still created at 1.0.0.')
+        .default(false);
+
     const hubCmd = new Command('hub').description('Interact with CALM Hub');
 
     // hub push
@@ -476,6 +479,7 @@ Example:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .addOption(hubVersionBumpOption)
+        .addOption(hubFailIfModifiedOption)
         .action(async (architectureFile, options) => {
             const pushOptions: PushOptions = {
                 calmHubOptions: { calmHubUrl: options.calmHubUrl },
@@ -483,7 +487,8 @@ Example:
                 description: options.description,
                 file: architectureFile,
                 format: options.format,
-                changeType: options.changeType.toUpperCase() as ResourceChangeType
+                changeType: options.changeType.toUpperCase() as ResourceChangeType,
+                failIfModified: options.failIfModified
             };
             await runPushArchitecture(pushOptions);
         });
@@ -496,6 +501,7 @@ Example:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .addOption(hubVersionBumpOption)
+        .addOption(hubFailIfModifiedOption)
         .action(async (patternFile, options) => {
             const pushPatternOptions: PushOptions = {
                 calmHubOptions: { calmHubUrl: options.calmHubUrl },
@@ -504,6 +510,7 @@ Example:
                 file: patternFile,
                 format: options.format,
                 changeType: options.changeType.toUpperCase() as ResourceChangeType,
+                failIfModified: options.failIfModified
             };
             await runPushPattern(pushPatternOptions);
         });
@@ -516,6 +523,7 @@ Example:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .addOption(hubVersionBumpOption)
+        .addOption(hubFailIfModifiedOption)
         .action(async (standardFile, options) => {
             const pushStandardOptions: PushOptions = {
                 calmHubOptions: { calmHubUrl: options.calmHubUrl },
@@ -524,6 +532,7 @@ Example:
                 file: standardFile,
                 format: options.format,
                 changeType: options.changeType.toUpperCase() as ResourceChangeType,
+                failIfModified: options.failIfModified
             };
             await runPushStandard(pushStandardOptions);
         });

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -543,12 +543,14 @@ Example:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .addOption(hubVersionBumpOption)
+        .addOption(hubFailIfModifiedOption)
         .action(async (requirementFile, options) => {
             const pushOptions: PushControlOptions = {
                 calmHubOptions: { calmHubUrl: options.calmHubUrl },
                 file: requirementFile,
                 format: options.format,
-                changeType: options.changeType.toUpperCase() as ResourceChangeType
+                changeType: options.changeType.toUpperCase() as ResourceChangeType,
+                failIfModified: options.failIfModified
             };
             await runPushControlRequirement(pushOptions);
         });
@@ -559,12 +561,14 @@ Example:
         .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
         .addOption(hubOutputOption)
         .addOption(hubVersionBumpOption)
+        .addOption(hubFailIfModifiedOption)
         .action(async (configFile, options) => {
             const pushOptions: PushControlOptions = {
                 calmHubOptions: { calmHubUrl: options.calmHubUrl },
                 file: configFile,
                 format: options.format,
-                changeType: options.changeType.toUpperCase() as ResourceChangeType
+                changeType: options.changeType.toUpperCase() as ResourceChangeType,
+                failIfModified: options.failIfModified
             };
             await runPushControlConfiguration(pushOptions);
         });

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -342,8 +342,15 @@ describe('hub-commands', () => {
             it('skips (does not create a new version) when content is unchanged from the latest published version', async () => {
                 const { mockClient } = await getSharedMocks();
                 vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue(['1.0.0']);
-                // Latest published version is byte-identical to the local document (key order ignored).
-                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue(JSON.parse(pushDoc('my-arch')));
+                // The stored document is the local doc as Hub normalises it on the way in: $id at the
+                // latest version and a defaulted empty description. The local file (pushDoc) has no
+                // description and is only compared after the same normalisation, so this must match.
+                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue({
+                    $id: 'http://hub/calm/namespaces/finos/architectures/my-arch/versions/1.0.0',
+                    title: 'my-arch',
+                    description: '',
+                    nodes: []
+                });
 
                 await runPushArchitecture({
                     calmHubOptions: { calmHubUrl: 'http://hub' },
@@ -356,6 +363,48 @@ describe('hub-commands', () => {
                 expect(fs.writeFile).not.toHaveBeenCalled();
                 expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
                     expect.objectContaining({ status: 'skipped', version: '1.0.0' })
+                );
+            });
+
+            it('does not flag a version-only difference (auto-bumped elsewhere) as modified', async () => {
+                const { mockClient } = await getSharedMocks();
+                // Hub has moved on to 1.1.0; the local file still declares 1.0.0 but the architecture
+                // content is identical. Normalising to the latest version must make these compare equal.
+                vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue(['1.0.0', '1.1.0']);
+                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue({
+                    $id: 'http://hub/calm/namespaces/finos/architectures/my-arch/versions/1.1.0',
+                    title: 'my-arch',
+                    description: '',
+                    nodes: []
+                });
+
+                await runPushArchitecture({
+                    calmHubOptions: { calmHubUrl: 'http://hub' },
+                    file: 'arch.json',
+                    failIfModified: true
+                });
+
+                expect(mockClient.getMappedResourceByVersion).toHaveBeenCalledWith('finos', 'my-arch', '1.1.0', 'architectures');
+                expect(mockClient.createMappedResourceVersion).not.toHaveBeenCalled();
+                expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
+                    expect.objectContaining({ status: 'skipped', version: '1.1.0' })
+                );
+            });
+
+            it('fails clearly when Hub returns an empty body for the latest version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue(['1.0.0']);
+                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue(undefined as unknown as object);
+
+                await expect(runPushArchitecture({
+                    calmHubOptions: { calmHubUrl: 'http://hub' },
+                    file: 'arch.json',
+                    failIfModified: true
+                })).rejects.toThrow('process.exit');
+
+                expect(mockClient.createMappedResourceVersion).not.toHaveBeenCalled();
+                expect(hubOutput.printError).toHaveBeenCalledWith(
+                    0, expect.stringContaining('Could not read the latest published version'), expect.any(String), 'json'
                 );
             });
 
@@ -1186,6 +1235,52 @@ describe('hub-commands', () => {
                 .rejects.toThrow('process.exit');
             expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Version already exists', expect.any(String), 'json');
         });
+
+        describe('--fail-if-modified', () => {
+            it('creates 1.0.0 for a brand-new requirement even with the flag set', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(fs.readFile).mockResolvedValue(controlReqDoc() as unknown as Uint8Array);
+                vi.mocked(mockClient.getControlRequirementVersions).mockResolvedValue([]);
+                vi.mocked(mockClient.createControlRequirementVersion).mockResolvedValue(reqId('1.0.0'));
+
+                await runPushControlRequirement({ calmHubOptions: { calmHubUrl: 'http://hub' }, file: 'req.json', failIfModified: true });
+
+                expect(mockClient.getControlRequirementVersion).not.toHaveBeenCalled();
+                expect(mockClient.createControlRequirementVersion).toHaveBeenCalledWith('security', 'access-control', '1.0.0', expect.any(String));
+            });
+
+            it('skips when the requirement is unchanged from the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(fs.readFile).mockResolvedValue(controlReqDoc() as unknown as Uint8Array);
+                vi.mocked(mockClient.getControlRequirementVersions).mockResolvedValue(['1.0.0']);
+                // Stored doc normalised to its latest version (only the $id version differs from disk).
+                vi.mocked(mockClient.getControlRequirementVersion).mockResolvedValue({ $id: reqId('1.0.0'), nodes: [] });
+
+                await runPushControlRequirement({ calmHubOptions: { calmHubUrl: 'http://hub' }, file: 'req.json', failIfModified: true });
+
+                expect(mockClient.getControlRequirementVersion).toHaveBeenCalledWith('security', 'access-control', '1.0.0');
+                expect(mockClient.createControlRequirementVersion).not.toHaveBeenCalled();
+                expect(fs.writeFile).not.toHaveBeenCalled();
+                expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
+                    expect.objectContaining({ status: 'skipped', version: '1.0.0' })
+                );
+            });
+
+            it('fails when the requirement has changed relative to the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(fs.readFile).mockResolvedValue(controlReqDoc() as unknown as Uint8Array);
+                vi.mocked(mockClient.getControlRequirementVersions).mockResolvedValue(['1.0.0']);
+                vi.mocked(mockClient.getControlRequirementVersion).mockResolvedValue({ $id: reqId('1.0.0'), nodes: [{ 'unique-id': 'changed' }] });
+
+                await expect(runPushControlRequirement({ calmHubOptions: { calmHubUrl: 'http://hub' }, file: 'req.json', failIfModified: true }))
+                    .rejects.toThrow('process.exit');
+
+                expect(mockClient.createControlRequirementVersion).not.toHaveBeenCalled();
+                expect(hubOutput.printError).toHaveBeenCalledWith(
+                    0, expect.stringContaining('has changed relative to the latest published version'), expect.any(String), 'json'
+                );
+            });
+        });
     });
 
     // ── runPushControlConfiguration ────────────────────────────────────────────
@@ -1239,6 +1334,38 @@ describe('hub-commands', () => {
             expect(hubOutput.printError).toHaveBeenCalledWith(
                 0, expect.stringContaining('describes a control requirement, but a control configuration was expected'), expect.any(String), 'json'
             );
+        });
+
+        describe('--fail-if-modified', () => {
+            it('skips when the configuration is unchanged from the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(fs.readFile).mockResolvedValue(controlConfigDoc() as unknown as Uint8Array);
+                vi.mocked(mockClient.getControlConfigurationVersions).mockResolvedValue(['1.0.0']);
+                vi.mocked(mockClient.getControlConfigurationVersion).mockResolvedValue({ $id: cfgId('1.0.0'), nodes: [] });
+
+                await runPushControlConfiguration({ calmHubOptions: { calmHubUrl: 'http://hub' }, file: 'config.json', failIfModified: true });
+
+                expect(mockClient.getControlConfigurationVersion).toHaveBeenCalledWith('security', 'access-control', 'prod', '1.0.0');
+                expect(mockClient.createControlConfigurationVersion).not.toHaveBeenCalled();
+                expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
+                    expect.objectContaining({ status: 'skipped', configName: 'prod', version: '1.0.0' })
+                );
+            });
+
+            it('fails when the configuration has changed relative to the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(fs.readFile).mockResolvedValue(controlConfigDoc() as unknown as Uint8Array);
+                vi.mocked(mockClient.getControlConfigurationVersions).mockResolvedValue(['1.0.0']);
+                vi.mocked(mockClient.getControlConfigurationVersion).mockResolvedValue({ $id: cfgId('1.0.0'), nodes: [{ 'unique-id': 'changed' }] });
+
+                await expect(runPushControlConfiguration({ calmHubOptions: { calmHubUrl: 'http://hub' }, file: 'config.json', failIfModified: true }))
+                    .rejects.toThrow('process.exit');
+
+                expect(mockClient.createControlConfigurationVersion).not.toHaveBeenCalled();
+                expect(hubOutput.printError).toHaveBeenCalledWith(
+                    0, expect.stringContaining('has changed relative to the latest published version'), expect.any(String), 'json'
+                );
+            });
         });
     });
 

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -16,6 +16,8 @@ vi.mock('@finos/calm-shared', async () => {
     const documentIdUtils = await vi.importActual<Record<string, unknown>>('@finos/calm-shared/dist/hub/document-id-utils');
     // Real (pure) semver helpers used by pushDocument's version-bump path.
     const semver = await vi.importActual('@finos/calm-shared/dist/hub/semver');
+    // Real (pure) canonical-equality helper used by pushDocument's fail-if-modified path.
+    const canonical = await vi.importActual('@finos/calm-shared/dist/hub/canonical');
     const mockClient = {
         createNamespace: vi.fn(),
         listNamespaces: vi.fn(),
@@ -41,6 +43,7 @@ vi.mock('@finos/calm-shared', async () => {
         ...documentIdUtils,
         extractDocumentMetadata: vi.fn(documentIdUtils['extractDocumentMetadata'] as (...args: unknown[]) => unknown),
         ...semver,
+        ...canonical,
         CalmHubClient: vi.fn(function () { return mockClient; }),
         HubClientError: class HubClientError extends Error {
             constructor(public status: number, public error: string, public request: string) {
@@ -311,6 +314,74 @@ describe('hub-commands', () => {
                 0, expect.stringContaining('namespace and mapping'), expect.any(String), 'json'
             );
         });
+
+        describe('--fail-if-modified', () => {
+            it('creates 1.0.0 for a brand-new mapping even with the flag set', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue([]);
+                vi.mocked(mockClient.createMappedResourceVersion).mockResolvedValue(
+                    'http://hub/calm/namespaces/finos/architectures/my-arch/versions/1.0.0'
+                );
+
+                await runPushArchitecture({
+                    calmHubOptions: { calmHubUrl: 'http://hub' },
+                    file: 'arch.json',
+                    failIfModified: true
+                });
+
+                expect(mockClient.getMappedResourceByVersion).not.toHaveBeenCalled();
+                expect(mockClient.createMappedResourceVersion).toHaveBeenCalledWith(
+                    expect.objectContaining({ version: '1.0.0' }),
+                    expect.any(String)
+                );
+                expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
+                    expect.objectContaining({ status: 'created', version: '1.0.0' })
+                );
+            });
+
+            it('skips (does not create a new version) when content is unchanged from the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue(['1.0.0']);
+                // Latest published version is byte-identical to the local document (key order ignored).
+                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue(JSON.parse(pushDoc('my-arch')));
+
+                await runPushArchitecture({
+                    calmHubOptions: { calmHubUrl: 'http://hub' },
+                    file: 'arch.json',
+                    failIfModified: true
+                });
+
+                expect(mockClient.getMappedResourceByVersion).toHaveBeenCalledWith('finos', 'my-arch', '1.0.0', 'architectures');
+                expect(mockClient.createMappedResourceVersion).not.toHaveBeenCalled();
+                expect(fs.writeFile).not.toHaveBeenCalled();
+                expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(
+                    expect.objectContaining({ status: 'skipped', version: '1.0.0' })
+                );
+            });
+
+            it('fails when the document has changed relative to the latest published version', async () => {
+                const { mockClient } = await getSharedMocks();
+                vi.mocked(mockClient.getMappedResourceVersions).mockResolvedValue(['1.0.0']);
+                // Latest published version differs from the local document.
+                vi.mocked(mockClient.getMappedResourceByVersion).mockResolvedValue({
+                    $id: 'http://hub/calm/namespaces/finos/architectures/my-arch/versions/1.0.0',
+                    title: 'my-arch',
+                    nodes: [{ 'unique-id': 'added-on-disk' }]
+                });
+
+                await expect(runPushArchitecture({
+                    calmHubOptions: { calmHubUrl: 'http://hub' },
+                    file: 'arch.json',
+                    failIfModified: true
+                })).rejects.toThrow('process.exit');
+
+                expect(mockClient.createMappedResourceVersion).not.toHaveBeenCalled();
+                expect(fs.writeFile).not.toHaveBeenCalled();
+                expect(hubOutput.printError).toHaveBeenCalledWith(
+                    0, expect.stringContaining('has changed relative to the latest published version'), expect.any(String), 'json'
+                );
+            });
+        });
     });
 
     // ── runPullArchitecture ────────────────────────────────────────────────
@@ -517,7 +588,7 @@ describe('hub-commands', () => {
     describe('printPushResult', () => {
         it('calls printTableSuccess with correct columns when format is pretty', async () => {
             printPushResult(
-                { mapping: 'my-arch', version: '1.0.0', namespace: 'finos', location: 'http://hub' },
+                { status: 'created', mapping: 'my-arch', version: '1.0.0', namespace: 'finos', location: 'http://hub' },
                 'pretty'
             );
 
@@ -533,8 +604,20 @@ describe('hub-commands', () => {
             expect(hubOutput.printJsonSuccess).not.toHaveBeenCalled();
         });
 
+        it('shows an Unchanged status for a skipped push', async () => {
+            printPushResult(
+                { status: 'skipped', mapping: 'my-arch', version: '1.0.0', namespace: 'finos', location: 'http://hub' },
+                'pretty'
+            );
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ STATUS: 'Unchanged', MAPPING: 'my-arch', VERSION: '1.0.0', LOCATION: 'http://hub' }],
+                expect.anything()
+            );
+        });
+
         it('calls printJsonSuccess when format is json', async () => {
-            const result = { mapping: 'my-arch', version: '1.0.0', namespace: 'finos', location: '/loc' };
+            const result = { status: 'created' as const, mapping: 'my-arch', version: '1.0.0', namespace: 'finos', location: '/loc' };
             printPushResult(result, 'json');
 
             expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(result);

--- a/cli/src/command-helpers/hub-commands.ts
+++ b/cli/src/command-helpers/hub-commands.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
-import { CalmHubClient, CalmHubOptions, HubClientError, HubDomainSummary, HubControlSummary, HubDomainCreateResult, DocumentMetadata, extractDocumentMetadata, computeSemVerBump, sortSemVer, ResourceChangeType, ResourceType, updateDocumentMetadata, constructDocumentId, ControlDocumentMetadata, ControlDocumentKind, extractControlMetadata, updateControlDocumentMetadata, canonicalEqual } from '@finos/calm-shared';
+import { CalmHubClient, CalmHubOptions, HubClientError, HubDomainSummary, HubControlSummary, HubDomainCreateResult, DocumentMetadata, extractDocumentMetadata, computeSemVerBump, sortSemVer, ResourceChangeType, ResourceType, updateDocumentMetadata, constructDocumentId, constructControlDocumentId, ControlDocumentMetadata, ControlDocumentKind, extractControlMetadata, updateControlDocumentMetadata, canonicalEqual } from '@finos/calm-shared';
 import { OutputFormat, parseOutputFormat, printError, printJsonSuccess, printTableSuccess } from './hub-output';
 import * as cliConfig from '../cli-config';
 
@@ -173,6 +173,30 @@ export function handleMetadataParsing(fileContent: string, requestedCommand: str
 }
 
 /**
+ * Compare a (already normalised) local document against what CALM Hub has published, for the
+ * `--fail-if-modified` strict-push paths.
+ *
+ * `localNormalised` must be the local file already rewritten the way Hub would store it at the
+ * version being compared (via `updateDocumentMetadata` / `updateControlDocumentMetadata`), so that
+ * version-only or default-field (e.g. `description`) differences are not seen as content changes.
+ *
+ * Throws a `HubCommandError` when `published` is missing/empty (e.g. a 200 with an empty body),
+ * rather than letting that masquerade as a content change.
+ *
+ * @returns `true` when the documents are equal, `false` when the local document has changed.
+ */
+function isUnchangedFromPublished(localNormalised: string, published: unknown, mapping: string, requestLabel: string): boolean {
+    if (!published || typeof published !== 'object' || Object.keys(published).length === 0) {
+        throw new HubCommandError(
+            0,
+            `Could not read the latest published version of '${mapping}' from CALM Hub to compare against (empty response).`,
+            requestLabel
+        );
+    }
+    return canonicalEqual(JSON.parse(localNormalised), published);
+}
+
+/**
  * Handles the actual push stage of the operation i.e. the integration with CalmHub.
  * Checks whether it already exists to determine whether to create a new mapping or update an existing one.
  * @param client The CalmHub client.
@@ -219,15 +243,20 @@ export async function pushDocument(
             // Strict mode: don't auto-bump. Compare the local document to the latest published
             // version — skip when unchanged, fail when it differs.
             const latest = await client.getMappedResourceByVersion(namespace, mapping, latestVersion, resourceType);
-            if (canonicalEqual(JSON.parse(fileContent), latest)) {
+            // Normalise the local document to how Hub would have stored it at the latest version
+            // (same $id/version, and default fields such as description applied) so a version-only
+            // or absent-description difference is not mistaken for a content change.
+            const localAtLatest = updateDocumentMetadata(fileContent, { ...newDocumentMetadata, version: latestVersion });
+            const requestLabel = `push ${resourceType} ${options.file}`;
+            if (isUnchangedFromPublished(localAtLatest, latest, mapping, requestLabel)) {
                 newDocumentMetadata.version = latestVersion;
                 return { action: 'skipped', metadata: newDocumentMetadata };
             }
             throw new HubCommandError(
                 0,
                 `Document '${mapping}' has changed relative to the latest published version (${latestVersion}) in CALM Hub. ` +
-                'Re-run without --fail-if-modified to publish a new version.',
-                `push ${resourceType} ${options.file}`
+                'Re-run without --fail-if-modified (optionally with --change-type) to publish a new version.',
+                requestLabel
             );
         }
 
@@ -641,9 +670,12 @@ export interface PushControlOptions {
     file: string;
     format?: string;
     changeType?: ResourceChangeType;
+    /** See {@link PushOptions.failIfModified}. */
+    failIfModified?: boolean;
 }
 
 export interface ControlPushResult {
+    status: PushAction;
     domain: string;
     controlName: string;
     configName?: string;
@@ -657,7 +689,7 @@ export interface ControlPushResult {
 function printControlPushResult(result: ControlPushResult, format: OutputFormat): void {
     if (format === 'pretty') {
         const row: Record<string, string> = {
-            STATUS: 'Created',
+            STATUS: result.status === 'created' ? 'Created' : 'Unchanged',
             DOMAIN: result.domain,
             CONTROL: result.controlName
         };
@@ -715,6 +747,35 @@ async function orchestrateControlPush(options: PushControlOptions, kind: Control
             ? await client.getControlConfigurationVersions(metadata.domain, metadata.controlName, metadata.configName!)
             : await client.getControlRequirementVersions(metadata.domain, metadata.controlName);
 
+        const controlLabel = metadata.configName ? `${metadata.controlName}/${metadata.configName}` : metadata.controlName;
+
+        if (options.failIfModified && existingVersions.length > 0) {
+            // Strict mode: don't auto-bump. Compare the local document to the latest published
+            // version — skip when unchanged, fail when it differs.
+            const latestVersion = sortSemVer(existingVersions)[existingVersions.length - 1];
+            const latest = kind === 'configuration'
+                ? await client.getControlConfigurationVersion(metadata.domain, metadata.controlName, metadata.configName!, latestVersion)
+                : await client.getControlRequirementVersion(metadata.domain, metadata.controlName, latestVersion);
+            const localAtLatest = updateControlDocumentMetadata(fileContent, { ...metadata, version: latestVersion });
+            if (isUnchangedFromPublished(localAtLatest, latest, controlLabel, requestedCommand)) {
+                printControlPushResult({
+                    status: 'skipped',
+                    domain: metadata.domain,
+                    controlName: metadata.controlName,
+                    configName: metadata.configName,
+                    version: latestVersion,
+                    location: constructControlDocumentId({ ...metadata, version: latestVersion })
+                }, format);
+                return;
+            }
+            throw new HubCommandError(
+                0,
+                `Control ${kind} '${controlLabel}' has changed relative to the latest published version (${latestVersion}) in CALM Hub. ` +
+                'Re-run without --fail-if-modified (optionally with --change-type) to publish a new version.',
+                requestedCommand
+            );
+        }
+
         let newVersion = '1.0.0';
         if (existingVersions.length > 0) {
             const sorted = sortSemVer(existingVersions);
@@ -731,6 +792,7 @@ async function orchestrateControlPush(options: PushControlOptions, kind: Control
         await writeFile(options.file, fileContent, 'utf-8');
 
         printControlPushResult({
+            status: 'created',
             domain: metadata.domain,
             controlName: metadata.controlName,
             configName: metadata.configName,

--- a/cli/src/command-helpers/hub-commands.ts
+++ b/cli/src/command-helpers/hub-commands.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
-import { CalmHubClient, CalmHubOptions, HubClientError, HubDomainSummary, HubControlSummary, HubDomainCreateResult, DocumentMetadata, extractDocumentMetadata, computeSemVerBump, sortSemVer, ResourceChangeType, ResourceType, updateDocumentMetadata, constructDocumentId, ControlDocumentMetadata, ControlDocumentKind, extractControlMetadata, updateControlDocumentMetadata } from '@finos/calm-shared';
+import { CalmHubClient, CalmHubOptions, HubClientError, HubDomainSummary, HubControlSummary, HubDomainCreateResult, DocumentMetadata, extractDocumentMetadata, computeSemVerBump, sortSemVer, ResourceChangeType, ResourceType, updateDocumentMetadata, constructDocumentId, ControlDocumentMetadata, ControlDocumentKind, extractControlMetadata, updateControlDocumentMetadata, canonicalEqual } from '@finos/calm-shared';
 import { OutputFormat, parseOutputFormat, printError, printJsonSuccess, printTableSuccess } from './hub-output';
 import * as cliConfig from '../cli-config';
 
@@ -58,13 +58,29 @@ export interface PushOptions {
     version?: string;
     format?: string;
     changeType?: ResourceChangeType;
+    /**
+     * Strict mode. When set, push does not auto-bump: if the mapping already exists, the local
+     * document is compared to the latest published version. Unchanged content is skipped; changed
+     * content fails the push (so a merge introduces only the versions it claims). A brand-new
+     * mapping is still created at 1.0.0.
+     */
+    failIfModified?: boolean;
 }
 
+/** Whether a push created a new version or skipped because the content was unchanged. */
+export type PushAction = 'created' | 'skipped';
+
 export interface PushResult {
+    status: PushAction;
     version: string;
     mapping: string;
     namespace: string;
     location: string;
+}
+
+export interface PushDocumentResult {
+    action: PushAction;
+    metadata: DocumentMetadata;
 }
 
 /**
@@ -74,8 +90,9 @@ export interface PushResult {
  */
 export function printPushResult(result: PushResult, format: OutputFormat): void {
     if (format === 'pretty') {
+        const statusLabel = result.status === 'created' ? 'Created' : 'Unchanged';
         printTableSuccess(
-            [{ STATUS: 'Created', MAPPING: result.mapping, VERSION: result.version, LOCATION: result.location }],
+            [{ STATUS: statusLabel, MAPPING: result.mapping, VERSION: result.version, LOCATION: result.location }],
             [
                 { key: 'STATUS', header: 'STATUS' },
                 { key: 'MAPPING', header: 'MAPPING' },
@@ -177,7 +194,7 @@ export async function pushDocument(
     fileContent: string, 
     resourceType: ResourceType,
     changeType: ResourceChangeType,
-    options: PushOptions): Promise<DocumentMetadata> {
+    options: PushOptions): Promise<PushDocumentResult> {
 
     // allow changing of name/description if not already set.
     const name = options.name ?? metadata.name;
@@ -197,6 +214,23 @@ export async function pushDocument(
         // Sort defensively so the highest version is last, regardless of the order Hub returns them in.
         const sortedVersions = sortSemVer(mappedResourceVersions);
         const latestVersion = sortedVersions[sortedVersions.length - 1];
+
+        if (options.failIfModified) {
+            // Strict mode: don't auto-bump. Compare the local document to the latest published
+            // version — skip when unchanged, fail when it differs.
+            const latest = await client.getMappedResourceByVersion(namespace, mapping, latestVersion, resourceType);
+            if (canonicalEqual(JSON.parse(fileContent), latest)) {
+                newDocumentMetadata.version = latestVersion;
+                return { action: 'skipped', metadata: newDocumentMetadata };
+            }
+            throw new HubCommandError(
+                0,
+                `Document '${mapping}' has changed relative to the latest published version (${latestVersion}) in CALM Hub. ` +
+                'Re-run without --fail-if-modified to publish a new version.',
+                `push ${resourceType} ${options.file}`
+            );
+        }
+
         const newVersion = computeSemVerBump(latestVersion, changeType);
         newDocumentMetadata.version = newVersion;
         fileContent = updateDocumentMetadata(fileContent, newDocumentMetadata);
@@ -206,7 +240,7 @@ export async function pushDocument(
         fileContent = updateDocumentMetadata(fileContent, newDocumentMetadata);
         await client.createMappedResourceVersion(newDocumentMetadata, fileContent);
     }
-    return newDocumentMetadata;
+    return { action: 'created', metadata: newDocumentMetadata };
 }
 
 /**
@@ -237,20 +271,24 @@ export async function orchestratePush(options: PushOptions, resourceType: Resour
     const namespace = metadata.namespace;
     const mapping = metadata.mapping;
 
-    let documentMetadata: DocumentMetadata;
     try {
-        documentMetadata = await pushDocument(
-            client, 
-            namespace, 
-            mapping, 
-            metadata, 
-            fileContent, 
-            resourceType, 
-            options.changeType ?? 'PATCH', 
+        const { action, metadata: documentMetadata } = await pushDocument(
+            client,
+            namespace,
+            mapping,
+            metadata,
+            fileContent,
+            resourceType,
+            options.changeType ?? 'PATCH',
             options);
-        const newDocument = updateDocumentMetadata(fileContent, documentMetadata);
-        await writeFile(options.file, newDocument, 'utf-8');
+        // Only rewrite the on-disk document when a new version was actually created; an unchanged
+        // document is left exactly as it is.
+        if (action === 'created') {
+            const newDocument = updateDocumentMetadata(fileContent, documentMetadata);
+            await writeFile(options.file, newDocument, 'utf-8');
+        }
         const result: PushResult = {
+            status: action,
             mapping,
             version: documentMetadata.version!,
             namespace,

--- a/shared/src/hub/canonical.spec.ts
+++ b/shared/src/hub/canonical.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalEqual, canonicalize } from './canonical';
+
+describe('canonical', () => {
+    describe('canonicalEqual', () => {
+        it('treats key-reordered objects as equal', () => {
+            expect(canonicalEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+        });
+
+        it('treats nested key-reordered objects as equal', () => {
+            expect(canonicalEqual(
+                { outer: { a: 1, b: { c: 3, d: 4 } } },
+                { outer: { b: { d: 4, c: 3 }, a: 1 } }
+            )).toBe(true);
+        });
+
+        it('detects value differences', () => {
+            expect(canonicalEqual({ a: 1 }, { a: 2 })).toBe(false);
+        });
+
+        it('is sensitive to array order', () => {
+            expect(canonicalEqual({ a: [1, 2] }, { a: [2, 1] })).toBe(false);
+        });
+
+        it('compares primitives directly', () => {
+            expect(canonicalEqual('x', 'x')).toBe(true);
+            expect(canonicalEqual('x', 'y')).toBe(false);
+        });
+    });
+
+    describe('canonicalize', () => {
+        it('sorts object keys recursively while preserving array order', () => {
+            expect(JSON.stringify(canonicalize({ b: 2, a: [{ y: 1, x: 2 }] })))
+                .toBe(JSON.stringify({ a: [{ x: 2, y: 1 }], b: 2 }));
+        });
+    });
+});

--- a/shared/src/hub/canonical.ts
+++ b/shared/src/hub/canonical.ts
@@ -1,0 +1,23 @@
+/**
+ * Recursively sort object keys so two documents with the same content but different key ordering
+ * compare equal. Array order is preserved.
+ */
+export function canonicalize(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+/**
+ * Deep content equality that ignores object key ordering (array order is preserved). Used to decide
+ * whether a local CALM document differs from the version CalmHub has already published.
+ */
+export function canonicalEqual(a: unknown, b: unknown): boolean {
+    return JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b));
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -87,6 +87,7 @@ export {
     type ControlDocumentKind
 } from './hub/document-id-utils.js';
 export { computeSemVerBump, compareSemVer, sortSemVer } from './hub/semver.js';
+export { canonicalEqual, canonicalize } from './hub/canonical.js';
 export {
     enrichWithDocumentPositions,
     parseDocumentWithPositions,


### PR DESCRIPTION
## Description

Adds a strict, non-bumping `--fail-if-modified` mode to `calm hub push` for `architecture`, `pattern` and `standard` documents.

By default `hub push` auto-bumps: whenever a mapping already exists it computes the next version and always creates a new version (even when the content is identical). `--fail-if-modified` makes the behaviour explicit and safe for merge-time CI:

- **brand-new mapping** → created at `1.0.0` (unchanged behaviour)
- **exists + unchanged** → skipped (no new version; the file on disk is left exactly as-is; status reported as `Unchanged`)
- **exists + modified** → the push fails

The default (auto-bump) path is completely unchanged.

The content comparison is a new shared helper, `canonicalEqual` in `@finos/calm-shared` (`shared/src/hub/canonical.ts`), which compares two documents ignoring object key ordering (array order is preserved). It is deliberately introduced in `shared` so the same comparison can be reused by other push paths (e.g. the upcoming `calm workspace push --fail-if-modified`) without duplicating logic.

> Note: scoped to the mapped-resource push commands (architecture/pattern/standard) that share `pushDocument`. The domain-scoped `control-requirement` / `control-configuration` push flow is a sensible follow-up (it needs an equivalent "get latest published version" comparison) and is intentionally not included here to keep this PR focused.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CLI (`cli/`)
- [x] Shared (`shared/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified on Node 26: `cli` and `shared` test suites pass with coverage gates held, and lint is clean for both. New tests cover the create / skip-unchanged / fail-on-modified paths in `hub-commands.spec.ts` and the shared `canonical.spec.ts`.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
