### PR TITLE
feat(calm-hub-ui): first-run landing, search disambiguation and dropzone polish

### DIFF
--- a/calm-hub-ui/src/admin/AdminPage.test.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.test.tsx
@@ -5,6 +5,10 @@ import { AdminPage } from './AdminPage.js';
 import { UserAccessContext } from './context/UserAccessContext.js';
 import { CurrentUserAccessState } from './hooks/useCurrentUserAccess.js';
 import { UserAccess } from '../model/user-access.js';
+import { colors } from '../theme/colors.js';
+
+// The redesign blue, as jsdom serialises it from inline style.
+const REDESIGN_BLUE_RGB = 'rgb(37, 99, 235)';
 
 const globalAdminGrant: UserAccess = { userAccessId: 1, username: 'alice', permission: 'admin', namespace: 'GLOBAL' };
 const nsAdminGrant: UserAccess = { userAccessId: 2, username: 'bob', permission: 'admin', namespace: 'finos' };
@@ -84,6 +88,34 @@ describe('AdminPage (layout)', () => {
     it('renders the domains panel when at that sub-route', () => {
         renderLayout(adminState, '/admin/domains');
         expect(screen.getByText('Domains panel')).toBeInTheDocument();
+    });
+});
+
+describe('AdminPage (active-state consistency, problem #8)', () => {
+    let restore: (() => void) | undefined;
+    afterEach(() => restore?.());
+
+    it('uses the redesign blue (not navy/neutral) on the active desktop sidebar link', () => {
+        renderLayout(adminState, '/admin/namespaces');
+        const activeLink = screen.getByRole('link', { name: /namespaces/i });
+        expect(activeLink).toHaveStyle({ color: REDESIGN_BLUE_RGB });
+        // Guard against regressing to the global navy brand or a neutral pill.
+        expect(colors.redesign.primary).toBe('#2563EB');
+        expect(activeLink).not.toHaveClass('menu-active');
+    });
+
+    it('does not apply the active blue to a resting desktop sidebar link', () => {
+        renderLayout(adminState, '/admin/namespaces');
+        const restingLink = screen.getByRole('link', { name: /entitlements/i });
+        expect(restingLink).not.toHaveStyle({ color: REDESIGN_BLUE_RGB });
+    });
+
+    it('uses the redesign blue on the active mobile tab', () => {
+        restore = mockMobileViewport(true);
+        renderLayout(adminState, '/admin/namespaces');
+        const activeTab = screen.getByRole('link', { name: /namespaces/i });
+        expect(activeTab).toHaveStyle({ color: REDESIGN_BLUE_RGB });
+        expect(activeTab).toHaveStyle({ borderBottomColor: REDESIGN_BLUE_RGB });
     });
 });
 

--- a/calm-hub-ui/src/admin/AdminPage.tsx
+++ b/calm-hub-ui/src/admin/AdminPage.tsx
@@ -2,13 +2,30 @@ import { NavLink, Outlet } from 'react-router-dom';
 import { Navbar } from '../components/navbar/Navbar.js';
 import { useUserAccess } from './context/UserAccessContext.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
