### PR TITLE
fix(calm-hub): security hardening for ec2 stack and read-only deployment

### DIFF
--- a/calm-hub/ec2/README.md
+++ b/calm-hub/ec2/README.md
@@ -2,7 +2,7 @@
 
 Runs [`finos/calm-hub:latest-read-only-native`](https://hub.docker.com/r/finos/calm-hub) — the
 self-contained CALM Hub image (NitriteDB baked in, no external database, no auth) — on a single
-EC2 host, auto-updated by [Watchtower](https://github.com/nickfedor/watchtower) whenever a new
+EC2 host, auto-updated by [Watchtower](https://github.com/nicholas-fedor/watchtower) whenever a new
 image is published to Docker Hub.
 
 Uses the [`nickfedor/watchtower`](https://hub.docker.com/r/nickfedor/watchtower) image — the
@@ -10,6 +10,11 @@ actively maintained continuation of the original `containrrr/watchtower` project
 archived in December 2025. The original image's frozen Docker client can no longer talk to
 current Docker daemons (it negotiates down to an API version below the daemon's minimum), so do
 not switch back to `containrrr/watchtower`.
+
+Watchtower is **pinned to a release tag** in `docker-compose.yml` (it holds the Docker socket, so
+it must not auto-track a mutable `latest` tag; Watchtower never updates itself). To bump it, pick
+a release from [nicholas-fedor/watchtower/releases](https://github.com/nicholas-fedor/watchtower/releases),
+update the `image:` tag, and run `sudo docker compose up -d`.
 
 This folder supersedes the previous on-box `setup.sh` / `restart.sh` scripts, which lived only on
 the instance and had to be run by hand.
@@ -68,6 +73,10 @@ remove any container, mount the host filesystem, and effectively escalate to roo
 limits *which containers Watchtower will act on*, not what the socket itself grants; it does not
 sandbox Watchtower's own privileges. Only deploy this stack on a dedicated, otherwise-locked-down
 box — don't run other untrusted workloads alongside it.
+
+Both containers run with `no-new-privileges` and all Linux capabilities dropped, and `calm-hub`
+runs on a read-only root filesystem (tmpfs `/tmp` only) — the app is a native binary serving a
+baked-in read-only database, so nothing needs to write to disk.
 
 **This swap is not zero-downtime.** The old container stops before the new one starts, causing a
 brief (<1s) gap in availability. Maintainers have accepted this tradeoff rather than adding a

--- a/calm-hub/ec2/docker-compose.yml
+++ b/calm-hub/ec2/docker-compose.yml
@@ -22,6 +22,16 @@ services:
       # Opts this container into Watchtower; --label-enable means Watchtower
       # ignores every other container on the box.
       - "com.centurylinklabs.watchtower.enable=true"
+    # Hardening: the app is a native binary reading a baked-in, read-only
+    # NitriteDB — it needs no capabilities, no privilege escalation, and no
+    # writable filesystem beyond /tmp (Vert.x cache).
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
     # No environment needed: the read-only-native image bakes in
     # QUARKUS_PROFILE=standalone, CALM_READONLY=true, the standalone data
     # directory, and disabled auth.
@@ -33,9 +43,23 @@ services:
   watchtower:
     # containrrr/watchtower was archived (Dec 2025) — nickfedor/watchtower is the
     # actively maintained, API-compatible continuation of the same project.
-    image: nickfedor/watchtower:latest
+    #
+    # Pinned to a release tag: this container holds the Docker socket
+    # (root-equivalent), so it must not auto-track a mutable `latest` tag.
+    # Watchtower never updates itself (--label-enable and it isn't labelled);
+    # bump the pin manually — releases at
+    # https://github.com/nicholas-fedor/watchtower/releases — then
+    # `sudo docker compose up -d`.
+    image: nickfedor/watchtower:1.19.0
     container_name: watchtower
     restart: unless-stopped
+    # Hardening: watchtower only talks to the Docker API over the mounted
+    # socket — it needs no capabilities and no privilege escalation. (The
+    # socket itself still grants root-equivalent control; see README.md.)
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command:

--- a/calm-hub/ec2/install.sh
+++ b/calm-hub/ec2/install.sh
@@ -41,12 +41,25 @@ if ! sudo docker compose version >/dev/null 2>&1; then
   ASSET="docker-compose-linux-${ARCH}"
   RELEASE_URL="https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}"
 
+  # Checksums vendored from the release's published .sha256 assets. Fetching
+  # the checksum from the same host as the binary at install time only proves
+  # the download wasn't corrupted; a vendored hash also detects a tampered
+  # release. When bumping COMPOSE_VERSION, update both hashes from the new
+  # release's .sha256 files.
+  case "${ARCH}" in
+    x86_64)  EXPECTED_SHA="ed1917fb54db184192ea9d0717bcd59e3662ea79db48bff36d3475516c480a6b" ;;
+    aarch64) EXPECTED_SHA="0c4591cf3b1ed039adcd803dbbeddf757375fc08c11245b0154135f838495a2f" ;;
+    *)
+      echo "!! No vendored Docker Compose checksum for architecture '${ARCH}' — aborting" >&2
+      exit 1
+      ;;
+  esac
+
   TMP_COMPOSE="$(mktemp)"
   curl -fsSL "${RELEASE_URL}/${ASSET}" -o "${TMP_COMPOSE}"
 
-  # Verify against Docker's published checksum before installing a root-owned
+  # Verify against the vendored checksum before installing a root-owned
   # binary — protects against a corrupted or tampered download.
-  EXPECTED_SHA="$(curl -fsSL "${RELEASE_URL}/${ASSET}.sha256" | awk '{print $1}')"
   ACTUAL_SHA="$(sha256sum "${TMP_COMPOSE}" | awk '{print $1}')"
   if [ "${EXPECTED_SHA}" != "${ACTUAL_SHA}" ]; then
     echo "!! Docker Compose checksum mismatch (expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}) — aborting" >&2

--- a/calm-hub/src/main/resources/application-secure.properties
+++ b/calm-hub/src/main/resources/application-secure.properties
@@ -7,6 +7,13 @@ quarkus.http.ssl.certificate.files=cert.pem
 quarkus.http.auth.permission.secured.paths=/calm/*
 quarkus.http.auth.permission.secured.policy=authenticated
 
+# Safety net for the namespace-scoped API: every method under /api/calm/* is
+# individually annotated (@PermissionsAllowed / @Authenticated), but this
+# coarse policy guarantees a future endpoint added without an annotation is
+# still rejected rather than silently unauthenticated.
+quarkus.http.auth.permission.api.paths=/api/calm/*
+quarkus.http.auth.permission.api.policy=authenticated
+
 quarkus.http.auth.permission.mcp-tools.paths=/mcp/*
 quarkus.http.auth.permission.mcp-tools.policy=authenticated
 

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -49,10 +49,15 @@ calm.auth.enabled=true
 
 #quarkus.http.port=8081
 
-# Security response headers — applied to all routes
+# Security response headers — applied to all routes.
+# nosniff stops browsers content-type-sniffing error bodies into HTML (the
+# backstop behind the STRICT_SANITIZATION_POLICY discipline on echoed input);
+# no-referrer keeps hub URLs out of outbound requests from Swagger UI links.
 quarkus.http.filter.security.matches=/.*
-quarkus.http.filter.security.methods=GET,POST,PUT,DELETE,PATCH
+quarkus.http.filter.security.methods=GET,HEAD,POST,PUT,DELETE,PATCH
 quarkus.http.filter.security.header."X-Frame-Options"=DENY
+quarkus.http.filter.security.header."X-Content-Type-Options"=nosniff
+quarkus.http.filter.security.header."Referrer-Policy"=no-referrer
 
 # MCP Server Configuration (experimental)
 # Gates MCP tool invocations. When false (the default), every @Tool method

--- a/calm-hub/src/test/java/org/finos/calm/security/TestSecurityResponseHeadersShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestSecurityResponseHeadersShould.java
@@ -3,6 +3,7 @@ package org.finos.calm.security;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import io.restassured.response.ValidatableResponse;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.Test;
@@ -21,31 +22,47 @@ import static org.mockito.Mockito.when;
 public class TestSecurityResponseHeadersShould {
 
     @InjectMock
-    NamespaceStore namespaceStore;
+    NamespaceStore mockNamespaceStore;
 
     @InjectMock
-    UserAccessStore userAccessStore;
+    UserAccessStore mockUserAccessStore;
 
-    @Test
-    void return_x_frame_options_deny_on_get_request() {
-        when(namespaceStore.getNamespaces()).thenReturn(new ArrayList<>());
-
-        given()
-                .when()
-                .get("/api/calm/namespaces")
-                .then()
-                .statusCode(200)
-                .header("X-Frame-Options", equalTo("DENY"));
+    private static void assertSecurityHeaders(ValidatableResponse response) {
+        response
+                .header("X-Frame-Options", equalTo("DENY"))
+                .header("X-Content-Type-Options", equalTo("nosniff"))
+                .header("Referrer-Policy", equalTo("no-referrer"));
     }
 
     @Test
-    void return_x_frame_options_deny_on_post_request() {
-        given()
+    void return_security_headers_on_get_request() {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(new ArrayList<>());
+
+        assertSecurityHeaders(given()
+                .when()
+                .get("/api/calm/namespaces")
+                .then()
+                .statusCode(200));
+    }
+
+    @Test
+    void return_security_headers_on_head_request() {
+        when(mockNamespaceStore.getNamespaces()).thenReturn(new ArrayList<>());
+
+        assertSecurityHeaders(given()
+                .when()
+                .head("/api/calm/namespaces")
+                .then()
+                .statusCode(200));
+    }
+
+    @Test
+    void return_security_headers_on_post_request() {
+        assertSecurityHeaders(given()
                 .contentType("application/json")
                 .body("{\"name\":\"test\",\"description\":\"test\"}")
                 .when()
                 .post("/api/calm/namespaces")
-                .then()
-                .header("X-Frame-Options", equalTo("DENY"));
+                .then());
     }
 }


### PR DESCRIPTION
## Description

Security scan of `calm-hub/ec2/` and the calm-hub read-only deployment, with the low-risk hardening applied. Read-only enforcement itself was assessed as robust (global `@PreMatching` verb filter + NitriteDB opened `readOnly(true)` + `chmod 0444` DB file — no per-endpoint gaps found).

**Fixed:**
- Pin `nickfedor/watchtower` to `1.19.0` — the container holding the Docker socket no longer auto-tracks a mutable `latest` tag (Watchtower never updates itself, so the pin is stable; bump instructions in compose comment + README)
- Add `no-new-privileges` + `cap_drop: ALL` to both ec2 services; `read_only` rootfs + tmpfs `/tmp` on `calm-hub` (native binary, baked-in read-only DB — nothing writes to disk)
- Vendor the Docker Compose v2.32.4 per-arch SHA256 checksums into `install.sh` — previously fetched from the same host as the binary, which only proves transport integrity
- Add `X-Content-Type-Options: nosniff` + `Referrer-Policy: no-referrer` response headers (all profiles) and include `HEAD` in the header filter's method list
- Add `/api/calm/*` → `authenticated` path policy to the secure profile — safety net so a future unannotated endpoint is rejected rather than silently unauthenticated (every current method is annotated; no behaviour change)
- Fix ec2 README Watchtower GitHub link (`nickfedor` → `nicholas-fedor`; old link 404s)

**Reviewed and accepted, no change (by design):**
- Watchtower Docker socket mount (documented in ec2 README security note)
- Auto-deploy from mutable `latest-read-only-native` tag (this is the feature; `sha-*` pinning documented)
- Open auth + Swagger UI on the public read-only image (genuinely public service)
- Plain HTTP on :80 (TLS terminates upstream)

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
- `fix(calm-hub): harden ec2 compose stack and pin watchtower`
- `fix(calm-hub): add nosniff and referrer-policy security headers`
- `fix(calm-hub): add authenticated path policy for /api/calm in secure profile`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verification performed:
- `../mvnw clean verify -Ddependency-check.skip=true` — 2143 tests, 0 failures, JaCoCo coverage check green
- Hardened compose stack booted locally with the published `latest-read-only-native` image; full `smoke-test.sh readonly` passed (all 405 assertions intact); Watchtower 1.19.0 healthy under `cap_drop: ALL`
- Response headers asserted via curl on GET and HEAD against the packaged jar (standalone profile) and covered by `TestSecurityResponseHeadersShould`
- Vendored checksums cross-checked against freshly downloaded v2.32.4 release binaries; `bash -n install.sh` clean

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards