### PR TITLE
feat(calm-hub-ui): adding detailed architecture navigation

### DIFF
--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import Hub from './Hub.js';
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { authStore } from '../service/utils/auth-store.js';
@@ -131,10 +131,44 @@ vi.mock('../components/navbar/Navbar', () => ({
     Navbar: () => <nav data-testid="navbar">Navbar</nav>,
 }));
 
-vi.mock('./components/diagram-section/DiagramSection', () => ({
-    DiagramSection: ({ data, onItemSelect }: { data: { id?: string }; onItemSelect?: (item: { data: unknown }) => void }) => (
+vi.mock('./components/diagram-section/DiagramSection', async () => {
+    // Real context, not a mock: the stub consumes Hub's provider exactly like the
+    // production tree (CustomNode / NodeDetails) does.
+    const { useDiagramActions } = await import('../visualizer/context/DiagramActionsContext.js');
+    const DiagramSection = ({
+        data,
+        onItemSelect,
+        breadcrumbs,
+        onDisplayNameChange,
+    }: {
+        data: { id?: string };
+        onItemSelect?: (item: { data: unknown }) => void;
+        breadcrumbs?: unknown[];
+        onDisplayNameChange?: (name: string | undefined) => void;
+    }) => {
+        const { onNavigateToDetailedArch } = useDiagramActions();
+        return (
         <div data-testid="diagram-section">
             Diagram: {data?.id}
+            {/* Trail from history state, echoed for breadcrumb-accumulation tests. */}
+            <div data-testid="breadcrumbs">{JSON.stringify(breadcrumbs ?? [])}</div>
+            {/* Simulates the summaries fetch resolving the display name. */}
+            <button data-testid="set-display-name" onClick={() => onDisplayNameChange?.('Nice Name')}>
+                set display name
+            </button>
+            {/* Simulates a node's "Explore Architecture" action (context consumer). */}
+            <button
+                data-testid="navigate-detailed-arch"
+                onClick={() => onNavigateToDetailedArch?.('/calm/namespaces/finos/architectures/target-arch/versions/2.0.0')}
+            >
+                navigate detailed
+            </button>
+            <button
+                data-testid="navigate-detailed-arch-bad"
+                onClick={() => onNavigateToDetailedArch?.('/not/a/calm/path')}
+            >
+                navigate bad
+            </button>
             {/* Lets tests simulate a node/edge tap on the graph so Hub's node-detail
                 wiring (the mobile bottom-sheet + prev/next steppers) is exercised.
                 `select-node` (n1) is retained for existing tests; `select-n1/n2/n3`
@@ -197,8 +231,10 @@ vi.mock('./components/diagram-section/DiagramSection', () => ({
                 select edge
             </button>
         </div>
-    ),
-}));
+        );
+    };
+    return { DiagramSection };
+});
 
 // Helpers to drive the captured load callbacks.
 const loadData = () =>
@@ -275,6 +311,21 @@ const renderAt = (path: string) =>
     render(
         <MemoryRouter initialEntries={[path]}>
             <Hub />
+        </MemoryRouter>
+    );
+
+// Echoes the live pathname so tests can assert where a context-triggered
+// navigation landed. Accepts entry objects so a test can seed history state.
+function LocationProbe() {
+    const location = useLocation();
+    return <div data-testid="location-pathname">{location.pathname}</div>;
+}
+
+const renderWithLocation = (entries: React.ComponentProps<typeof MemoryRouter>['initialEntries']) =>
+    render(
+        <MemoryRouter initialEntries={entries}>
+            <Hub />
+            <LocationProbe />
         </MemoryRouter>
     );
 
@@ -722,4 +773,69 @@ describe('Hub', () => {
             expect(screen.queryByTestId('adr-renderer')).not.toBeInTheDocument();
         });
     });
+    describe('detailed-architecture navigation (breadcrumb state)', () => {
+        const readCrumbs = () => JSON.parse(screen.getByTestId('breadcrumbs').textContent!);
+
+        it('pushes the current resource as a named crumb and navigates to the parsed target', () => {
+            renderWithLocation(['/test-namespace/architectures/arch/1.0']);
+            loadArchitectureWithNodes();
+            fireEvent.click(screen.getByTestId('set-display-name'));
+
+            fireEvent.click(screen.getByTestId('navigate-detailed-arch'));
+
+            expect(screen.getByTestId('location-pathname')).toHaveTextContent(
+                '/finos/architectures/target-arch/2.0.0'
+            );
+            // The new route's resource loads; the remounted diagram receives the trail.
+            loadArchitectureWithNodes();
+            expect(readCrumbs()).toEqual([
+                { namespace: 'test-namespace', type: 'architectures', id: 'arch', version: '1.0', name: 'Nice Name' },
+            ]);
+        });
+
+        it('accumulates one crumb per hop and omits the name when it never resolved', () => {
+            renderWithLocation(['/test-namespace/architectures/arch/1.0']);
+            loadArchitectureWithNodes();
+            fireEvent.click(screen.getByTestId('navigate-detailed-arch'));
+            loadArchitectureWithNodes();
+            expect(readCrumbs()).toHaveLength(1);
+
+            fireEvent.click(screen.getByTestId('navigate-detailed-arch'));
+            loadArchitectureWithNodes();
+
+            const crumbs = readCrumbs();
+            expect(crumbs).toHaveLength(2);
+            // No set-display-name click before either hop's navigation: the crumb
+            // carries no name and consumers fall back to the id.
+            expect(crumbs[0].name).toBeUndefined();
+            expect(crumbs[1]).toEqual({ namespace: 'test-namespace', type: 'architectures', id: 'arch', version: '1.0' });
+        });
+
+        it('ignores references that are not CALM Hub paths, keeping the current view intact', () => {
+            renderWithLocation(['/test-namespace/architectures/arch/1.0']);
+            loadArchitectureWithNodes();
+
+            fireEvent.click(screen.getByTestId('navigate-detailed-arch-bad'));
+
+            expect(screen.getByTestId('location-pathname')).toHaveTextContent(
+                '/test-namespace/architectures/arch/1.0'
+            );
+            // No navigation happened, so the loaded diagram was not cleared.
+            expect(screen.getByTestId('diagram-section')).toHaveTextContent('Diagram: arch');
+        });
+
+        it('filters malformed entries out of untrusted history state', () => {
+            const valid = { namespace: 'finos', type: 'architectures', id: 'parent', version: '1.0.0' };
+            renderWithLocation([
+                {
+                    pathname: '/test-namespace/architectures/arch/1.0',
+                    state: { breadcrumbs: [valid, { junk: true }, 'nonsense', null, { namespace: 'x', type: 'flows', id: 'y', version: '1' }] },
+                },
+            ]);
+            loadArchitectureWithNodes();
+
+            expect(readCrumbs()).toEqual([valid]);
+        });
+    });
+
 });

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -372,6 +372,7 @@ export default function Hub() {
             namespace={detailMatch.params.namespace!}
             id={detailMatch.params.id!}
             version={detailMatch.params.version!}
+            type={detailMatch.params.type}
             breadcrumbs={breadcrumbs}
         />
     ) : isDetailRoute || interfaceData || adrData || data ? (

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useMatch, useNavigate } from 'react-router-dom';
 import { IoChevronForwardOutline, IoCompassOutline } from 'react-icons/io5';
 import { ExploreRail } from './components/explore-rail/ExploreRail.js';
@@ -8,7 +8,7 @@ import { DomainPage } from './components/domain-page/DomainPage.js';
 import { FirstRunLanding } from './components/first-run-landing/FirstRunLanding.js';
 import { useResourceFromRoute } from './hooks/useResourceFromRoute.js';
 import { useIsMobile } from '../hooks/useMediaQuery.js';
-import { Data, Adr } from '../model/calm.js';
+import { BreadcrumbItem, Data, Adr } from '../model/calm.js';
 import { ControlData } from '../model/control.js';
 import { InterfaceData } from '../model/interface.js';
 import { NamespaceCounts, DomainControlCount } from '../model/counts.js';
@@ -21,12 +21,36 @@ import { InterfaceDetailSection } from './components/interface-detail-section/In
 import { DiagramSection } from './components/diagram-section/DiagramSection.js';
 import { Sidebar } from '../visualizer/components/sidebar/Sidebar.js';
 import { NodeSheet } from '../visualizer/components/sidebar/NodeSheet.js';
+import { DiagramActionsContext } from '../visualizer/context/DiagramActionsContext.js';
+import { ResourceNotFound } from './components/resource-not-found/ResourceNotFound.js';
+import { parseCALMHubPath } from '../visualizer/components/reactflow/utils/calmHelpers.js';
 import type { SelectedItem } from '../visualizer/contracts/contracts.js';
 import type { CalmNodeSchema } from '@finos/calm-models/types';
 import { authStore } from '../service/utils/auth-store.js';
 import './Hub.css';
 
+// Breadcrumbs live in history state so Back restores the parent's trail for free,
+// at the documented cost that a hard refresh or shared deep link starts with an
+// empty trail. History state is untyped and can be stale (older sessions) or set
+// by other code, so validate the shape instead of trusting a cast.
+function readBreadcrumbs(state: unknown): BreadcrumbItem[] {
+    const crumbs = (state as { breadcrumbs?: unknown } | null)?.breadcrumbs;
+    if (!Array.isArray(crumbs)) return [];
+    return crumbs.filter(
+        (c): c is BreadcrumbItem =>
+            typeof c === 'object' &&
+            c !== null &&
+            typeof (c as BreadcrumbItem).namespace === 'string' &&
+            ((c as BreadcrumbItem).type === 'architectures' || (c as BreadcrumbItem).type === 'patterns') &&
+            typeof (c as BreadcrumbItem).id === 'string' &&
+            typeof (c as BreadcrumbItem).version === 'string'
+    );
+}
+
 export default function Hub() {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const currentDisplayNameRef = useRef<string | undefined>(undefined);
     const [data, setData] = useState<Data | undefined>();
     const [adrData, setAdrData] = useState<Adr | undefined>();
     const [controlData, setControlData] = useState<ControlData | undefined>();
@@ -34,6 +58,9 @@ export default function Hub() {
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(true);
     const [selectedItem, setSelectedItem] = useState<SelectedItem>(null);
+    // A detail-route load rejected (missing resource, dangling reference). Cleared
+    // on every navigation; renders ResourceNotFound instead of an empty pane.
+    const [resourceLoadFailed, setResourceLoadFailed] = useState(false);
     const [namespaceCounts, setNamespaceCounts] = useState<NamespaceCounts[]>([]);
     const [namespaceCountsLoaded, setNamespaceCountsLoaded] = useState(false);
     // Distinct from "loaded": a failed counts fetch means counts are unknown, not
@@ -46,8 +73,6 @@ export default function Hub() {
     // Route-first content selection (redesign problem #4): the same <Hub/> element
     // is reused across `/`, `/namespace/:ns`, `/domain/:domain` and the detail
     // route, so the URL — not residual state — decides what renders.
-    const { key: locationKey } = useLocation();
-    const navigate = useNavigate();
     const namespaceMatch = useMatch('/namespace/:ns');
     const domainMatch = useMatch('/domain/:domain');
     const detailMatch = useMatch('/:namespace/:type/:id/:version');
@@ -107,7 +132,8 @@ export default function Hub() {
         setControlData(undefined);
         setInterfaceData(undefined);
         setSelectedItem(null);
-    }, [locationKey]);
+        setResourceLoadFailed(false);
+    }, [location.key]);
 
     const handleDataLoad = useCallback((loaded: Data) => {
         setData(loaded);
@@ -116,6 +142,7 @@ export default function Hub() {
         setInterfaceData(undefined);
         setSelectedItem(null);
         setIsMobileNavOpen(false);
+        currentDisplayNameRef.current = undefined;
     }, []);
 
     const handleAdrLoad = useCallback((adr: Adr) => {
@@ -145,12 +172,18 @@ export default function Hub() {
         setIsMobileNavOpen(false);
     }, []);
 
+    const handleResourceLoadError = useCallback((error: unknown) => {
+        console.error('%s', 'Failed to load routed resource:', error);
+        setResourceLoadFailed(true);
+    }, []);
+
     // Single owner of deep-link / external-navigation loading for the detail route.
     useResourceFromRoute({
         onDataLoad: handleDataLoad,
         onAdrLoad: handleAdrLoad,
         onControlLoad: handleControlLoad,
         onInterfaceLoad: handleInterfaceLoad,
+        onLoadError: handleResourceLoadError,
     });
 
     const handleItemSelect = useCallback((item: SelectedItem) => {
@@ -190,6 +223,41 @@ export default function Hub() {
             }
         },
         [isDetailRoute, navigate, handleControlLoad]
+    );
+
+    // The resource's display name is fetched by DiagramSection (it owns the
+    // summaries fetch) and mirrored here so the crumb pushed on navigation can
+    // carry it. A ref, not state: it is only read imperatively at navigate time,
+    // so Hub need not re-render when it resolves. This handler MUST stay memoised
+    // (identity-stable) — DiagramSection lists it in a fetch effect's deps.
+    const handleDisplayNameChange = useCallback((name: string | undefined) => {
+        currentDisplayNameRef.current = name;
+    }, []);
+
+    const handleNavigateToDetailedArch = useCallback((ref: string) => {
+        const parsed = parseCALMHubPath(ref);
+        if (!parsed || !data) return;
+        const currentCrumb: BreadcrumbItem = {
+            namespace: data.name,
+            type: data.calmType === 'Architectures' ? 'architectures' : 'patterns',
+            id: data.id,
+            version: data.version,
+            name: currentDisplayNameRef.current,
+        };
+        navigate(`/${parsed.namespace}/${parsed.type}/${parsed.id}/${parsed.version}`, {
+            state: { breadcrumbs: [...readBreadcrumbs(location.state), currentCrumb] }
+        });
+    }, [navigate, data, location.state]);
+
+    const breadcrumbs = useMemo(() => readBreadcrumbs(location.state), [location.state]);
+
+    // Single, memoised provider value for every detailed-architecture navigation
+    // consumer: CustomNode (which ReactFlow instantiates internally, out of reach
+    // of props) and NodeDetails (rendered in both the Sidebar and the NodeSheet).
+    // Memoised so consumers don't re-render on unrelated Hub renders.
+    const diagramActions = useMemo(
+        () => ({ onNavigateToDetailedArch: handleNavigateToDetailedArch }),
+        [handleNavigateToDetailedArch]
     );
 
     const isDiagramView = data?.calmType === 'Architectures' || data?.calmType === 'Patterns';
@@ -269,7 +337,13 @@ export default function Hub() {
     ) : adrData ? (
         <AdrRenderer adrDetails={adrData} />
     ) : isDiagramView ? (
-        <DiagramSection data={data} onItemSelect={handleItemSelect} hasDetailsPanel={!!selectedItem} />
+        <DiagramSection
+            data={data}
+            onItemSelect={handleItemSelect}
+            hasDetailsPanel={!!selectedItem}
+            breadcrumbs={breadcrumbs}
+            onDisplayNameChange={handleDisplayNameChange}
+        />
     ) : (
         <DocumentDetailSection data={data} />
     );
@@ -290,6 +364,15 @@ export default function Hub() {
             controlCount={controlDomainCount}
             onControlLoad={handleControlActivate}
             selectedControlId={controlData.controlId}
+        />
+    ) : isDetailRoute && resourceLoadFailed && !interfaceData && !adrData && !data ? (
+        // The routed resource failed to load: show a recoverable not-found state
+        // (never a blank pane). Loaded data wins if a late success ever lands.
+        <ResourceNotFound
+            namespace={detailMatch.params.namespace!}
+            id={detailMatch.params.id!}
+            version={detailMatch.params.version!}
+            breadcrumbs={breadcrumbs}
         />
     ) : isDetailRoute || interfaceData || adrData || data ? (
         detailContent
@@ -313,6 +396,7 @@ export default function Hub() {
     );
 
     return (
+        <DiagramActionsContext.Provider value={diagramActions}>
         <div className="flex flex-col h-screen overflow-hidden">
             <Navbar />
             {isMobile && !isMobileNavOpen && (
@@ -415,5 +499,6 @@ export default function Hub() {
                 )}
             </div>
         </div>
+        </DiagramActionsContext.Provider>
     );
 }

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, useNavigate } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { DiagramSection } from './DiagramSection.js';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { Data } from '../../../model/calm.js';
+import { BreadcrumbItem, Data } from '../../../model/calm.js';
 
 const calmServiceMock = {
     fetchDeploymentDecoratorsForArchitecture: vi.fn().mockResolvedValue([]),
@@ -317,7 +317,7 @@ describe('DiagramSection', () => {
 
             await user.click(screen.getByText('nav-2.0.0'));
 
-            expect(navigate).toHaveBeenCalledWith('/arch-namespace/architectures/test-arch/2.0.0');
+            expect(navigate).toHaveBeenCalledWith('/arch-namespace/architectures/test-arch/2.0.0', expect.objectContaining({ state: null }));
         });
 
         it('keeps the timeline bar visible across tabs', async () => {
@@ -334,23 +334,25 @@ describe('DiagramSection', () => {
         });
     });
 
+    // Shared: force useIsMobile() to report a mobile viewport. Returns a restore fn.
+    function mockMobileViewport() {
+        const original = window.matchMedia;
+        window.matchMedia = ((query: string) => ({
+            matches: query.includes('max-width: 1023px'),
+            media: query,
+            onchange: null,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            addListener: () => {},
+            removeListener: () => {},
+            dispatchEvent: () => false,
+        })) as unknown as typeof window.matchMedia;
+        return () => {
+            window.matchMedia = original;
+        };
+    }
+
     describe('mobile view pill (#11)', () => {
-        function mockMobileViewport() {
-            const original = window.matchMedia;
-            window.matchMedia = ((query: string) => ({
-                matches: query.includes('max-width: 1023px'),
-                media: query,
-                onchange: null,
-                addEventListener: () => {},
-                removeEventListener: () => {},
-                addListener: () => {},
-                removeListener: () => {},
-                dispatchEvent: () => false,
-            })) as unknown as typeof window.matchMedia;
-            return () => {
-                window.matchMedia = original;
-            };
-        }
 
         it('renders a labelled "View" pill (not a bare icon) as the menu trigger on mobile', () => {
             const restore = mockMobileViewport();
@@ -400,6 +402,133 @@ describe('DiagramSection', () => {
             // the role="tab" view-mode buttons).
             expect(screen.queryByRole('button', { name: /view options/i })).not.toBeInTheDocument();
             expect(screen.queryByText('View')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('breadcrumb navigation', () => {
+        it('renders parent breadcrumb in the heading when breadcrumbs prop is provided', () => {
+            const crumbs: BreadcrumbItem[] = [
+                { namespace: 'finos', type: 'patterns', id: 'api-gateway-pattern', version: '1.0.0' },
+            ];
+
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} breadcrumbs={crumbs} />
+                </MemoryRouter>
+            );
+
+            const heading = screen.getByRole('heading');
+            expect(heading).toHaveTextContent('api-gateway-pattern');
+        });
+
+        it('navigates to parent when breadcrumb is clicked', async () => {
+            const navigate = vi.fn();
+            vi.mocked(useNavigate).mockReturnValue(navigate);
+            const user = userEvent.setup();
+            const crumbs: BreadcrumbItem[] = [
+                { namespace: 'finos', type: 'patterns', id: 'api-gateway-pattern', version: '1.0.0' },
+            ];
+
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} breadcrumbs={crumbs} />
+                </MemoryRouter>
+            );
+
+            await user.click(screen.getByRole('button', { name: 'api-gateway-pattern' }));
+
+            expect(navigate).toHaveBeenCalledWith(
+                '/finos/patterns/api-gateway-pattern/1.0.0',
+                { state: { breadcrumbs: [] } }
+            );
+        });
+    });
+
+    describe('mobile breadcrumb back bar', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'root-arch', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'parent-arch', version: '2.0.0', name: 'Parent Arch' },
+        ];
+
+        it('renders a back chip to the immediate parent on mobile', () => {
+            const restore = mockMobileViewport();
+            try {
+                render(
+                    <MemoryRouter>
+                        <DiagramSection data={architectureData} breadcrumbs={crumbs} />
+                    </MemoryRouter>
+                );
+
+                expect(screen.getByRole('button', { name: /back to Parent Arch/i })).toBeInTheDocument();
+            } finally {
+                restore();
+            }
+        });
+
+        it('navigates to the parent with the trail sliced when tapped', async () => {
+            const restore = mockMobileViewport();
+            try {
+                const navigate = vi.fn();
+                vi.mocked(useNavigate).mockReturnValue(navigate);
+                const user = userEvent.setup();
+                render(
+                    <MemoryRouter>
+                        <DiagramSection data={architectureData} breadcrumbs={crumbs} />
+                    </MemoryRouter>
+                );
+
+                await user.click(screen.getByRole('button', { name: /back to Parent Arch/i }));
+
+                expect(navigate).toHaveBeenCalledWith('/finos/architectures/parent-arch/2.0.0', {
+                    state: { breadcrumbs: [crumbs[0]] },
+                });
+            } finally {
+                restore();
+            }
+        });
+
+        it('falls back to the parent id when the crumb has no display name', () => {
+            const restore = mockMobileViewport();
+            try {
+                render(
+                    <MemoryRouter>
+                        <DiagramSection data={architectureData} breadcrumbs={[crumbs[0]]} />
+                    </MemoryRouter>
+                );
+
+                expect(screen.getByRole('button', { name: /back to root-arch/i })).toBeInTheDocument();
+            } finally {
+                restore();
+            }
+        });
+
+        it('does not render the chip without a trail (canvas stays full-bleed)', () => {
+            const restore = mockMobileViewport();
+            try {
+                render(
+                    <MemoryRouter>
+                        <DiagramSection data={architectureData} />
+                    </MemoryRouter>
+                );
+
+                expect(screen.queryByRole('button', { name: /back to/i })).not.toBeInTheDocument();
+            } finally {
+                restore();
+            }
+        });
+
+        // Desktop boundary guard: the chip lives only in the mobile return; desktop
+        // shows the header trail instead. No matchMedia mock — default is desktop.
+        it('does not render the chip on desktop even with a trail', () => {
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={architectureData} breadcrumbs={crumbs} />
+                </MemoryRouter>
+            );
+
+            expect(screen.queryByRole('button', { name: /back to/i })).not.toBeInTheDocument();
+            // The trail itself renders in the header instead.
+            expect(screen.getByRole('button', { name: 'Parent Arch' })).toBeInTheDocument();
         });
     });
 

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoCheckmarkOutline } from 'react-icons/io5';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
+import { IoChevronBackOutline, IoConstructOutline, IoGridOutline, IoEyeOutline, IoCodeOutline, IoRocketOutline, IoTimeOutline, IoCloseOutline, IoCheckmarkOutline } from 'react-icons/io5';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
-import { Data } from '../../../model/calm.js';
+import { BreadcrumbItem, Data } from '../../../model/calm.js';
 import { sortVersionsDescending } from '../../../model/version.js';
 import { JsonRenderer } from '../json-renderer/JsonRenderer.js';
 import { Drawer } from '../../../visualizer/components/drawer/Drawer.js';
@@ -33,6 +33,14 @@ interface DiagramSectionProps {
     data: Data & { calmType: 'Architectures' | 'Patterns' };
     onItemSelect?: (item: SelectedItem) => void;
     hasDetailsPanel?: boolean;
+    breadcrumbs?: BreadcrumbItem[];
+    /**
+     * Mirrors the resolved display name up to Hub, which snapshots it into the
+     * breadcrumb pushed on detailed-architecture navigation. Must be
+     * identity-stable (memoised by the caller): it is listed in the deps of the
+     * fetch effect that reports it.
+     */
+    onDisplayNameChange?: (name: string | undefined) => void;
 }
 
 const iconMap = {
@@ -42,9 +50,10 @@ const iconMap = {
 
 type DiagramTabType = 'diagram' | 'json' | 'deployments';
 
-export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramSectionProps) {
+export function DiagramSection({ data, onItemSelect, hasDetailsPanel, breadcrumbs, onDisplayNameChange }: DiagramSectionProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
+    const location = useLocation();
     const tabParam = searchParams.get('tab') as DiagramTabType | null;
     const activeTab: DiagramTabType = tabParam ?? 'diagram';
     const isMobile = useIsMobile();
@@ -95,7 +104,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
     const [compareError, setCompareError] = useState<string | null>(null);
 
     const setActiveTab = (tab: DiagramTabType) => {
-        setSearchParams({ tab }, { replace: true });
+        setSearchParams({ tab }, { replace: true, state: location.state });
     };
 
     const isArchitecture = data.calmType === 'Architectures';
@@ -109,10 +118,16 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         setCompareFrom(null);
         setCompareTo(null);
         if (version === data.version) return;
-        // Preserve the active tab when switching version.
+        // Preserve the active tab and breadcrumb state when switching version.
         const query = activeTab !== 'diagram' ? `?tab=${activeTab}` : '';
-        navigate(`/${data.name}/${urlType}/${data.id}/${version}${query}`);
+        navigate(`/${data.name}/${urlType}/${data.id}/${version}${query}`, { state: location.state });
     };
+
+    const handleBreadcrumbClick = useCallback((crumb: BreadcrumbItem, index: number) => {
+        navigate(`/${crumb.namespace}/${crumb.type}/${crumb.id}/${crumb.version}`, {
+            state: { breadcrumbs: (breadcrumbs || []).slice(0, index) }
+        });
+    }, [navigate, breadcrumbs]);
 
     const startCompare = (from: string, to: string) => {
         setCompareFrom(from);
@@ -192,14 +207,18 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                 if (cancelled) return;
                 const match = list.find((s) => String(s.id) === data.id || s.customId === data.id);
                 setDisplayName(match?.name);
+                onDisplayNameChange?.(match?.name);
             })
             .catch(() => {
-                if (!cancelled) setDisplayName(undefined);
+                if (!cancelled) {
+                    setDisplayName(undefined);
+                    onDisplayNameChange?.(undefined);
+                }
             });
         return () => {
             cancelled = true;
         };
-    }, [calmService, data.name, data.id, isArchitecture]);
+    }, [calmService, data.name, data.id, isArchitecture, onDisplayNameChange]);
 
     useEffect(() => {
         let cancelled = false;
@@ -287,7 +306,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         const query = activeTab !== 'diagram' ? `?tab=${activeTab}` : '';
         navigate(
             `/${data.name}/${urlType}/${data.id}/${currentMoment.version}${query}`,
-            { replace: true }
+            { replace: true, state: location.state }
         );
     }, [
         isArchitecture,
@@ -301,6 +320,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         urlType,
         activeTab,
         navigate,
+        location.state,
     ]);
 
     const Icon = iconMap[data.calmType];
@@ -514,6 +534,8 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
                         displayName={displayName}
                         typeLabel={typeLabel}
                         rightContent={tabs}
+                        breadcrumbs={breadcrumbs}
+                        onBreadcrumbClick={handleBreadcrumbClick}
                     />
                     <div className="flex-1 min-h-0 overflow-hidden">{content}</div>
                     {timelineBar}
@@ -531,6 +553,24 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel }: DiagramS
         <div className="w-full h-full">
             {navbarSlot ? createPortal(viewMenu, navbarSlot) : viewMenu}
             <div className="h-full bg-base-100 overflow-hidden flex flex-col">
+                {/* Mobile has no SectionHeader (full-bleed canvas), so after a
+                    detailed-architecture hop the trail would be unreachable.
+                    iOS-style single back chip instead: one full-width tap target
+                    to the immediate parent, mirroring Hub's Explore bar. Absent
+                    without a trail, so the plain diagram view stays full-bleed. */}
+                {breadcrumbs && breadcrumbs.length > 0 && (
+                    <button
+                        className="w-full flex items-center gap-2 px-4 py-2 bg-base-200 border-b border-base-300 text-sm text-primary shrink-0"
+                        onClick={() =>
+                            handleBreadcrumbClick(breadcrumbs[breadcrumbs.length - 1], breadcrumbs.length - 1)
+                        }
+                    >
+                        <IoChevronBackOutline size={16} className="shrink-0" />
+                        <span className="truncate">
+                            Back to {breadcrumbs[breadcrumbs.length - 1].name || breadcrumbs[breadcrumbs.length - 1].id}
+                        </span>
+                    </button>
+                )}
                 <div className="flex-1 min-h-0 overflow-hidden relative">
                     {content}
                 </div>

--- a/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.test.tsx
+++ b/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { ResourceNotFound } from './ResourceNotFound.js';
+import { BreadcrumbItem } from '../../../model/calm.js';
+
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>();
+    return {
+        ...actual,
+        useNavigate: vi.fn(function () {
+            return vi.fn();
+        }),
+    };
+});
+
+function renderAt(props: Parameters<typeof ResourceNotFound>[0]) {
+    return render(
+        <MemoryRouter>
+            <ResourceNotFound {...props} />
+        </MemoryRouter>
+    );
+}
+
+describe('ResourceNotFound', () => {
+    it('echoes the requested resource and always offers the hub root', () => {
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0' });
+
+        expect(screen.getByText('Architecture not found')).toBeInTheDocument();
+        expect(screen.getByText('finos/model-registry@1.0.0')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /browse the hub/i })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /back to/i })).not.toBeInTheDocument();
+    });
+
+    it('navigates to the parent crumb with the trail sliced, mirroring a breadcrumb click', async () => {
+        const navigate = vi.fn();
+        vi.mocked(useNavigate).mockReturnValue(navigate);
+        const user = userEvent.setup();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'payment-service', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'ml-scoring-service', version: '1.0.0', name: 'ML Scoring' },
+        ];
+
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0', breadcrumbs: crumbs });
+
+        await user.click(screen.getByRole('button', { name: 'Back to ML Scoring' }));
+
+        expect(navigate).toHaveBeenCalledWith('/finos/architectures/ml-scoring-service/1.0.0', {
+            state: { breadcrumbs: [crumbs[0]] },
+        });
+    });
+
+    it('navigates home from the hub-root action', async () => {
+        const navigate = vi.fn();
+        vi.mocked(useNavigate).mockReturnValue(navigate);
+        const user = userEvent.setup();
+
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0' });
+
+        await user.click(screen.getByRole('button', { name: /browse the hub/i }));
+
+        expect(navigate).toHaveBeenCalledWith('/');
+    });
+
+    it('falls back to the parent id when the crumb has no display name', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'ml-scoring-service', version: '1.0.0' },
+        ];
+
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0', breadcrumbs: crumbs });
+
+        expect(screen.getByRole('button', { name: 'Back to ml-scoring-service' })).toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.test.tsx
+++ b/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.test.tsx
@@ -25,12 +25,29 @@ function renderAt(props: Parameters<typeof ResourceNotFound>[0]) {
 
 describe('ResourceNotFound', () => {
     it('echoes the requested resource and always offers the hub root', () => {
-        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0' });
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0', type: 'architectures' });
 
         expect(screen.getByText('Architecture not found')).toBeInTheDocument();
         expect(screen.getByText('finos/model-registry@1.0.0')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /browse the hub/i })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /back to/i })).not.toBeInTheDocument();
+    });
+
+    it('derives the heading noun from the route type', () => {
+        const { rerender } = renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0', type: 'architectures' });
+        expect(screen.getByText('Architecture not found')).toBeInTheDocument();
+
+        rerender(
+            <MemoryRouter>
+                <ResourceNotFound namespace="finos" id="api-gateway" version="1.0.0" type="patterns" />
+            </MemoryRouter>
+        );
+        expect(screen.getByText('Pattern not found')).toBeInTheDocument();
+    });
+
+    it('falls back to a neutral noun for an unknown or absent type', () => {
+        renderAt({ namespace: 'finos', id: 'model-registry', version: '1.0.0' });
+        expect(screen.getByText('Resource not found')).toBeInTheDocument();
     });
 
     it('navigates to the parent crumb with the trail sliced, mirroring a breadcrumb click', async () => {

--- a/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.tsx
+++ b/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.tsx
@@ -7,8 +7,25 @@ interface ResourceNotFoundProps {
     namespace: string;
     id: string;
     version: string;
+    /**
+     * The route resource type (`architectures` | `patterns`); drives the heading noun.
+     * Any other/absent value falls back to the neutral "Resource".
+     */
+    type?: string;
     /** Breadcrumb trail from history state; when present the primary action returns to the last crumb. */
     breadcrumbs?: BreadcrumbItem[];
+}
+
+/** Human-readable, singular noun for the not-found heading, derived from the route type. */
+function resourceNoun(type: string | undefined): string {
+    switch (type) {
+        case 'architectures':
+            return 'Architecture';
+        case 'patterns':
+            return 'Pattern';
+        default:
+            return 'Resource';
+    }
 }
 
 /**
@@ -18,7 +35,7 @@ interface ResourceNotFoundProps {
  * user always has a recovery path: back to the parent architecture when a
  * breadcrumb trail exists (in-app navigation), otherwise back to the hub root.
  */
-export function ResourceNotFound({ namespace, id, version, breadcrumbs }: ResourceNotFoundProps) {
+export function ResourceNotFound({ namespace, id, version, type, breadcrumbs }: ResourceNotFoundProps) {
     const navigate = useNavigate();
     const parent = breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1] : undefined;
 
@@ -35,7 +52,7 @@ export function ResourceNotFound({ namespace, id, version, breadcrumbs }: Resour
         <div className="flex items-center justify-center h-full bg-base-200 p-6">
             <div className="bg-base-100 rounded-box shadow-xl p-8 max-w-md text-center flex flex-col items-center gap-3">
                 <IoAlertCircleOutline size={40} className="text-warning" aria-hidden="true" />
-                <h2 className="text-lg font-semibold">Architecture not found</h2>
+                <h2 className="text-lg font-semibold">{resourceNoun(type)} not found</h2>
                 <p className="text-sm text-base-content/70">
                     <span className="font-mono break-all">
                         {namespace}/{id}@{version}

--- a/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.tsx
+++ b/calm-hub-ui/src/hub/components/resource-not-found/ResourceNotFound.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom';
+import { IoArrowBackOutline, IoAlertCircleOutline, IoHomeOutline } from 'react-icons/io5';
+import { BreadcrumbItem } from '../../../model/calm.js';
+
+interface ResourceNotFoundProps {
+    /** The route segments that failed to load, echoed back so the user sees what was requested. */
+    namespace: string;
+    id: string;
+    version: string;
+    /** Breadcrumb trail from history state; when present the primary action returns to the last crumb. */
+    breadcrumbs?: BreadcrumbItem[];
+}
+
+/**
+ * Inline not-found state for the item-detail route, shown when the routed
+ * resource fails to load (dangling detailed-architecture reference, stale deep
+ * link, deleted resource). Rendered in place of the blank detail pane so the
+ * user always has a recovery path: back to the parent architecture when a
+ * breadcrumb trail exists (in-app navigation), otherwise back to the hub root.
+ */
+export function ResourceNotFound({ namespace, id, version, breadcrumbs }: ResourceNotFoundProps) {
+    const navigate = useNavigate();
+    const parent = breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1] : undefined;
+
+    const goToParent = () => {
+        if (!parent) return;
+        // Mirror SectionHeader's breadcrumb click: the trail on the parent entry
+        // excludes the parent itself.
+        navigate(`/${parent.namespace}/${parent.type}/${parent.id}/${parent.version}`, {
+            state: { breadcrumbs: breadcrumbs!.slice(0, -1) },
+        });
+    };
+
+    return (
+        <div className="flex items-center justify-center h-full bg-base-200 p-6">
+            <div className="bg-base-100 rounded-box shadow-xl p-8 max-w-md text-center flex flex-col items-center gap-3">
+                <IoAlertCircleOutline size={40} className="text-warning" aria-hidden="true" />
+                <h2 className="text-lg font-semibold">Architecture not found</h2>
+                <p className="text-sm text-base-content/70">
+                    <span className="font-mono break-all">
+                        {namespace}/{id}@{version}
+                    </span>{' '}
+                    could not be loaded. It may not exist yet, or the reference pointing here may be out of
+                    date.
+                </p>
+                <div className="flex flex-wrap items-center justify-center gap-2 mt-2">
+                    {parent && (
+                        <button className="btn btn-primary btn-sm" onClick={goToParent}>
+                            <IoArrowBackOutline aria-hidden="true" />
+                            Back to {parent.name || parent.id}
+                        </button>
+                    )}
+                    <button className={`btn btn-sm ${parent ? 'btn-ghost' : 'btn-primary'}`} onClick={() => navigate('/')}>
+                        <IoHomeOutline aria-hidden="true" />
+                        Browse the hub
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { BreadcrumbTrail } from './BreadcrumbTrail.js';
+import { BreadcrumbItem } from '../../../model/calm.js';
+
+const threeCrumbs: BreadcrumbItem[] = [
+    { namespace: 'finos', type: 'architectures', id: 'level-1', version: '1.0.0' },
+    { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+    { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+];
+
+describe('BreadcrumbTrail', () => {
+    it('renders nothing for an empty trail', () => {
+        const { container } = render(<BreadcrumbTrail breadcrumbs={[]} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('closes the ellipsis dropdown on Escape and returns focus to the trigger', async () => {
+        const user = userEvent.setup();
+        render(<BreadcrumbTrail breadcrumbs={threeCrumbs} />);
+
+        const trigger = screen.getByRole('button', { name: 'Show hidden breadcrumbs' });
+        await user.click(trigger);
+        expect(screen.getByRole('button', { name: 'level-2' })).toBeInTheDocument();
+
+        await user.keyboard('{Escape}');
+
+        expect(screen.queryByRole('button', { name: 'level-2' })).not.toBeInTheDocument();
+        expect(trigger).toHaveFocus();
+    });
+
+    it('reports the original index for a crumb chosen from the dropdown', async () => {
+        const user = userEvent.setup();
+        const onBreadcrumbClick = vi.fn();
+        render(<BreadcrumbTrail breadcrumbs={threeCrumbs} onBreadcrumbClick={onBreadcrumbClick} />);
+
+        await user.click(screen.getByRole('button', { name: 'Show hidden breadcrumbs' }));
+        await user.click(screen.getByRole('button', { name: 'level-2' }));
+
+        expect(onBreadcrumbClick).toHaveBeenCalledWith(threeCrumbs[1], 1);
+    });
+});

--- a/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.test.tsx
@@ -40,4 +40,13 @@ describe('BreadcrumbTrail', () => {
 
         expect(onBreadcrumbClick).toHaveBeenCalledWith(threeCrumbs[1], 1);
     });
+
+    it('gives the immediate-parent (last) crumb a wider truncation cap than the first', () => {
+        render(<BreadcrumbTrail breadcrumbs={threeCrumbs} />);
+
+        // The last crumb is the primary "go back" target, so it is capped wider
+        // (12rem) than the first/middle crumbs (8rem) to stay readable.
+        expect(screen.getByRole('button', { name: 'level-1' })).toHaveClass('max-w-[8rem]');
+        expect(screen.getByRole('button', { name: 'level-3' })).toHaveClass('max-w-[12rem]');
+    });
 });

--- a/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react';
+import { BreadcrumbItem } from '../../../model/calm.js';
+
+interface BreadcrumbTrailProps {
+    breadcrumbs: BreadcrumbItem[];
+    onBreadcrumbClick?: (crumb: BreadcrumbItem, index: number) => void;
+}
+
+function CrumbButton({ crumb, onClick }: { crumb: BreadcrumbItem; onClick: () => void }) {
+    return (
+        <button
+            onClick={onClick}
+            className="text-accent hover:underline max-w-[8rem] truncate shrink-0"
+            title={crumb.name || crumb.id}
+        >
+            {crumb.name || crumb.id}
+        </button>
+    );
+}
+
+function Separator() {
+    return (
+        <>
+            {' '}
+            <span className="text-base-content/40">/</span>{' '}
+        </>
+    );
+}
+
+/**
+ * Parent-architecture trail rendered before the current resource's own
+ * namespace/id trail in the SectionHeader heading. More than two crumbs
+ * collapse to `first / … / last`, with the hidden middle reachable through the
+ * ellipsis dropdown (outside click or Escape closes it; Escape returns focus to
+ * the trigger).
+ */
+export function BreadcrumbTrail({ breadcrumbs, onBreadcrumbClick }: BreadcrumbTrailProps) {
+    const [ellipsisOpen, setEllipsisOpen] = useState(false);
+    const ellipsisRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (!ellipsisOpen) return;
+        function handleClickOutside(e: MouseEvent) {
+            if (ellipsisRef.current && !ellipsisRef.current.contains(e.target as Node)) {
+                setEllipsisOpen(false);
+            }
+        }
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                setEllipsisOpen(false);
+                triggerRef.current?.focus();
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [ellipsisOpen]);
+
+    if (breadcrumbs.length === 0) return null;
+
+    const first = breadcrumbs[0];
+    const last = breadcrumbs[breadcrumbs.length - 1];
+    const lastIndex = breadcrumbs.length - 1;
+    const hasEllipsis = breadcrumbs.length > 2;
+    const hiddenCrumbs = breadcrumbs.slice(1, -1);
+
+    return (
+        <>
+            <CrumbButton crumb={first} onClick={() => onBreadcrumbClick?.(first, 0)} />
+            <Separator />
+            {hasEllipsis && (
+                <>
+                    <div className="relative shrink-0" ref={ellipsisRef}>
+                        <button
+                            ref={triggerRef}
+                            onClick={() => setEllipsisOpen((o) => !o)}
+                            className="text-base-content/40 hover:text-base-content px-1 rounded hover:bg-base-300 transition-colors"
+                            aria-label="Show hidden breadcrumbs"
+                            aria-expanded={ellipsisOpen}
+                            aria-haspopup="true"
+                        >
+                            …
+                        </button>
+                        {ellipsisOpen && (
+                            <div className="absolute top-full left-0 mt-1 z-50 bg-base-100 border border-base-300 rounded-lg shadow-lg py-1 min-w-[10rem]">
+                                {hiddenCrumbs.map((crumb, i) => (
+                                    <button
+                                        key={i}
+                                        onClick={() => {
+                                            onBreadcrumbClick?.(crumb, i + 1);
+                                            setEllipsisOpen(false);
+                                        }}
+                                        className="w-full text-left px-3 py-1.5 text-sm text-accent hover:bg-base-200 truncate block"
+                                        title={crumb.name || crumb.id}
+                                    >
+                                        {crumb.name || crumb.id}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                    <Separator />
+                </>
+            )}
+            {breadcrumbs.length > 1 && (
+                <>
+                    <CrumbButton crumb={last} onClick={() => onBreadcrumbClick?.(last, lastIndex)} />
+                    <Separator />
+                </>
+            )}
+        </>
+    );
+}

--- a/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/BreadcrumbTrail.tsx
@@ -6,11 +6,22 @@ interface BreadcrumbTrailProps {
     onBreadcrumbClick?: (crumb: BreadcrumbItem, index: number) => void;
 }
 
-function CrumbButton({ crumb, onClick }: { crumb: BreadcrumbItem; onClick: () => void }) {
+function CrumbButton({
+    crumb,
+    onClick,
+    // The immediate parent (last crumb) is the primary "go back" target, so it
+    // gets a wider cap than the first/middle crumbs to avoid collapsing a long
+    // name into a bare, ambiguous ellipsis.
+    maxWidthClass = 'max-w-[8rem]',
+}: {
+    crumb: BreadcrumbItem;
+    onClick: () => void;
+    maxWidthClass?: string;
+}) {
     return (
         <button
             onClick={onClick}
-            className="text-accent hover:underline max-w-[8rem] truncate shrink-0"
+            className={`text-accent hover:underline ${maxWidthClass} truncate shrink-0`}
             title={crumb.name || crumb.id}
         >
             {crumb.name || crumb.id}
@@ -108,7 +119,7 @@ export function BreadcrumbTrail({ breadcrumbs, onBreadcrumbClick }: BreadcrumbTr
             )}
             {breadcrumbs.length > 1 && (
                 <>
-                    <CrumbButton crumb={last} onClick={() => onBreadcrumbClick?.(last, lastIndex)} />
+                    <CrumbButton crumb={last} onClick={() => onBreadcrumbClick?.(last, lastIndex)} maxWidthClass="max-w-[12rem]" />
                     <Separator />
                 </>
             )}

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SectionHeader } from './SectionHeader.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import type { BreadcrumbItem } from '../../../model/calm.js';
 
 describe('SectionHeader', () => {
     it('renders icon, namespace, id, and version', () => {
@@ -142,5 +144,234 @@ describe('SectionHeader', () => {
         );
 
         expect(screen.queryByTestId('share-bar')).not.toBeInTheDocument();
+    });
+
+    it('renders a single breadcrumb as a button before the current trail', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'patterns', id: 'api-gateway-pattern', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="api-platform"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        const heading = screen.getByRole('heading');
+        expect(heading).toHaveTextContent('api-gateway-pattern');
+        expect(heading).toHaveTextContent('api-platform');
+        expect(screen.queryByText('…')).not.toBeInTheDocument();
+    });
+
+    it('renders two breadcrumbs as two buttons with no ellipsis', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'microservices-platform', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'backend-services', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="order-service"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        const heading = screen.getByRole('heading');
+        expect(heading).toHaveTextContent('microservices-platform');
+        expect(heading).toHaveTextContent('backend-services');
+        expect(screen.queryByText('…')).not.toBeInTheDocument();
+    });
+
+    it('collapses middle breadcrumbs into an ellipsis when there are more than two', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'level-1', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="level-4"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'level-1' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'level-3' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'level-2' })).not.toBeInTheDocument();
+        expect(screen.getByText('…')).toBeInTheDocument();
+    });
+
+    it('calls onBreadcrumbClick with the correct crumb and index when a breadcrumb is clicked', async () => {
+        const user = userEvent.setup();
+        const onBreadcrumbClick = vi.fn();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'patterns', id: 'api-gateway-pattern', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="api-platform"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+                onBreadcrumbClick={onBreadcrumbClick}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'api-gateway-pattern' }));
+        expect(onBreadcrumbClick).toHaveBeenCalledWith(crumbs[0], 0);
+    });
+
+    it('collapses to first and last and navigates to the last crumb when clicked with 3+ breadcrumbs', async () => {
+        const user = userEvent.setup();
+        const onBreadcrumbClick = vi.fn();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'root', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'middle', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'parent', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="current"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+                onBreadcrumbClick={onBreadcrumbClick}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'parent' }));
+        expect(onBreadcrumbClick).toHaveBeenCalledWith(crumbs[2], 2);
+    });
+
+    it('opens a dropdown with hidden breadcrumbs when the ellipsis is clicked', async () => {
+        const user = userEvent.setup();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'level-1', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="level-4"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        expect(screen.queryByRole('button', { name: 'level-2' })).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Show hidden breadcrumbs' }));
+
+        expect(screen.getByRole('button', { name: 'level-2' })).toBeInTheDocument();
+    });
+
+    it('calls onBreadcrumbClick with the correct crumb and index when a dropdown item is clicked', async () => {
+        const user = userEvent.setup();
+        const onBreadcrumbClick = vi.fn();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'level-1', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="level-4"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+                onBreadcrumbClick={onBreadcrumbClick}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Show hidden breadcrumbs' }));
+        await user.click(screen.getByRole('button', { name: 'level-2' }));
+
+        expect(onBreadcrumbClick).toHaveBeenCalledWith(crumbs[1], 1);
+        expect(screen.queryByRole('button', { name: 'level-2' })).not.toBeInTheDocument();
+    });
+
+    it('closes the dropdown when clicking outside', async () => {
+        const user = userEvent.setup();
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: 'level-1', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="level-4"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Show hidden breadcrumbs' }));
+        expect(screen.getByRole('button', { name: 'level-2' })).toBeInTheDocument();
+
+        await user.click(document.body);
+        expect(screen.queryByRole('button', { name: 'level-2' })).not.toBeInTheDocument();
+    });
+
+    // Long trails must fit narrow (mobile) viewports. The header has no JS
+    // viewport branching — mobile fit is pure CSS — so this locks the two
+    // structural affordances that make it work: the heading wraps
+    // (`flex-wrap`), and every crumb is width-capped and truncated with a
+    // title tooltip carrying the full text. jsdom cannot measure layout;
+    // the visual check at a real mobile width stays a manual step.
+    it('keeps the heading wrappable and long crumbs truncated so deep trails fit narrow viewports', () => {
+        const longId = 'a-very-long-architecture-identifier-that-would-overflow-a-phone-screen';
+        const crumbs: BreadcrumbItem[] = [
+            { namespace: 'finos', type: 'architectures', id: longId, version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-2', version: '1.0.0' },
+            { namespace: 'finos', type: 'architectures', id: 'level-3', version: '1.0.0' },
+        ];
+
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="finos"
+                id="level-4"
+                version="1.0.0"
+                typeSegment="architectures"
+                breadcrumbs={crumbs}
+            />
+        );
+
+        expect(screen.getByRole('heading')).toHaveClass('flex-wrap');
+
+        const crumbButton = screen.getByRole('button', { name: longId });
+        expect(crumbButton).toHaveClass('truncate', 'max-w-[8rem]');
+        expect(crumbButton).toHaveAttribute('title', longId);
     });
 });

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 import { IoCopyOutline, IoCheckmarkOutline, IoLinkOutline } from 'react-icons/io5';
-import { isSlug } from '../../../model/calm.js';
+import { BreadcrumbItem, isSlug } from '../../../model/calm.js';
+import { BreadcrumbTrail } from './BreadcrumbTrail.js';
 
 interface SectionHeaderProps {
     icon: ReactNode;
@@ -21,9 +22,12 @@ interface SectionHeaderProps {
     displayName?: string;
     /** Element type label inserted into the trail (e.g. "Architecture"). */
     typeLabel?: string;
+    /** Parent breadcrumbs to render as clickable items before the current trail. */
+    breadcrumbs?: BreadcrumbItem[];
+    onBreadcrumbClick?: (crumb: BreadcrumbItem, index: number) => void;
 }
 
-export function SectionHeader({ icon, namespace, id, version, typeSegment, rightContent, versions, onVersionChange, titleActions, showVersion = true, displayName, typeLabel }: SectionHeaderProps) {
+export function SectionHeader({ icon, namespace, id, version, typeSegment, rightContent, versions, onVersionChange, titleActions, showVersion = true, displayName, typeLabel, breadcrumbs, onBreadcrumbClick }: SectionHeaderProps) {
     const [copied, setCopied] = useState(false);
     const showShareBar = isSlug(id);
     const shareUrl = `${window.location.origin}/calm/namespaces/${encodeURIComponent(namespace)}/${typeSegment}/${encodeURIComponent(id)}/versions/${encodeURIComponent(version)}`;
@@ -40,6 +44,7 @@ export function SectionHeader({ icon, namespace, id, version, typeSegment, right
             <div className="bg-base-200 px-4 sm:px-6 py-3 sm:py-4 flex flex-wrap items-center justify-between gap-2 border-b border-base-300">
                 <h2 className="text-base sm:text-xl font-semibold flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0">
                     {icon}
+                    {breadcrumbs && <BreadcrumbTrail breadcrumbs={breadcrumbs} onBreadcrumbClick={onBreadcrumbClick} />}
                     {namespace}
                     {typeLabel && (
                         <>
@@ -73,7 +78,7 @@ export function SectionHeader({ icon, namespace, id, version, typeSegment, right
                     )}
                     {titleActions}
                 </h2>
-                {rightContent}
+                {rightContent && <div className="shrink-0">{rightContent}</div>}
             </div>
             {showShareBar && (
                 <div className="bg-base-200 px-4 sm:px-6 py-2 flex items-center gap-2 border-b border-base-300" data-testid="share-bar">

--- a/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.test.ts
+++ b/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resolveResourceDetailPath } from './navigation-loaders.js';
+import { loadResource, loadResourceForId, resolveResourceDetailPath } from './navigation-loaders.js';
 import { CalmService } from '../../../service/calm-service.js';
 import { AdrService } from '../../../service/adr-service/adr-service.js';
 
@@ -33,5 +33,66 @@ describe('resolveResourceDetailPath', () => {
         const path = await resolveResourceDetailPath('1', 'Architectures', 'traderx', calmService, adrService);
 
         expect(path).toBeNull();
+    });
+});
+
+describe('loadResource error handling', () => {
+    it('invokes onError when the architecture fetch rejects', async () => {
+        const error = new Error('404');
+        const calmService = {
+            fetchArchitecture: vi.fn().mockRejectedValue(error),
+        } as unknown as CalmService;
+        const adrService = {} as AdrService;
+        const onDataLoad = vi.fn();
+        const onError = vi.fn();
+
+        loadResource({
+            version: '1.0.0',
+            type: 'Architectures',
+            namespace: 'finos',
+            resourceID: '1',
+            calmService,
+            onDataLoad,
+            onAdrLoad: vi.fn(),
+            adrService,
+            onError,
+        });
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(error));
+        expect(onDataLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not reject unhandled when the fetch rejects and no onError is given', async () => {
+        const calmService = {
+            fetchPattern: vi.fn().mockRejectedValue(new Error('404')),
+        } as unknown as CalmService;
+
+        loadResource({
+            version: '1.0.0',
+            type: 'Patterns',
+            namespace: 'finos',
+            resourceID: '1',
+            calmService,
+            onDataLoad: vi.fn(),
+            onAdrLoad: vi.fn(),
+            adrService: {} as AdrService,
+        });
+        // Flush the rejection; an unhandled rejection would fail the test run.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+});
+
+describe('loadResourceForId error handling', () => {
+    it('invokes onError when the custom-id fetch rejects', async () => {
+        const error = new Error('404');
+        const calmService = {
+            fetchResourceByCustomId: vi.fn().mockRejectedValue(error),
+        } as unknown as CalmService;
+        const onDataLoad = vi.fn();
+        const onError = vi.fn();
+
+        loadResourceForId('1.0.0', 'Architectures', 'finos', 'model-registry', calmService, onDataLoad, onError);
+
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(error));
+        expect(onDataLoad).not.toHaveBeenCalled();
     });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.ts
+++ b/calm-hub-ui/src/hub/components/tree-navigation/navigation-loaders.ts
@@ -15,6 +15,8 @@ export interface LoadResourceOptions {
     onDataLoad: (data: Data) => void;
     onAdrLoad: (adr: Adr) => void;
     adrService: AdrService;
+    /** Invoked when the resource fetch rejects (e.g. the resource does not exist). */
+    onError?: (error: unknown) => void;
 }
 
 export function mapTypeInUrlToTypeInUI(urlType: TypeInUrl): TypeInUI {
@@ -66,9 +68,13 @@ export function loadResourceForId(
     resourceID: string,
     calmService: CalmService,
     onDataLoad: (data: Data) => void,
+    onError?: (error: unknown) => void,
 ) {
     if (isSlug(resourceID)) {
-        calmService.fetchResourceByCustomId(namespace, resourceID, version, type).then(onDataLoad);
+        calmService
+            .fetchResourceByCustomId(namespace, resourceID, version, type)
+            .then(onDataLoad)
+            .catch((error) => onError?.(error));
     }
 }
 
@@ -138,16 +144,18 @@ export function loadResource({
     onDataLoad,
     onAdrLoad,
     adrService,
+    onError,
 }: LoadResourceOptions) {
+    const handleError = (error: unknown) => onError?.(error);
     if (type === 'Architectures') {
-        calmService.fetchArchitecture(namespace, resourceID, version).then(onDataLoad);
+        calmService.fetchArchitecture(namespace, resourceID, version).then(onDataLoad).catch(handleError);
     } else if (type === 'Patterns') {
-        calmService.fetchPattern(namespace, resourceID, version).then(onDataLoad);
+        calmService.fetchPattern(namespace, resourceID, version).then(onDataLoad).catch(handleError);
     } else if (type === 'Flows') {
-        calmService.fetchFlow(namespace, resourceID, version).then(onDataLoad);
+        calmService.fetchFlow(namespace, resourceID, version).then(onDataLoad).catch(handleError);
     } else if (type === 'Standards') {
-        calmService.fetchStandard(namespace, resourceID, version).then(onDataLoad);
+        calmService.fetchStandard(namespace, resourceID, version).then(onDataLoad).catch(handleError);
     } else if (type === 'ADRs') {
-        adrService.fetchAdr(namespace, resourceID, version).then(onAdrLoad);
+        adrService.fetchAdr(namespace, resourceID, version).then(onAdrLoad).catch(handleError);
     }
 }

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
@@ -146,3 +146,61 @@ describe('useResourceFromRoute — load failures', () => {
         expect(callbacks.onDataLoad).not.toHaveBeenCalled();
     });
 });
+
+describe('useResourceFromRoute — stale results after navigation', () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('drops a late numeric-id success that resolves after cleanup', async () => {
+        let emitData: ((data: unknown) => void) | undefined;
+        vi.spyOn(loaders, 'loadResource').mockImplementation(({ onDataLoad }) => {
+            emitData = onDataLoad as (data: unknown) => void;
+        });
+        const { unmount } = renderAt('/finos/architectures/42/1.0.0');
+        await waitFor(() => expect(emitData).toBeDefined());
+
+        unmount();
+        emitData!({ id: 'stale' });
+
+        expect(callbacks.onDataLoad).not.toHaveBeenCalled();
+    });
+
+    it('drops a late slug success that resolves after cleanup', async () => {
+        let emitData: ((data: unknown) => void) | undefined;
+        vi.spyOn(loaders, 'loadResourceForId').mockImplementation(
+            (_version, _type, _ns, _id, _svc, onData) => {
+                emitData = onData as (data: unknown) => void;
+            }
+        );
+        const { unmount } = renderAt('/finos/architectures/my-arch/1.0.0');
+        await waitFor(() => expect(emitData).toBeDefined());
+
+        unmount();
+        emitData!({ id: 'stale' });
+
+        expect(callbacks.onDataLoad).not.toHaveBeenCalled();
+    });
+
+    it('drops a late interface success that resolves after cleanup', async () => {
+        let resolveInterfaces: (value: unknown) => void = () => undefined;
+        fetchInterfacesForNamespace.mockReturnValue(new Promise((resolve) => { resolveInterfaces = resolve; }));
+        const { unmount } = renderAt('/traderx/interfaces/7/detail');
+
+        unmount();
+        resolveInterfaces([{ id: 7, name: 'My Interface', description: 'desc' }]);
+        await flush();
+
+        expect(callbacks.onInterfaceLoad).not.toHaveBeenCalled();
+    });
+
+    it('drops a late control success that resolves after cleanup', async () => {
+        let resolveControls: (value: unknown) => void = () => undefined;
+        fetchControlsForDomain.mockReturnValue(new Promise((resolve) => { resolveControls = resolve; }));
+        const { unmount } = renderAt('/security/controls/5/detail');
+
+        unmount();
+        resolveControls([{ id: 5, name: 'Encryption', description: 'desc' }]);
+        await flush();
+
+        expect(callbacks.onControlLoad).not.toHaveBeenCalled();
+    });
+});

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
@@ -21,6 +21,7 @@ const callbacks = {
     onAdrLoad: vi.fn(),
     onControlLoad: vi.fn(),
     onInterfaceLoad: vi.fn(),
+    onLoadError: vi.fn(),
 };
 
 function Harness() {
@@ -73,6 +74,7 @@ describe('useResourceFromRoute', () => {
                 'traderx',
                 'my-arch',
                 expect.anything(),
+                expect.any(Function),
                 expect.any(Function)
             );
         });
@@ -120,5 +122,27 @@ describe('useResourceFromRoute', () => {
                 controlTitle: 'Encryption at rest',
             });
         });
+    });
+});
+
+describe('useResourceFromRoute — load failures', () => {
+    it('reports a failed slug load through onLoadError', async () => {
+        vi.spyOn(loaders, 'loadResourceForId').mockImplementation(
+            (_version, _type, _ns, _id, _svc, _onData, onError) => {
+                onError?.(new Error('404'));
+            }
+        );
+        renderAt('/finos/architectures/model-registry/1.0.0');
+        await waitFor(() => expect(callbacks.onLoadError).toHaveBeenCalled());
+        expect(callbacks.onDataLoad).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed numeric-id load through onLoadError', async () => {
+        vi.spyOn(loaders, 'loadResource').mockImplementation(({ onError }) => {
+            onError?.(new Error('404'));
+        });
+        renderAt('/finos/architectures/42/1.0.0');
+        await waitFor(() => expect(callbacks.onLoadError).toHaveBeenCalled());
+        expect(callbacks.onDataLoad).not.toHaveBeenCalled();
     });
 });

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
@@ -26,6 +26,13 @@ interface UseResourceFromRouteOptions {
     onAdrLoad: (adr: Adr) => void;
     onControlLoad: (control: ControlData) => void;
     onInterfaceLoad: (iface: InterfaceData) => void;
+    /**
+     * Invoked when the routed resource fails to load (e.g. a deep link or a
+     * detailed-architecture reference to a resource that does not exist), so the
+     * page can show a not-found state instead of an empty pane. Never invoked
+     * for a load started for a previous route. Expected stable (memoised).
+     */
+    onLoadError?: (error: unknown) => void;
 }
 
 /**
@@ -44,6 +51,7 @@ export function useResourceFromRoute({
     onAdrLoad,
     onControlLoad,
     onInterfaceLoad,
+    onLoadError,
 }: UseResourceFromRouteOptions) {
     const params = useParams<HubParams>();
 
@@ -61,6 +69,13 @@ export function useResourceFromRoute({
         if (!(params.namespace && params.type && params.id && params.version)) return;
         const uiType = mapTypeInUrlToTypeInUI(params.type);
         const namespace = params.namespace;
+
+        // The loaders have no cancellation, so a rejection can arrive after the
+        // user has already navigated on; only report errors for the current route.
+        let cancelled = false;
+        const reportError = (error: unknown) => {
+            if (!cancelled) onLoadError?.(error);
+        };
 
         if (uiType === 'Interfaces') {
             interfaceService
@@ -102,7 +117,7 @@ export function useResourceFromRoute({
         }
 
         if (isSlug(params.id)) {
-            loadResourceForId(params.version, uiType, namespace, params.id, calmService, onDataLoad);
+            loadResourceForId(params.version, uiType, namespace, params.id, calmService, onDataLoad, reportError);
         } else {
             loadResource({
                 version: params.version,
@@ -113,7 +128,11 @@ export function useResourceFromRoute({
                 onDataLoad,
                 onAdrLoad,
                 adrService,
+                onError: reportError,
             });
         }
-    }, [params, calmService, adrService, interfaceService, controlService, onDataLoad, onAdrLoad]);
+        return () => {
+            cancelled = true;
+        };
+    }, [params, calmService, adrService, interfaceService, controlService, onDataLoad, onAdrLoad, onLoadError]);
 }

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
@@ -70,17 +70,29 @@ export function useResourceFromRoute({
         const uiType = mapTypeInUrlToTypeInUI(params.type);
         const namespace = params.namespace;
 
-        // The loaders have no cancellation, so a rejection can arrive after the
-        // user has already navigated on; only report errors for the current route.
+        // The loaders have no cancellation, so a promise can settle after the user
+        // has already navigated on. Guard every callback behind `cancelled` (flipped
+        // by the cleanup) so a stale result from a previous route neither renders the
+        // wrong resource nor reports a spurious error.
         let cancelled = false;
+        const cleanup = () => {
+            cancelled = true;
+        };
         const reportError = (error: unknown) => {
             if (!cancelled) onLoadError?.(error);
+        };
+        const emitData = (data: Data) => {
+            if (!cancelled) onDataLoad(data);
+        };
+        const emitAdr = (adr: Adr) => {
+            if (!cancelled) onAdrLoad(adr);
         };
 
         if (uiType === 'Interfaces') {
             interfaceService
                 .fetchInterfacesForNamespace(namespace)
                 .then((interfaces) => {
+                    if (cancelled) return;
                     const match = interfaces.find((i) => i.id === Number(params.id));
                     if (match) {
                         onInterfaceLoadRef.current({
@@ -92,13 +104,14 @@ export function useResourceFromRoute({
                     }
                 })
                 .catch(() => undefined);
-            return;
+            return cleanup;
         }
 
         if (uiType === 'Controls') {
             controlService
                 .fetchControlsForDomain(namespace)
                 .then((controls) => {
+                    if (cancelled) return;
                     // Controls are deep-linked both by numeric id (mobile drill-down) and by
                     // name slug (global/Explorer search -> /controls/<name>/detail), so match either.
                     const match = controls.find((c) => String(c.id) === params.id || c.name === params.id);
@@ -113,11 +126,11 @@ export function useResourceFromRoute({
                     }
                 })
                 .catch(() => undefined);
-            return;
+            return cleanup;
         }
 
         if (isSlug(params.id)) {
-            loadResourceForId(params.version, uiType, namespace, params.id, calmService, onDataLoad, reportError);
+            loadResourceForId(params.version, uiType, namespace, params.id, calmService, emitData, reportError);
         } else {
             loadResource({
                 version: params.version,
@@ -125,14 +138,12 @@ export function useResourceFromRoute({
                 namespace,
                 resourceID: params.id,
                 calmService,
-                onDataLoad,
-                onAdrLoad,
+                onDataLoad: emitData,
+                onAdrLoad: emitAdr,
                 adrService,
                 onError: reportError,
             });
         }
-        return () => {
-            cancelled = true;
-        };
+        return cleanup;
     }, [params, calmService, adrService, interfaceService, controlService, onDataLoad, onAdrLoad, onLoadError]);
 }

--- a/calm-hub-ui/src/model/calm.ts
+++ b/calm-hub-ui/src/model/calm.ts
@@ -61,6 +61,15 @@ export interface AdrSummary {
     status: string;
 }
 
+export interface BreadcrumbItem {
+    namespace: string;
+    type: 'architectures' | 'patterns';
+    id: string;
+    version: string;
+    /** Human-readable display name; falls back to id when absent. */
+    name?: string;
+}
+
 export type Data =
     | {
         id: string;

--- a/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CustomNode } from './CustomNode.js';
+import { DiagramActionsContext } from '../../context/DiagramActionsContext.js';
+
+vi.mock('reactflow', () => ({
+    Handle: () => null,
+    Position: { Right: 'right', Left: 'left' },
+}));
+
+function makeNodeProps(details?: Record<string, unknown>) {
+    return {
+        id: 'node-1',
+        type: 'custom',
+        selected: false,
+        zIndex: 0,
+        isConnectable: true,
+        xPos: 0,
+        yPos: 0,
+        dragging: false,
+        data: {
+            label: 'Test Node',
+            description: 'A test node',
+            'node-type': 'service',
+            details,
+        },
+    };
+}
+
+function renderNode(props: ReturnType<typeof makeNodeProps>, onNavigateToDetailedArch?: (ref: string) => void) {
+    return render(
+        <DiagramActionsContext.Provider value={{ onNavigateToDetailedArch }}>
+            <CustomNode {...props} />
+        </DiagramActionsContext.Provider>
+    );
+}
+
+describe('CustomNode — external URL support', () => {
+    let openSpy: ReturnType<typeof vi.fn>;
+    const originalOpen = window.open;
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+        openSpy = vi.fn();
+        window.open = openSpy as unknown as typeof window.open;
+    });
+
+    afterEach(() => {
+        window.open = originalOpen;
+        Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    });
+
+    function setHostname(hostname: string) {
+        Object.defineProperty(window, 'location', {
+            value: { ...originalLocation, hostname },
+            writable: true,
+        });
+    }
+
+    function hoverNode() {
+        fireEvent.mouseEnter(screen.getByTestId('custom-node'));
+    }
+
+    it('renders "Open Architecture" button and auth warning for https:// URLs on a different hostname', () => {
+        const props = makeNodeProps({ 'detailed-architecture': 'https://calm-hub.example.com/architectures/my-arch' });
+        renderNode(props);
+
+        hoverNode();
+        expect(screen.getByText('Open Architecture')).toBeInTheDocument();
+        expect(screen.getByText('External resource — may require authentication')).toBeInTheDocument();
+    });
+
+    it('opens the URL in a new tab when "Open Architecture" is clicked', () => {
+        const url = 'https://calm-hub.example.com/architectures/my-arch';
+        const props = makeNodeProps({ 'detailed-architecture': url });
+        renderNode(props);
+
+        hoverNode();
+        fireEvent.click(screen.getByText('Open Architecture'));
+
+        expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener,noreferrer');
+    });
+
+    it('renders "Explore Architecture" for same-hostname absolute URLs even on a different port', () => {
+        setHostname('localhost');
+        const navigate = vi.fn();
+        const props = makeNodeProps({ 'detailed-architecture': 'http://localhost:8080/calm/namespaces/finos/architectures/my-arch/versions/1.0.0' });
+        renderNode(props, navigate);
+
+        hoverNode();
+        expect(screen.getByText('Explore Architecture')).toBeInTheDocument();
+        expect(screen.queryByText('Open Architecture')).not.toBeInTheDocument();
+    });
+
+    it('calls onNavigateToDetailedArch with only the pathname for same-hostname absolute URLs', () => {
+        setHostname('localhost');
+        const navigate = vi.fn();
+        const props = makeNodeProps({ 'detailed-architecture': 'http://localhost:8080/calm/namespaces/finos/architectures/my-arch/versions/1.0.0' });
+        renderNode(props, navigate);
+
+        hoverNode();
+        fireEvent.click(screen.getByText('Explore Architecture'));
+
+        expect(navigate).toHaveBeenCalledWith('/calm/namespaces/finos/architectures/my-arch/versions/1.0.0');
+        expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('renders "Open Architecture" for http:// URLs on a different hostname', () => {
+        setHostname('localhost');
+        const props = makeNodeProps({ 'detailed-architecture': 'http://calm-hub.other.com/calm/namespaces/finos/architectures/my-arch/versions/1.0.0' });
+        renderNode(props);
+
+        hoverNode();
+        expect(screen.getByText('Open Architecture')).toBeInTheDocument();
+        expect(screen.queryByText('Explore Architecture')).not.toBeInTheDocument();
+    });
+
+    it('renders "Explore Architecture" for legacy /calm/ paths', () => {
+        const navigate = vi.fn();
+        const props = makeNodeProps({ 'detailed-architecture': '/calm/namespaces/finos/architectures/my-arch/versions/1-0-0' });
+        renderNode(props, navigate);
+
+        hoverNode();
+        expect(screen.getByText('Explore Architecture')).toBeInTheDocument();
+        expect(screen.queryByText('Open Architecture')).not.toBeInTheDocument();
+    });
+
+    it('calls onNavigateToDetailedArch for legacy /calm/ paths', () => {
+        const navigate = vi.fn();
+        const path = '/calm/namespaces/finos/architectures/my-arch/versions/1-0-0';
+        const props = makeNodeProps({ 'detailed-architecture': path });
+        renderNode(props, navigate);
+
+        hoverNode();
+        fireEvent.click(screen.getByText('Explore Architecture'));
+
+        expect(navigate).toHaveBeenCalledWith(path);
+        expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not render either architecture button when no detailed-architecture is set', () => {
+        const props = makeNodeProps();
+        renderNode(props);
+
+        hoverNode();
+        expect(screen.queryByText('Explore Architecture')).not.toBeInTheDocument();
+        expect(screen.queryByText('Open Architecture')).not.toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.test.tsx
@@ -146,4 +146,30 @@ describe('CustomNode — external URL support', () => {
         expect(screen.queryByText('Explore Architecture')).not.toBeInTheDocument();
         expect(screen.queryByText('Open Architecture')).not.toBeInTheDocument();
     });
+
+    it('suppresses the drill-down indicator for an unresolvable ref (bare filename)', () => {
+        const props = makeNodeProps({ 'detailed-architecture': 'api-platform.json' });
+        renderNode(props);
+
+        // No "Has detailed architecture" badge is advertised when there is no action for it.
+        expect(screen.queryByTitle('Has detailed architecture')).not.toBeInTheDocument();
+    });
+
+    it('surfaces the raw ref (no button) in the hover panel for an unresolvable ref', () => {
+        const props = makeNodeProps({ 'detailed-architecture': 'api-platform.json' });
+        renderNode(props);
+
+        hoverNode();
+        expect(screen.getByText('Detailed Architecture:')).toBeInTheDocument();
+        expect(screen.getByText('api-platform.json')).toBeInTheDocument();
+        expect(screen.queryByText('Explore Architecture')).not.toBeInTheDocument();
+        expect(screen.queryByText('Open Architecture')).not.toBeInTheDocument();
+    });
+
+    it('shows the drill-down indicator for a resolvable internal ref', () => {
+        const props = makeNodeProps({ 'detailed-architecture': '/calm/namespaces/finos/architectures/my-arch/versions/1-0-0' });
+        renderNode(props, vi.fn());
+
+        expect(screen.getByTitle('Has detailed architecture')).toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.tsx
@@ -86,6 +86,10 @@ export function CustomNode({ data }: NodeProps) {
   const archResolution = resolveDetailedArchitecture(detailedArchitecture);
   const isSameOriginArch = archResolution.type === 'internal';
   const isExternalArch = archResolution.type === 'external';
+  // A truthy ref that resolves to neither an in-app path nor an openable URL
+  // (e.g. a bare filename). There is no drill-down action for it, so the header
+  // indicator is suppressed and the hover panel surfaces the raw value instead.
+  const isUnknownArch = !!detailedArchitecture && archResolution.type === 'unknown';
   const archPath = archResolution.type === 'internal' ? archResolution.path : undefined;
 
     // Extract AIGF data (if present in node metadata)
@@ -182,7 +186,7 @@ export function CustomNode({ data }: NodeProps) {
         <div style={{ fontWeight: 600, marginBottom: '4px', flex: 1, display: 'flex', alignItems: 'center', gap: '8px' }}>
           <NodeIcon style={{ width: '16px', height: '16px', flexShrink: 0, color: nodeTypeStyle.color }} />
           <span>{data.label}</span>
-          {detailedArchitecture && (
+          {detailedArchitecture && !isUnknownArch && (
             <div title="Has detailed architecture">
               <ZoomIn style={{ width: '20px', height: '20px', flexShrink: 0, color: THEME.colors.accentText }} />
             </div>
@@ -351,6 +355,14 @@ export function CustomNode({ data }: NodeProps) {
             <div style={{ fontSize: '12px', color: THEME.colors.muted, marginBottom: '4px' }}>Description:</div>
             <div style={{ fontSize: '12px', color: THEME.colors.foreground, lineHeight: 1.5 }}>{description}</div>
           </div>
+          {isUnknownArch && (
+            <div style={{ borderTop: `1px solid ${THEME.colors.border}`, paddingTop: '8px', marginTop: '8px' }}>
+              <div style={{ fontSize: '12px', color: THEME.colors.muted, marginBottom: '4px' }}>Detailed Architecture:</div>
+              <div style={{ fontSize: '12px', fontFamily: 'monospace', color: THEME.colors.foreground, wordBreak: 'break-all' }}>
+                {detailedArchitecture}
+              </div>
+            </div>
+          )}
           {(onShowDetails || isExternalArch || (isSameOriginArch && onNavigateToDetailedArch)) && (
             <div style={{ borderTop: `1px solid ${THEME.colors.border}`, paddingTop: '8px', marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
               {onShowDetails && (

--- a/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/CustomNode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 import {
     Shield,
@@ -14,14 +14,67 @@ import {
     Globe2,
     FileText,
     ZoomIn,
+    ExternalLink,
     Info,
 } from 'lucide-react';
-import { extractId, extractNodeType } from './utils/calmHelpers.js';
+import { extractId, extractNodeType, resolveDetailedArchitecture } from './utils/calmHelpers.js';
 import { THEME, getNodeTypeColor, getRiskLevelColor } from './theme.js';
 import type { RiskItem, MitigationItem, ControlItem } from '../../contracts/contracts.js';
+import { useDiagramActions } from '../../context/DiagramActionsContext.js';
+
+/**
+ * Shared style for the hover-panel action buttons ("Show Details", "Explore
+ * Architecture", "Open Architecture"): one filled `primary` and one bordered
+ * `outline` variant. Inline styles (not classes) are the file's idiom — the
+ * visualiser themes through JS tokens.
+ */
+function PanelButton({
+  variant,
+  onClick,
+  children,
+}: {
+  variant: 'primary' | 'outline';
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  const isPrimary = variant === 'primary';
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      style={{
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '8px',
+        padding: '8px 12px',
+        fontSize: '12px',
+        fontWeight: 500,
+        borderRadius: '6px',
+        background: isPrimary ? THEME.colors.accent : 'transparent',
+        color: isPrimary ? '#ffffff' : THEME.colors.accent,
+        border: isPrimary ? 'none' : `1px solid ${THEME.colors.accent}`,
+        cursor: 'pointer',
+        transition: 'opacity 0.2s',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.opacity = isPrimary ? '0.9' : '0.8';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.opacity = '1';
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function CustomNode({ data }: NodeProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const { onNavigateToDetailedArch } = useDiagramActions();
 
   // Get callbacks from data
   const onShowDetails = data.onShowDetails;
@@ -30,6 +83,10 @@ export function CustomNode({ data }: NodeProps) {
   const description = data.description || 'No description available';
   const nodeType = extractNodeType(data) || 'Unknown';
   const detailedArchitecture = data.details?.['detailed-architecture'];
+  const archResolution = resolveDetailedArchitecture(detailedArchitecture);
+  const isSameOriginArch = archResolution.type === 'internal';
+  const isExternalArch = archResolution.type === 'external';
+  const archPath = archResolution.type === 'internal' ? archResolution.path : undefined;
 
     // Extract AIGF data (if present in node metadata)
     const aigf = data.metadata?.aigf;
@@ -93,6 +150,7 @@ export function CustomNode({ data }: NodeProps) {
 
   return (
     <div
+      data-testid="custom-node"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       style={{
@@ -126,7 +184,7 @@ export function CustomNode({ data }: NodeProps) {
           <span>{data.label}</span>
           {detailedArchitecture && (
             <div title="Has detailed architecture">
-              <ZoomIn style={{ width: '14px', height: '14px', flexShrink: 0, color: THEME.colors.accentText }} />
+              <ZoomIn style={{ width: '20px', height: '20px', flexShrink: 0, color: THEME.colors.accentText }} />
             </div>
           )}
         </div>
@@ -293,39 +351,34 @@ export function CustomNode({ data }: NodeProps) {
             <div style={{ fontSize: '12px', color: THEME.colors.muted, marginBottom: '4px' }}>Description:</div>
             <div style={{ fontSize: '12px', color: THEME.colors.foreground, lineHeight: 1.5 }}>{description}</div>
           </div>
-          {onShowDetails && (
-            <div style={{ borderTop: `1px solid ${THEME.colors.border}`, paddingTop: '8px', marginTop: '8px' }}>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onShowDetails(data);
-                }}
-                style={{
-                  width: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '8px',
-                  padding: '8px 12px',
-                  fontSize: '12px',
-                  fontWeight: 500,
-                  borderRadius: '6px',
-                  background: THEME.colors.accent,
-                  color: '#ffffff',
-                  border: 'none',
-                  cursor: 'pointer',
-                  transition: 'opacity 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.opacity = '0.9';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.opacity = '1';
-                }}
-              >
-                <Info style={{ width: '14px', height: '14px' }} />
-                Show Details
-              </button>
+          {(onShowDetails || isExternalArch || (isSameOriginArch && onNavigateToDetailedArch)) && (
+            <div style={{ borderTop: `1px solid ${THEME.colors.border}`, paddingTop: '8px', marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              {onShowDetails && (
+                <PanelButton variant="primary" onClick={() => onShowDetails(data)}>
+                  <Info style={{ width: '14px', height: '14px' }} />
+                  Show Details
+                </PanelButton>
+              )}
+              {isSameOriginArch && onNavigateToDetailedArch && (
+                <PanelButton variant="outline" onClick={() => onNavigateToDetailedArch(archPath!)}>
+                  <ZoomIn style={{ width: '14px', height: '14px' }} />
+                  Explore Architecture
+                </PanelButton>
+              )}
+              {isExternalArch && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                  <PanelButton
+                    variant="outline"
+                    onClick={() => window.open(detailedArchitecture, '_blank', 'noopener,noreferrer')}
+                  >
+                    <ExternalLink style={{ width: '14px', height: '14px' }} />
+                    Open Architecture
+                  </PanelButton>
+                  <div style={{ fontSize: '11px', color: THEME.colors.muted, textAlign: 'center' }}>
+                    External resource — may require authentication
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmHelpers.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmHelpers.test.ts
@@ -1,4 +1,4 @@
-import { extractId, extractNodeType, extractRelationshipType, getRelationshipTypeDisplayString } from "./calmHelpers.js";
+import { extractId, extractNodeType, extractRelationshipType, getRelationshipTypeDisplayString, parseCALMHubPath, resolveDetailedArchitecture } from "./calmHelpers.js";
 import { describe, expect, it } from "vitest";
 
 describe('calmHelpers', () => {
@@ -102,6 +102,75 @@ describe('calmHelpers', () => {
 
         it('should return undefined for undefined input', () => {
             expect(extractRelationshipType(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('resolveDetailedArchitecture', () => {
+        it('returns internal with the bare path for /calm/ paths', () => {
+            expect(resolveDetailedArchitecture('/calm/namespaces/finos/architectures/my-arch/versions/1-0-0', 'localhost'))
+                .toEqual({ type: 'internal', path: '/calm/namespaces/finos/architectures/my-arch/versions/1-0-0' });
+        });
+
+        it('returns internal with the pathname for same-hostname absolute URLs', () => {
+            expect(resolveDetailedArchitecture('http://localhost:8080/calm/namespaces/finos/architectures/my-arch/versions/1.0.0', 'localhost'))
+                .toEqual({ type: 'internal', path: '/calm/namespaces/finos/architectures/my-arch/versions/1.0.0' });
+        });
+
+        it('returns external for absolute URLs on a different hostname', () => {
+            expect(resolveDetailedArchitecture('https://calm.finos.org/calm/namespaces/finos/architectures/my-arch/versions/1.0.0', 'localhost'))
+                .toEqual({ type: 'external' });
+        });
+
+        it('returns unknown for unrecognised values', () => {
+            expect(resolveDetailedArchitecture('trades-api.architecture.json', 'localhost'))
+                .toEqual({ type: 'unknown' });
+        });
+
+        it('returns unknown for undefined input', () => {
+            expect(resolveDetailedArchitecture(undefined, 'localhost'))
+                .toEqual({ type: 'unknown' });
+        });
+
+        it('returns external for a malformed URL', () => {
+            expect(resolveDetailedArchitecture('http://:bad-url', 'localhost'))
+                .toEqual({ type: 'external' });
+        });
+
+        it('returns external for same-hostname URLs whose path is not a CALM Hub resource', () => {
+            expect(resolveDetailedArchitecture('http://localhost:8080/some/other/page', 'localhost'))
+                .toEqual({ type: 'external' });
+        });
+
+        it('returns unknown for bare paths that are not a CALM Hub resource', () => {
+            expect(resolveDetailedArchitecture('/calm/controls/some-control', 'localhost'))
+                .toEqual({ type: 'unknown' });
+        });
+    });
+
+    describe('parseCALMHubPath', () => {
+        it('parses an architectures path into its segments', () => {
+            expect(parseCALMHubPath('/calm/namespaces/finos/architectures/my-arch/versions/1-0-0')).toEqual({
+                namespace: 'finos',
+                type: 'architectures',
+                id: 'my-arch',
+                version: '1-0-0',
+            });
+        });
+
+        it('parses a patterns path into its segments', () => {
+            expect(parseCALMHubPath('/calm/namespaces/finos/patterns/api-gateway/versions/1.0.0')).toEqual({
+                namespace: 'finos',
+                type: 'patterns',
+                id: 'api-gateway',
+                version: '1.0.0',
+            });
+        });
+
+        it('returns null for non-resource paths', () => {
+            expect(parseCALMHubPath('/calm/namespaces/finos/flows/my-flow/versions/1.0.0')).toBeNull();
+            expect(parseCALMHubPath('/calm/namespaces/finos/architectures/my-arch')).toBeNull();
+            expect(parseCALMHubPath('/other/path')).toBeNull();
+            expect(parseCALMHubPath('/calm/namespaces/finos/architectures/my-arch/versions/1.0.0/extra')).toBeNull();
         });
     });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/calmHelpers.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/calmHelpers.ts
@@ -41,6 +41,69 @@ export function extractRelationshipType(relationship: CalmRelationshipSchema | n
   return relationship?.['relationship-type'];
 }
 
+export type DetailedArchResolution =
+    | { type: 'internal'; path: string }
+    | { type: 'external' }
+    | { type: 'unknown' };
+
+export interface ParsedCALMHubPath {
+    namespace: string;
+    type: 'architectures' | 'patterns';
+    id: string;
+    version: string;
+}
+
+/**
+ * Parses a CALM Hub resource path (`/calm/namespaces/<ns>/<architectures|patterns>/<id>/versions/<v>`)
+ * into its segments, or returns null for any other shape.
+ */
+export function parseCALMHubPath(path: string): ParsedCALMHubPath | null {
+    const match = path.match(/^\/calm\/namespaces\/([^/]+)\/(architectures|patterns)\/([^/]+)\/versions\/([^/]+)$/);
+    if (!match) return null;
+    return { namespace: match[1], type: match[2] as 'architectures' | 'patterns', id: match[3], version: match[4] };
+}
+
+/**
+ * Resolves a detailed-architecture reference to one of three outcomes:
+ *  - 'internal': a CALM Hub resource path (bare, or inside a same-hostname URL)
+ *    → navigate within the app, using `path`
+ *  - 'external': an absolute URL that is not an internal resource → open in a new tab
+ *  - 'unknown': any other value → display as plain text
+ *
+ * Matching is intentionally by hostname, not same-origin: in local dev the UI
+ * (e.g. :5173) and the hub backend (:8080) share a hostname but not a port, and
+ * hub-issued absolute URLs must still resolve as internal. Only paths that parse
+ * as a CALM Hub resource count as internal, so consumers never render an in-app
+ * navigation affordance for a path the router cannot handle.
+ *
+ * The `hostname` parameter defaults to `window.location.hostname` and can be
+ * overridden in tests.
+ */
+export function resolveDetailedArchitecture(
+    ref: string | undefined,
+    hostname: string = window.location.hostname,
+): DetailedArchResolution {
+    if (!ref) return { type: 'unknown' };
+
+    if (ref.startsWith('http://') || ref.startsWith('https://')) {
+        try {
+            const url = new URL(ref);
+            if (url.hostname === hostname && parseCALMHubPath(url.pathname)) {
+                return { type: 'internal', path: url.pathname };
+            }
+            return { type: 'external' };
+        } catch {
+            return { type: 'external' };
+        }
+    }
+
+    if (parseCALMHubPath(ref)) {
+        return { type: 'internal', path: ref };
+    }
+
+    return { type: 'unknown' };
+}
+
 export function getRelationshipTypeDisplayString(relType: CalmRelationshipTypeSchema | null | undefined): string {
   if (!relType) return 'unknown';
   if ('connects' in relType) return 'connects';

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.test.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.test.ts
@@ -443,6 +443,26 @@ describe('parsePatternData', () => {
         expect(result.nodes[0].id).toBe('node-1');
     });
 
+    it('extracts detailed-architecture from node details schema', () => {
+        const pattern = makePattern([
+            schemaNode('api-gateway', 'API Gateway', 'system', {
+                details: {
+                    properties: {
+                        'detailed-architecture': {
+                            const: '/calm/namespaces/finos/architectures/api-platform/versions/1-0-0',
+                        },
+                    },
+                    required: ['detailed-architecture'],
+                },
+            }),
+        ]);
+        const result = parsePatternData(pattern);
+        const node = result.nodes.find((n) => n.id === 'api-gateway');
+        expect(node?.data.details).toEqual({
+            'detailed-architecture': '/calm/namespaces/finos/architectures/api-platform/versions/1-0-0',
+        });
+    });
+
     it('does not create edges for unknown node references', () => {
         const pattern = makePattern(
             [schemaNode('node-1', 'Node 1', 'service')],

--- a/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/utils/patternTransformer.ts
@@ -127,6 +127,14 @@ function extractPatternControls(item: SchemaObject): SchemaObject | undefined {
 
 // ---- Node extraction ----
 
+function extractPatternDetails(item: SchemaObject): { 'detailed-architecture': string } | undefined {
+    const detailsSchema = item['properties']?.['details'];
+    if (!detailsSchema) return undefined;
+    const detailedArch = detailsSchema['properties']?.['detailed-architecture']?.['const'];
+    if (!detailedArch) return undefined;
+    return { 'detailed-architecture': String(detailedArch) };
+}
+
 interface ExtractedNode {
     uniqueId: string;
     name: string;
@@ -134,6 +142,7 @@ interface ExtractedNode {
     description: string;
     interfaces?: SchemaObject[];
     controls?: SchemaObject;
+    details?: { 'detailed-architecture': string };
     decisionGroupId?: string;
 }
 
@@ -147,6 +156,7 @@ function extractNodeFromSchemaItem(item: SchemaObject): ExtractedNode | null {
         description: readSchemaValue(item, 'description') || '',
         interfaces: extractInterfaces(item),
         controls: extractPatternControls(item),
+        details: extractPatternDetails(item),
     };
 }
 
@@ -420,6 +430,7 @@ function createReactFlowNodes(
         };
         if (node.interfaces) data['interfaces'] = node.interfaces;
         if (node.controls) data['controls'] = node.controls;
+        if (node.details) data['details'] = node.details;
         return data;
     }
 

--- a/calm-hub-ui/src/visualizer/components/sidebar/NodeDetails.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/NodeDetails.test.tsx
@@ -1,7 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
 import { NodeDetails } from './NodeDetails.js';
+import { DiagramActionsContext } from '../../context/DiagramActionsContext.js';
 import { CalmNodeSchema } from '@finos/calm-models/types';
+
+function renderWithNavigation(node: CalmNodeSchema, onNavigateToDetailedArch: (ref: string) => void) {
+    return render(
+        <DiagramActionsContext.Provider value={{ onNavigateToDetailedArch }}>
+            <NodeDetails data={node} />
+        </DiagramActionsContext.Provider>
+    );
+}
 
 const baseNode: CalmNodeSchema = {
     'unique-id': 'node-001',
@@ -89,14 +99,79 @@ describe('NodeDetails', () => {
         expect(screen.getByText('Encryption at rest')).toBeInTheDocument();
     });
 
-    it('renders detailed architecture indicator when present', () => {
+    it('renders detailed architecture label and reference value when present', () => {
         const nodeWithDetails: CalmNodeSchema = {
             ...baseNode,
-            details: { 'detailed-architecture': 'arch-ref-001' },
+            details: { 'detailed-architecture': 'api-platform.json' },
         };
         render(<NodeDetails data={nodeWithDetails} />);
 
-        expect(screen.getByText('Has detailed architecture')).toBeInTheDocument();
+        expect(screen.getByText('Detailed Architecture')).toBeInTheDocument();
+        expect(screen.getByText('api-platform.json')).toBeInTheDocument();
+    });
+
+    it('renders detailed architecture as a clickable button when reference is a CALM Hub path', async () => {
+        const user = userEvent.setup();
+        const onNavigate = vi.fn();
+        const nodeWithDetails: CalmNodeSchema = {
+            ...baseNode,
+            details: { 'detailed-architecture': '/calm/namespaces/finos/architectures/2/versions/1-0-0' },
+        };
+        renderWithNavigation(nodeWithDetails, onNavigate);
+
+        const btn = screen.getByRole('button', { name: '/calm/namespaces/finos/architectures/2/versions/1-0-0' });
+        expect(btn).toBeInTheDocument();
+        await user.click(btn);
+        expect(onNavigate).toHaveBeenCalledWith('/calm/namespaces/finos/architectures/2/versions/1-0-0');
+    });
+
+    it('renders an internal reference as plain text when no navigation handler is provided', () => {
+        const nodeWithDetails: CalmNodeSchema = {
+            ...baseNode,
+            details: { 'detailed-architecture': '/calm/namespaces/finos/architectures/2/versions/1-0-0' },
+        };
+        // No DiagramActionsContext provider: the default empty context means there
+        // is nowhere to navigate, so no clickable affordance may render.
+        render(<NodeDetails data={nodeWithDetails} />);
+
+        expect(screen.getByText('/calm/namespaces/finos/architectures/2/versions/1-0-0')).toBeInTheDocument();
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders detailed architecture as a link when reference is an http URL on a different hostname', () => {
+        const nodeWithDetails: CalmNodeSchema = {
+            ...baseNode,
+            details: { 'detailed-architecture': 'https://calm.finos.org/calm/namespaces/finos/architectures/2/versions/1.0.0' },
+        };
+        render(<NodeDetails data={nodeWithDetails} />);
+
+        const link = screen.getByRole('link', { name: 'https://calm.finos.org/calm/namespaces/finos/architectures/2/versions/1.0.0' });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('renders detailed architecture as a clickable button for same-hostname absolute URLs (e.g. different port in dev)', async () => {
+        const originalLocation = window.location;
+        Object.defineProperty(window, 'location', { value: { ...originalLocation, hostname: 'localhost' }, writable: true });
+
+        // try/finally: a failing assertion must not leak the overridden
+        // window.location into the tests that follow.
+        try {
+            const user = userEvent.setup();
+            const onNavigate = vi.fn();
+            const nodeWithDetails: CalmNodeSchema = {
+                ...baseNode,
+                details: { 'detailed-architecture': 'http://localhost:8080/calm/namespaces/finos/architectures/2/versions/1.0.0' },
+            };
+            renderWithNavigation(nodeWithDetails, onNavigate);
+
+            const btn = screen.getByRole('button', { name: 'http://localhost:8080/calm/namespaces/finos/architectures/2/versions/1.0.0' });
+            expect(btn).toBeInTheDocument();
+            await user.click(btn);
+            expect(onNavigate).toHaveBeenCalledWith('/calm/namespaces/finos/architectures/2/versions/1.0.0');
+        } finally {
+            Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+        }
     });
 
     it('renders extra properties not in the known set', () => {

--- a/calm-hub-ui/src/visualizer/components/sidebar/NodeDetails.tsx
+++ b/calm-hub-ui/src/visualizer/components/sidebar/NodeDetails.tsx
@@ -1,7 +1,8 @@
 import { CalmNodeSchema } from '@finos/calm-models/types';
 import { ZoomIn } from 'lucide-react';
-import { extractNodeType } from '../reactflow/utils/calmHelpers.js';
+import { extractNodeType, resolveDetailedArchitecture } from '../reactflow/utils/calmHelpers.js';
 import { getNodeTypeColor } from '../../../theme/helpers.js';
+import { useDiagramActions } from '../../context/DiagramActionsContext.js';
 import type { ControlItem } from '../../contracts/contracts.js';
 import {
     Badge, RiskLevelBadge,
@@ -15,6 +16,7 @@ const KNOWN_FIELDS = new Set([
 ]);
 
 export function NodeDetails({ data }: { data: CalmNodeSchema }) {
+    const { onNavigateToDetailedArch } = useDiagramActions();
     const nodeType = extractNodeType(data) || 'Unknown';
     const Icon = getNodeIcon(nodeType);
 
@@ -25,8 +27,10 @@ export function NodeDetails({ data }: { data: CalmNodeSchema }) {
 
     const controls: Record<string, ControlItem> = data.controls || {};
     const interfaces = (data.interfaces || []) as Record<string, unknown>[];
-    const detailedArch = data.details?.['detailed-architecture'];
+    const detailedArchRaw = data.details?.['detailed-architecture'];
     const extraProps = getExtraProperties(data as unknown as Record<string, unknown>, KNOWN_FIELDS);
+
+    const archResolution = resolveDetailedArchitecture(detailedArchRaw);
 
     return (
         <div className="flex flex-col gap-3 p-4 overflow-auto">
@@ -43,10 +47,31 @@ export function NodeDetails({ data }: { data: CalmNodeSchema }) {
                 <p className="text-sm text-base-content/70 leading-relaxed">{data.description}</p>
             )}
 
-            {detailedArch && (
-                <div className="flex items-center gap-2 text-xs text-accent font-medium bg-accent/10 rounded-lg px-3 py-2">
-                    <ZoomIn className="w-3.5 h-3.5" />
-                    Has detailed architecture
+            {detailedArchRaw && (
+                <div className="flex items-start gap-2 text-xs text-accent font-medium bg-accent/10 rounded-lg px-3 py-2">
+                    <ZoomIn className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                    <div className="flex flex-col min-w-0">
+                        <span>Detailed Architecture</span>
+                        {archResolution.type === 'internal' && onNavigateToDetailedArch ? (
+                            <button
+                                onClick={() => onNavigateToDetailedArch(archResolution.path)}
+                                className="font-mono font-normal text-accent underline hover:text-accent/70 truncate text-left"
+                            >
+                                {detailedArchRaw}
+                            </button>
+                        ) : archResolution.type === 'external' ? (
+                            <a
+                                href={detailedArchRaw}
+                                className="font-mono font-normal text-accent underline hover:text-accent/70 truncate"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {detailedArchRaw}
+                            </a>
+                        ) : (
+                            <span className="font-mono font-normal text-base-content/60 truncate">{detailedArchRaw}</span>
+                        )}
+                    </div>
                 </div>
             )}
 

--- a/calm-hub-ui/src/visualizer/context/DiagramActionsContext.ts
+++ b/calm-hub-ui/src/visualizer/context/DiagramActionsContext.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+
+interface DiagramActionsContextValue {
+    onNavigateToDetailedArch?: (ref: string) => void;
+}
+
+export const DiagramActionsContext = createContext<DiagramActionsContextValue>({});
+export const useDiagramActions = () => useContext(DiagramActionsContext);


### PR DESCRIPTION
## Description
Adding a new feature that allow CALM Hub users to drill into detailed architectures. Addressing issue #2616 

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [X] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [X] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
