### PR TITLE
feat(calm-hub-ui): control-domain controls as a card grid with a detail panel

### DIFF
--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -108,15 +108,11 @@ vi.mock('../service/counts-service', () => ({
 }));
 
 vi.mock('./components/json-renderer/JsonRenderer', () => ({
-    JsonRenderer: ({ json }: { json: unknown }) => (
-        <div data-testid="json-renderer">{json ? 'JSON' : ''}</div>
-    ),
+    JsonRenderer: ({ json }: { json: unknown }) => <div data-testid="json-renderer">{json ? 'JSON' : ''}</div>,
 }));
 
 vi.mock('./components/adr-renderer/AdrRenderer', () => ({
-    AdrRenderer: ({ adrDetails }: { adrDetails: { id?: string } }) => (
-        <div data-testid="adr-renderer">ADR: {adrDetails?.id}</div>
-    ),
+    AdrRenderer: ({ adrDetails }: { adrDetails: { id?: string } }) => <div data-testid="adr-renderer">ADR: {adrDetails?.id}</div>,
 }));
 
 vi.mock('./components/control-detail-section/ControlDetailSection', () => ({
@@ -136,13 +132,7 @@ vi.mock('../components/navbar/Navbar', () => ({
 }));
 
 vi.mock('./components/diagram-section/DiagramSection', () => ({
-    DiagramSection: ({
-        data,
-        onItemSelect,
-    }: {
-        data: { id?: string };
-        onItemSelect?: (item: { data: unknown }) => void;
-    }) => (
+    DiagramSection: ({ data, onItemSelect }: { data: { id?: string }; onItemSelect?: (item: { data: unknown }) => void }) => (
         <div data-testid="diagram-section">
             Diagram: {data?.id}
             {/* Lets tests simulate a node/edge tap on the graph so Hub's node-detail
@@ -439,21 +429,64 @@ describe('Hub', () => {
             expect(await screen.findByTestId('namespace-page')).toHaveTextContent('Namespace: finos (1)');
         });
 
-        it('shows an in-place control load on a domain page and keeps it across a no-nav re-render', () => {
+        it('opens a control detail panel beside the domain grid and keeps both across a no-nav re-render', () => {
             renderAt('/domain/security');
-            // Before selecting a control, the domain page (control list) shows.
+            // Before selecting a control, the domain page (card grid) shows.
             expect(screen.getByTestId('domain-page')).toBeInTheDocument();
 
-            // Selecting a control loads it in place (no navigation) — control detail shows.
+            // Selecting a control opens its panel in place (no navigation): the
+            // control detail shows AND the card grid stays, so closing the panel
+            // returns to the grid rather than navigating "back" out of the domain.
             loadControl();
             expect(screen.getByTestId('control-detail-section')).toBeInTheDocument();
-            expect(screen.queryByTestId('domain-page')).not.toBeInTheDocument();
+            expect(screen.getByTestId('domain-page')).toBeInTheDocument();
 
             // A re-render that does NOT navigate (e.g. collapsing the sidebar) must not
             // clear the in-place control — location.key is unchanged.
             fireEvent.click(screen.getByLabelText('Collapse sidebar'));
             expect(screen.getByTestId('control-detail-section')).toBeInTheDocument();
-            expect(screen.queryByTestId('domain-page')).not.toBeInTheDocument();
+            expect(screen.getByTestId('domain-page')).toBeInTheDocument();
+        });
+
+        it('closes the control panel back to the grid without navigating', () => {
+            renderAt('/domain/security');
+            loadControl();
+            expect(screen.getByTestId('control-detail-section')).toBeInTheDocument();
+
+            // Closing the panel clears the in-place control; the grid remains.
+            fireEvent.click(screen.getByLabelText('Close control details'));
+            expect(screen.queryByTestId('control-detail-section')).not.toBeInTheDocument();
+            expect(screen.getByTestId('domain-page')).toBeInTheDocument();
+        });
+
+        it('on the detail route, keeps the domain grid behind the panel and closes back to the grid', () => {
+            // A control reached via the detail route (deep-link / mobile drill-down,
+            // which navigates to /:domain/controls/:id/detail) must not blank the
+            // content pane behind the panel, and closing must land on the grid.
+            renderWithNav('/test-domain/controls/1/detail', []);
+            loadControl(); // domain: 'test-domain'
+            expect(screen.getByTestId('domain-page')).toHaveTextContent('Domain: test-domain');
+            expect(screen.getByTestId('control-detail-section')).toBeInTheDocument();
+
+            // Close from a detail route navigates to /domain/test-domain → grid, no panel.
+            fireEvent.click(screen.getByLabelText('Close control details'));
+            expect(screen.queryByTestId('control-detail-section')).not.toBeInTheDocument();
+            expect(screen.getByTestId('domain-page')).toHaveTextContent('Domain: test-domain');
+        });
+
+        it('renders the control panel as a full-screen takeover on mobile', () => {
+            const restore = mockMobileViewport(true);
+            try {
+                renderAt('/domain/security');
+                loadControl();
+                const closeBtn = screen.getByLabelText('Close control details');
+                expect(closeBtn).toBeInTheDocument();
+                // On mobile the panel is wrapped in a full-screen takeover dialog
+                // (desktop renders it inline, with no enclosing dialog).
+                expect(closeBtn.closest('[role="dialog"]')).not.toBeNull();
+            } finally {
+                restore();
+            }
         });
 
         it('returns to the domain control list when re-navigating to the already-active domain (B2)', () => {

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -174,6 +174,24 @@ export default function Hub() {
         }
     }, [isDetailRoute, controlData, navigate]);
 
+    // Activating a card from the backdrop grid. On the detail route the URL owns the
+    // selected control, so navigate to the new control's detail route (which reloads
+    // it via useResourceFromRoute) rather than swapping it in place — otherwise the
+    // URL and panel desync and Back/refresh reverts to the deep-linked control. Off
+    // the detail route (/domain/:domain) load in place as before. For controls the
+    // domain segment is the namespace (see useResourceFromRoute), so the route is
+    // /<domain>/controls/<id>/detail.
+    const handleControlActivate = useCallback(
+        (control: ControlData) => {
+            if (isDetailRoute) {
+                navigate(`/${encodeURIComponent(control.domain)}/controls/${control.controlId}/detail`);
+            } else {
+                handleControlLoad(control);
+            }
+        },
+        [isDetailRoute, navigate, handleControlLoad]
+    );
+
     const isDiagramView = data?.calmType === 'Architectures' || data?.calmType === 'Patterns';
 
     // Mobile node bottom-sheet prev/next steppers (Frame G). The ordered node list
@@ -230,17 +248,20 @@ export default function Hub() {
             }
         );
     }, [namespaceCounts, namespaceCountsLoaded, namespaceCountsFailed, activeNamespace]);
+    // Both counts stay `undefined` until the domain-counts fetch settles, so a
+    // deep-link shows "controls" rather than a misleading "0 controls" before it
+    // resolves (mirrors the activeNamespaceCounts gate above).
     const domainControlCount = useMemo(
-        () => domainCounts.find((c) => c.domain === activeDomain)?.controlCount ?? 0,
-        [domainCounts, activeDomain]
+        () => (domainCountsLoaded ? (domainCounts.find((c) => c.domain === activeDomain)?.controlCount ?? 0) : undefined),
+        [domainCounts, domainCountsLoaded, activeDomain]
     );
     // Count for the grid shown behind a selected control's panel — the control's own
     // domain, which may differ from the route's activeDomain when reached via the
     // detail route (deep-link / mobile drill-down).
     const controlDomain = controlData?.domain;
     const controlDomainCount = useMemo(
-        () => domainCounts.find((c) => c.domain === controlDomain)?.controlCount ?? 0,
-        [domainCounts, controlDomain]
+        () => (domainCountsLoaded ? (domainCounts.find((c) => c.domain === controlDomain)?.controlCount ?? 0) : undefined),
+        [domainCounts, domainCountsLoaded, controlDomain]
     );
 
     const detailContent = interfaceData ? (
@@ -267,7 +288,7 @@ export default function Hub() {
         <DomainPage
             domain={controlData.domain}
             controlCount={controlDomainCount}
-            onControlLoad={handleControlLoad}
+            onControlLoad={handleControlActivate}
             selectedControlId={controlData.controlId}
         />
     ) : isDetailRoute || interfaceData || adrData || data ? (
@@ -279,7 +300,6 @@ export default function Hub() {
             domain={activeDomain}
             controlCount={domainControlCount}
             onControlLoad={handleControlLoad}
-            selectedControlId={controlData?.controlId}
         />
     ) : (
         <FirstRunLanding
@@ -370,19 +390,29 @@ export default function Hub() {
                     — the control-domain counterpart of the diagram's node Sidebar.
                     Desktop: inline right column. Mobile: full-screen takeover. The
                     grid stays mounted, so closing returns to it (not "back"). */}
-                {controlData &&
-                    (isMobile ? (
-                        <div
-                            className="fixed inset-0 z-40 bg-base-100 animate-slide-in-right flex flex-col"
-                            role="dialog"
-                            aria-modal="true"
-                            aria-label="Control details"
-                        >
-                            <ControlPanel controlData={controlData} onClose={handleControlClose} />
-                        </div>
-                    ) : (
-                        <ControlPanel controlData={controlData} onClose={handleControlClose} />
-                    ))}
+                {controlData && (
+                    // One stable element type across the breakpoint so a resize past it
+                    // doesn't remount the panel (which would reset the view mode / refetch).
+                    // On desktop the wrapper is layout-transparent (display:contents); on
+                    // mobile it's the full-screen overlay dialog. The key resets the panel's
+                    // view mode when the selected control changes.
+                    <div
+                        className={
+                            isMobile
+                                ? 'fixed inset-0 z-40 bg-base-100 animate-slide-in-right flex flex-col'
+                                : 'contents'
+                        }
+                        {...(isMobile
+                            ? { role: 'dialog', 'aria-modal': true, 'aria-label': 'Control details' }
+                            : {})}
+                    >
+                        <ControlPanel
+                            key={controlData.controlId}
+                            controlData={controlData}
+                            onClose={handleControlClose}
+                        />
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
-import { useLocation, useMatch } from 'react-router-dom';
+import { useLocation, useMatch, useNavigate } from 'react-router-dom';
 import { IoChevronForwardOutline, IoCompassOutline } from 'react-icons/io5';
 import { ExploreRail } from './components/explore-rail/ExploreRail.js';
 import { MobileNavMenu } from './components/tree-navigation/MobileNavMenu.js';
@@ -16,7 +16,7 @@ import { CountsService } from '../service/counts-service.js';
 import { Navbar } from '../components/navbar/Navbar.js';
 import { AdrRenderer } from './components/adr-renderer/AdrRenderer.js';
 import { DocumentDetailSection } from './components/document-detail-section/DocumentDetailSection.js';
-import { ControlDetailSection } from './components/control-detail-section/ControlDetailSection.js';
+import { ControlPanel } from './components/control-detail-section/ControlPanel.js';
 import { InterfaceDetailSection } from './components/interface-detail-section/InterfaceDetailSection.js';
 import { DiagramSection } from './components/diagram-section/DiagramSection.js';
 import { Sidebar } from '../visualizer/components/sidebar/Sidebar.js';
@@ -47,6 +47,7 @@ export default function Hub() {
     // is reused across `/`, `/namespace/:ns`, `/domain/:domain` and the detail
     // route, so the URL — not residual state — decides what renders.
     const { key: locationKey } = useLocation();
+    const navigate = useNavigate();
     const namespaceMatch = useMatch('/namespace/:ns');
     const domainMatch = useMatch('/domain/:domain');
     const detailMatch = useMatch('/:namespace/:type/:id/:version');
@@ -160,6 +161,19 @@ export default function Hub() {
         setSelectedItem(null);
     }, []);
 
+    // Closes the control detail panel. On the detail route (a control reached via a
+    // deep-link or the mobile drill-down, which navigates to /:domain/controls/:id/
+    // detail) navigate to the domain grid so closing lands on the cards, not a blank
+    // detail route. For an in-place selection on /domain/:domain the grid is already
+    // the backdrop, so just clear the control.
+    const handleControlClose = useCallback(() => {
+        if (isDetailRoute && controlData) {
+            navigate(`/domain/${encodeURIComponent(controlData.domain)}`);
+        } else {
+            setControlData(undefined);
+        }
+    }, [isDetailRoute, controlData, navigate]);
+
     const isDiagramView = data?.calmType === 'Architectures' || data?.calmType === 'Patterns';
 
     // Mobile node bottom-sheet prev/next steppers (Frame G). The ordered node list
@@ -190,12 +204,9 @@ export default function Hub() {
         if (node) setSelectedItem({ data: node });
     };
 
-    const onPrevNode =
-        selectedNodeIndex > 0 ? () => stepToNode(selectedNodeIndex - 1) : undefined;
+    const onPrevNode = selectedNodeIndex > 0 ? () => stepToNode(selectedNodeIndex - 1) : undefined;
     const onNextNode =
-        selectedNodeIndex >= 0 && selectedNodeIndex < diagramNodes.length - 1
-            ? () => stepToNode(selectedNodeIndex + 1)
-            : undefined;
+        selectedNodeIndex >= 0 && selectedNodeIndex < diagramNodes.length - 1 ? () => stepToNode(selectedNodeIndex + 1) : undefined;
 
     // The active namespace's full per-type counts, passed straight to NamespacePage
     // so its type tabs show counts without a second fetch. `undefined` while the
@@ -223,11 +234,17 @@ export default function Hub() {
         () => domainCounts.find((c) => c.domain === activeDomain)?.controlCount ?? 0,
         [domainCounts, activeDomain]
     );
+    // Count for the grid shown behind a selected control's panel — the control's own
+    // domain, which may differ from the route's activeDomain when reached via the
+    // detail route (deep-link / mobile drill-down).
+    const controlDomain = controlData?.domain;
+    const controlDomainCount = useMemo(
+        () => domainCounts.find((c) => c.domain === controlDomain)?.controlCount ?? 0,
+        [domainCounts, controlDomain]
+    );
 
     const detailContent = interfaceData ? (
         <InterfaceDetailSection interfaceData={interfaceData} />
-    ) : controlData ? (
-        <ControlDetailSection controlData={controlData} />
     ) : adrData ? (
         <AdrRenderer adrDetails={adrData} />
     ) : isDiagramView ? (
@@ -237,28 +254,43 @@ export default function Hub() {
     );
 
     // Route decides the content pane. A loaded resource (including an in-place
-    // control/interface selected from the domain/namespace page) takes precedence
-    // over the route-driven page so its detail view shows. With nothing loaded and
-    // no namespace/domain route (i.e. `/`), the first-run landing fills what was
-    // the ~75% blank canvas (redesign problem #7).
-    const content =
-        isDetailRoute || controlData || interfaceData || adrData || data ? (
-            detailContent
-        ) : activeNamespace ? (
-            <NamespacePage namespace={activeNamespace} counts={activeNamespaceCounts} />
-        ) : activeDomain ? (
-            <DomainPage domain={activeDomain} controlCount={domainControlCount} onControlLoad={handleControlLoad} />
-        ) : (
-            <FirstRunLanding
-                namespaceCounts={namespaceCounts}
-                domainCounts={domainCounts}
-                // Ready only once both fetches have settled AND the namespace fetch
-                // didn't fail: the tiles include a Controls total from domainCounts (so
-                // namespace-only gating would flash a 0 for Controls), and a failed
-                // namespace fetch is unknown, not zero — hold the placeholder in both cases.
-                countsLoaded={namespaceCountsLoaded && domainCountsLoaded && !namespaceCountsFailed}
-            />
-        );
+    // interface selected from the namespace page) takes precedence over the
+    // route-driven page so its detail view shows. A selected control is the
+    // exception: it keeps its domain's card grid as the backdrop and opens the
+    // ControlPanel beside it (below) rather than replacing the pane — this holds
+    // whether the control was selected in-place on /domain/:domain OR reached via
+    // the detail route (deep-link / mobile drill-down), so the grid is never blank
+    // behind the panel and closing returns to it. With nothing loaded and no
+    // namespace/domain route (i.e. `/`), the first-run landing fills what was the
+    // ~75% blank canvas (redesign problem #7).
+    const content = controlData ? (
+        <DomainPage
+            domain={controlData.domain}
+            controlCount={controlDomainCount}
+            onControlLoad={handleControlLoad}
+            selectedControlId={controlData.controlId}
+        />
+    ) : isDetailRoute || interfaceData || adrData || data ? (
+        detailContent
+    ) : activeNamespace ? (
+        <NamespacePage namespace={activeNamespace} counts={activeNamespaceCounts} />
+    ) : activeDomain ? (
+        <DomainPage
+            domain={activeDomain}
+            controlCount={domainControlCount}
+            onControlLoad={handleControlLoad}
+            selectedControlId={controlData?.controlId}
+        />
+    ) : (
+        <FirstRunLanding
+            namespaceCounts={namespaceCounts}
+            domainCounts={domainCounts}
+            // Ready only once both fetches have settled AND the namespace fetch didn't
+            // fail: the tiles include a Controls total from domainCounts, and a failed
+            // namespace fetch is unknown, not zero — hold the placeholder in both cases.
+            countsLoaded={namespaceCountsLoaded && domainCountsLoaded && !namespaceCountsFailed}
+        />
+    );
 
     return (
         <div className="flex flex-col h-screen overflow-hidden">
@@ -324,20 +356,32 @@ export default function Hub() {
                     <div className="flex-1 overflow-auto min-w-0">{content}</div>
                 </div>
 
-                {selectedItem && isDiagramView && (
-                    isMobile ? (
+                {selectedItem &&
+                    isDiagramView &&
+                    (isMobile ? (
                         // Mobile: bottom-sheet that keeps the diagram peeking above
                         // (Frame G), replacing the old full-screen takeover.
-                        <NodeSheet
-                            selectedData={selectedItem.data}
-                            closeSheet={closeSidebar}
-                            onPrev={onPrevNode}
-                            onNext={onNextNode}
-                        />
+                        <NodeSheet selectedData={selectedItem.data} closeSheet={closeSidebar} onPrev={onPrevNode} onNext={onNextNode} />
                     ) : (
                         <Sidebar selectedData={selectedItem.data} closeSidebar={closeSidebar} />
-                    )
-                )}
+                    ))}
+
+                {/* Selected control opens a detail panel beside the domain card grid
+                    — the control-domain counterpart of the diagram's node Sidebar.
+                    Desktop: inline right column. Mobile: full-screen takeover. The
+                    grid stays mounted, so closing returns to it (not "back"). */}
+                {controlData &&
+                    (isMobile ? (
+                        <div
+                            className="fixed inset-0 z-40 bg-base-100 animate-slide-in-right flex flex-col"
+                            role="dialog"
+                            aria-modal="true"
+                        >
+                            <ControlPanel controlData={controlData} onClose={handleControlClose} />
+                        </div>
+                    ) : (
+                        <ControlPanel controlData={controlData} onClose={handleControlClose} />
+                    ))}
             </div>
         </div>
     );

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -376,6 +376,7 @@ export default function Hub() {
                             className="fixed inset-0 z-40 bg-base-100 animate-slide-in-right flex flex-col"
                             role="dialog"
                             aria-modal="true"
+                            aria-label="Control details"
                         >
                             <ControlPanel controlData={controlData} onClose={handleControlClose} />
                         </div>

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -1,19 +1,26 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { IoShieldCheckmarkOutline } from 'react-icons/io5';
+import { IoShieldCheckmarkOutline, IoEyeOutline, IoCodeOutline } from 'react-icons/io5';
 import { ControlConfigDetail, ControlData } from '../../../model/control.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { ReadableJsonView } from './ReadableJsonView.js';
 import { ControlService } from '../../../service/control-service.js';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 
-type ViewMode = 'readable' | 'raw';
+export type ViewMode = 'readable' | 'raw';
 type ControlPanel = 'requirement' | 'configuration';
 
 interface ControlDetailSectionProps {
     controlData: ControlData;
+    /**
+     * When provided, the readable/raw view is controlled by the parent (the
+     * ControlPanel renders a single toggle in its title bar, like the diagram node
+     * Sidebar) and the per-panel breadcrumb toggles are hidden. When omitted, the
+     * section manages its own per-panel toggles (standalone use).
+     */
+    viewMode?: ViewMode;
 }
 
-export function ControlDetailSection({ controlData }: ControlDetailSectionProps) {
+export function ControlDetailSection({ controlData, viewMode }: ControlDetailSectionProps) {
     const controlService = useMemo(() => new ControlService(), []);
     const isMobile = useIsMobile();
 
@@ -104,21 +111,30 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
     // ── Shared builders (used by both the desktop stacked layout and the
     //    mobile tabbed layout) so role/name selectors stay identical. ─────────
 
+    // Readable / Raw toggle as icon buttons, matching the diagram node Sidebar's
+    // Details/JSON switch (eye = readable, code = raw) — the text labels read
+    // cramped in the control panel. Accessible names stay "Readable" / "Raw JSON".
     const viewToggle = (mode: ViewMode, setMode: (m: ViewMode) => void) => (
-        <div role="tablist" className="tabs tabs-boxed tabs-xs bg-base-100">
+        <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
             <button
                 role="tab"
-                className={`tab ${mode === 'readable' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+                aria-label="Readable"
+                aria-selected={mode === 'readable'}
+                title="Readable"
+                className={`p-1.5 rounded-md transition-colors ${mode === 'readable' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
                 onClick={() => setMode('readable')}
             >
-                Readable
+                <IoEyeOutline size={14} />
             </button>
             <button
                 role="tab"
-                className={`tab ${mode === 'raw' ? 'tab-active !bg-primary !text-primary-content' : ''}`}
+                aria-label="Raw JSON"
+                aria-selected={mode === 'raw'}
+                title="Raw JSON"
+                className={`p-1.5 rounded-md transition-colors ${mode === 'raw' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
                 onClick={() => setMode('raw')}
             >
-                Raw JSON
+                <IoCodeOutline size={14} />
             </button>
         </div>
     );
@@ -156,13 +172,13 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
         </button>
     ));
 
-    const requirementContent = reqViewMode === 'readable' ? (
+    const requirementContent = (viewMode ?? reqViewMode) === 'readable' ? (
         <ReadableJsonView json={requirementJson} />
     ) : (
         <JsonRenderer json={requirementJson} />
     );
 
-    const configurationContent = cfgViewMode === 'readable' ? (
+    const configurationContent = (viewMode ?? cfgViewMode) === 'readable' ? (
         <ReadableJsonView json={configJson} />
     ) : (
         <JsonRenderer json={configJson} />
@@ -217,7 +233,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                             <h2 className="text-xs font-semibold text-base-content/70 truncate">
                                 Requirement{selectedReqVersion ? ` / ${selectedReqVersion}` : ''}
                             </h2>
-                            {viewToggle(reqViewMode, setReqViewMode)}
+                            {viewMode === undefined && viewToggle(reqViewMode, setReqViewMode)}
                         </div>
                         {requirementVersions.length > 1 && (
                             <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
@@ -239,7 +255,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                                 {selectedCfgLabel ? ` / ${selectedCfgLabel}` : ''}
                                 {selectedConfigVersion ? ` / ${selectedConfigVersion}` : ''}
                             </h2>
-                            {viewToggle(cfgViewMode, setCfgViewMode)}
+                            {viewMode === undefined && viewToggle(cfgViewMode, setCfgViewMode)}
                         </div>
                         <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
                             <div className="flex items-center gap-2 w-max">
@@ -285,7 +301,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    {viewToggle(reqViewMode, setReqViewMode)}
+                    {viewMode === undefined && viewToggle(reqViewMode, setReqViewMode)}
                 </div>
 
                 {/* Requirement version tabs */}
@@ -327,7 +343,7 @@ export function ControlDetailSection({ controlData }: ControlDetailSectionProps)
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    {viewToggle(cfgViewMode, setCfgViewMode)}
+                    {viewMode === undefined && viewToggle(cfgViewMode, setCfgViewMode)}
                 </div>
 
                 {/* Configuration breadcrumb navigation */}

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -117,6 +117,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
     const viewToggle = (mode: ViewMode, setMode: (m: ViewMode) => void) => (
         <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
             <button
+                type="button"
                 role="tab"
                 aria-label="Readable"
                 aria-selected={mode === 'readable'}
@@ -127,6 +128,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                 <IoEyeOutline size={14} />
             </button>
             <button
+                type="button"
                 role="tab"
                 aria-label="Raw JSON"
                 aria-selected={mode === 'raw'}
@@ -141,6 +143,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
 
     const reqVersionButtons = requirementVersions.map((v) => (
         <button
+            type="button"
             key={v}
             role="tab"
             className={`tab gap-1 rounded-lg ${selectedReqVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
@@ -152,6 +155,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
 
     const configIdButtons = configs.map((cfg) => (
         <button
+            type="button"
             key={cfg.id}
             role="tab"
             className={`tab gap-1 rounded-lg ${selectedConfigId === cfg.id ? 'tab-active !bg-primary !text-primary-content' : ''}`}
@@ -163,6 +167,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
 
     const configVersionButtons = configVersions.map((v) => (
         <button
+            type="button"
             key={v}
             role="tab"
             className={`tab gap-1 rounded-lg ${selectedConfigVersion === v ? 'tab-active !bg-primary !text-primary-content' : ''}`}
@@ -209,6 +214,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                 {/* Requirement / Configuration tabs */}
                 <div role="tablist" className="tabs tabs-bordered bg-base-100 border-b border-base-200 px-2">
                     <button
+                        type="button"
                         role="tab"
                         className={`tab flex-1 ${panel === 'requirement' ? 'tab-active text-primary font-semibold' : ''}`}
                         onClick={() => setActivePanel('requirement')}
@@ -217,6 +223,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                     </button>
                     {showConfig && (
                         <button
+                            type="button"
                             role="tab"
                             className={`tab flex-1 ${panel === 'configuration' ? 'tab-active text-primary font-semibold' : ''}`}
                             onClick={() => setActivePanel('configuration')}

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlDetailSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { IoShieldCheckmarkOutline, IoEyeOutline, IoCodeOutline } from 'react-icons/io5';
+import { IoShieldCheckmarkOutline } from 'react-icons/io5';
+import { ViewToggle } from './ViewToggle.js';
 import { ControlConfigDetail, ControlData } from '../../../model/control.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { ReadableJsonView } from './ReadableJsonView.js';
@@ -111,36 +112,6 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
     // ── Shared builders (used by both the desktop stacked layout and the
     //    mobile tabbed layout) so role/name selectors stay identical. ─────────
 
-    // Readable / Raw toggle as icon buttons, matching the diagram node Sidebar's
-    // Details/JSON switch (eye = readable, code = raw) — the text labels read
-    // cramped in the control panel. Accessible names stay "Readable" / "Raw JSON".
-    const viewToggle = (mode: ViewMode, setMode: (m: ViewMode) => void) => (
-        <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
-            <button
-                type="button"
-                role="tab"
-                aria-label="Readable"
-                aria-selected={mode === 'readable'}
-                title="Readable"
-                className={`p-1.5 rounded-md transition-colors ${mode === 'readable' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
-                onClick={() => setMode('readable')}
-            >
-                <IoEyeOutline size={14} />
-            </button>
-            <button
-                type="button"
-                role="tab"
-                aria-label="Raw JSON"
-                aria-selected={mode === 'raw'}
-                title="Raw JSON"
-                className={`p-1.5 rounded-md transition-colors ${mode === 'raw' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
-                onClick={() => setMode('raw')}
-            >
-                <IoCodeOutline size={14} />
-            </button>
-        </div>
-    );
-
     const reqVersionButtons = requirementVersions.map((v) => (
         <button
             type="button"
@@ -240,7 +211,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                             <h2 className="text-xs font-semibold text-base-content/70 truncate">
                                 Requirement{selectedReqVersion ? ` / ${selectedReqVersion}` : ''}
                             </h2>
-                            {viewMode === undefined && viewToggle(reqViewMode, setReqViewMode)}
+                            {viewMode === undefined && <ViewToggle mode={reqViewMode} onChange={setReqViewMode} />}
                         </div>
                         {requirementVersions.length > 1 && (
                             <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
@@ -262,7 +233,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                                 {selectedCfgLabel ? ` / ${selectedCfgLabel}` : ''}
                                 {selectedConfigVersion ? ` / ${selectedConfigVersion}` : ''}
                             </h2>
-                            {viewMode === undefined && viewToggle(cfgViewMode, setCfgViewMode)}
+                            {viewMode === undefined && <ViewToggle mode={cfgViewMode} onChange={setCfgViewMode} />}
                         </div>
                         <div className="bg-base-200 px-4 pb-2 border-b border-base-300 overflow-x-auto">
                             <div className="flex items-center gap-2 w-max">
@@ -308,7 +279,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    {viewMode === undefined && viewToggle(reqViewMode, setReqViewMode)}
+                    {viewMode === undefined && <ViewToggle mode={reqViewMode} onChange={setReqViewMode} />}
                 </div>
 
                 {/* Requirement version tabs */}
@@ -350,7 +321,7 @@ export function ControlDetailSection({ controlData, viewMode }: ControlDetailSec
                         )}
                     </h2>
                     {/* Readable / Raw toggle */}
-                    {viewMode === undefined && viewToggle(cfgViewMode, setCfgViewMode)}
+                    {viewMode === undefined && <ViewToggle mode={cfgViewMode} onChange={setCfgViewMode} />}
                 </div>
 
                 {/* Configuration breadcrumb navigation */}

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.test.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ControlPanel } from './ControlPanel.js';
+
+// ControlDetailSection (wrapped by the panel) fetches via ControlService on mount;
+// stub it so the panel renders without real network calls.
+vi.mock('../../../service/control-service.js', () => ({
+    ControlService: vi.fn().mockImplementation(function () {
+        return {
+            fetchRequirementVersions: vi.fn().mockResolvedValue([]),
+            fetchConfigurationsForControl: vi.fn().mockResolvedValue([]),
+            fetchRequirementForVersion: vi.fn().mockResolvedValue({}),
+            fetchConfigurationVersions: vi.fn().mockResolvedValue([]),
+            fetchConfigurationForVersion: vi.fn().mockResolvedValue({}),
+        };
+    }),
+}));
+
+const controlData = {
+    domain: 'security',
+    controlId: 5,
+    controlName: 'Encryption',
+    controlDescription: 'Encrypt data',
+};
+
+describe('ControlPanel', () => {
+    it('renders Sidebar-style chrome with a close affordance', () => {
+        render(<ControlPanel controlData={controlData} onClose={vi.fn()} />);
+        expect(screen.getByRole('heading', { name: /control/i })).toBeInTheDocument();
+        expect(screen.getByLabelText('Close control details')).toBeInTheDocument();
+    });
+
+    it('calls onClose when the close button is clicked', () => {
+        const onClose = vi.fn();
+        render(<ControlPanel controlData={controlData} onClose={onClose} />);
+        fireEvent.click(screen.getByLabelText('Close control details'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a single readable/raw toggle in the title bar, defaulting to readable', () => {
+        render(<ControlPanel controlData={controlData} onClose={vi.fn()} />);
+        // The controlled section hides its per-panel toggles, so these are the only
+        // Readable/Raw tabs — and they live in the title bar (one toggle each).
+        expect(screen.getByRole('tab', { name: 'Readable' })).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByRole('tab', { name: 'Raw JSON' })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('switches the view mode from the title-bar toggle', () => {
+        render(<ControlPanel controlData={controlData} onClose={vi.fn()} />);
+        fireEvent.click(screen.getByRole('tab', { name: 'Raw JSON' }));
+        expect(screen.getByRole('tab', { name: 'Raw JSON' })).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByRole('tab', { name: 'Readable' })).toHaveAttribute('aria-selected', 'false');
+    });
+});

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { IoShieldCheckmarkOutline, IoCloseOutline, IoEyeOutline, IoCodeOutline } from 'react-icons/io5';
+import { ControlData } from '../../../model/control.js';
+import { ControlDetailSection, type ViewMode } from './ControlDetailSection.js';
+
+interface ControlPanelProps {
+    controlData: ControlData;
+    /** Closes the panel, returning to the domain's control card grid. */
+    onClose: () => void;
+}
+
+/**
+ * Right-hand detail panel for a selected control — the control-domain counterpart
+ * of the diagram's node/relationship Sidebar. Clicking a control card on the
+ * domain page opens this panel (desktop right column / mobile full-screen
+ * takeover) while the card grid stays on the page, so closing returns to the grid
+ * rather than navigating away. Wraps {@link ControlDetailSection} (requirement /
+ * configuration); the single readable/raw toggle lives in this title bar next to
+ * the close button (like the node Sidebar's Details/JSON switch), not in the
+ * section's per-panel breadcrumbs.
+ */
+export function ControlPanel({ controlData, onClose }: ControlPanelProps) {
+    const [viewMode, setViewMode] = useState<ViewMode>('readable');
+
+    return (
+        <div className="h-full w-full lg:w-[460px] shrink-0 lg:p-4 lg:pl-2">
+            <div className="h-full bg-base-100 lg:rounded-box lg:shadow-xl flex flex-col overflow-hidden border-l border-base-300 lg:border-l-0">
+                <div className="bg-base-200 px-4 py-3 border-b border-base-300 flex items-center justify-between gap-2">
+                    <h2 className="text-base font-semibold flex items-center gap-2 text-primary min-w-0">
+                        <IoShieldCheckmarkOutline className="shrink-0" />
+                        <span>Control</span>
+                    </h2>
+                    <div className="flex items-center gap-1">
+                        <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
+                            <button
+                                role="tab"
+                                aria-label="Readable"
+                                aria-selected={viewMode === 'readable'}
+                                title="Readable"
+                                className={`p-1.5 rounded-md transition-colors ${viewMode === 'readable' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
+                                onClick={() => setViewMode('readable')}
+                            >
+                                <IoEyeOutline size={14} />
+                            </button>
+                            <button
+                                role="tab"
+                                aria-label="Raw JSON"
+                                aria-selected={viewMode === 'raw'}
+                                title="Raw JSON"
+                                className={`p-1.5 rounded-md transition-colors ${viewMode === 'raw' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
+                                onClick={() => setViewMode('raw')}
+                            >
+                                <IoCodeOutline size={14} />
+                            </button>
+                        </div>
+                        <button
+                            aria-label="Close control details"
+                            onClick={onClose}
+                            className="btn btn-ghost btn-xs btn-circle"
+                        >
+                            <IoCloseOutline size={20} />
+                        </button>
+                    </div>
+                </div>
+                <div className="flex-1 min-h-0 overflow-hidden">
+                    <ControlDetailSection controlData={controlData} viewMode={viewMode} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { IoShieldCheckmarkOutline, IoCloseOutline, IoEyeOutline, IoCodeOutline } from 'react-icons/io5';
+import { IoShieldCheckmarkOutline, IoCloseOutline } from 'react-icons/io5';
 import { ControlData } from '../../../model/control.js';
 import { ControlDetailSection, type ViewMode } from './ControlDetailSection.js';
+import { ViewToggle } from './ViewToggle.js';
 
 interface ControlPanelProps {
     controlData: ControlData;
@@ -31,30 +32,7 @@ export function ControlPanel({ controlData, onClose }: ControlPanelProps) {
                         <span>Control</span>
                     </h2>
                     <div className="flex items-center gap-1">
-                        <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
-                            <button
-                                type="button"
-                                role="tab"
-                                aria-label="Readable"
-                                aria-selected={viewMode === 'readable'}
-                                title="Readable"
-                                className={`p-1.5 rounded-md transition-colors ${viewMode === 'readable' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
-                                onClick={() => setViewMode('readable')}
-                            >
-                                <IoEyeOutline size={14} />
-                            </button>
-                            <button
-                                type="button"
-                                role="tab"
-                                aria-label="Raw JSON"
-                                aria-selected={viewMode === 'raw'}
-                                title="Raw JSON"
-                                className={`p-1.5 rounded-md transition-colors ${viewMode === 'raw' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
-                                onClick={() => setViewMode('raw')}
-                            >
-                                <IoCodeOutline size={14} />
-                            </button>
-                        </div>
+                        <ViewToggle mode={viewMode} onChange={setViewMode} />
                         <button
                             type="button"
                             aria-label="Close control details"

--- a/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ControlPanel.tsx
@@ -33,6 +33,7 @@ export function ControlPanel({ controlData, onClose }: ControlPanelProps) {
                     <div className="flex items-center gap-1">
                         <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
                             <button
+                                type="button"
                                 role="tab"
                                 aria-label="Readable"
                                 aria-selected={viewMode === 'readable'}
@@ -43,6 +44,7 @@ export function ControlPanel({ controlData, onClose }: ControlPanelProps) {
                                 <IoEyeOutline size={14} />
                             </button>
                             <button
+                                type="button"
                                 role="tab"
                                 aria-label="Raw JSON"
                                 aria-selected={viewMode === 'raw'}
@@ -54,6 +56,7 @@ export function ControlPanel({ controlData, onClose }: ControlPanelProps) {
                             </button>
                         </div>
                         <button
+                            type="button"
                             aria-label="Close control details"
                             onClick={onClose}
                             className="btn btn-ghost btn-xs btn-circle"

--- a/calm-hub-ui/src/hub/components/control-detail-section/ViewToggle.tsx
+++ b/calm-hub-ui/src/hub/components/control-detail-section/ViewToggle.tsx
@@ -1,0 +1,41 @@
+import { IoEyeOutline, IoCodeOutline } from 'react-icons/io5';
+import type { ViewMode } from './ControlDetailSection.js';
+
+interface ViewToggleProps {
+    mode: ViewMode;
+    onChange: (mode: ViewMode) => void;
+}
+
+/**
+ * Readable / Raw icon toggle (eye = readable, code = raw), shared by the control
+ * panel title bar and the control detail section so the role/name selectors and
+ * styling stay identical. Accessible names are "Readable" / "Raw JSON".
+ */
+export function ViewToggle({ mode, onChange }: ViewToggleProps) {
+    return (
+        <div role="tablist" className="inline-flex rounded-lg bg-base-300 p-0.5">
+            <button
+                type="button"
+                role="tab"
+                aria-label="Readable"
+                aria-selected={mode === 'readable'}
+                title="Readable"
+                className={`p-1.5 rounded-md transition-colors ${mode === 'readable' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
+                onClick={() => onChange('readable')}
+            >
+                <IoEyeOutline size={14} />
+            </button>
+            <button
+                type="button"
+                role="tab"
+                aria-label="Raw JSON"
+                aria-selected={mode === 'raw'}
+                title="Raw JSON"
+                className={`p-1.5 rounded-md transition-colors ${mode === 'raw' ? 'bg-primary text-primary-content' : 'text-base-content/50 hover:text-base-content'}`}
+                onClick={() => onChange('raw')}
+            >
+                <IoCodeOutline size={14} />
+            </button>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ControlCard } from './ControlCard.js';
+
+describe('ControlCard', () => {
+    it('renders the control name, description, Control pill and mono id', () => {
+        render(
+            <ControlCard
+                name="Encryption at rest"
+                description="All persisted data must be encrypted."
+                controlId={5}
+                onActivate={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText('Encryption at rest')).toBeInTheDocument();
+        expect(screen.getByText('All persisted data must be encrypted.')).toBeInTheDocument();
+        expect(screen.getByText('Control')).toBeInTheDocument();
+        expect(screen.getByText('#5')).toBeInTheDocument();
+    });
+
+    it('activates the card when clicked', () => {
+        const onActivate = vi.fn();
+        render(<ControlCard name="Access Control" controlId={6} onActivate={onActivate} />);
+
+        fireEvent.click(screen.getByTestId('control-card'));
+
+        expect(onActivate).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the card as selected (aria-pressed) when active', () => {
+        render(<ControlCard name="Encryption" controlId={5} active onActivate={vi.fn()} />);
+        expect(screen.getByTestId('control-card')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('is not pressed when inactive (default)', () => {
+        render(<ControlCard name="Encryption" controlId={5} onActivate={vi.fn()} />);
+        expect(screen.getByTestId('control-card')).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('renders without a description', () => {
+        render(<ControlCard name="Audit Logging" controlId={9} onActivate={vi.fn()} />);
+
+        expect(screen.getByText('Audit Logging')).toBeInTheDocument();
+        expect(screen.getByText('#9')).toBeInTheDocument();
+        // No description paragraph rendered.
+        expect(screen.queryByText(/must be/i)).not.toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
@@ -1,0 +1,88 @@
+import { IoShieldCheckmarkOutline } from 'react-icons/io5';
+import { colors } from '../../../theme/colors.js';
+import { redesignTokens } from '../../../theme/redesign-tokens.js';
+
+interface ControlCardProps {
+    name: string;
+    description?: string;
+    /** The control's numeric id, shown as the mono footer meta (`#5`). */
+    controlId: number;
+    /** Whether this control's detail panel is currently open (selected styling). */
+    active?: boolean;
+    /** Activates the card — opens the control's detail panel. */
+    onActivate: () => void;
+}
+
+/**
+ * A browse card for a single control in a domain — the control-domain counterpart
+ * of {@link import('../namespace-page/ItemCard.js').ItemCard}. A shield-motif
+ * tinted header marks it as a control, then the control name, a 2-line-clamped
+ * description and a footer with a "Control" pill plus the mono control id.
+ *
+ * Matches ItemCard's anatomy (striped header / name / clamped description /
+ * footer) and full-card click: the name is a `<button>` whose stretched `::after`
+ * (`after:absolute after:inset-0`) makes the whole card the activation target,
+ * loading the control via the existing `onControlLoad` flow.
+ */
+export function ControlCard({ name, description, controlId, active = false, onActivate }: ControlCardProps) {
+    const accent = colors.redesign.primary;
+    const tint = colors.redesign.tintBg;
+    // Striped header from the redesign primary tokens (tint + accent at low alpha),
+    // mirroring ItemCard so the control browse grid reads as the same family.
+    const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
+
+    return (
+        <article
+            className="group relative rounded-[12px] overflow-hidden bg-base-100 hover:-translate-y-0.5 hover:shadow-md"
+            style={{
+                // Selected card mirrors the diagram's selected-node treatment: a
+                // 2px interaction-blue outline + elevated shadow while its panel is open.
+                border: `1px solid ${active ? accent : colors.redesign.border}`,
+                boxShadow: active ? redesignTokens.shadow.floating : redesignTokens.shadow.card,
+                outline: active ? `2px solid ${accent}` : undefined,
+                outlineOffset: active ? '1px' : undefined,
+                transition: redesignTokens.transition,
+            }}
+        >
+            <div className="flex items-center justify-center" style={{ height: 96, background: stripes }}>
+                <IoShieldCheckmarkOutline size={30} style={{ color: accent, opacity: 0.55 }} />
+            </div>
+            <div className="p-[14px]">
+                <button
+                    type="button"
+                    data-testid="control-card"
+                    aria-pressed={active}
+                    onClick={onActivate}
+                    className="block w-full text-left text-[14px] font-semibold truncate rounded-[2px] after:absolute after:inset-0 after:content-[''] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-interaction)]"
+                    style={{ color: colors.redesign.ink }}
+                >
+                    {name}
+                </button>
+                {description && (
+                    <p
+                        className="text-[12px] leading-[1.45] mt-[5px] mb-[11px] line-clamp-2"
+                        style={{ color: colors.redesign.mutedAlt }}
+                    >
+                        {description}
+                    </p>
+                )}
+                {/* The button's transparent stretched `::after` overlays this footer,
+                    so a click anywhere on the card activates it. */}
+                <div className={`flex items-center gap-2 ${description ? '' : 'mt-[11px]'}`}>
+                    <span
+                        className="inline-block text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
+                        style={{ backgroundColor: tint, color: accent }}
+                    >
+                        Control
+                    </span>
+                    <span
+                        className="font-mono-jb text-[10.5px] ml-auto truncate"
+                        style={{ color: colors.redesign.mutedAlt }}
+                    >
+                        #{controlId}
+                    </span>
+                </div>
+            </div>
+        </article>
+    );
+}

--- a/calm-hub-ui/src/hub/components/domain-page/DomainPage.test.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/DomainPage.test.tsx
@@ -11,10 +11,15 @@ vi.mock('../../../service/control-service.js', () => ({
     }); }),
 }));
 
-const renderPage = (controlCount = 2, onControlLoad = vi.fn()) =>
+const renderPage = (controlCount = 2, onControlLoad = vi.fn(), selectedControlId?: number) =>
     render(
         <MemoryRouter>
-            <DomainPage domain="security" controlCount={controlCount} onControlLoad={onControlLoad} />
+            <DomainPage
+                domain="security"
+                controlCount={controlCount}
+                onControlLoad={onControlLoad}
+                selectedControlId={selectedControlId}
+            />
         </MemoryRouter>
     );
 
@@ -45,6 +50,14 @@ describe('DomainPage', () => {
         renderPage();
         expect(await screen.findByText('Encryption')).toBeInTheDocument();
         expect(screen.getByText('Access Control')).toBeInTheDocument();
+    });
+
+    it('marks the selected control card as active', async () => {
+        renderPage(2, vi.fn(), 5);
+        const selected = await screen.findByText('Encryption');
+        expect(selected).toHaveAttribute('aria-pressed', 'true');
+        // The other card is not selected.
+        expect(screen.getByText('Access Control')).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('loads a control via onControlLoad when a control is clicked', async () => {

--- a/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
@@ -4,13 +4,16 @@ import { IoShieldCheckmarkOutline } from 'react-icons/io5';
 import { ControlService } from '../../../service/control-service.js';
 import { ControlData, ControlDetail } from '../../../model/control.js';
 import { colors } from '../../../theme/colors.js';
+import { ControlCard } from './ControlCard.js';
 
 interface DomainPageProps {
     domain: string;
     /** Control count for the header meta (from the domain counts endpoint). */
     controlCount: number;
-    /** Loads a control into the existing ControlDetailSection flow. */
+    /** Opens a control's detail panel (kept on-page beside the card grid). */
     onControlLoad: (control: ControlData) => void;
+    /** Id of the control whose detail panel is open, for selected-card styling. */
+    selectedControlId?: number;
 }
 
 /**
@@ -18,7 +21,7 @@ interface DomainPageProps {
  * domain's controls; selecting one loads it via the existing `onControlLoad`
  * mechanism (ControlDetailSection), preserving control browsing.
  */
-export function DomainPage({ domain, controlCount, onControlLoad }: DomainPageProps) {
+export function DomainPage({ domain, controlCount, onControlLoad, selectedControlId }: DomainPageProps) {
     const controlService = useMemo(() => new ControlService(), []);
     const [controls, setControls] = useState<ControlDetail[]>([]);
     const [loading, setLoading] = useState(true);
@@ -80,27 +83,26 @@ export function DomainPage({ domain, controlCount, onControlLoad }: DomainPagePr
                         No controls in this domain yet.
                     </p>
                 ) : (
-                    <ul className="flex flex-col gap-1">
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         {controls.map((control) => (
-                            <li key={control.id}>
-                                <button
-                                    className="w-full text-left px-3 py-2 rounded-[7px] text-[14px] hover:bg-base-200"
-                                    style={{ color: colors.redesign.bodyStrong }}
-                                    onClick={() =>
-                                        onControlLoad({
-                                            domain,
-                                            controlId: control.id,
-                                            controlName: control.name,
-                                            controlDescription: control.description,
-                                            controlTitle: control.title,
-                                        })
-                                    }
-                                >
-                                    {control.title ?? control.name}
-                                </button>
-                            </li>
+                            <ControlCard
+                                key={control.id}
+                                name={control.title ?? control.name}
+                                description={control.description}
+                                controlId={control.id}
+                                active={control.id === selectedControlId}
+                                onActivate={() =>
+                                    onControlLoad({
+                                        domain,
+                                        controlId: control.id,
+                                        controlName: control.name,
+                                        controlDescription: control.description,
+                                        controlTitle: control.title,
+                                    })
+                                }
+                            />
                         ))}
-                    </ul>
+                    </div>
                 )}
             </div>
         </div>

--- a/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
@@ -8,8 +8,12 @@ import { ControlCard } from './ControlCard.js';
 
 interface DomainPageProps {
     domain: string;
-    /** Control count for the header meta (from the domain counts endpoint). */
-    controlCount: number;
+    /**
+     * Control count for the header meta (from the domain counts endpoint).
+     * `undefined` while the counts fetch is in flight — distinct from a known 0 —
+     * so a deep-link renders "controls" rather than a misleading "0 controls".
+     */
+    controlCount: number | undefined;
     /** Opens a control's detail panel (kept on-page beside the card grid). */
     onControlLoad: (control: ControlData) => void;
     /** Id of the control whose detail panel is open, for selected-card styling. */
@@ -69,7 +73,9 @@ export function DomainPage({ domain, controlCount, onControlLoad, selectedContro
                     {domain}
                 </h1>
                 <span className="font-mono-jb text-[13px] whitespace-nowrap" style={{ color: colors.redesign.mutedAlt }}>
-                    {controlCount} {controlCount === 1 ? 'control' : 'controls'}
+                    {controlCount === undefined
+                        ? 'controls'
+                        : `${controlCount} ${controlCount === 1 ? 'control' : 'controls'}`}
                 </span>
             </div>
 


### PR DESCRIPTION
> 🚧 **Draft — stacked on #2765 (phase 5 of the CALM Hub redesign).** Ready for review once #2765 is merged; I'll then rebase this onto `main` so it shows only its own changes. Until then GitHub shows the **cumulative** diff (this phase plus the not-yet-merged prior ones).

Closes #2754.

## Description

Phase 6 (final) of the CALM Hub redesign — gives control domains the same browse-and-detail treatment as namespaces.

- **`ControlCard` grid** — the domain page's flat control list becomes a responsive card grid, mirroring the namespace `ItemCard` (shield-motif header, name, 2-line description, "Control" pill, mono id).
- **`ControlPanel` (detail panel)** — selecting a control opens its detail in a **right-hand panel** (the control-domain counterpart of the diagram's node `Sidebar`) beside the card grid — desktop right column, mobile full-screen takeover — so closing returns to the grid instead of navigating "back" out of the domain. The selected card gets the diagram's selected-node outline.
- **Single readable/raw toggle** in the panel title bar (eye / code icons, like the node Sidebar's Details/JSON switch) controlling the whole panel, instead of cramped per-section toggles. Wraps the existing `ControlDetailSection` unchanged via an optional controlled `viewMode`.
- Backdrop/close behaviour also works for controls reached via a deep-link or the mobile drill-down (renders the domain grid behind the panel; close lands on the grid).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards