### PR TITLE
fix(calm-hub): register control DTOs for native reflection

### DIFF
--- a/calm-hub/smoke-test.sh
+++ b/calm-hub/smoke-test.sh
@@ -23,6 +23,8 @@
 #   GET    /api/calm/namespaces                              body contains "finos.calm","finos.traderx","workshop"
 #   GET    /api/calm/namespaces/finos.calm/standards         -> 200 + body contains "name"
 #   GET    /api/calm/namespaces/finos.calm/interfaces        -> 200 + body contains "name"
+#   GET    /api/calm/domains/counts                          -> 200 + body contains "controlCount","finos-ai-governance"
+#   GET    /api/calm/domains/finos-ai-governance/controls    -> 200 + body contains "id":1,"AIR-OP-004
 #   GET    /api/calm/namespaces/workshop/patterns            -> 200 + body contains "Conference Signup Pattern"
 #   GET    /api/calm/namespaces/workshop/architectures       -> 200 + body contains "name","description"
 #   GET    /api/calm/namespaces/finos.traderx/architectures  -> 200 + body contains "name"
@@ -119,6 +121,20 @@ if [[ "${MODE}" == "readonly" ]]; then
     assert_body_contains GET /api/calm/namespaces/finos.calm/standards '"name"'
     assert GET /api/calm/namespaces/finos.calm/interfaces 200
     assert_body_contains GET /api/calm/namespaces/finos.calm/interfaces '"name"'
+
+    # Control-domain counts (browse rail) — guards against DomainControlCount
+    # serializing as an empty object in native (missing @RegisterForReflection)
+    assert GET /api/calm/domains/counts 200
+    assert_body_contains GET /api/calm/domains/counts '"controlCount"'
+    assert_body_contains GET /api/calm/domains/counts '"finos-ai-governance"'
+
+    # Control detail list (domain page) — same native reflection guard, for
+    # ControlDetail. (ControlConfigDetail's /configurations endpoint has no
+    # equivalent coverage: the curated seed creates no control configurations,
+    # so there is no populated body to assert against.)
+    assert GET /api/calm/domains/finos-ai-governance/controls 200
+    assert_body_contains GET /api/calm/domains/finos-ai-governance/controls '"id":1'
+    assert_body_contains GET /api/calm/domains/finos-ai-governance/controls '"AIR-OP-004'
 
     # workshop — patterns and architectures must be present with populated payloads
     # (native-image serialization regression guard: non-empty name/description fields)

--- a/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlConfigDetail.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlConfigDetail.java
@@ -1,11 +1,14 @@
 package org.finos.calm.domain.controls;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.Objects;
 
 /**
  * Lightweight projection returned by the User Facing API that pairs a configuration's
  * numeric storage id with its human-readable name slug.
  */
+@RegisterForReflection
 public class ControlConfigDetail {
 
     private Integer id;

--- a/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlDetail.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/controls/ControlDetail.java
@@ -1,7 +1,10 @@
 package org.finos.calm.domain.controls;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.Objects;
 
+@RegisterForReflection
 public class ControlDetail {
     private Integer id;
     private String name;

--- a/calm-hub/src/main/java/org/finos/calm/domain/controls/DomainControlCount.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/controls/DomainControlCount.java
@@ -1,5 +1,6 @@
 package org.finos.calm.domain.controls;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.json.bind.annotation.JsonbPropertyOrder;
 
 import java.util.Objects;
@@ -9,6 +10,7 @@ import java.util.Objects;
  * the browse rail's control-domain section can show live counts without one
  * client round-trip per domain.
  */
+@RegisterForReflection
 @JsonbPropertyOrder({"domain", "controlCount"})
 public class DomainControlCount {
     private final String domain;


### PR DESCRIPTION
DomainControlCount, ControlDetail, and ControlConfigDetail were returned via Response/ValueWrapper without @RegisterForReflection, so the GraalVM native image serialized them as empty objects, leaving the CALM Hub UI's control-domains rail blank.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
