### PR TITLE
refactor(calm-hub-ui): reuse ItemCard for ControlCard

### DIFF
--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
@@ -33,7 +33,9 @@ export function ControlCard({ name, description, controlId, active = false, onAc
             thumbnailIcon={
                 <IoShieldCheckmarkOutline
                     size={30}
-                    style={{ color: colors.redesign.primary, opacity: 0.55 }}
+                    // Same control-type accent the striped header and pill use, so the
+                    // shield can't drift if the control colours are adjusted independently.
+                    style={{ color: colors.resourceTypes.control.accent, opacity: 0.55 }}
                 />
             }
             active={active}

--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
@@ -1,6 +1,6 @@
 import { IoShieldCheckmarkOutline } from 'react-icons/io5';
 import { colors } from '../../../theme/colors.js';
-import { redesignTokens } from '../../../theme/redesign-tokens.js';
+import { ItemCard } from '../namespace-page/ItemCard.js';
 
 interface ControlCardProps {
     name: string;
@@ -14,75 +14,31 @@ interface ControlCardProps {
 }
 
 /**
- * A browse card for a single control in a domain — the control-domain counterpart
- * of {@link import('../namespace-page/ItemCard.js').ItemCard}. A shield-motif
- * tinted header marks it as a control, then the control name, a 2-line-clamped
- * description and a footer with a "Control" pill plus the mono control id.
+ * A browse card for a single control in a domain. Reuses {@link ItemCard} (the shared
+ * striped-thumbnail / name / clamped-description / footer anatomy and full-card click)
+ * rather than re-implementing it, so the control grid can't drift from the namespace
+ * item cards.
  *
- * Matches ItemCard's anatomy (striped header / name / clamped description /
- * footer) and full-card click: the name is a `<button>` whose stretched `::after`
- * (`after:absolute after:inset-0`) makes the whole card the activation target,
- * loading the control via the existing `onControlLoad` flow.
+ * Control-specific bits are passed through: the `Controls` type paints the blue
+ * thumbnail + "Control" pill, a shield glyph marks the header, the mono footer shows
+ * the control id (`#5`), and `active` drives the selected treatment + `aria-pressed`.
  */
 export function ControlCard({ name, description, controlId, active = false, onActivate }: ControlCardProps) {
-    const accent = colors.redesign.primary;
-    const tint = colors.redesign.tintBg;
-    // Striped header from the redesign primary tokens (tint + accent at low alpha),
-    // mirroring ItemCard so the control browse grid reads as the same family.
-    const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
-
     return (
-        <article
-            className="group relative rounded-[12px] overflow-hidden bg-base-100 hover:-translate-y-0.5 hover:shadow-md"
-            style={{
-                // Selected card mirrors the diagram's selected-node treatment: a
-                // 2px interaction-blue outline + elevated shadow while its panel is open.
-                border: `1px solid ${active ? accent : colors.redesign.border}`,
-                boxShadow: active ? redesignTokens.shadow.floating : redesignTokens.shadow.card,
-                outline: active ? `2px solid ${accent}` : undefined,
-                outlineOffset: active ? '1px' : undefined,
-                transition: redesignTokens.transition,
-            }}
-        >
-            <div className="flex items-center justify-center" style={{ height: 96, background: stripes }}>
-                <IoShieldCheckmarkOutline size={30} style={{ color: accent, opacity: 0.55 }} />
-            </div>
-            <div className="p-[14px]">
-                <button
-                    type="button"
-                    data-testid="control-card"
-                    aria-pressed={active}
-                    onClick={onActivate}
-                    className="block w-full text-left text-[14px] font-semibold truncate rounded-[2px] after:absolute after:inset-0 after:content-[''] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-interaction)]"
-                    style={{ color: colors.redesign.ink }}
-                >
-                    {name}
-                </button>
-                {description && (
-                    <p
-                        className="text-[12px] leading-[1.45] mt-[5px] mb-[11px] line-clamp-2"
-                        style={{ color: colors.redesign.mutedAlt }}
-                    >
-                        {description}
-                    </p>
-                )}
-                {/* The button's transparent stretched `::after` overlays this footer,
-                    so a click anywhere on the card activates it. */}
-                <div className={`flex items-center gap-2 ${description ? '' : 'mt-[11px]'}`}>
-                    <span
-                        className="inline-block text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
-                        style={{ backgroundColor: tint, color: accent }}
-                    >
-                        Control
-                    </span>
-                    <span
-                        className="font-mono-jb text-[10.5px] ml-auto truncate"
-                        style={{ color: colors.redesign.mutedAlt }}
-                    >
-                        #{controlId}
-                    </span>
-                </div>
-            </div>
-        </article>
+        <ItemCard
+            name={name}
+            description={description}
+            type="Controls"
+            meta={`#${controlId}`}
+            thumbnailIcon={
+                <IoShieldCheckmarkOutline
+                    size={30}
+                    style={{ color: colors.redesign.primary, opacity: 0.55 }}
+                />
+            }
+            active={active}
+            testId="control-card"
+            onActivate={onActivate}
+        />
     );
 }

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
@@ -106,4 +106,31 @@ describe('ItemCard', () => {
         );
         expect(screen.getByText('1 version')).toBeInTheDocument();
     });
+
+    it('carries no aria-pressed on a plain browse card (not a toggle)', () => {
+        // Browse cards omit `active`, so the activation button must not read as a toggle.
+        render(<ItemCard name="Browse Me" type="Architectures" onActivate={() => {}} />);
+        expect(screen.getByTestId('item-card')).not.toHaveAttribute('aria-pressed');
+    });
+
+    it('reflects the selected state via aria-pressed when active is provided', () => {
+        const { rerender } = render(
+            <ItemCard name="Selectable" type="Controls" active={false} onActivate={() => {}} />
+        );
+        expect(screen.getByTestId('item-card')).toHaveAttribute('aria-pressed', 'false');
+        rerender(<ItemCard name="Selectable" type="Controls" active onActivate={() => {}} />);
+        expect(screen.getByTestId('item-card')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('renders a thumbnail icon in the header when provided', () => {
+        render(
+            <ItemCard
+                name="With Icon"
+                type="Controls"
+                thumbnailIcon={<svg data-testid="thumb-icon" />}
+                onActivate={() => {}}
+            />
+        );
+        expect(screen.getByTestId('thumb-icon')).toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -75,8 +75,10 @@ export function ItemCard({
     const { accent, tint } = getResourceTypeColors(type);
     // Selected treatment mirrors the diagram's selected-node style: an interaction-blue
     // outline + elevated shadow while the item's detail panel is open. Uses the brand
-    // interaction blue (not the type accent) so selection reads consistently.
-    const selected = active === true;
+    // interaction blue (not the type accent) so selection reads consistently. Only the
+    // button form is a toggle, so this is gated to cards without an href — a link-card
+    // is plain navigation and never carries the "selected" treatment (or aria-pressed).
+    const selected = active === true && href === undefined;
     const selectedAccent = colors.redesign.primary;
     // Striped header derived from the type's own tokens (tint + accent at low
     // alpha) rather than hardcoded mockup hexes, so it tracks the palette.

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -1,13 +1,14 @@
+import { type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { TypeBadge } from './TypeBadge.js';
-import { type NamespaceResourceType, getResourceTypeColors } from './resource-type-meta.js';
+import { type CardResourceType, getResourceTypeColors } from './resource-type-meta.js';
 
 interface ItemCardProps {
     name: string;
     description?: string;
-    type: NamespaceResourceType;
+    type: CardResourceType;
     /** Optional mono identifier (the item's customId / slug) shown in the footer. */
     customId?: string;
     /**
@@ -24,6 +25,19 @@ interface ItemCardProps {
     meta?: string;
     /** Thumbnail header height in px (default 96; landing highlights use a shorter one). */
     thumbnailHeight?: number;
+    /**
+     * Optional glyph centred in the striped thumbnail (e.g. a shield for a control).
+     * Namespace cards leave the header a plain stripe; only control-style cards set it.
+     */
+    thumbnailIcon?: ReactNode;
+    /**
+     * When defined, the card is a selectable toggle whose pressed state this reflects:
+     * `true` paints the selected treatment (interaction-blue outline + elevated shadow)
+     * and sets `aria-pressed` on the activation button. Left `undefined` for plain
+     * browse cards so they carry no `aria-pressed` and don't read as toggles.
+     * Only meaningful on the `<button>` form (unset {@link href}).
+     */
+    active?: boolean;
     /** `data-testid` for the activation element (default `item-card`). */
     testId?: string;
     /**
@@ -52,11 +66,18 @@ export function ItemCard({
     versionCount,
     meta,
     thumbnailHeight = 96,
+    thumbnailIcon,
+    active,
     testId = 'item-card',
     href,
     onActivate,
 }: ItemCardProps) {
     const { accent, tint } = getResourceTypeColors(type);
+    // Selected treatment mirrors the diagram's selected-node style: an interaction-blue
+    // outline + elevated shadow while the item's detail panel is open. Uses the brand
+    // interaction blue (not the type accent) so selection reads consistently.
+    const selected = active === true;
+    const selectedAccent = colors.redesign.primary;
     // Striped header derived from the type's own tokens (tint + accent at low
     // alpha) rather than hardcoded mockup hexes, so it tracks the palette.
     const stripes = `repeating-linear-gradient(135deg, ${tint}, ${tint} 7px, ${accent}20 7px, ${accent}20 14px)`;
@@ -80,12 +101,19 @@ export function ItemCard({
         <article
             className="group relative rounded-[12px] overflow-hidden bg-base-100 hover:-translate-y-0.5 hover:shadow-md"
             style={{
-                border: `1px solid ${colors.redesign.border}`,
-                boxShadow: redesignTokens.shadow.card,
+                border: `1px solid ${selected ? selectedAccent : colors.redesign.border}`,
+                boxShadow: selected ? redesignTokens.shadow.floating : redesignTokens.shadow.card,
+                outline: selected ? `2px solid ${selectedAccent}` : undefined,
+                outlineOffset: selected ? '1px' : undefined,
                 transition: redesignTokens.transition,
             }}
         >
-            <div style={{ height: thumbnailHeight, background: stripes }} />
+            <div
+                className={thumbnailIcon ? 'flex items-center justify-center' : undefined}
+                style={{ height: thumbnailHeight, background: stripes }}
+            >
+                {thumbnailIcon}
+            </div>
             <div className="p-[14px]">
                 {href ? (
                     <Link to={href} data-testid={testId} className={activationClass} style={{ color: colors.redesign.ink }}>
@@ -95,6 +123,9 @@ export function ItemCard({
                     <button
                         type="button"
                         data-testid={testId}
+                        // Only forwarded when `active` is defined, so plain browse cards
+                        // (which don't pass it) carry no aria-pressed and aren't toggles.
+                        aria-pressed={active}
                         onClick={onActivate}
                         className={activationClass}
                         style={{ color: colors.redesign.ink }}

--- a/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.test.tsx
@@ -92,6 +92,14 @@ describe('NamespacePage', () => {
         expect(screen.getByTestId('type-tab-Interfaces')).toBeInTheDocument();
     });
 
+    it('renders exactly the six browse tabs and no Controls tab', () => {
+        // Controls reuse the shared card/badge, but must not become a namespace tab:
+        // guards against the card-surface type widening leaking into the tab set.
+        renderPage();
+        expect(screen.getAllByRole('tab')).toHaveLength(6);
+        expect(screen.queryByTestId('type-tab-Controls')).not.toBeInTheDocument();
+    });
+
     it('defaults the active tab to the first type with items', async () => {
         renderPage();
         expect(screen.getByTestId('type-tab-Architectures')).toHaveAttribute('aria-selected', 'true');

--- a/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.test.tsx
@@ -27,4 +27,12 @@ describe('TypeBadge', () => {
             color: colors.resourceTypes.interface.accent,
         });
     });
+
+    it('renders the "Control" label and control accent for the Controls card type', () => {
+        render(<TypeBadge type="Controls" />);
+        const badge = screen.getByTestId('type-badge');
+        expect(badge).toHaveTextContent('Control');
+        expect(badge).toHaveStyle({ color: colors.resourceTypes.control.accent });
+        expect(badge).toHaveStyle({ backgroundColor: colors.resourceTypes.control.tint });
+    });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.tsx
@@ -1,12 +1,12 @@
 import {
-    type NamespaceResourceType,
+    type CardResourceType,
     getResourceTypeColors,
     getResourceTypeMeta,
 } from './resource-type-meta.js';
 
 interface TypeBadgeProps {
     /** Resource type whose accent / tint and singular label the pill shows. */
-    type: NamespaceResourceType;
+    type: CardResourceType;
 }
 
 /**

--- a/calm-hub-ui/src/hub/components/namespace-page/resource-type-meta.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/resource-type-meta.ts
@@ -7,8 +7,22 @@ import { NamespaceCounts } from '../../../model/counts.js';
  * `Controls` (a control-domain concept, not a namespace browse type). Derived from
  * `TypeInUI` so a new browsable type can't silently miss a tab — adding one to
  * `TypeInUI` makes this union (and the `Record`s keyed on it) require it.
+ *
+ * Only the browse-tab machinery (`NAMESPACE_RESOURCE_TYPES`, `COUNT_FIELD`,
+ * `SegmentedTypeTabs`) keys on this narrow union, so widening the card surface below
+ * never grows the tab set.
  */
 export type NamespaceResourceType = Exclude<TypeInUI, 'Controls'>;
+
+/**
+ * The resource types a browse *card* (and its {@link TypeBadge} / thumbnail colours)
+ * can represent — the browse types plus `Controls`. Controls reuse the shared card
+ * anatomy in the control-domain grid but are deliberately absent from the namespace
+ * tabs; this superset lets ItemCard/TypeBadge/`getResourceType*` accept a control
+ * without leaking a `Controls` tab into {@link NamespaceResourceType}. Equal to
+ * `TypeInUI` today; named for intent.
+ */
+export type CardResourceType = NamespaceResourceType | 'Controls';
 
 type ResourceTypeKey = keyof typeof colors.resourceTypes;
 
@@ -31,17 +45,20 @@ interface ResourceTypeMeta {
  * TypeBadge, ItemCard thumbnails and the type tabs all derive colour and label
  * from one place rather than re-deriving the plural→singular / colour mapping.
  *
- * Only the six namespace browse types are represented; `Controls` is not a
- * namespace browse type and is intentionally excluded by the `NamespaceResourceType`
- * narrowing on consumers.
+ * Keyed on {@link CardResourceType}, so `Controls` is included for the shared browse
+ * card (its "Control" pill + blue thumbnail) even though it is not a namespace tab —
+ * the tab exports below stay narrowed to {@link NamespaceResourceType}. Indexed only
+ * (`RESOURCE_TYPE_META[type]`), never enumerated, so the `Controls` row can't leak
+ * into any tab list.
  */
-const RESOURCE_TYPE_META: Record<NamespaceResourceType, ResourceTypeMeta> = {
+const RESOURCE_TYPE_META: Record<CardResourceType, ResourceTypeMeta> = {
     Architectures: { label: 'Architecture', pluralLabel: 'architectures', colorKey: 'architecture' },
     Patterns: { label: 'Pattern', pluralLabel: 'patterns', colorKey: 'pattern' },
     Flows: { label: 'Flow', pluralLabel: 'flows', colorKey: 'flow' },
     Standards: { label: 'Standard', pluralLabel: 'standards', colorKey: 'standard' },
     ADRs: { label: 'ADR', pluralLabel: 'ADRs', colorKey: 'adr' },
     Interfaces: { label: 'Interface', pluralLabel: 'interfaces', colorKey: 'interface' },
+    Controls: { label: 'Control', pluralLabel: 'controls', colorKey: 'control' },
 };
 
 /**
@@ -74,11 +91,11 @@ export const NAMESPACE_RESOURCE_TYPES: NamespaceResourceType[] = [
     'Interfaces',
 ];
 
-export function getResourceTypeMeta(type: NamespaceResourceType): ResourceTypeMeta {
+export function getResourceTypeMeta(type: CardResourceType): ResourceTypeMeta {
     return RESOURCE_TYPE_META[type];
 }
 
-/** The accent + tint colour pair for a browse resource type. */
-export function getResourceTypeColors(type: NamespaceResourceType): { accent: string; tint: string } {
+/** The accent + tint colour pair for a browse (or control) card resource type. */
+export function getResourceTypeColors(type: CardResourceType): { accent: string; tint: string } {
     return colors.resourceTypes[RESOURCE_TYPE_META[type].colorKey];
 }

--- a/calm-hub-ui/src/theme/colors.ts
+++ b/calm-hub-ui/src/theme/colors.ts
@@ -183,6 +183,10 @@ export const colors = {
         standard: { accent: '#D97706', tint: '#FCF1E2' },
         adr: { accent: '#DB2777', tint: '#FCE9F2' },
         interface: { accent: '#059669', tint: '#E4F5EE' },
+        // Controls aren't a namespace browse type, but their browse card reuses the
+        // shared ItemCard/TypeBadge. Uses the interaction/selection blue (matching
+        // redesign.primary / tintBg) so control cards read as the selectable family.
+        control: { accent: '#2563EB', tint: '#EEF4FF' },
     },
     diffPalette: {
         add: { bg: '#e8f6ee', border: '#b6dfc6', fg: '#15803d', sign: '+' },


### PR DESCRIPTION
## Description
`ControlCard` rebuilt `ItemCard`'s striped-thumbnail / footer / stretched-full-card-click anatomy
by hand instead of reusing it. This refactors `ControlCard` into a thin wrapper over `ItemCard`
(as `CatalogueCard` already does), so the control-domain grid and the namespace item cards can't
drift apart.

To let the shared card render a control **without** adding a "Controls" tab to the namespace browse
page, a superset type `CardResourceType` (= `NamespaceResourceType | 'Controls'`) is introduced for
the card/badge surface only. `ItemCard`, `TypeBadge`, `getResourceTypeColors` and `getResourceTypeMeta`
accept the superset; the tab exports (`NAMESPACE_RESOURCE_TYPES`, `COUNT_FIELD`, `SegmentedTypeTabs`)
stay narrowed to `NamespaceResourceType`, so the browse tabs remain the six existing types. `ItemCard`
gained optional `thumbnailIcon` (the control shield) and `active` (selected border/outline/shadow +
pass-through `aria-pressed`; unset on plain browse cards so they don't read as toggles). The control
card colours (`resourceTypes.control` = `#2563EB`/`#EEF4FF`) and the "Control" pill reproduce the
previous hardcoded values exactly, so this is a visual no-op.

Control-card grid (unchanged by the refactor — same shield thumbnail, "Control" pill, `#id`, and
selected-card ring, now rendered via the shared `ItemCard`):

![Control-card grid after the refactor](https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/pr-2786/control-grid.png)

Follow-up to #2766; closes #2786.

## Type of Change
- [x] ♻️ Refactoring (no functional changes)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Full calm-hub-ui suite: 99 files / 1103 tests passing. Lint: 0 errors. Build: succeeds. Added tests:
`ItemCard` carries no `aria-pressed` on a plain browse card but reflects the selected state when
`active` is provided, and renders `thumbnailIcon`; `TypeBadge` renders the "Control" label + control
colours; `NamespacePage` still shows exactly six tabs and no Controls tab.

## Checklist
- [x] My commits follow the conventional commit format
- [ ] I have updated documentation if necessary (n/a — internal refactor, no behaviour change)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