+import { colors } from '../theme/colors.js';
+
+// One active-state system (redesign problem #8): both Admin nav surfaces use the
+// redesign blue (`colors.redesign.primary`) inline — the same accent the browse
+// rail and view tabs use. DaisyUI's `text-primary`/`menu-active` resolve to the
+// global navy brand (`--color-primary` = #000063) / a neutral pill, so they are
+// NOT used for the active accent here.
+const ACTIVE = colors.redesign.primary;
+const ACTIVE_TINT = colors.redesign.tintBg;
 
 function sidebarNavClass({ isActive }: { isActive: boolean }) {
-    return isActive ? 'menu-active' : '';
+    return isActive ? 'font-semibold' : '';
+}
+
+function sidebarNavStyle({ isActive }: { isActive: boolean }) {
+    return isActive ? { backgroundColor: ACTIVE_TINT, color: ACTIVE } : undefined;
 }
 
 function mobileTabClass({ isActive }: { isActive: boolean }) {
-    return `flex-1 text-center py-2 text-sm border-b-2 transition-colors ${isActive ? 'border-primary font-semibold text-primary' : 'border-transparent hover:border-base-content/20'}`;
+    return `flex-1 text-center py-2 text-sm border-b-2 transition-colors ${isActive ? 'font-semibold' : 'border-transparent hover:border-base-content/20'}`;
+}
+
+function mobileTabStyle({ isActive }: { isActive: boolean }) {
+    return isActive ? { borderBottomColor: ACTIVE, color: ACTIVE } : undefined;
 }
 
 export function AdminPage() {
@@ -34,9 +51,9 @@ export function AdminPage() {
                     {/* Mobile: tab bar for section navigation */}
                     {isMobile && (
                         <nav className="flex border-b border-base-300 bg-base-200" aria-label="Admin sections">
-                            <NavLink to="namespaces" className={mobileTabClass}>Namespaces</NavLink>
-                            {isGlobalAdmin && <NavLink to="domains" className={mobileTabClass}>Domains</NavLink>}
-                            <NavLink to="entitlements" className={mobileTabClass}>Entitlements</NavLink>
+                            <NavLink to="namespaces" className={mobileTabClass} style={mobileTabStyle}>Namespaces</NavLink>
+                            {isGlobalAdmin && <NavLink to="domains" className={mobileTabClass} style={mobileTabStyle}>Domains</NavLink>}
+                            <NavLink to="entitlements" className={mobileTabClass} style={mobileTabStyle}>Entitlements</NavLink>
                         </nav>
                     )}
 
@@ -45,9 +62,9 @@ export function AdminPage() {
                         {!isMobile && (
                             <aside className="w-52 bg-base-200 flex-shrink-0 border-r border-base-300">
                                 <ul className="menu p-4 gap-1">
-                                    <li><NavLink to="namespaces" className={sidebarNavClass}>Namespaces</NavLink></li>
-                                    {isGlobalAdmin && <li><NavLink to="domains" className={sidebarNavClass}>Domains</NavLink></li>}
-                                    <li><NavLink to="entitlements" className={sidebarNavClass}>Entitlements</NavLink></li>
+                                    <li><NavLink to="namespaces" className={sidebarNavClass} style={sidebarNavStyle}>Namespaces</NavLink></li>
+                                    {isGlobalAdmin && <li><NavLink to="domains" className={sidebarNavClass} style={sidebarNavStyle}>Domains</NavLink></li>}
+                                    <li><NavLink to="entitlements" className={sidebarNavClass} style={sidebarNavStyle}>Entitlements</NavLink></li>
                                 </ul>
                             </aside>
                         )}

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.test.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.test.tsx
@@ -29,6 +29,21 @@ const mockResults: GroupedSearchResults = {
     adrs: [],
 };
 
+// Two architectures sharing a name but living in different namespaces — the
+// ambiguous-duplicate case the namespace chip must disambiguate (problem #9).
+const duplicateNameResults: GroupedSearchResults = {
+    architectures: [
+        { namespace: 'finos', id: 1, name: 'TraderX Architecture', description: 'in finos' },
+        { namespace: 'traderx', id: 2, name: 'TraderX Architecture', description: 'in traderx' },
+    ],
+    patterns: [],
+    flows: [],
+    standards: [],
+    interfaces: [],
+    controls: [],
+    adrs: [],
+};
+
 function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
     return { search: searchFn } as unknown as SearchService;
 }
@@ -98,6 +113,52 @@ describe('GlobalSearchBar', () => {
         expect(screen.getByText('Test Pattern')).toBeInTheDocument();
         expect(screen.getByText('Architectures')).toBeInTheDocument();
         expect(screen.getByText('Patterns')).toBeInTheDocument();
+    });
+
+    it('renders a namespace chip on each result row', async () => {
+        const searchFn = vi.fn().mockResolvedValue(mockResults);
+        const service = createMockSearchService(searchFn);
+        renderSearchBar(service);
+
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        const chips = screen.getAllByTestId('result-namespace-chip');
+        expect(chips).toHaveLength(2); // one per result (arch + pattern)
+        expect(chips.every((c) => c.textContent === 'finos')).toBe(true);
+
+        // The name must shrink-truncate (min-w-0 + truncate) so a long name never
+        // pushes the namespace chip off the row — the #9 disambiguation depends on
+        // the chip staying visible.
+        const name = screen.getByText('Test Architecture');
+        expect(name).toHaveClass('truncate');
+        expect(name).toHaveClass('min-w-0');
+    });
+
+    it('disambiguates duplicate names via the namespace chip', async () => {
+        const searchFn = vi.fn().mockResolvedValue(duplicateNameResults);
+        const service = createMockSearchService(searchFn);
+        renderSearchBar(service);
+
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'traderx' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        // Both rows show the same name...
+        expect(screen.getAllByText('TraderX Architecture')).toHaveLength(2);
+        // ...but distinct namespace chips tell them apart.
+        const chips = screen.getAllByTestId('result-namespace-chip');
+        const chipText = chips.map((c) => c.textContent).sort();
+        expect(chipText).toEqual(['finos', 'traderx']);
     });
 
     it('shows no results message when search returns empty', async () => {

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
@@ -5,6 +5,7 @@ import { SearchService } from '../../service/search-service.js';
 import { CalmService } from '../../service/calm-service.js';
 import { AdrService } from '../../service/adr-service/adr-service.js';
 import { GroupedSearchResults, SearchResult } from '../../model/search.js';
+import { colors } from '../../theme/colors.js';
 
 interface FlatResult {
     type: string;
@@ -253,7 +254,10 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
 
         return groups.map(([type, items]) => (
             <div key={type}>
-                <div className="px-3 py-1 text-xs font-semibold text-base-content/50 uppercase tracking-wide bg-base-200">
+                <div
+                    className="px-3 py-1 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
+                    style={{ color: colors.redesign.faintAlt, backgroundColor: colors.redesign.surface }}
+                >
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {
@@ -268,9 +272,33 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
                             role="option"
                             aria-selected={currentIndex === selectedIndex}
                         >
-                            <div className="font-medium text-base-content">{item.name}</div>
+                            {/* Name + a right-aligned mono namespace chip so duplicate
+                                names across namespaces (problem #9) are distinguishable.
+                                No version chip: SearchResult carries no version and
+                                resolving it per result would be an N+1 — deferred. */}
+                            <div className="flex items-center gap-2">
+                                <span
+                                    className="font-medium truncate min-w-0"
+                                    style={{ color: colors.redesign.ink }}
+                                >
+                                    {item.name}
+                                </span>
+                                <span
+                                    data-testid="result-namespace-chip"
+                                    className="ml-auto shrink-0 font-mono-jb text-[10px] rounded-[6px] px-1.5 py-0.5"
+                                    style={{
+                                        backgroundColor: colors.redesign.badgeBg,
+                                        color: colors.redesign.mutedAlt,
+                                    }}
+                                >
+                                    {item.namespace}
+                                </span>
+                            </div>
                             {item.description && (
-                                <div className="text-xs text-base-content/60 truncate">
+                                <div
+                                    className="text-xs truncate mt-0.5"
+                                    style={{ color: colors.redesign.mutedAlt }}
+                                >
                                     {item.description}
                                 </div>
                             )}

--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -84,6 +84,15 @@ vi.mock('./components/domain-page/DomainPage', () => ({
     ),
 }));
 
+// Mocked at the seam: the real landing fires a bounded CalmService fetch on mount,
+// which is exercised in its own spec. Here we only need to confirm Hub renders it
+// on the empty `/` route.
+vi.mock('./components/first-run-landing/FirstRunLanding', () => ({
+    FirstRunLanding: ({ namespaceCounts }: { namespaceCounts: { namespace: string }[] }) => (
+        <div data-testid="first-run-landing">Landing ({namespaceCounts.length})</div>
+    ),
+}));
+
 // Counts service returns deterministic data for the page meta assertions.
 vi.mock('../service/counts-service', () => ({
     CountsService: class {
@@ -294,10 +303,12 @@ describe('Hub', () => {
             expect(await screen.findByTestId('domain-page')).toHaveTextContent('Domain: security (3)');
         });
 
-        it('does not render NamespacePage on the empty landing route', () => {
+        it('renders the first-run landing (not a namespace/domain page) on the empty / route', async () => {
             renderAt('/');
             expect(screen.queryByTestId('namespace-page')).not.toBeInTheDocument();
             expect(screen.queryByTestId('domain-page')).not.toBeInTheDocument();
+            // Landing receives the namespace counts Hub fetched (one in the mock).
+            expect(await screen.findByTestId('first-run-landing')).toHaveTextContent('Landing (1)');
         });
     });
 

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -5,6 +5,7 @@ import { ExploreRail } from './components/explore-rail/ExploreRail.js';
 import { MobileNavMenu } from './components/tree-navigation/MobileNavMenu.js';
 import { NamespacePage } from './components/namespace-page/NamespacePage.js';
 import { DomainPage } from './components/domain-page/DomainPage.js';
+import { FirstRunLanding } from './components/first-run-landing/FirstRunLanding.js';
 import { useResourceFromRoute } from './hooks/useResourceFromRoute.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
 import { Data, Adr } from '../model/calm.js';
@@ -195,7 +196,9 @@ export default function Hub() {
 
     // Route decides the content pane. A loaded resource (including an in-place
     // control/interface selected from the domain/namespace page) takes precedence
-    // over the route-driven page so its detail view shows.
+    // over the route-driven page so its detail view shows. With nothing loaded and
+    // no namespace/domain route (i.e. `/`), the first-run landing fills what was
+    // the ~75% blank canvas (redesign problem #7).
     const content =
         isDetailRoute || controlData || interfaceData || adrData || data ? (
             detailContent
@@ -204,11 +207,11 @@ export default function Hub() {
         ) : activeDomain ? (
             <DomainPage domain={activeDomain} controlCount={domainControlCount} onControlLoad={handleControlLoad} />
         ) : (
-            // Dedicated landing arm: nothing loaded and no browse route active. Kept separate
-            // from detailContent so it never renders DocumentDetailSection with undefined data.
-            <div className="flex-1 flex items-center justify-center text-[14px] text-base-content/50">
-                Select a namespace or control domain from the Explore rail to begin.
-            </div>
+            <FirstRunLanding
+                namespaceCounts={namespaceCounts}
+                domainCounts={domainCounts}
+                countsLoaded={namespaceCountsLoaded}
+            />
         );
 
     return (

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -38,6 +38,7 @@ export default function Hub() {
     // zero, so consumers must render them as unknown rather than a misleading 0.
     const [namespaceCountsFailed, setNamespaceCountsFailed] = useState(false);
     const [domainCounts, setDomainCounts] = useState<DomainControlCount[]>([]);
+    const [domainCountsLoaded, setDomainCountsLoaded] = useState(false);
     const isMobile = useIsMobile();
 
     // Route-first content selection (redesign problem #4): the same <Hub/> element
@@ -71,7 +72,11 @@ export default function Hub() {
             // unknown (loading)" from "known zero" — an absent namespace after a
             // successful fetch is genuinely zero, not still loading.
             .finally(() => setNamespaceCountsLoaded(true));
-        countsService.fetchDomainCounts().then(setDomainCounts).catch(() => setDomainCounts([]));
+        countsService
+            .fetchDomainCounts()
+            .then(setDomainCounts)
+            .catch(() => setDomainCounts([]))
+            .finally(() => setDomainCountsLoaded(true));
     }, [countsService]);
 
     useEffect(() => {
@@ -210,7 +215,9 @@ export default function Hub() {
             <FirstRunLanding
                 namespaceCounts={namespaceCounts}
                 domainCounts={domainCounts}
-                countsLoaded={namespaceCountsLoaded}
+                // Both must settle: the tiles include a Controls total from domainCounts,
+                // so gating on namespace counts alone would flash a 0 for Controls.
+                countsLoaded={namespaceCountsLoaded && domainCountsLoaded}
             />
         );
 

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -215,9 +215,11 @@ export default function Hub() {
             <FirstRunLanding
                 namespaceCounts={namespaceCounts}
                 domainCounts={domainCounts}
-                // Both must settle: the tiles include a Controls total from domainCounts,
-                // so gating on namespace counts alone would flash a 0 for Controls.
-                countsLoaded={namespaceCountsLoaded && domainCountsLoaded}
+                // Ready only once both fetches have settled AND the namespace fetch
+                // didn't fail: the tiles include a Controls total from domainCounts (so
+                // namespace-only gating would flash a 0 for Controls), and a failed
+                // namespace fetch is unknown, not zero — hold the placeholder in both cases.
+                countsLoaded={namespaceCountsLoaded && domainCountsLoaded && !namespaceCountsFailed}
             />
         );
 

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
@@ -180,6 +180,21 @@ describe('DiagramSection', () => {
             expect(screen.getByRole('tab', { name: /deployments/i })).toBeInTheDocument();
         });
 
+        it('paints the active view tab with the redesign brand blue, not the old accent (#8)', () => {
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} />
+                </MemoryRouter>
+            );
+
+            // Default active tab is Diagram — the one blue active system is the
+            // interaction token (--color-interaction → #2563EB), so the filled pill
+            // must carry the token-backed brand-blue class (not bg-accent).
+            const activeTab = screen.getByRole('tab', { name: /diagram/i });
+            expect(activeTab).toHaveClass('!bg-[var(--color-interaction)]');
+            expect(activeTab.className).not.toContain('bg-accent');
+        });
+
         it('renders Deployments tab only for architectures, not patterns', () => {
             const { rerender } = render(
                 <MemoryRouter>

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -311,7 +311,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             <button
                 role="tab"
                 aria-label="Diagram"
-                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'diagram' ? 'tab-active !bg-accent !text-white' : ''}`}
+                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'diagram' ? 'tab-active !bg-[var(--color-interaction)] !text-white' : ''}`}
                 onClick={() => setActiveTab('diagram')}
             >
                 <IoEyeOutline />
@@ -320,7 +320,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             <button
                 role="tab"
                 aria-label="JSON"
-                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'json' ? 'tab-active !bg-accent !text-white' : ''}`}
+                className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'json' ? 'tab-active !bg-[var(--color-interaction)] !text-white' : ''}`}
                 onClick={() => setActiveTab('json')}
             >
                 <IoCodeOutline />
@@ -330,7 +330,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                 <button
                     role="tab"
                     aria-label="Deployments"
-                    className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'deployments' ? 'tab-active !bg-accent !text-white' : ''}`}
+                    className={`tab gap-1 rounded-lg ${!comparing && activeTab === 'deployments' ? 'tab-active !bg-[var(--color-interaction)] !text-white' : ''}`}
                     onClick={() => setActiveTab('deployments')}
                 >
                     <IoRocketOutline />
@@ -345,7 +345,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     // shows the active view icon.
     const breadcrumb = (
         <h2 className="px-4 py-3 text-sm font-medium flex flex-wrap items-center gap-x-1 border-b border-base-200 text-base-content">
-            <Icon className="text-accent shrink-0" />
+            <Icon className="text-[var(--color-interaction)] shrink-0" />
             {data.name}
             {typeLabel && (
                 <>
@@ -371,12 +371,12 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                     onSelect?.();
                 }}
                 className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-base-200 active:bg-base-200 ${
-                    active ? 'bg-base-200 text-accent font-semibold' : 'text-base-content'
+                    active ? 'bg-base-200 text-[var(--color-interaction)] font-semibold' : 'text-base-content'
                 }`}
             >
-                <span className={active ? 'text-accent' : 'text-base-content/60'}>{icon}</span>
+                <span className={active ? 'text-[var(--color-interaction)]' : 'text-base-content/60'}>{icon}</span>
                 <span className="flex-1 min-w-0 truncate">{label}</span>
-                {active && <IoCheckmarkOutline size={18} className="text-accent shrink-0" />}
+                {active && <IoCheckmarkOutline size={18} className="text-[var(--color-interaction)] shrink-0" />}
             </button>
         );
     };
@@ -496,7 +496,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
             <div className={`w-full h-full py-4 pl-2 ${hasDetailsPanel ? 'pr-2' : 'pr-4'}`}>
                 <div className="h-full bg-base-100 rounded-box overflow-hidden flex flex-col shadow-xl">
                     <SectionHeader
-                        icon={<Icon className="text-accent" />}
+                        icon={<Icon className="text-[var(--color-interaction)]" />}
                         namespace={data.name}
                         id={data.id}
                         version={data.version}

--- a/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CatalogueCard } from './CatalogueCard.js';
+import type { CatalogueHighlight } from './useCatalogueHighlights.js';
+
+describe('CatalogueCard', () => {
+    const archItem: CatalogueHighlight = {
+        namespace: 'finos',
+        id: 'arch-1',
+        name: 'TraderX Architecture',
+        type: 'Architectures',
+    };
+
+    it('shows the name, an Architecture badge and a mono namespace chip', () => {
+        render(
+            <MemoryRouter>
+                <CatalogueCard item={archItem} />
+            </MemoryRouter>
+        );
+        expect(screen.getByText('TraderX Architecture')).toBeInTheDocument();
+        expect(screen.getByTestId('type-badge')).toHaveTextContent('Architecture');
+        expect(screen.getByText('finos')).toBeInTheDocument();
+    });
+
+    it('links to the namespace page (architectures tab), not a precomputed detail route', () => {
+        render(
+            <MemoryRouter>
+                <CatalogueCard item={archItem} />
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('catalogue-card')).toHaveAttribute(
+            'href',
+            '/namespace/finos?type=architectures'
+        );
+    });
+
+    it('uses the item\'s own type for a pattern: Pattern badge and the patterns tab', () => {
+        const patternItem: CatalogueHighlight = {
+            namespace: 'traderx',
+            id: 'pat-1',
+            name: 'Microservice Pattern',
+            type: 'Patterns',
+        };
+        render(
+            <MemoryRouter>
+                <CatalogueCard item={patternItem} />
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('type-badge')).toHaveTextContent('Pattern');
+        expect(screen.getByTestId('catalogue-card')).toHaveAttribute(
+            'href',
+            '/namespace/traderx?type=patterns'
+        );
+    });
+});

--- a/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom';
+import { colors } from '../../../theme/colors.js';
+import { redesignTokens } from '../../../theme/redesign-tokens.js';
+import { TypeBadge } from '../namespace-page/TypeBadge.js';
+import { getResourceTypeColors } from '../namespace-page/resource-type-meta.js';
+import type { CatalogueHighlight } from './useCatalogueHighlights.js';
+
+interface CatalogueCardProps {
+    item: CatalogueHighlight;
+}
+
+/**
+ * A compact catalogue-highlight card for the landing's "Browse the catalogue"
+ * strip: a type-tinted striped thumbnail, the item name, a resource-type
+ * {@link TypeBadge} and a mono namespace chip. Thumbnail tint and badge are
+ * driven by the item's own type, so architectures and patterns read distinctly.
+ *
+ * It links to the item's namespace page (not its detail route): the detail route
+ * needs the latest version, which is only resolvable via a per-item fetch — an
+ * N+1 the landing must avoid. The namespace page resolves the version on click.
+ */
+export function CatalogueCard({ item }: CatalogueCardProps) {
+    const { accent, tint } = getResourceTypeColors(item.type);
+    const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
+    const tabParam = item.type === 'Patterns' ? 'patterns' : 'architectures';
+
+    return (
+        <Link
+            to={`/namespace/${item.namespace}?type=${tabParam}`}
+            data-testid="catalogue-card"
+            className="group relative block rounded-[12px] overflow-hidden bg-base-100 no-underline hover:-translate-y-0.5 hover:shadow-md"
+            style={{
+                border: `1px solid ${colors.redesign.border}`,
+                boxShadow: redesignTokens.shadow.card,
+                transition: redesignTokens.transition,
+            }}
+        >
+            <div style={{ height: 64, background: stripes }} />
+            <div className="p-[14px]">
+                <div
+                    className="text-[13px] font-semibold truncate"
+                    style={{ color: colors.redesign.ink }}
+                >
+                    {item.name}
+                </div>
+                <div className="flex items-center gap-2 mt-[11px]">
+                    <TypeBadge type={item.type} />
+                    <span
+                        className="font-mono-jb text-[10.5px] ml-auto truncate"
+                        style={{ color: colors.redesign.mutedAlt }}
+                    >
+                        {item.namespace}
+                    </span>
+                </div>
+            </div>
+        </Link>
+    );
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/CatalogueCard.tsx
@@ -1,8 +1,4 @@
-import { Link } from 'react-router-dom';
-import { colors } from '../../../theme/colors.js';
-import { redesignTokens } from '../../../theme/redesign-tokens.js';
-import { TypeBadge } from '../namespace-page/TypeBadge.js';
-import { getResourceTypeColors } from '../namespace-page/resource-type-meta.js';
+import { ItemCard } from '../namespace-page/ItemCard.js';
 import type { CatalogueHighlight } from './useCatalogueHighlights.js';
 
 interface CatalogueCardProps {
@@ -10,49 +6,24 @@ interface CatalogueCardProps {
 }
 
 /**
- * A compact catalogue-highlight card for the landing's "Browse the catalogue"
- * strip: a type-tinted striped thumbnail, the item name, a resource-type
- * {@link TypeBadge} and a mono namespace chip. Thumbnail tint and badge are
- * driven by the item's own type, so architectures and patterns read distinctly.
+ * A catalogue-highlight card for the landing's "Browse the catalogue" strip. Reuses
+ * {@link ItemCard} (compact thumbnail, the namespace as the mono meta chip) rather
+ * than duplicating the card shell.
  *
  * It links to the item's namespace page (not its detail route): the detail route
  * needs the latest version, which is only resolvable via a per-item fetch — an
  * N+1 the landing must avoid. The namespace page resolves the version on click.
  */
 export function CatalogueCard({ item }: CatalogueCardProps) {
-    const { accent, tint } = getResourceTypeColors(item.type);
-    const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
     const tabParam = item.type === 'Patterns' ? 'patterns' : 'architectures';
-
     return (
-        <Link
-            to={`/namespace/${item.namespace}?type=${tabParam}`}
-            data-testid="catalogue-card"
-            className="group relative block rounded-[12px] overflow-hidden bg-base-100 no-underline hover:-translate-y-0.5 hover:shadow-md"
-            style={{
-                border: `1px solid ${colors.redesign.border}`,
-                boxShadow: redesignTokens.shadow.card,
-                transition: redesignTokens.transition,
-            }}
-        >
-            <div style={{ height: 64, background: stripes }} />
-            <div className="p-[14px]">
-                <div
-                    className="text-[13px] font-semibold truncate"
-                    style={{ color: colors.redesign.ink }}
-                >
-                    {item.name}
-                </div>
-                <div className="flex items-center gap-2 mt-[11px]">
-                    <TypeBadge type={item.type} />
-                    <span
-                        className="font-mono-jb text-[10.5px] ml-auto truncate"
-                        style={{ color: colors.redesign.mutedAlt }}
-                    >
-                        {item.namespace}
-                    </span>
-                </div>
-            </div>
-        </Link>
+        <ItemCard
+            name={item.name}
+            type={item.type}
+            meta={item.namespace}
+            thumbnailHeight={64}
+            testId="catalogue-card"
+            href={`/namespace/${item.namespace}?type=${tabParam}`}
+        />
     );
 }

--- a/calm-hub-ui/src/hub/components/first-run-landing/CatalogueHighlights.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/CatalogueHighlights.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CatalogueHighlights } from './CatalogueHighlights.js';
+
+function renderHighlights(props: Parameters<typeof CatalogueHighlights>[0]) {
+    return render(
+        <MemoryRouter>
+            <CatalogueHighlights {...props} />
+        </MemoryRouter>
+    );
+}
+
+describe('CatalogueHighlights', () => {
+    it('shows a spinner (no heading) while loading', () => {
+        const { container } = renderHighlights({ highlights: [], loading: true });
+        expect(screen.queryByText(/browse the catalogue/i)).not.toBeInTheDocument();
+        expect(container.querySelector('.loading-spinner')).toBeInTheDocument();
+    });
+
+    it('renders nothing once loaded with no highlights', () => {
+        renderHighlights({ highlights: [], loading: false });
+        expect(screen.queryByText(/browse the catalogue/i)).not.toBeInTheDocument();
+        expect(screen.queryByTestId('catalogue-card')).not.toBeInTheDocument();
+    });
+
+    it('renders the honest heading and cards of mixed types when there are highlights', () => {
+        renderHighlights({
+            highlights: [
+                { namespace: 'finos', id: 'a1', name: 'Arch One', type: 'Architectures' },
+                { namespace: 'traderx', id: 'p1', name: 'Pattern One', type: 'Patterns' },
+            ],
+            loading: false,
+        });
+        expect(screen.getByText(/browse the catalogue/i)).toBeInTheDocument();
+        expect(screen.queryByText(/recently updated/i)).not.toBeInTheDocument();
+        expect(screen.getAllByTestId('catalogue-card')).toHaveLength(2);
+        // Each card carries its own type's badge — the strip spans more than one type.
+        const badges = screen.getAllByTestId('type-badge').map((b) => b.textContent);
+        expect(badges).toEqual(['Architecture', 'Pattern']);
+    });
+
+    it('renders both cards (no key collision) when an architecture and pattern share a namespace + id', () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        renderHighlights({
+            highlights: [
+                { namespace: 'finos', id: '1', name: 'Arch', type: 'Architectures' },
+                { namespace: 'finos', id: '1', name: 'Pattern', type: 'Patterns' },
+            ],
+            loading: false,
+        });
+        expect(screen.getAllByTestId('catalogue-card')).toHaveLength(2);
+        // The type-qualified key keeps React from warning about duplicate keys.
+        expect(errorSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('two children with the same key'),
+            expect.anything(),
+            expect.anything()
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/calm-hub-ui/src/hub/components/first-run-landing/CatalogueHighlights.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/CatalogueHighlights.tsx
@@ -1,0 +1,48 @@
+import { colors } from '../../../theme/colors.js';
+import { CatalogueCard } from './CatalogueCard.js';
+import type { CatalogueHighlight } from './useCatalogueHighlights.js';
+
+interface CatalogueHighlightsProps {
+    highlights: CatalogueHighlight[];
+    loading: boolean;
+}
+
+/**
+ * The landing's "Browse the catalogue" section: a mono section label and up to
+ * three real {@link CatalogueCard}s.
+ *
+ * Honesty note: deliberately labelled "Browse the catalogue" — NOT "Recently
+ * updated". There is no recency signal in the API, so the items are a genuine
+ * sample of real architectures, not an (un)ordered "recent" list. Renders nothing
+ * when there are no items (a brand-new, empty hub).
+ */
+export function CatalogueHighlights({ highlights, loading }: CatalogueHighlightsProps) {
+    if (loading) {
+        return (
+            <div className="flex items-center gap-2 py-2">
+                <span className="loading loading-spinner loading-sm text-base-content/40" />
+            </div>
+        );
+    }
+
+    if (highlights.length === 0) return null;
+
+    return (
+        <section>
+            <div
+                className="font-mono-jb text-[11px] uppercase tracking-[0.1em] mb-3"
+                style={{ color: colors.redesign.faintAlt }}
+            >
+                Browse the catalogue
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-[640px]">
+                {highlights.map((item) => (
+                    // Architectures and patterns carry independent per-namespace id
+                    // sequences, so the type is part of the key to avoid a collision
+                    // when both share a numeric id within one namespace.
+                    <CatalogueCard key={`${item.type}/${item.namespace}/${item.id}`} item={item} />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/FirstRunLanding.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/FirstRunLanding.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
+
+// Mock the bounded fetch hook so the landing renders deterministically without
+// touching CalmService. Its own behaviour is covered in useCatalogueHighlights.test.
+const mockUse = vi.fn();
+vi.mock('./useCatalogueHighlights.js', () => ({
+    useCatalogueHighlights: (...args: unknown[]) => mockUse(...args),
+}));
+
+import { FirstRunLanding } from './FirstRunLanding.js';
+
+const counts = (over: Partial<NamespaceCounts>): NamespaceCounts => ({
+    namespace: 'ns',
+    architectures: 0,
+    patterns: 0,
+    flows: 0,
+    standards: 0,
+    adrs: 0,
+    interfaces: 0,
+    total: 0,
+    ...over,
+});
+
+const namespaceCounts: NamespaceCounts[] = [
+    counts({ namespace: 'finos', architectures: 2, patterns: 1 }),
+    counts({ namespace: 'traderx', architectures: 1, patterns: 3 }),
+];
+const domainCounts: DomainControlCount[] = [{ domain: 'security', controlCount: 4 }];
+
+function renderLanding() {
+    return render(
+        <MemoryRouter>
+            <FirstRunLanding namespaceCounts={namespaceCounts} domainCounts={domainCounts} />
+        </MemoryRouter>
+    );
+}
+
+describe('FirstRunLanding', () => {
+    it('renders the heading, sub-paragraph and stat tiles with values from counts', () => {
+        mockUse.mockReturnValue({ highlights: [], loading: false });
+        renderLanding();
+
+        expect(
+            screen.getByRole('heading', { name: /explore the architecture catalogue/i })
+        ).toBeInTheDocument();
+
+        expect(screen.getByText('Namespaces').closest('[data-testid="stat-tile"]')).toHaveTextContent('2');
+        expect(screen.getByText('Architectures').closest('[data-testid="stat-tile"]')).toHaveTextContent('3');
+        expect(screen.getByText('Patterns').closest('[data-testid="stat-tile"]')).toHaveTextContent('4');
+        expect(screen.getByText('Controls').closest('[data-testid="stat-tile"]')).toHaveTextContent('4');
+    });
+
+    it('renders catalogue highlights under an honest "Browse the catalogue" heading (not "Recently updated")', () => {
+        mockUse.mockReturnValue({
+            highlights: [
+                { namespace: 'finos', id: 'a1', name: 'TraderX Architecture', type: 'Architectures' },
+            ],
+            loading: false,
+        });
+        renderLanding();
+
+        expect(screen.getByText(/browse the catalogue/i)).toBeInTheDocument();
+        expect(screen.queryByText(/recently updated/i)).not.toBeInTheDocument();
+        expect(screen.getByText('TraderX Architecture')).toBeInTheDocument();
+    });
+
+    it('omits the catalogue section when there are no highlights', () => {
+        mockUse.mockReturnValue({ highlights: [], loading: false });
+        renderLanding();
+        expect(screen.queryByText(/browse the catalogue/i)).not.toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/hub/components/first-run-landing/FirstRunLanding.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/FirstRunLanding.tsx
@@ -1,0 +1,66 @@
+import { colors } from '../../../theme/colors.js';
+import { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
+import { LandingStatTiles } from './LandingStatTiles.js';
+import { CatalogueHighlights } from './CatalogueHighlights.js';
+import { useCatalogueHighlights } from './useCatalogueHighlights.js';
+
+interface FirstRunLandingProps {
+    namespaceCounts: NamespaceCounts[];
+    domainCounts: DomainControlCount[];
+    /**
+     * Whether the namespace counts fetch has settled. While `false` the stat
+     * tiles show a placeholder rather than a misleading all-zero flash before the
+     * real catalogue totals arrive.
+     */
+    countsLoaded?: boolean;
+}
+
+/**
+ * First-run / empty landing (redesign problem #7) — replaces the ~75% blank grey
+ * canvas shown on `/` when nothing is loaded. Heading + sub-paragraph, the 4-up
+ * catalogue stat tiles (values from the counts Hub already holds), and a small
+ * honest sample of real catalogue items (NOT "recently updated" — see
+ * {@link useCatalogueHighlights}).
+ *
+ * Desktop-first per Frame 01, but lays out responsively (tiles + cards stack on
+ * narrow widths). On mobile the drill-down overlay covers `/`; this sits behind it
+ * and shows when that drawer is closed, so it must not break at small widths.
+ */
+export function FirstRunLanding({
+    namespaceCounts,
+    domainCounts,
+    countsLoaded = true,
+}: FirstRunLandingProps) {
+    const { highlights, loading } = useCatalogueHighlights(namespaceCounts);
+
+    return (
+        <div
+            data-testid="first-run-landing"
+            className="h-full overflow-auto bg-base-100"
+            style={{ padding: '44px 48px' }}
+        >
+            <div className="flex flex-col gap-8">
+                <header>
+                    <h1 className="text-[32px] font-bold" style={{ color: colors.redesign.ink }}>
+                        Explore the architecture catalogue
+                    </h1>
+                    <p
+                        className="text-[15px] mt-3 max-w-[520px]"
+                        style={{ color: colors.redesign.muted }}
+                    >
+                        Browse versioned CALM artefacts across your namespaces, or pick up where you
+                        left off — every architecture, pattern and control is one click away.
+                    </p>
+                </header>
+
+                <LandingStatTiles
+                    namespaceCounts={namespaceCounts}
+                    domainCounts={domainCounts}
+                    loaded={countsLoaded}
+                />
+
+                <CatalogueHighlights highlights={highlights} loading={loading} />
+            </div>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/LandingStatTiles.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/LandingStatTiles.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LandingStatTiles } from './LandingStatTiles.js';
+import { colors } from '../../../theme/colors.js';
+import type { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
+
+const counts = (over: Partial<NamespaceCounts>): NamespaceCounts => ({
+    namespace: 'ns',
+    architectures: 0,
+    patterns: 0,
+    flows: 0,
+    standards: 0,
+    adrs: 0,
+    interfaces: 0,
+    total: 0,
+    ...over,
+});
+
+const namespaceCounts: NamespaceCounts[] = [
+    counts({ namespace: 'finos', architectures: 3, patterns: 2 }),
+    counts({ namespace: 'traderx', architectures: 1, patterns: 4 }),
+];
+const domainCounts: DomainControlCount[] = [
+    { domain: 'security', controlCount: 5 },
+    { domain: 'resilience', controlCount: 2 },
+];
+
+describe('LandingStatTiles', () => {
+    it('derives all four totals from the counts (no extra fetch)', () => {
+        render(<LandingStatTiles namespaceCounts={namespaceCounts} domainCounts={domainCounts} />);
+
+        const tiles = screen.getAllByTestId('stat-tile');
+        expect(tiles).toHaveLength(4);
+
+        // Namespaces = number of namespaces (2)
+        expect(screen.getByText('Namespaces').closest('[data-testid="stat-tile"]')).toHaveTextContent('2');
+        // Architectures = 3 + 1
+        expect(screen.getByText('Architectures').closest('[data-testid="stat-tile"]')).toHaveTextContent('4');
+        // Patterns = 2 + 4
+        expect(screen.getByText('Patterns').closest('[data-testid="stat-tile"]')).toHaveTextContent('6');
+        // Controls = 5 + 2 (from domain counts)
+        expect(screen.getByText('Controls').closest('[data-testid="stat-tile"]')).toHaveTextContent('7');
+    });
+
+    it('renders the Namespaces number in the redesign blue accent', () => {
+        render(<LandingStatTiles namespaceCounts={namespaceCounts} domainCounts={domainCounts} />);
+        const nsTile = screen.getByText('Namespaces').closest('[data-testid="stat-tile"]')!;
+        const numberEl = nsTile.querySelector('.font-mono-jb') as HTMLElement;
+        // jsdom normalises hex to rgb; compare via the element's inline style colour.
+        expect(numberEl.style.color.replace(/\s/g, '')).toBe('rgb(37,99,235)');
+        expect(colors.redesign.primary).toBe('#2563EB');
+    });
+
+    it('renders zeros for an empty catalogue', () => {
+        render(<LandingStatTiles namespaceCounts={[]} domainCounts={[]} />);
+        const tiles = screen.getAllByTestId('stat-tile');
+        tiles.forEach((t) => expect(t).toHaveTextContent('0'));
+    });
+
+    it('shows a dash placeholder (no zero-flash) until counts have loaded', () => {
+        render(
+            <LandingStatTiles namespaceCounts={namespaceCounts} domainCounts={domainCounts} loaded={false} />
+        );
+        const tiles = screen.getAllByTestId('stat-tile');
+        expect(tiles).toHaveLength(4);
+        tiles.forEach((t) => {
+            expect(t).toHaveTextContent('—');
+            expect(t).not.toHaveTextContent(/[0-9]/);
+        });
+    });
+});

--- a/calm-hub-ui/src/hub/components/first-run-landing/LandingStatTiles.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/LandingStatTiles.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
+import { StatTile } from './StatTile.js';
+
+interface LandingStatTilesProps {
+    namespaceCounts: NamespaceCounts[];
+    domainCounts: DomainControlCount[];
+    /** When false the tiles show a placeholder instead of an all-zero flash. */
+    loaded?: boolean;
+}
+
+/**
+ * The 4-up catalogue stat tiles. Every value is derived from the counts Hub
+ * already fetched — no extra request:
+ *  - Namespaces  = number of namespaces
+ *  - Architectures / Patterns = summed across namespaces
+ *  - Controls    = summed across control domains
+ */
+export function LandingStatTiles({ namespaceCounts, domainCounts, loaded = true }: LandingStatTilesProps) {
+    const totals = useMemo(() => {
+        const architectures = namespaceCounts.reduce((sum, c) => sum + c.architectures, 0);
+        const patterns = namespaceCounts.reduce((sum, c) => sum + c.patterns, 0);
+        const controls = domainCounts.reduce((sum, d) => sum + d.controlCount, 0);
+        return { namespaces: namespaceCounts.length, architectures, patterns, controls };
+    }, [namespaceCounts, domainCounts]);
+
+    return (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-[14px] max-w-[640px]">
+            <StatTile value={totals.namespaces} label="Namespaces" accent loaded={loaded} />
+            <StatTile value={totals.architectures} label="Architectures" loaded={loaded} />
+            <StatTile value={totals.patterns} label="Patterns" loaded={loaded} />
+            <StatTile value={totals.controls} label="Controls" loaded={loaded} />
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/StatTile.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/StatTile.tsx
@@ -1,0 +1,49 @@
+import { colors } from '../../../theme/colors.js';
+import { redesignTokens } from '../../../theme/redesign-tokens.js';
+
+interface StatTileProps {
+    /** The metric value (rendered mono, per the metadata convention). */
+    value: number;
+    /** Short lower-case-ish label, e.g. "Namespaces". */
+    label: string;
+    /** When true the number is brand blue (used for the Namespaces tile). */
+    accent?: boolean;
+    /** When false, shows a dash placeholder instead of a (likely-zero) value. */
+    loaded?: boolean;
+}
+
+/**
+ * One catalogue stat tile: a big mono number over a small muted label. The
+ * Namespaces tile renders its number in the redesign blue ({@link accent}); the
+ * rest render in ink. Pure presentational — totals are computed by the parent.
+ * Until {@link loaded}, shows a faint dash so the landing doesn't flash zeros
+ * before the counts fetch settles.
+ */
+export function StatTile({ value, label, accent = false, loaded = true }: StatTileProps) {
+    return (
+        <div
+            data-testid="stat-tile"
+            className="rounded-[11px] p-4"
+            style={{
+                border: `1px solid ${colors.redesign.border}`,
+                boxShadow: redesignTokens.shadow.card,
+            }}
+        >
+            <div
+                className="font-mono-jb text-[28px] font-bold leading-none"
+                style={{
+                    color: !loaded
+                        ? colors.redesign.disabled
+                        : accent
+                          ? colors.redesign.primary
+                          : colors.redesign.ink,
+                }}
+            >
+                {loaded ? value : '—'}
+            </div>
+            <div className="text-[12px] mt-2" style={{ color: colors.redesign.mutedAlt }}>
+                {label}
+            </div>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCatalogueHighlights } from './useCatalogueHighlights.js';
+import { CalmService } from '../../../service/calm-service.js';
+import type { NamespaceCounts } from '../../../model/counts.js';
+import type { ResourceSummary } from '../../../model/calm.js';
+
+const counts = (over: Partial<NamespaceCounts>): NamespaceCounts => ({
+    namespace: 'ns',
+    architectures: 0,
+    patterns: 0,
+    flows: 0,
+    standards: 0,
+    adrs: 0,
+    interfaces: 0,
+    total: 0,
+    ...over,
+});
+
+const summary = (id: number, name: string): ResourceSummary => ({ id, name, description: `${name} desc` });
+
+function mockService(
+    archFn: (ns: string) => Promise<ResourceSummary[]>,
+    patternFn: (ns: string) => Promise<ResourceSummary[]> = async () => []
+): CalmService {
+    return {
+        fetchArchitectureSummaries: vi.fn(archFn),
+        fetchPatternSummaries: vi.fn(patternFn),
+    } as unknown as CalmService;
+}
+
+describe('useCatalogueHighlights', () => {
+    it('fetches architecture and pattern summaries for namespaces with content, bounded to two', async () => {
+        const arch = vi.fn(async (ns: string) => [summary(1, `${ns}-arch`)]);
+        const pattern = vi.fn(async (ns: string) => [summary(2, `${ns}-pattern`)]);
+        const service = {
+            fetchArchitectureSummaries: arch,
+            fetchPatternSummaries: pattern,
+        } as unknown as CalmService;
+        const namespaceCounts: NamespaceCounts[] = [
+            counts({ namespace: 'a', architectures: 2 }),
+            counts({ namespace: 'b', architectures: 0, patterns: 0 }), // skipped (no content)
+            counts({ namespace: 'c', patterns: 1 }), // qualifies via patterns
+            counts({ namespace: 'd', architectures: 5 }), // beyond the cap of 2
+        ];
+
+        const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        // Only the first two namespaces WITH content (a, c) are probed, for BOTH types.
+        expect(arch).toHaveBeenCalledTimes(2);
+        expect(pattern).toHaveBeenCalledTimes(2);
+        expect(arch).toHaveBeenCalledWith('a');
+        expect(pattern).toHaveBeenCalledWith('c');
+        expect(arch).not.toHaveBeenCalledWith('b');
+        expect(arch).not.toHaveBeenCalledWith('d');
+    });
+
+    it('tags highlights with their true type, spanning architectures and patterns', async () => {
+        const service = mockService(
+            async (ns) => [summary(1, `${ns}-arch`)],
+            async (ns) => [summary(2, `${ns}-pattern`)]
+        );
+        const namespaceCounts: NamespaceCounts[] = [
+            counts({ namespace: 'a', architectures: 1, patterns: 1 }),
+        ];
+
+        const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.highlights).toEqual([
+            expect.objectContaining({ namespace: 'a', name: 'a-arch', type: 'Architectures' }),
+            expect.objectContaining({ namespace: 'a', name: 'a-pattern', type: 'Patterns' }),
+        ]);
+    });
+
+    it('returns at most three real highlights with their namespace', async () => {
+        const service = mockService(async (ns) => [
+            summary(1, `${ns}-1`),
+            summary(2, `${ns}-2`),
+        ]);
+        const namespaceCounts: NamespaceCounts[] = [
+            counts({ namespace: 'a', architectures: 2 }),
+            counts({ namespace: 'c', architectures: 2 }),
+        ];
+
+        const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.highlights).toHaveLength(3);
+        expect(result.current.highlights[0]).toMatchObject({
+            namespace: 'a',
+            name: 'a-1',
+            type: 'Architectures',
+        });
+        expect(result.current.highlights.every((h) => h.namespace)).toBe(true);
+    });
+
+    it('does not fetch and reports loaded when no namespace has architectures or patterns', async () => {
+        const arch = vi.fn(async () => []);
+        const pattern = vi.fn(async () => []);
+        const service = {
+            fetchArchitectureSummaries: arch,
+            fetchPatternSummaries: pattern,
+        } as unknown as CalmService;
+        const namespaceCounts: NamespaceCounts[] = [
+            counts({ namespace: 'a', architectures: 0, patterns: 0 }),
+        ];
+
+        const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(arch).not.toHaveBeenCalled();
+        expect(pattern).not.toHaveBeenCalled();
+        expect(result.current.highlights).toEqual([]);
+    });
+
+    it('tolerates a failing summary fetch (returns the rest)', async () => {
+        const service = mockService(async (ns) => {
+            if (ns === 'a') throw new Error('boom');
+            return [summary(1, `${ns}-ok`)];
+        });
+        const namespaceCounts: NamespaceCounts[] = [
+            counts({ namespace: 'a', architectures: 2 }),
+            counts({ namespace: 'c', architectures: 2 }),
+        ];
+
+        const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.highlights).toEqual([
+            expect.objectContaining({ namespace: 'c', name: 'c-ok', type: 'Architectures' }),
+        ]);
+    });
+});

--- a/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.test.tsx
+++ b/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.test.tsx
@@ -47,11 +47,15 @@ describe('useCatalogueHighlights', () => {
         const { result } = renderHook(() => useCatalogueHighlights(namespaceCounts, service));
         await waitFor(() => expect(result.current.loading).toBe(false));
 
-        // Only the first two namespaces WITH content (a, c) are probed, for BOTH types.
-        expect(arch).toHaveBeenCalledTimes(2);
-        expect(pattern).toHaveBeenCalledTimes(2);
+        // The first two namespaces WITH content (a, c) are probed, and only for the
+        // type each actually has: 'a' has architectures, 'c' has patterns — the
+        // zero-count type is skipped rather than fetched and discarded.
+        expect(arch).toHaveBeenCalledTimes(1);
+        expect(pattern).toHaveBeenCalledTimes(1);
         expect(arch).toHaveBeenCalledWith('a');
         expect(pattern).toHaveBeenCalledWith('c');
+        expect(arch).not.toHaveBeenCalledWith('c');
+        expect(pattern).not.toHaveBeenCalledWith('a');
         expect(arch).not.toHaveBeenCalledWith('b');
         expect(arch).not.toHaveBeenCalledWith('d');
     });

--- a/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.ts
+++ b/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.ts
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CalmService } from '../../../service/calm-service.js';
+import { NamespaceCounts } from '../../../model/counts.js';
+import { ResourceSummary } from '../../../model/calm.js';
+
+/** Resource types surfaced in the catalogue strip. */
+export type CatalogueHighlightType = 'Architectures' | 'Patterns';
+
+export interface CatalogueHighlight {
+    namespace: string;
+    id: string;
+    name: string;
+    description?: string;
+    /** Mono slug identifier, shown as meta when present. */
+    customId?: string;
+    /** The resource type this highlight came from — drives its card badge/colour. */
+    type: CatalogueHighlightType;
+}
+
+/** Max namespaces probed for highlights — keeps the landing fetch bounded. */
+const MAX_NAMESPACES = 2;
+/** Max cards rendered in the "Browse the catalogue" strip. */
+const MAX_HIGHLIGHTS = 3;
+
+/** Map a namespace's summaries to typed highlights. */
+function toHighlights(
+    summaries: ResourceSummary[],
+    namespace: string,
+    type: CatalogueHighlightType
+): CatalogueHighlight[] {
+    return summaries.map((s) => ({
+        namespace,
+        id: s.customId ?? s.id.toString(),
+        name: s.name,
+        description: s.description,
+        customId: s.customId,
+        type,
+    }));
+}
+
+/**
+ * A small, honest sample of real catalogue items for the first-run landing.
+ *
+ * There is no recency API — records carry no reliable updated-timestamp we can
+ * query cheaply — so this deliberately does NOT claim "recently updated". It
+ * fetches architecture AND pattern summaries for the first one or two namespaces
+ * that hold either (per the counts Hub already holds) and returns up to three
+ * real items — each tagged with its true resource type — under a truthful
+ * "Browse the catalogue" heading.
+ *
+ * The fetch is bounded: at most {@link MAX_NAMESPACES} namespaces are probed (two
+ * summary requests each — architectures + patterns — with no N+1, no per-item
+ * version resolution).
+ */
+export function useCatalogueHighlights(
+    namespaceCounts: NamespaceCounts[],
+    calmService?: CalmService
+): { highlights: CatalogueHighlight[]; loading: boolean } {
+    const service = useMemo(() => calmService ?? new CalmService(), [calmService]);
+
+    // The namespaces to probe: those with at least one architecture or pattern,
+    // capped. Memoised on a stable key so a fresh array identity each render
+    // doesn't re-trigger the fetch.
+    const targetKey = useMemo(
+        () =>
+            namespaceCounts
+                .filter((c) => c.architectures > 0 || c.patterns > 0)
+                .slice(0, MAX_NAMESPACES)
+                .map((c) => c.namespace)
+                .join(','),
+        [namespaceCounts]
+    );
+
+    const [highlights, setHighlights] = useState<CatalogueHighlight[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const targets = targetKey ? targetKey.split(',') : [];
+        if (targets.length === 0) {
+            setHighlights([]);
+            setLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setLoading(true);
+
+        Promise.all(
+            targets.map((namespace) =>
+                Promise.all([
+                    service
+                        .fetchArchitectureSummaries(namespace)
+                        .then((summaries) => toHighlights(summaries, namespace, 'Architectures'))
+                        .catch(() => [] as CatalogueHighlight[]),
+                    service
+                        .fetchPatternSummaries(namespace)
+                        .then((summaries) => toHighlights(summaries, namespace, 'Patterns'))
+                        .catch(() => [] as CatalogueHighlight[]),
+                ]).then(([architectures, patterns]) => [...architectures, ...patterns])
+            )
+        ).then((perNamespace) => {
+            if (cancelled) return;
+            setHighlights(perNamespace.flat().slice(0, MAX_HIGHLIGHTS));
+            setLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [targetKey, service]);
+
+    return { highlights, loading };
+}

--- a/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.ts
+++ b/calm-hub-ui/src/hub/components/first-run-landing/useCatalogueHighlights.ts
@@ -60,13 +60,14 @@ export function useCatalogueHighlights(
 
     // The namespaces to probe: those with at least one architecture or pattern,
     // capped. Memoised on a stable key so a fresh array identity each render
-    // doesn't re-trigger the fetch.
+    // doesn't re-trigger the fetch. The key encodes which of the two types each
+    // namespace actually has, so the effect can skip fetching a type with 0 count.
     const targetKey = useMemo(
         () =>
             namespaceCounts
                 .filter((c) => c.architectures > 0 || c.patterns > 0)
                 .slice(0, MAX_NAMESPACES)
-                .map((c) => c.namespace)
+                .map((c) => `${c.namespace}|${c.architectures > 0 ? 1 : 0}|${c.patterns > 0 ? 1 : 0}`)
                 .join(','),
         [namespaceCounts]
     );
@@ -75,7 +76,12 @@ export function useCatalogueHighlights(
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const targets = targetKey ? targetKey.split(',') : [];
+        const targets = targetKey
+            ? targetKey.split(',').map((entry) => {
+                  const [namespace, hasArch, hasPattern] = entry.split('|');
+                  return { namespace, hasArchitectures: hasArch === '1', hasPatterns: hasPattern === '1' };
+              })
+            : [];
         if (targets.length === 0) {
             setHighlights([]);
             setLoading(false);
@@ -85,17 +91,23 @@ export function useCatalogueHighlights(
         let cancelled = false;
         setLoading(true);
 
+        const empty = Promise.resolve([] as CatalogueHighlight[]);
         Promise.all(
-            targets.map((namespace) =>
+            targets.map(({ namespace, hasArchitectures, hasPatterns }) =>
                 Promise.all([
-                    service
-                        .fetchArchitectureSummaries(namespace)
-                        .then((summaries) => toHighlights(summaries, namespace, 'Architectures'))
-                        .catch(() => [] as CatalogueHighlight[]),
-                    service
-                        .fetchPatternSummaries(namespace)
-                        .then((summaries) => toHighlights(summaries, namespace, 'Patterns'))
-                        .catch(() => [] as CatalogueHighlight[]),
+                    // Only fetch a type the namespace actually has — skip the wasted request otherwise.
+                    hasArchitectures
+                        ? service
+                              .fetchArchitectureSummaries(namespace)
+                              .then((summaries) => toHighlights(summaries, namespace, 'Architectures'))
+                              .catch(() => [] as CatalogueHighlight[])
+                        : empty,
+                    hasPatterns
+                        ? service
+                              .fetchPatternSummaries(namespace)
+                              .then((summaries) => toHighlights(summaries, namespace, 'Patterns'))
+                              .catch(() => [] as CatalogueHighlight[])
+                        : empty,
                 ]).then(([architectures, patterns]) => [...architectures, ...patterns])
             )
         ).then((perNamespace) => {

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { TypeBadge } from './TypeBadge.js';
@@ -17,35 +18,64 @@ interface ItemCardProps {
      */
     versionCount?: number;
     /**
-     * Activates the card (opens the item's detail route). The card cannot be a
-     * static router `<Link>`: the detail route needs the item's latest version,
-     * which is only resolvable via a per-item fetch — so navigation is resolved on
-     * click by the parent rather than precomputed, to avoid an N+1 on render.
+     * Overrides the footer mono chip (e.g. a namespace on the landing highlights).
+     * When unset the footer falls back to the "N versions" scent or {@link customId}.
      */
-    onActivate: () => void;
+    meta?: string;
+    /** Thumbnail header height in px (default 96; landing highlights use a shorter one). */
+    thumbnailHeight?: number;
+    /** `data-testid` for the activation element (default `item-card`). */
+    testId?: string;
+    /**
+     * When set, the whole card is a router {@link Link} to this path — used by cards
+     * that navigate to a static route (e.g. a namespace page). When unset the card is
+     * a `<button>` calling {@link onActivate} (the detail route needs a per-item version
+     * fetch resolved on click, so it can't be a static Link).
+     */
+    href?: string;
+    /** Click handler for the button form; required when {@link href} is not set. */
+    onActivate?: () => void;
 }
 
 /**
- * A browse card for a single namespace item: a type-tinted striped thumbnail
- * header, the item name, a 2-line-clamped description and a footer with its
- * {@link TypeBadge}. The name is a `<button>` whose stretched `::after` makes the
- * whole card the activation target for the item's detail route.
- *
- * The footer meta shows the "N versions" scent when the item carries a version
- * count (the version-map types); otherwise it falls back to the mono customId.
+ * A browse card for a single resource: a type-tinted striped thumbnail header, the
+ * item name, an optional 2-line-clamped description and a footer {@link TypeBadge}
+ * plus a mono meta chip. The name is the activation target — a `<button>` (default)
+ * or a router {@link Link} when {@link href} is given — whose stretched `::after`
+ * makes the whole card clickable while keeping its accessible name to just the name.
  */
-export function ItemCard({ name, description, type, customId, versionCount, onActivate }: ItemCardProps) {
+export function ItemCard({
+    name,
+    description,
+    type,
+    customId,
+    versionCount,
+    meta,
+    thumbnailHeight = 96,
+    testId = 'item-card',
+    href,
+    onActivate,
+}: ItemCardProps) {
     const { accent, tint } = getResourceTypeColors(type);
     // Striped header derived from the type's own tokens (tint + accent at low
     // alpha) rather than hardcoded mockup hexes, so it tracks the palette.
     const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
 
-    // A `<button>` can't legally wrap the card's block content (it takes phrasing
-    // content only). So the card is a positioned `<article>` holding the visual
-    // content, and a single `<button>` whose `::after` (`after:absolute
-    // after:inset-0`) stretches over the whole card to keep the full-card click
-    // target. The button's text is just the item name, so its accessible name is
-    // the name (not name + description + badge + customId).
+    // A `<button>`/`<a>` can't legally wrap the card's block content (phrasing content
+    // only). So the card is a positioned `<article>` and the activation element's
+    // `::after` (`after:absolute after:inset-0`) stretches over the whole card to keep
+    // the full-card click target, while its accessible name stays just the item name.
+    const activationClass =
+        "block w-full text-left text-[14px] font-semibold truncate rounded-[2px] no-underline after:absolute after:inset-0 after:content-[''] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-interaction)]";
+
+    // Footer chip: an explicit meta override, else the "N versions" scent, else the customId.
+    const chip =
+        meta !== undefined
+            ? meta
+            : versionCount !== undefined
+              ? `${versionCount} ${versionCount === 1 ? 'version' : 'versions'}`
+              : customId;
+
     return (
         <article
             className="group relative rounded-[12px] overflow-hidden bg-base-100 hover:-translate-y-0.5 hover:shadow-md"
@@ -55,17 +85,23 @@ export function ItemCard({ name, description, type, customId, versionCount, onAc
                 transition: redesignTokens.transition,
             }}
         >
-            <div style={{ height: 96, background: stripes }} />
+            <div style={{ height: thumbnailHeight, background: stripes }} />
             <div className="p-[14px]">
-                <button
-                    type="button"
-                    data-testid="item-card"
-                    onClick={onActivate}
-                    className="block w-full text-left text-[14px] font-semibold truncate rounded-[2px] after:absolute after:inset-0 after:content-[''] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-interaction)]"
-                    style={{ color: colors.redesign.ink }}
-                >
-                    {name}
-                </button>
+                {href ? (
+                    <Link to={href} data-testid={testId} className={activationClass} style={{ color: colors.redesign.ink }}>
+                        {name}
+                    </Link>
+                ) : (
+                    <button
+                        type="button"
+                        data-testid={testId}
+                        onClick={onActivate}
+                        className={activationClass}
+                        style={{ color: colors.redesign.ink }}
+                    >
+                        {name}
+                    </button>
+                )}
                 {description && (
                     <p
                         className="text-[12px] leading-[1.45] mt-[5px] mb-[11px] line-clamp-2"
@@ -74,29 +110,17 @@ export function ItemCard({ name, description, type, customId, versionCount, onAc
                         {description}
                     </p>
                 )}
-                {/* No stacking context here: the button's transparent stretched
-                    `::after` overlays the footer so a click anywhere on the card
-                    (including over the badge/customId) activates it. */}
+                {/* No stacking context here: the transparent stretched `::after` overlays
+                    the footer so a click anywhere on the card activates it. */}
                 <div className={`flex items-center gap-2 ${description ? '' : 'mt-[11px]'}`}>
                     <TypeBadge type={type} />
-                    {/* "N versions" scent for the version-map types; otherwise the
-                        customId. A genuine 0 still reads as "0 versions". */}
-                    {versionCount !== undefined ? (
+                    {chip !== undefined && (
                         <span
                             className="font-mono-jb text-[10.5px] ml-auto truncate"
                             style={{ color: colors.redesign.mutedAlt }}
                         >
-                            {versionCount} {versionCount === 1 ? 'version' : 'versions'}
+                            {chip}
                         </span>
-                    ) : (
-                        customId && (
-                            <span
-                                className="font-mono-jb text-[10.5px] ml-auto truncate"
-                                style={{ color: colors.redesign.mutedAlt }}
-                            >
-                                {customId}
-                            </span>
-                        )
                     )}
                 </div>
             </div>

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
@@ -1,9 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { Drawer } from './Drawer.js';
 import { Data } from '../../../model/calm.js';
 import type { ReactFlowVisualizerProps } from '../../contracts/contracts.js';
 import { DropzoneOptions } from 'react-dropzone';
+
+// Captures the `onDrop` the Drawer hands to react-dropzone so tests can invoke
+// it directly with a fake File. Hoisted so the (hoisted) vi.mock factory below
+// can reference it without hitting the temporal-dead-zone.
+const { mockDropzone } = vi.hoisted(() => ({
+    mockDropzone: {} as { onDrop?: (files: File[]) => void | Promise<void> },
+}));
+
+/** A minimal File stand-in whose `.text()` resolves to the given contents. */
+function fakeFile(text: string): File {
+    return { text: () => Promise.resolve(text) } as unknown as File;
+}
 
 const mockFetchDeploymentDecoratorsForArchitecture = vi.fn().mockResolvedValue([]);
 
@@ -32,12 +44,15 @@ vi.mock('react-dropzone', async () => {
     const actual = await vi.importActual('react-dropzone');
     return {
         ...actual,
-        useDropzone: ({ onDrop }: DropzoneOptions) => ({
-            getRootProps: () => ({}),
-            getInputProps: () => ({}),
-            isDragActive: false,
-            onDrop,
-        }),
+        useDropzone: ({ onDrop }: DropzoneOptions) => {
+            mockDropzone.onDrop = onDrop as (files: File[]) => void | Promise<void>;
+            return {
+                getRootProps: () => ({}),
+                getInputProps: () => ({}),
+                isDragActive: false,
+                onDrop,
+            };
+        },
     };
 });
 
@@ -111,10 +126,12 @@ describe('Drawer', () => {
         vi.clearAllMocks();
     });
 
-    it('renders dropzone placeholder when no data is provided', () => {
+    it('renders the bordered dropzone empty state when no data is provided', () => {
         render(<Drawer />);
-        expect(screen.getByText(/Drag and drop your file here or/i)).toBeInTheDocument();
+        expect(screen.getByTestId('dropzone-empty-state')).toBeInTheDocument();
+        expect(screen.getByText(/Drag & drop or/i)).toBeInTheDocument();
         expect(screen.getByText(/Browse/i)).toBeInTheDocument();
+        expect(screen.getByText(/Accepts CALM JSON/i)).toBeInTheDocument();
     });
 
     it('renders ReactFlowVisualizer when data is provided', () => {
@@ -127,6 +144,37 @@ describe('Drawer', () => {
     it('does not show sidebar initially', () => {
         render(<Drawer data={calmData as unknown as Data} />);
         expect(screen.queryByLabelText('close-sidebar')).not.toBeInTheDocument();
+    });
+
+    it('surfaces an error (and does not throw) when a non-JSON file is dropped', async () => {
+        render(<Drawer />);
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([fakeFile('this is { not json')]);
+        });
+
+        expect(screen.getByText(/Couldn't read that file/i)).toBeInTheDocument();
+        // Still resting on the empty state — the bad file was not accepted.
+        expect(screen.getByTestId('dropzone-empty-state')).toBeInTheDocument();
+        expect(screen.queryByTestId('reactflow-visualizer')).not.toBeInTheDocument();
+    });
+
+    it('clears the error and renders the diagram once a valid file is dropped', async () => {
+        render(<Drawer />);
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([fakeFile('not json')]);
+        });
+        expect(screen.getByText(/Couldn't read that file/i)).toBeInTheDocument();
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([
+                fakeFile(JSON.stringify({ nodes: [], relationships: [] })),
+            ]);
+        });
+
+        expect(screen.queryByText(/Couldn't read that file/i)).not.toBeInTheDocument();
+        expect(screen.getByTestId('reactflow-visualizer')).toBeInTheDocument();
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -6,6 +6,7 @@ import { PatternVisualizer } from '../reactflow/PatternVisualizer.js';
 import { MetadataPanel } from '../reactflow/MetadataPanel.js';
 import { toSidebarNodeData, toSidebarEdgeData } from '../reactflow/utils/patternClickHandlers.js';
 import { CalmService } from '../../../service/calm-service.js';
+import { DropzoneEmptyState } from './DropzoneEmptyState.js';
 import type { DrawerProps, Flow, Control, Decorator } from '../../contracts/contracts.js';
 
 /**
@@ -31,6 +32,9 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
     const [calmInstance, setCALMInstance] = useState<CalmArchitectureSchema | undefined>(undefined);
     const [patternInstance, setPatternInstance] = useState<Record<string, unknown> | undefined>(undefined);
     const [fileInstance, setFileInstance] = useState<Record<string, unknown> | undefined>(undefined);
+    // Set when a dropped/browsed file can't be read as JSON, so the empty state
+    // can surface the failure instead of throwing an unhandled rejection.
+    const [dropError, setDropError] = useState<string | undefined>(undefined);
     const [decoratorsState, setDecoratorsState] = useState<Decorator[]>([]);
     // Default to collapsed as per user request
     const [isMetadataCollapsed, setIsMetadataCollapsed] = useState(true);
@@ -38,14 +42,30 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
     const [metadataPanelHeight, setMetadataPanelHeight] = useState(250);
 
     const onDrop = useCallback(async (acceptedFiles: File[]) => {
-        if (acceptedFiles[0]) {
+        if (!acceptedFiles[0]) return;
+        try {
             const fileText = await acceptedFiles[0].text();
             const parsed = JSON.parse(fileText);
+            setDropError(undefined);
             setFileInstance(parsed);
+        } catch {
+            // Non-JSON or malformed file: surface the failure rather than
+            // accepting it and throwing an unhandled rejection downstream.
+            setDropError(
+                "Couldn't read that file — expected CALM JSON (architecture / pattern)."
+            );
         }
     }, []);
 
-    const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
+    // Clear any prior error as soon as a new drag begins, so a fresh attempt
+    // starts from a clean slate.
+    const onDragEnter = useCallback(() => setDropError(undefined), []);
+
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
+        onDrop,
+        onDragEnter,
+        accept: { 'application/json': ['.json'] },
+    });
 
     // Identifies the diagram (ignoring version) so its viewport can be remembered
     // across version/moment switches and refreshes. A dropped file has no identity.
@@ -245,16 +265,7 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
                     )}
                 </>
             ) : (
-                <div className="flex justify-center items-center h-full w-full">
-                    {isDragActive ? (
-                        <p>Drop your file here ...</p>
-                    ) : (
-                        <p>
-                            {'Drag and drop your file here or '}
-                            <span className="border-b border-dotted border-black pb-1">Browse</span>
-                        </p>
-                    )}
-                </div>
+                <DropzoneEmptyState isDragActive={isDragActive} error={dropError} />
             )}
         </div>
     );

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -7,6 +7,7 @@ import { MetadataPanel } from '../reactflow/MetadataPanel.js';
 import { toSidebarNodeData, toSidebarEdgeData } from '../reactflow/utils/patternClickHandlers.js';
 import { CalmService } from '../../../service/calm-service.js';
 import { DropzoneEmptyState } from './DropzoneEmptyState.js';
+import { colors } from '../../../theme/colors.js';
 import type { DrawerProps, Flow, Control, Decorator } from '../../contracts/contracts.js';
 
 /**
@@ -61,17 +62,13 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
     // starts from a clean slate.
     const onDragEnter = useCallback(() => setDropError(undefined), []);
 
-    // A file rejected by `accept` (wrong type) never reaches onDrop's acceptedFiles,
-    // so surface it here rather than failing silently.
-    const onDropRejected = useCallback(() => {
-        setDropError('That file type isn’t supported — drop a CALM JSON file (architecture / pattern).');
-    }, []);
-
+    // No `accept` filter: CALM JSON is often saved with a non-.json extension
+    // (.calm, .txt, none), and an extension/MIME filter would reject those before
+    // onDrop ever runs. onDrop parses the file and surfaces a clear dropError on
+    // anything that isn't valid JSON, so validation lives there, not in the filter.
     const { getRootProps, getInputProps, isDragActive } = useDropzone({
         onDrop,
         onDragEnter,
-        onDropRejected,
-        accept: { 'application/json': ['.json'] },
     });
 
     // Identifies the diagram (ignoring version) so its viewport can be remembered
@@ -224,6 +221,21 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
             {!hasContent && <input {...getInputProps()} />}
             {hasContent ? (
                 <>
+                    {/* A bad drop over already-loaded content still needs feedback: the
+                        empty state (which normally shows dropError) isn't mounted here. */}
+                    {dropError && (
+                        <div
+                            role="alert"
+                            className="shrink-0 mx-3 mt-2 px-3 py-2 rounded-md text-[12px]"
+                            style={{
+                                color: colors.status.error,
+                                border: `1px solid ${colors.status.error}`,
+                                backgroundColor: colors.redesign.surface,
+                            }}
+                        >
+                            {dropError}
+                        </div>
+                    )}
                     <div
                         style={{
                             flex: 1,

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -61,9 +61,16 @@ export function Drawer({ data, onItemSelect, decorators: decoratorsProp }: Drawe
     // starts from a clean slate.
     const onDragEnter = useCallback(() => setDropError(undefined), []);
 
+    // A file rejected by `accept` (wrong type) never reaches onDrop's acceptedFiles,
+    // so surface it here rather than failing silently.
+    const onDropRejected = useCallback(() => {
+        setDropError('That file type isn’t supported — drop a CALM JSON file (architecture / pattern).');
+    }, []);
+
     const { getRootProps, getInputProps, isDragActive } = useDropzone({
         onDrop,
         onDragEnter,
+        onDropRejected,
         accept: { 'application/json': ['.json'] },
     });
 

--- a/calm-hub-ui/src/visualizer/components/drawer/DropzoneEmptyState.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/DropzoneEmptyState.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DropzoneEmptyState } from './DropzoneEmptyState.js';
+
+describe('DropzoneEmptyState', () => {
+    it('shows the resting prompt and format helper when not dragging', () => {
+        render(<DropzoneEmptyState isDragActive={false} />);
+        expect(screen.getByTestId('dropzone-empty-state')).toBeInTheDocument();
+        expect(screen.getByText(/Drag & drop or/i)).toBeInTheDocument();
+        expect(screen.getByText('Browse')).toBeInTheDocument();
+        expect(screen.getByText(/Accepts CALM JSON \(architecture \/ pattern\)/i)).toBeInTheDocument();
+    });
+
+    it('shows the drop prompt and tints the surface when dragging', () => {
+        render(<DropzoneEmptyState isDragActive />);
+        expect(screen.getByText(/Drop your file here/i)).toBeInTheDocument();
+        // The format helper is hidden while a file is over the zone.
+        expect(screen.queryByText(/Accepts CALM JSON/i)).not.toBeInTheDocument();
+    });
+
+    it('replaces the format helper with an alert when an error is given', () => {
+        render(
+            <DropzoneEmptyState
+                isDragActive={false}
+                error="Couldn't read that file — expected CALM JSON (architecture / pattern)."
+            />
+        );
+        expect(screen.getByRole('alert')).toHaveTextContent(/Couldn't read that file/i);
+        // The neutral helper line is replaced by the error, not shown alongside it.
+        expect(screen.queryByText(/Accepts CALM JSON/i)).not.toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/drawer/DropzoneEmptyState.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/DropzoneEmptyState.tsx
@@ -1,0 +1,68 @@
+import { IoCloudUploadOutline } from 'react-icons/io5';
+import { colors } from '../../../theme/colors.js';
+
+interface DropzoneEmptyStateProps {
+    /** Whether a file is currently being dragged over the dropzone. */
+    isDragActive: boolean;
+    /**
+     * Message shown when the last dropped file couldn't be read as CALM JSON.
+     * When present it replaces the neutral format-helper line with a
+     * danger-toned hint. Cleared by {@link Drawer} on a new drag or valid drop.
+     */
+    error?: string;
+}
+
+/**
+ * The Visualizer's empty-state dropzone: a bordered, dashed drop area with an
+ * upload glyph, a primary "Drag & drop or Browse" line and a format helper line.
+ * Purely the resting/idle visual — the `react-dropzone` wiring (root/input props,
+ * parse-on-drop) stays in {@link Drawer}; this only restyles what it renders when
+ * no diagram is loaded. Drag-active state tints the surface.
+ */
+export function DropzoneEmptyState({ isDragActive, error }: DropzoneEmptyStateProps) {
+    return (
+        <div className="flex justify-center items-center h-full w-full p-6">
+            <div
+                data-testid="dropzone-empty-state"
+                className="flex flex-col items-center justify-center text-center gap-2 rounded-[12px] w-full max-w-md px-8 py-12 transition-colors"
+                style={{
+                    border: `2px dashed ${colors.border.dark}`,
+                    backgroundColor: isDragActive ? colors.redesign.tint2 : colors.redesign.surface,
+                }}
+            >
+                <IoCloudUploadOutline
+                    size={36}
+                    style={{ color: colors.redesign.primary }}
+                    aria-hidden="true"
+                />
+                {isDragActive ? (
+                    <p className="text-[15px] font-medium" style={{ color: colors.redesign.primary }}>
+                        Drop your file here…
+                    </p>
+                ) : (
+                    <>
+                        <p className="text-[15px]" style={{ color: colors.redesign.body }}>
+                            Drag &amp; drop or{' '}
+                            <span className="font-semibold" style={{ color: colors.redesign.primary }}>
+                                Browse
+                            </span>
+                        </p>
+                        {error ? (
+                            <p
+                                role="alert"
+                                className="text-[12px]"
+                                style={{ color: colors.status.error }}
+                            >
+                                {error}
+                            </p>
+                        ) : (
+                            <p className="text-[12px]" style={{ color: colors.redesign.mutedAlt }}>
+                                Accepts CALM JSON (architecture / pattern)
+                            </p>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
> 🚧 **Draft — stacked on #2763 (phase 3 of the CALM Hub redesign).** Ready for review once #2763 is merged; I'll then rebase this onto `main` so it shows only its own changes. Until then GitHub shows the **cumulative** diff (this phase plus the not-yet-merged prior ones).

Part of #2754.

## Description

Phase 4 of the CALM Hub redesign — replaces the ~75% blank landing canvas and disambiguates global search.

- **First-run landing** — a heading + sub-copy, 4 catalogue **stat tiles** (Namespaces / Architectures / Patterns / Controls, from the real counts the Hub already holds — not hardcoded), and a "Browse the catalogue" strip of real sample items spanning architectures **and** patterns.
- **Global search disambiguation** — each result now shows its **namespace** chip, so two identically-named items can be told apart.
- **Active-state unification (problem #8)** — the diagram view-tab pill (Diagram / JSON / Deployments) and the Admin active tabs are re-tokenised to the one interaction blue, replacing the inconsistent per-surface highlights.
- **Visualizer dropzone polish** — a bordered dropzone with an icon, an accepted-file-type hint, and error handling (`accept` + a guarded parse) for the standalone upload.

**Note for reviewers:** there is no recency API, so the landing intentionally shows a "Browse the catalogue" sample (architectures + patterns) rather than "recently updated". The standalone Visualizer page itself was removed in phase 1; the hardened dropzone lives on the shared `Drawer`.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards