### PR TITLE
feat(calm-hub-ui): refine diagram minimap, node legibility and version timeline

### DIFF
--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/MomentCards.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/MomentCards.tsx
@@ -137,13 +137,15 @@ export function MomentCards({
                     ? moment.version === compareFrom || moment.version === compareTo
                     : moment.version === currentVersion;
 
-                // The pill highlight (blue border + blueSoft bg + shadow) follows
-                // the viewed card. Badges (NOW / FROM / TO) are independent.
-                const borderColor = isViewed ? colors.calm.blue : colors.ink[200];
-                const background = isViewed ? colors.calm.blueSoft : '#ffffff';
+                // The pill highlight (blue border + tint bg + shadow) follows the
+                // viewed card. Re-tokenised to redesign.primary so the timeline's
+                // active state matches the one blue active system used elsewhere
+                // (redesign problem #8). Badges (NOW / FROM / TO) are independent.
+                const borderColor = isViewed ? colors.redesign.primary : colors.ink[200];
+                const background = isViewed ? colors.redesign.tintBg : '#ffffff';
                 const titleColor =
                     badge === 'FROM' || badge === 'TO'
-                        ? colors.calm.blueDeep
+                        ? colors.redesign.primary
                         : isViewed
                             ? colors.ink[900]
                             : colors.ink[700];
@@ -193,7 +195,7 @@ export function MomentCards({
                                     padding: '10px 14px',
                                     minWidth: 124,
                                     boxShadow: isViewed
-                                        ? '0 6px 14px rgba(31,109,255,0.18)'
+                                        ? `0 6px 14px ${colors.redesign.primary}2e`
                                         : 'none',
                                 }}
                             >

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { IoChevronUpOutline, IoTimeOutline } from 'react-icons/io5';
+import { IoChevronUpOutline } from 'react-icons/io5';
 import { colors } from '../../../../theme/colors.js';
+import { TimelineHeader } from './TimelineHeader.js';
 import type { TimelineMoment } from './TimelineBar.js';
 
 interface SparklineProps {
@@ -24,10 +25,13 @@ interface ContextMenuState {
 }
 
 /**
- * Collapsed timeline strip — a sparkline of version dots with title + date below
- * each. Single mode highlights the viewed version; compare mode shows progress
- * between FROM and TO. Left-click navigates; right-click opens a compare-from /
- * compare-to menu.
+ * Collapsed timeline strip — a "Browse versions" header (with the current-version
+ * pill) above a sparkline of version dots with title + date below each. Single
+ * mode highlights the viewed version; compare mode shows progress between FROM and
+ * TO. Left-click navigates; right-click opens a compare-from / compare-to menu.
+ *
+ * A single-version resource collapses to just the header + version pill — there is
+ * no meaningful track to scrub, so an inert one-dot slider is suppressed.
  */
 export function Sparkline({
     moments,
@@ -45,6 +49,7 @@ export function Sparkline({
 
     const comparing = compareFrom !== null && compareTo !== null;
     const total = moments.length;
+    const singleVersion = total <= 1;
     // Evenly distribute dots from left to right. With a single moment, centre it.
     const pct = (i: number) => (total <= 1 ? 50 : (i / (total - 1)) * 100);
 
@@ -109,147 +114,145 @@ export function Sparkline({
         setMenu(null);
     };
 
+    const newPill = showNewPill ? (
+        <span
+            data-testid="timeline-new-pill"
+            className="font-inter rounded-full text-white"
+            style={{ backgroundColor: colors.new, fontSize: 9.5, fontWeight: 700, padding: '2px 6px' }}
+        >
+            NEW
+        </span>
+    ) : null;
+
+    const expandButton = (
+        <button
+            type="button"
+            onClick={handleExpand}
+            aria-label="Expand timeline"
+            title="Expand timeline"
+            className="shrink-0 flex items-center justify-center bg-transparent border-0 p-0 cursor-pointer"
+            style={{ width: 28, height: 28 }}
+        >
+            <IoChevronUpOutline size={14} style={{ color: colors.ink[500], strokeWidth: 2 }} />
+        </button>
+    );
+
     return (
         <div
             data-testid="timeline-bar-collapsed"
-            className="flex items-start gap-4 bg-white border-t font-inter"
-            style={{ borderTopColor: colors.ink[200], padding: '12px 20px 14px' }}
+            className="flex flex-col bg-white border-t font-inter"
+            style={{ borderTopColor: colors.ink[200], padding: '12px 20px 14px', gap: 8 }}
         >
-            {/* Left cluster: clock + Timeline + (optional) NEW pill */}
-            <div className="flex items-center gap-2 shrink-0" style={{ paddingTop: 4 }}>
-                <IoTimeOutline size={14} style={{ color: colors.ink[500], strokeWidth: 2 }} />
-                <span
-                    className="font-inter"
-                    style={{ fontSize: 12, fontWeight: 500, color: colors.ink[500] }}
+            {/* Header row: purpose + version pill on the left, NEW pill + expand on the right. */}
+            <div className="flex items-center gap-2">
+                <TimelineHeader currentVersion={currentVersion}>{newPill}</TimelineHeader>
+                <div className="ml-auto">{expandButton}</div>
+            </div>
+
+            {/* Track row. A single-version resource has nothing to scrub, so the
+                track is suppressed (the version pill already states what's shown).
+                overflow-hidden clips long labels at the track edge (#2728). */}
+            {!singleVersion && (
+                <div
+                    data-testid="timeline-sparkline-track"
+                    className="relative"
+                    style={{ height: 72, overflow: 'hidden' }}
                 >
-                    Timeline
-                </span>
-                {showNewPill && (
-                    <span
-                        data-testid="timeline-new-pill"
-                        className="font-inter rounded-full text-white"
-                        style={{
-                            backgroundColor: colors.new,
-                            fontSize: 9.5,
-                            fontWeight: 700,
-                            padding: '2px 6px',
-                        }}
-                    >
-                        NEW
-                    </span>
-                )}
-            </div>
-
-            {/* Centre: sparkline track with dots + labels. overflow-hidden clips
-                long labels at the track edge so they can never paint over the
-                statically-positioned expand button (#2728). The height must fully
-                contain the dot + label + date stack, otherwise the same clip would
-                cut off the date row beneath each dot. */}
-            <div
-                data-testid="timeline-sparkline-track"
-                className="relative flex-1"
-                style={{ height: 72, overflow: 'hidden' }}
-            >
-                {/* Inner track wrapper inset 10px each side so dot percentages map directly */}
-                <div className="absolute" style={{ left: 10, right: 10, top: 0, bottom: 0 }}>
-                    <div
-                        className="absolute"
-                        style={{ left: 0, right: 0, top: 18, height: 2, backgroundColor: colors.ink[200] }}
-                    />
-                    {progressRight > progressLeft && (
+                    {/* Inner track wrapper inset 10px each side so dot percentages map directly */}
+                    <div className="absolute" style={{ left: 10, right: 10, top: 0, bottom: 0 }}>
                         <div
-                            data-testid="timeline-progress"
                             className="absolute"
-                            style={{
-                                left: `${progressLeft}%`,
-                                width: `${progressRight - progressLeft}%`,
-                                top: 18,
-                                height: 2,
-                                backgroundColor: colors.calm.blue,
-                            }}
+                            style={{ left: 0, right: 0, top: 18, height: 2, backgroundColor: colors.ink[200] }}
                         />
-                    )}
-                    {moments.map((moment, i) => {
-                        // Highlight the dot for whatever the diagram is currently showing
-                        // (the viewed version). In compare mode the two endpoints are
-                        // highlighted via isFrom / isTo below instead.
-                        const isCurrent = !comparing && i === viewedIdx;
-                        const isFrom = comparing && i === fromIdx;
-                        const isTo = comparing && i === toIdx;
-                        const isActive = isCurrent || isFrom || isTo;
-                        const dotSize = isActive ? 22 : 14;
-                        const dotMt = isActive ? 8 : 12;
-                        return (
+                        {progressRight > progressLeft && (
                             <div
-                                key={moment.key}
-                                className="absolute top-0 flex flex-col items-center"
-                                style={{ left: `${pct(i)}%`, transform: 'translateX(-50%)' }}
-                            >
-                                <button
-                                    type="button"
-                                    aria-label={`Moment ${moment.label}`}
-                                    aria-current={isCurrent ? 'true' : undefined}
-                                    aria-pressed={isFrom || isTo ? true : undefined}
-                                    onClick={() => handleDotClick(moment)}
-                                    onContextMenu={(e) => handleDotContextMenu(e, moment)}
-                                    className="bg-transparent p-0 border-0 cursor-pointer flex justify-center"
-                                    style={{ width: 32, height: 32 }}
-                                >
-                                    <div
-                                        style={{
-                                            width: dotSize,
-                                            height: dotSize,
-                                            borderRadius: 999,
-                                            backgroundColor: isActive ? colors.calm.blue : '#ffffff',
-                                            border: `2px solid ${isActive ? colors.calm.blue : colors.ink[300]}`,
-                                            marginTop: dotMt,
-                                        }}
-                                    />
-                                </button>
+                                data-testid="timeline-progress"
+                                className="absolute"
+                                style={{
+                                    left: `${progressLeft}%`,
+                                    width: `${progressRight - progressLeft}%`,
+                                    top: 18,
+                                    height: 2,
+                                    backgroundColor: colors.redesign.primary,
+                                }}
+                            />
+                        )}
+                        {moments.map((moment, i) => {
+                            // Highlight the dot for whatever the diagram is currently showing
+                            // (the viewed version). In compare mode the two endpoints are
+                            // highlighted via isFrom / isTo below instead.
+                            const isCurrent = !comparing && i === viewedIdx;
+                            const isFrom = comparing && i === fromIdx;
+                            const isTo = comparing && i === toIdx;
+                            const isActive = isCurrent || isFrom || isTo;
+                            // Active = filled 12px blue dot with a halo; others = 9px white
+                            // dots with a slate ring (redesign #4 anatomy).
+                            const dotSize = isActive ? 12 : 9;
+                            return (
                                 <div
-                                    className="font-inter"
-                                    style={{
-                                        marginTop: 4,
-                                        fontSize: 12,
-                                        fontWeight: isActive ? 600 : 500,
-                                        color: isActive ? colors.ink[900] : colors.ink[700],
-                                        textAlign: 'center',
-                                        // Bound + truncate long names so the strip stays
-                                        // readable; the title tooltip shows the full name (#2728).
-                                        maxWidth: 120,
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                    }}
-                                    title={moment.label}
+                                    key={moment.key}
+                                    className="absolute top-0 flex flex-col items-center"
+                                    style={{ left: `${pct(i)}%`, transform: 'translateX(-50%)' }}
                                 >
-                                    {moment.label}
-                                </div>
-                                {moment.validFrom && (
-                                    <div
-                                        className="font-mono-jb"
-                                        style={{ fontSize: 10, color: colors.ink[400] }}
+                                    <button
+                                        type="button"
+                                        aria-label={`Moment ${moment.label}`}
+                                        aria-current={isCurrent ? 'true' : undefined}
+                                        aria-pressed={isFrom || isTo ? true : undefined}
+                                        onClick={() => handleDotClick(moment)}
+                                        onContextMenu={(e) => handleDotContextMenu(e, moment)}
+                                        className="bg-transparent p-0 border-0 cursor-pointer flex items-center justify-center"
+                                        style={{ width: 32, height: 32 }}
                                     >
-                                        {moment.validFrom}
+                                        <div
+                                            data-active={isActive ? 'true' : undefined}
+                                            style={{
+                                                width: dotSize,
+                                                height: dotSize,
+                                                borderRadius: 999,
+                                                backgroundColor: isActive ? colors.redesign.primary : '#ffffff',
+                                                border: isActive
+                                                    ? `2px solid ${colors.redesign.primary}`
+                                                    : `1.5px solid ${colors.ink[400]}`,
+                                                boxShadow: isActive
+                                                    ? `0 0 0 4px ${colors.redesign.primary}33`
+                                                    : 'none',
+                                            }}
+                                        />
+                                    </button>
+                                    <div
+                                        className="font-inter"
+                                        style={{
+                                            marginTop: 4,
+                                            fontSize: 12,
+                                            fontWeight: isActive ? 600 : 500,
+                                            color: isActive ? colors.ink[900] : colors.ink[700],
+                                            textAlign: 'center',
+                                            // Bound + truncate long names so the strip stays
+                                            // readable; the title tooltip shows the full name (#2728).
+                                            maxWidth: 120,
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                            whiteSpace: 'nowrap',
+                                        }}
+                                        title={moment.label}
+                                    >
+                                        {moment.label}
                                     </div>
-                                )}
-                            </div>
-                        );
-                    })}
+                                    {moment.validFrom && (
+                                        <div
+                                            className="font-mono-jb"
+                                            style={{ fontSize: 10, color: colors.ink[400] }}
+                                        >
+                                            {moment.validFrom}
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
                 </div>
-            </div>
-
-            {/* Right cluster: chevron-up to expand */}
-            <button
-                type="button"
-                onClick={handleExpand}
-                aria-label="Expand timeline"
-                title="Expand timeline"
-                className="shrink-0 flex items-center justify-center bg-transparent border-0 p-0 cursor-pointer"
-                style={{ width: 28, height: 28 }}
-            >
-                <IoChevronUpOutline size={14} style={{ color: colors.ink[500], strokeWidth: 2 }} />
-            </button>
+            )}
 
             {menu && (
                 <div

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -162,7 +162,7 @@ export function Sparkline({
                     <div className="absolute" style={{ left: 10, right: 10, top: 0, bottom: 0 }}>
                         <div
                             className="absolute"
-                            style={{ left: 0, right: 0, top: 18, height: 2, backgroundColor: colors.ink[200] }}
+                            style={{ left: 0, right: 0, top: 15, height: 2, backgroundColor: colors.ink[200] }}
                         />
                         {progressRight > progressLeft && (
                             <div
@@ -171,7 +171,7 @@ export function Sparkline({
                                 style={{
                                     left: `${progressLeft}%`,
                                     width: `${progressRight - progressLeft}%`,
-                                    top: 18,
+                                    top: 15,
                                     height: 2,
                                     backgroundColor: colors.redesign.primary,
                                 }}

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
@@ -33,6 +33,100 @@ function renderBar(overrides?: {
 describe('TimelineBar', () => {
     beforeEach(() => localStorage.clear());
 
+    describe('version-navigator labelling (#4)', () => {
+        it('labels the collapsed strip "Browse versions" with an explanatory line', () => {
+            renderBar();
+            expect(screen.getByText('Browse versions')).toBeInTheDocument();
+            expect(
+                screen.getByText(/click a moment to re-render the diagram & JSON at that version/i)
+            ).toBeInTheDocument();
+        });
+
+        it('shows the current version as a right-aligned mono pill', () => {
+            renderBar({ currentVersion: '1.5.0' });
+            const pill = screen.getByTestId('timeline-version-pill');
+            expect(pill).toHaveTextContent('v1.5.0');
+        });
+
+        it('keeps the "Browse versions" label and version pill in the expanded panel', () => {
+            renderBar({ currentVersion: '2.0.0' });
+            fireEvent.click(screen.getByRole('button', { name: /expand timeline/i }));
+            expect(screen.getByTestId('timeline-bar-expanded')).toBeInTheDocument();
+            expect(screen.getByText('Browse versions')).toBeInTheDocument();
+            expect(screen.getByTestId('timeline-version-pill')).toHaveTextContent('v2.0.0');
+        });
+
+        it('renders the active moment dot in the redesign primary blue', () => {
+            renderBar({ currentVersion: '1.5.0' });
+            const activeMarker = screen.getByLabelText('Moment 1.5.0');
+            const dot = activeMarker.querySelector('[data-active="true"]') as HTMLElement;
+            expect(dot).toBeTruthy();
+            // redesign.primary #2563EB → rgb(37, 99, 235)
+            expect(dot).toHaveStyle({ backgroundColor: 'rgb(37, 99, 235)' });
+        });
+    });
+
+    describe('collapsed sparkline interactions', () => {
+        it('left-click on a collapsed dot navigates to that version', () => {
+            const { onNavigate } = renderBar({ currentVersion: '1.5.0' });
+            // No expand — drive the default collapsed sparkline directly.
+            fireEvent.click(screen.getByLabelText('Moment 2.0.0'));
+            expect(onNavigate).toHaveBeenCalledWith('2.0.0');
+        });
+
+        it('right-click on a collapsed dot opens a compare menu and starts a compare', () => {
+            const { onCompare } = renderBar({ currentVersion: '1.5.0' });
+            fireEvent.contextMenu(screen.getByLabelText('Moment 1.0.0'));
+            expect(screen.getByTestId('timeline-context-menu')).toBeInTheDocument();
+            fireEvent.click(screen.getByRole('menuitem', { name: /compare from/i }));
+            // from = this moment (1.0.0), to = current (1.5.0)
+            expect(onCompare).toHaveBeenCalledWith('1.0.0', '1.5.0');
+        });
+
+        it('shows a blue progress overlay between the compared endpoints', () => {
+            renderBar({ currentVersion: '1.5.0', compareFrom: '1.0.0', compareTo: '2.0.0' });
+            expect(screen.getByTestId('timeline-progress')).toBeInTheDocument();
+        });
+    });
+
+    describe('single-version resources collapse the track', () => {
+        const single: TimelineMoment[] = [{ key: 'm1', label: '1.0.0', version: '1.0.0' }];
+
+        function renderSingle() {
+            return render(
+                <TimelineBar
+                    moments={single}
+                    currentVersion="1.0.0"
+                    compareFrom={null}
+                    compareTo={null}
+                    onNavigate={vi.fn()}
+                    onCompare={vi.fn()}
+                />
+            );
+        }
+
+        it('hides the dot track and shows just the header + version pill', () => {
+            renderSingle();
+            expect(screen.getByTestId('timeline-bar-collapsed')).toBeInTheDocument();
+            expect(screen.queryByTestId('timeline-sparkline-track')).not.toBeInTheDocument();
+            expect(screen.getByText('Browse versions')).toBeInTheDocument();
+            expect(screen.getByTestId('timeline-version-pill')).toHaveTextContent('v1.0.0');
+        });
+
+        it('does not render an inert single moment dot', () => {
+            renderSingle();
+            expect(screen.queryByLabelText('Moment 1.0.0')).not.toBeInTheDocument();
+        });
+
+        it('expands a single-version resource without crashing, keeping the header and pill', () => {
+            renderSingle();
+            fireEvent.click(screen.getByRole('button', { name: /expand timeline/i }));
+            expect(screen.getByTestId('timeline-bar-expanded')).toBeInTheDocument();
+            expect(screen.getByText('Browse versions')).toBeInTheDocument();
+            expect(screen.getByTestId('timeline-version-pill')).toHaveTextContent('v1.0.0');
+        });
+    });
+
     it('renders the collapsed sparkline by default with all version dots, NEW pill and an expand chevron', () => {
         renderBar();
         expect(screen.getByTestId('timeline-bar-collapsed')).toBeInTheDocument();

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { IoChevronDownOutline, IoTimeOutline } from 'react-icons/io5';
+import { IoChevronDownOutline } from 'react-icons/io5';
 import type { DiffResult } from '@finos/calm-models/diff';
 import { colors } from '../../../../theme/colors.js';
 import { MomentCards } from './MomentCards.js';
 import { InlineDiffSummary } from './InlineDiffSummary.js';
 import { Sparkline } from './Sparkline.js';
+import { TimelineHeader } from './TimelineHeader.js';
 import { VersionDetail } from './VersionDetail.js';
 import type { VersionChange } from './perVersionChanges.js';
 
@@ -217,11 +218,13 @@ export function TimelineBar({
                         className="flex items-center"
                         style={{ padding: '14px 22px 10px', gap: 10 }}
                     >
-                        <IoTimeOutline size={14} style={{ color: colors.ink[500], strokeWidth: 2 }} />
-                        <span style={{ fontSize: 13, fontWeight: 600, color: colors.ink[900] }}>
-                            Timeline
+                        <TimelineHeader currentVersion={currentVersion} />
+                        <span
+                            className="truncate min-w-0"
+                            style={{ fontSize: 12, color: colors.ink[500] }}
+                        >
+                            {headerSubLabel}
                         </span>
-                        <span style={{ fontSize: 12, color: colors.ink[500] }}>{headerSubLabel}</span>
                         <button
                             type="button"
                             className="ml-auto flex items-center justify-center bg-transparent border-0 p-0 cursor-pointer"

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import { IoTimeOutline } from 'react-icons/io5';
+import { colors } from '../../../../theme/colors.js';
+
+interface TimelineHeaderProps {
+    /** The version currently shown in the main area — surfaced as the mono pill. */
+    currentVersion: string;
+    /**
+     * Trailing controls (NEW pill, expand/collapse chevron). Rendered after the
+     * version pill, pushed to the right by the flex row.
+     */
+    children?: ReactNode;
+}
+
+/**
+ * Shared header for the version timeline (collapsed sparkline + expanded panel).
+ *
+ * Names the strip's purpose — "Browse versions" with an explanatory line — so it
+ * no longer reads as an inert "Timeline" slider (redesign problem #4), and shows
+ * the current version as a right-aligned mono pill. The explanatory copy makes it
+ * obvious that clicking a moment re-renders both the Diagram and JSON views.
+ */
+export function TimelineHeader({ currentVersion, children }: TimelineHeaderProps) {
+    return (
+        <div className="flex items-center gap-2 shrink-0" style={{ paddingTop: 4 }}>
+            <IoTimeOutline size={14} style={{ color: colors.ink[500], strokeWidth: 2 }} />
+            <span
+                className="font-inter"
+                style={{ fontSize: 13, fontWeight: 600, color: colors.ink[900] }}
+            >
+                Browse versions
+            </span>
+            <span
+                className="font-inter whitespace-nowrap hidden lg:inline"
+                style={{ fontSize: 12, color: colors.ink[500] }}
+            >
+                — click a moment to re-render the diagram &amp; JSON at that version
+            </span>
+            <span
+                data-testid="timeline-version-pill"
+                className="font-mono-jb rounded-full"
+                style={{
+                    backgroundColor: colors.redesign.tintBg,
+                    color: colors.redesign.primary,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    padding: '2px 8px',
+                }}
+                title={`Viewing version ${currentVersion}`}
+            >
+                v{currentVersion}
+            </span>
+            {children}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
@@ -38,7 +38,7 @@ export function TimelineHeader({ currentVersion, children }: TimelineHeaderProps
             </span>
             <span
                 data-testid="timeline-version-pill"
-                className="font-mono-jb rounded-full"
+                className="font-mono-jb rounded-full ml-auto"
                 style={{
                     backgroundColor: colors.redesign.tintBg,
                     color: colors.redesign.primary,

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineHeader.tsx
@@ -5,10 +5,7 @@ import { colors } from '../../../../theme/colors.js';
 interface TimelineHeaderProps {
     /** The version currently shown in the main area — surfaced as the mono pill. */
     currentVersion: string;
-    /**
-     * Trailing controls (NEW pill, expand/collapse chevron). Rendered after the
-     * version pill, pushed to the right by the flex row.
-     */
+    /** Trailing controls (NEW pill, expand/collapse chevron), rendered after the version pill. */
     children?: ReactNode;
 }
 
@@ -17,8 +14,9 @@ interface TimelineHeaderProps {
  *
  * Names the strip's purpose — "Browse versions" with an explanatory line — so it
  * no longer reads as an inert "Timeline" slider (redesign problem #4), and shows
- * the current version as a right-aligned mono pill. The explanatory copy makes it
- * obvious that clicking a moment re-renders both the Diagram and JSON views.
+ * the current version as a mono pill (inline after the label, gap-separated). The
+ * explanatory copy makes it obvious that clicking a moment re-renders both the
+ * Diagram and JSON views.
  */
 export function TimelineHeader({ currentVersion, children }: TimelineHeaderProps) {
     return (
@@ -38,7 +36,7 @@ export function TimelineHeader({ currentVersion, children }: TimelineHeaderProps
             </span>
             <span
                 data-testid="timeline-version-pill"
-                className="font-mono-jb rounded-full ml-auto"
+                className="font-mono-jb rounded-full"
                 style={{
                     backgroundColor: colors.redesign.tintBg,
                     color: colors.redesign.primary,

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CalmArchitectureSchema } from '@finos/calm-models/types';
+import { ArchitectureGraph } from './ArchitectureGraph';
+
+/**
+ * Capture the props ReactFlow and MiniMap are rendered with, and render
+ * Controls' children so the minimap toggle button is reachable. The real
+ * ReactFlow is heavy and DOM-measurement dependent, so we stub it but keep the
+ * props we assert on observable.
+ */
+const reactFlowProps: { current: Record<string, unknown> | null } = { current: null };
+const miniMapProps: { current: Record<string, unknown> | null } = { current: null };
+
+vi.mock('reactflow', async () => {
+    // Keep the real hooks (useNodesState/useEdgesState/useStore) so the graph's
+    // node state populates as it does in production; stub only the heavy,
+    // DOM-measuring view components and capture their props.
+    const actual = await vi.importActual<typeof import('reactflow')>('reactflow');
+    return {
+        ...actual,
+        __esModule: true,
+        default: (props: Record<string, unknown>) => {
+            reactFlowProps.current = props;
+            return <div data-testid="react-flow">{props.children as ReactNode}</div>;
+        },
+        Background: () => <div data-testid="rf-background" />,
+        Controls: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-controls">{children}</div>
+        ),
+        ControlButton: ({
+            children,
+            ...rest
+        }: { children?: ReactNode } & Record<string, unknown>) => (
+            <button {...(rest as Record<string, unknown>)}>{children}</button>
+        ),
+        MiniMap: (props: Record<string, unknown>) => {
+            miniMapProps.current = props;
+            return <div data-testid="diagram-minimap" />;
+        },
+        Panel: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-panel">{children}</div>
+        ),
+    };
+});
+
+const mockCalmData: CalmArchitectureSchema = {
+    nodes: [
+        { 'unique-id': 'node-1', name: 'Service A', description: 'A service', 'node-type': 'service' },
+        { 'unique-id': 'node-2', name: 'Database B', description: 'A database', 'node-type': 'database' },
+    ],
+    relationships: [
+        {
+            'unique-id': 'rel-1',
+            description: 'connects to',
+            'relationship-type': {
+                connects: { source: { node: 'node-1' }, destination: { node: 'node-2' } },
+            },
+        },
+    ],
+};
+
+describe('ArchitectureGraph', () => {
+    beforeEach(() => {
+        reactFlowProps.current = null;
+        miniMapProps.current = null;
+        sessionStorage.clear();
+        vi.clearAllMocks();
+    });
+
+    it('floors and caps fitView zoom so dense graphs stay legible (#6)', () => {
+        render(<ArchitectureGraph jsonData={mockCalmData} />);
+        // minZoom floor keeps a dense graph from shrinking below readability;
+        // maxZoom caps fit-to-view so a sparse graph isn't oversized.
+        expect(reactFlowProps.current?.fitViewOptions).toEqual({
+            padding: 0.2,
+            minZoom: 0.6,
+            maxZoom: 1.2,
+        });
+        // The pane-level minZoom still lets the user pinch out past the fit floor.
+        expect(reactFlowProps.current?.minZoom).toBe(0.1);
+    });
+
+    describe('minimap (#5)', () => {
+        it('renders the minimap at a fixed compact size on desktop', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(screen.getByTestId('diagram-minimap')).toBeInTheDocument();
+            const style = miniMapProps.current?.style as Record<string, unknown>;
+            expect(style.width).toBe(132);
+            expect(style.height).toBe(84);
+            expect(style.overflow).toBe('hidden');
+        });
+
+        it('gives the minimap a primary-blue viewport rect and a light mask', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(miniMapProps.current?.maskStrokeColor).toBe('#2563EB');
+            expect(miniMapProps.current?.maskStrokeWidth).toBe(1.5);
+            // Light (~25%) mask via the existing `${color}AA` alpha-suffix pattern.
+            expect(String(miniMapProps.current?.maskColor)).toMatch(/^#F8FAFC40$/i);
+        });
+
+        it('hides the minimap when toggled off and persists the choice', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(screen.getByTestId('diagram-minimap')).toBeInTheDocument();
+            fireEvent.click(screen.getByRole('button', { name: /hide minimap/i }));
+            expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
+            expect(sessionStorage.getItem('calmHub.diagramMinimapHidden')).toBe('1');
+        });
+
+        it('restores the hidden minimap when toggled back on', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            fireEvent.click(screen.getByRole('button', { name: /hide minimap/i }));
+            fireEvent.click(screen.getByRole('button', { name: /show minimap/i }));
+            expect(screen.getByTestId('diagram-minimap')).toBeInTheDocument();
+            expect(sessionStorage.getItem('calmHub.diagramMinimapHidden')).toBe('0');
+        });
+
+        it('starts hidden when the persisted preference says so', () => {
+            sessionStorage.setItem('calmHub.diagramMinimapHidden', '1');
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /show minimap/i })).toBeInTheDocument();
+        });
+    });
+
+    describe('mobile', () => {
+        function mockMobileViewport() {
+            window.matchMedia = (query: string) =>
+                ({
+                    matches: query.includes('max-width: 1023px'),
+                    media: query,
+                    onchange: null,
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    addListener: () => {},
+                    removeListener: () => {},
+                    dispatchEvent: () => false,
+                }) as unknown as MediaQueryList;
+        }
+
+        it('omits the minimap and its toggle on mobile (Phase 5 owns mobile diagram)', () => {
+            mockMobileViewport();
+            render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('rf-controls')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { CalmArchitectureSchema } from '@finos/calm-models/types';
@@ -96,7 +96,7 @@ describe('ArchitectureGraph', () => {
             render(<ArchitectureGraph jsonData={mockCalmData} />);
             expect(miniMapProps.current?.maskStrokeColor).toBe('#2563EB');
             expect(miniMapProps.current?.maskStrokeWidth).toBe(1.5);
-            // Light (~25%) mask via the existing `${color}AA` alpha-suffix pattern.
+            // Light (~25%) mask via the `${color}40` alpha-suffix pattern.
             expect(String(miniMapProps.current?.maskColor)).toMatch(/^#F8FAFC40$/i);
         });
 
@@ -125,6 +125,13 @@ describe('ArchitectureGraph', () => {
     });
 
     describe('mobile', () => {
+        // Restore the real matchMedia after each mobile test so the "mobile" viewport
+        // doesn't leak into later tests (in this or other files).
+        const originalMatchMedia = window.matchMedia;
+        afterEach(() => {
+            window.matchMedia = originalMatchMedia;
+        });
+
         function mockMobileViewport() {
             window.matchMedia = (query: string) =>
                 ({

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
     Node,
     Background,
     Controls,
+    ControlButton,
     MiniMap,
     Panel,
     useNodesState,
@@ -10,12 +11,14 @@ import ReactFlow, {
     type Viewport,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { Map as MapIcon } from 'lucide-react';
 import { readViewportForKey, saveViewportForKey } from './utils/viewportStore.js';
 import { FloatingEdge } from './FloatingEdge.js';
 import { CustomNode } from './CustomNode.js';
 import { SystemGroupNode } from './SystemGroupNode.js';
 import { SearchBar } from './SearchBar.js';
 import { THEME } from './theme.js';
+import { colors } from '../../../theme/colors.js';
 import { EmptyGraphState } from './EmptyGraphState.js';
 import { parseCALMData } from './utils/calmTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
@@ -28,6 +31,28 @@ import type { ArchitectureGraphProps } from '../../contracts/contracts.js';
 const edgeTypes = { custom: FloatingEdge };
 const nodeTypes = { custom: CustomNode, group: SystemGroupNode };
 const GROUP_NODE_TYPES = ['group'];
+
+/**
+ * fitView floors the zoom so a dense graph doesn't shrink nodes below the point
+ * where their labels are legible (redesign problem #6); the user can still pinch
+ * out past this via the pane-level minZoom. maxZoom caps fit-to-view so a sparse
+ * graph doesn't render its few nodes oversized. padding leaves breathing room.
+ * A dense graph can therefore load with some nodes off-screen; the default-on
+ * minimap is the off-screen cue (pan/pinch reveal the rest), so keep it default
+ * visible — a future change that hides it by default would silently regress #6.
+ */
+const FIT_VIEW_OPTIONS = { padding: 0.2, minZoom: 0.6, maxZoom: 1.2 } as const;
+
+/** Persist the minimap show/hide choice so it survives a refresh. */
+const MINIMAP_HIDDEN_KEY = 'calmHub.diagramMinimapHidden';
+
+function readMinimapHidden(): boolean {
+    try {
+        return sessionStorage.getItem(MINIMAP_HIDDEN_KEY) === '1';
+    } catch {
+        return false;
+    }
+}
 
 export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewportKey }: ArchitectureGraphProps) {
     // Restore the saved viewport for this diagram (so a refresh keeps the zoom/pan);
@@ -48,6 +73,23 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
     const sourceNodesRef = useRef<Node[]>([]);
 
     const isMobile = useIsMobile();
+
+    // Minimap is a help on dense graphs but clutter on sparse ones, so let the
+    // user hide it; the choice persists for the session. Desktop-only — mobile
+    // hides the minimap entirely (Phase 5 owns the mobile diagram).
+    const [minimapHidden, setMinimapHidden] = useState<boolean>(() => readMinimapHidden());
+
+    const toggleMinimap = () => {
+        setMinimapHidden((prev) => {
+            const next = !prev;
+            try {
+                sessionStorage.setItem(MINIMAP_HIDDEN_KEY, next ? '1' : '0');
+            } catch {
+                /* ignore unavailable storage */
+            }
+            return next;
+        });
+    };
 
     const {
         onNodesChange,
@@ -124,7 +166,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                 }}
                 fitView={!savedViewport}
                 defaultViewport={savedViewport}
-                fitViewOptions={{ padding: 0.2 }}
+                fitViewOptions={FIT_VIEW_OPTIONS}
                 minZoom={0.1}
                 attributionPosition="bottom-left"
                 style={{ background: THEME.colors.background }}
@@ -137,16 +179,48 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                             border: `1px solid ${THEME.colors.border}`,
                             borderRadius: '8px',
                         }}
-                    />
+                    >
+                        <ControlButton
+                            onClick={toggleMinimap}
+                            title={minimapHidden ? 'Show minimap' : 'Hide minimap'}
+                            aria-label={minimapHidden ? 'Show minimap' : 'Hide minimap'}
+                            aria-pressed={!minimapHidden}
+                        >
+                            <MapIcon
+                                size={14}
+                                color={minimapHidden ? THEME.colors.muted : colors.redesign.primary}
+                            />
+                        </ControlButton>
+                    </Controls>
                 )}
-                {!isMobile && (
+                {!isMobile && !minimapHidden && (
                     <MiniMap
+                        data-testid="diagram-minimap"
+                        pannable
+                        zoomable
+                        // Fixed compact panel so the minimap can't overflow the canvas
+                        // or collide with the drawer/timeline (redesign problem #5). The
+                        // bottom offset clears the timeline bar pinned below the canvas.
                         style={{
-                            background: THEME.colors.backgroundSecondary,
-                            border: `1px solid ${THEME.colors.border}`,
+                            width: 132,
+                            height: 84,
+                            bottom: 16,
+                            background: colors.redesign.surface,
+                            border: `1px solid ${colors.redesign.borderStrong}`,
+                            borderRadius: 8,
+                            overflow: 'hidden',
+                            boxShadow: '0 2px 6px rgba(16,24,40,.06)',
                         }}
-                        nodeColor={THEME.colors.accent}
-                        maskColor={`${THEME.colors.background}cc`}
+                        // Faint tinted node chips so the map reads as a soft field,
+                        // not solid accent on every node.
+                        nodeColor={`${colors.redesign.primary}40`}
+                        nodeStrokeColor={`${colors.redesign.primary}66`}
+                        // Light mask (~25%) so the surrounding field stays faint and the
+                        // transparent viewport hole reads clearly; the primary-blue stroke
+                        // outlines the current viewport rect.
+                        maskColor={`${colors.redesign.surface}40`}
+                        maskStrokeColor={colors.redesign.primary}
+                        maskStrokeWidth={1.5}
                     />
                 )}
                 {!externalSearch && (


### PR DESCRIPTION
> 🚧 **Draft — stacked on #2762 (phase 2 of the CALM Hub redesign).** Ready for review once #2762 is merged; I'll then rebase this onto `main` so it shows only its own changes. Until then GitHub shows the **cumulative** diff (this phase plus the not-yet-merged prior ones).

Part of #2754.

## Description

Phase 3 of the CALM Hub redesign — refines the existing React Flow diagram view (node/edge semantics unchanged). Fixes the oversized minimap, illegible node labels, and the unclear timeline.

- **MiniMap** — constrained to a fixed 132×84 panel with a low mask opacity, a clear viewport rect, padded clear of the timeline, and made **toggleable** (was an oversized near-solid-blue block overflowing the canvas).
- **Node-label legibility** — labels stay legible after `fitView` and scale with zoom (a zoom floor), instead of shrinking to nothing on dense graphs.
- **Version timeline** — relabelled to **"Browse versions"** with an explanatory line and a version pill, surfacing the existing cross-view behaviour (clicking a moment re-renders the Diagram **and** JSON at that version). Single-version items collapse the strip. This reuses the existing `TimelineBar`, not a rewrite.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards