### PR TITLE
feat(shared): Validation Engine Redesign with articulated assumptions

### DIFF
--- a/calm-models/src/model/resolvable.ts
+++ b/calm-models/src/model/resolvable.ts
@@ -1,3 +1,11 @@
+/**
+ * A resolvable node in the CALM model — either a plain {@link Resolvable} or a
+ * {@link ResolvableAndAdaptable}. Both expose `reference`, `isResolved` and `value`.
+ */
+export type AnyResolvable =
+    | Resolvable<unknown>
+    | ResolvableAndAdaptable<unknown, unknown>;
+
 export class Resolvable<T> {
     constructor(
         public reference: string,

--- a/cli/smoke/fixtures/genval/bad-control.architecture.json
+++ b/cli/smoke/fixtures/genval/bad-control.architecture.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+  "unique-id": "smoke-online-bad-control",
+  "nodes": [
+    {
+      "unique-id": "svc",
+      "node-type": "service",
+      "name": "Service",
+      "description": "A service whose security control config breaks its CalmHub-hosted requirement",
+      "controls": {
+        "security": {
+          "description": "Security controls for the service",
+          "requirements": [
+            {
+              "requirement-url": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/requirement/versions/1.0.0",
+              "config-url": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/configurations/bad/versions/1.0.0"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "relationships": []
+}

--- a/cli/smoke/fixtures/genval/conference-signup.pattern.json
+++ b/cli/smoke/fixtures/genval/conference-signup.pattern.json
@@ -384,7 +384,7 @@
                               "const": "https://calm.finos.org/getting-started/controls/permitted-connection.requirement.json"
                             },
                             "config-url": {
-                              "const": "https://calm.finos.org/getting-started/controls/permitted-connection-jdbc.config.json"
+                              "const": "https://calm.finos.org/getting-started/controls/permitted-connection-http.config.json"
                             }
                           }
                         }

--- a/cli/smoke/fixtures/genval/controls/security-control-bad.config.json
+++ b/cli/smoke/fixtures/genval/controls/security-control-bad.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/requirement/versions/1.0.0",
+  "$id": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/configurations/bad/versions/1.0.0",
+  "control-id": "security-999",
+  "name": "Smoke Online Security Control",
+  "description": "A deliberately mismatched control config whose control-id breaks the hub-hosted requirement const"
+}

--- a/cli/smoke/fixtures/genval/controls/security-control-good.config.json
+++ b/cli/smoke/fixtures/genval/controls/security-control-good.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/requirement/versions/1.0.0",
+  "$id": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/configurations/good/versions/1.0.0",
+  "control-id": "security-100",
+  "name": "Smoke Online Security Control",
+  "description": "A compliant control config whose control-id matches the hub-hosted requirement const"
+}

--- a/cli/smoke/fixtures/genval/controls/security-control.requirement.json
+++ b/cli/smoke/fixtures/genval/controls/security-control.requirement.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/requirement/versions/1.0.0",
+  "title": "Smoke online security control requirement",
+  "type": "object",
+  "properties": {
+    "control-id": {
+      "const": "security-100"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "control-id",
+    "name",
+    "description"
+  ]
+}

--- a/cli/smoke/fixtures/genval/good-control.architecture.json
+++ b/cli/smoke/fixtures/genval/good-control.architecture.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+  "unique-id": "smoke-online-good-control",
+  "nodes": [
+    {
+      "unique-id": "svc",
+      "node-type": "service",
+      "name": "Service",
+      "description": "A service whose security control config satisfies its CalmHub-hosted requirement",
+      "controls": {
+        "security": {
+          "description": "Security controls for the service",
+          "requirements": [
+            {
+              "requirement-url": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/requirement/versions/1.0.0",
+              "config-url": "http://localhost:8080/calm/domains/smoke-online/controls/security-control/configurations/good/versions/1.0.0"
+            }
+          ]
+        }
+      },
+      "details": {
+        "detailed-architecture": "http://localhost:8080/calm/namespaces/smoke-genval/architectures/service-detail/versions/1.0.0"
+      }
+    }
+  ],
+  "relationships": []
+}

--- a/cli/smoke/fixtures/genval/service-detail.architecture.json
+++ b/cli/smoke/fixtures/genval/service-detail.architecture.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+  "$id": "http://localhost:8080/calm/namespaces/smoke-genval/architectures/service-detail/versions/1.0.0",
+  "title": "Smoke service detailed architecture",
+  "description": "The detailed architecture referenced from the service node's node-details",
+  "unique-id": "smoke-service-detail",
+  "nodes": [
+    {
+      "unique-id": "db",
+      "node-type": "database",
+      "name": "Database",
+      "description": "A leaf node inside the service's detailed architecture"
+    }
+  ],
+  "relationships": []
+}

--- a/cli/smoke/generate-validate.smoke.spec.ts
+++ b/cli/smoke/generate-validate.smoke.spec.ts
@@ -12,12 +12,56 @@ const PATTERN_FIXTURE = path.resolve(__dirname, 'fixtures/genval/conference-sign
 const PATTERN_URL = hubDocId(NS, 'patterns', 'conference-signup', '1.0.0');
 const api = hubApi();
 
+const CONTROLS_DIR = path.resolve(__dirname, 'fixtures/genval/controls');
+const CONTROL_DOMAIN = 'smoke-online';
+const REQUIREMENT = path.join(CONTROLS_DIR, 'security-control.requirement.json');
+const GOOD_CONFIG = path.join(CONTROLS_DIR, 'security-control-good.config.json');
+const BAD_CONFIG = path.join(CONTROLS_DIR, 'security-control-bad.config.json');
+const SERVICE_DETAIL_ARCH = path.resolve(__dirname, 'fixtures/genval/service-detail.architecture.json');
+const GOOD_CONTROL_ARCH = path.resolve(__dirname, 'fixtures/genval/good-control.architecture.json');
+const BAD_CONTROL_ARCH = path.resolve(__dirname, 'fixtures/genval/bad-control.architecture.json');
+
+interface ValidationOutput {
+    code?: string;
+    severity?: string;
+    message?: string;
+    path?: string;
+}
+
+interface ValidationResult {
+    hasErrors: boolean;
+    jsonSchemaValidationOutputs: ValidationOutput[];
+    spectralSchemaValidationOutputs: ValidationOutput[];
+}
+
 describe('Flow 2: generate/validate (local + CalmHub refs)', () => {
     let cli: CliInstall;
 
     beforeAll(async () => {
         cli = installPackedCli(CLI_ROOT, 'calm-smoke-genval');
         await cli.run(['hub', 'create', 'namespace', '--name', NS, '--description', 'smoke genval', '-c', SMOKE_HUB_URL]);
+
+        // Push from temp copies: `hub push` rewrites the document $id in place, which would
+        // otherwise dirty the fixtures.
+        //
+        // NB: this assumes CalmHub's push endpoints store control documents as-is and do NOT
+        // validate a configuration against its requirement on ingest. If that changes, pushing the
+        // deliberately-bad config here would be rejected and the bad-config case below would need to
+        // seed its fixtures another way (e.g. write directly to storage, or validate against a
+        // locally-mapped requirement instead).
+        await cli.run(['hub', 'create', 'domain', '--name', CONTROL_DOMAIN, '-c', SMOKE_HUB_URL]);
+        const reqTmp = path.join(cli.tempDir, 'requirement.json');
+        const goodTmp = path.join(cli.tempDir, 'good.config.json');
+        const badTmp = path.join(cli.tempDir, 'bad.config.json');
+        const serviceDetailTmp = path.join(cli.tempDir, 'service-detail.architecture.json');
+        fs.copyFileSync(REQUIREMENT, reqTmp);
+        fs.copyFileSync(GOOD_CONFIG, goodTmp);
+        fs.copyFileSync(BAD_CONFIG, badTmp);
+        fs.copyFileSync(SERVICE_DETAIL_ARCH, serviceDetailTmp);
+        await cli.run(['hub', 'push', 'control-requirement', reqTmp, '-c', SMOKE_HUB_URL]);
+        await cli.run(['hub', 'push', 'control-configuration', goodTmp, '-c', SMOKE_HUB_URL]);
+        await cli.run(['hub', 'push', 'control-configuration', badTmp, '-c', SMOKE_HUB_URL]);
+        await cli.run(['hub', 'push', 'architecture', serviceDetailTmp, '-c', SMOKE_HUB_URL]);
     }, 120_000);
 
     afterAll(() => cli?.cleanup());
@@ -52,10 +96,58 @@ describe('Flow 2: generate/validate (local + CalmHub refs)', () => {
         expect(nodes.length).toBeGreaterThan(0);
     });
 
-    test('validate against a CalmHub-hosted pattern URL passes', async () => {
+    // Known limitation tracked by #2827: when validating with `-c`, CalmHubDocumentLoader claims
+    // external http(s) control-schema references (here https://calm.finos.org/...) and fetches them
+    // path-only against the `-c` hub, which fails. We deliberately assert this unsupported behaviour
+    // so that adopting a loader routing rule (host-scoped fall-through) trips this test and forces an
+    // update, rather than the limitation regressing silently.
+    test('validate with -c against a pattern referencing cross-host CalmHub control schemas is not supported yet (see #2827)', async () => {
         const arch = path.join(cli.tempDir, 'hub-arch.json');
         expect(fs.existsSync(arch)).toBe(true);
-        const { stdout } = await cli.run(['validate', '-p', PATTERN_URL, '-a', arch, '-f', 'json', '-c', SMOKE_HUB_URL]);
-        expect(JSON.parse(stdout).hasErrors).toBe(false);
+
+        const result = await cli
+            .run(['validate', '-p', PATTERN_URL, '-a', arch, '-f', 'json', '-c', SMOKE_HUB_URL])
+            .catch(e => e);
+
+        expect(result.exitCode).toBe(1);
+
+        const parsed = JSON.parse(result.stdout) as ValidationResult;
+        expect(parsed.hasErrors).toBe(true);
+
+        const controlErrors = parsed.jsonSchemaValidationOutputs.filter(
+            o => o.code === 'control-requirement-validation'
+        );
+        expect(controlErrors.length).toBeGreaterThan(0);
+        expect(
+            controlErrors.every(o => (o.message ?? '').includes('Failed to load document from CALMHub'))
+        ).toBe(true);
+    });
+
+    // Online counterpart to the #2827 limitation above: when the control requirement and config are
+    // hosted on the SAME host as -c, CalmHubDocumentLoader resolves them correctly and the control is
+    // validated end to end. The good architecture also carries a node-details detailed-architecture
+    // (itself hub-hosted), exercising the recursive descent into detailed architectures.
+    test('a compliant control validated against its CalmHub-hosted requirement passes', async () => {
+        const { stdout } = await cli.run(['validate', '-a', GOOD_CONTROL_ARCH, '-c', SMOKE_HUB_URL, '-f', 'json']);
+        const result = JSON.parse(stdout) as ValidationResult;
+        expect(result.hasErrors).toBe(false);
+        const controlErrors = result.jsonSchemaValidationOutputs.filter(
+            o => o.code === 'control-requirement-validation'
+        );
+        expect(controlErrors).toEqual([]);
+    });
+
+    test('a control whose config-id breaks its CalmHub-hosted requirement is reported', async () => {
+        const result = await cli
+            .run(['validate', '-a', BAD_CONTROL_ARCH, '-c', SMOKE_HUB_URL, '-f', 'json'])
+            .catch(e => e);
+        expect(result.exitCode).toBe(1);
+        const parsed = JSON.parse(result.stdout) as ValidationResult;
+        expect(parsed.hasErrors).toBe(true);
+        const controlErrors = parsed.jsonSchemaValidationOutputs.filter(
+            o => o.code === 'control-requirement-validation'
+        );
+        expect(controlErrors.length).toBeGreaterThan(0);
+        expect(controlErrors[0].path).toContain('/control-id');
     });
 });

--- a/shared/src/commands/validate/ValidationTechnicalSpecification.md
+++ b/shared/src/commands/validate/ValidationTechnicalSpecification.md
@@ -1,0 +1,333 @@
+# Validation Technical Specification
+
+Technical design for CALM document validation in `shared` (`@finos/calm-models` model +
+`shared/src/commands/validate`). Validation is a phased pipeline built from **`ValidationRule`**
+units executed by a **`ValidationEngine`**. `validate(...)` builds a `ValidationContext` and calls
+`ValidationEngine.validate`, which runs the registered rules and aggregates their results into a
+single `ValidationOutcome`. Rules come in two families over a shared context: Spectral-backed
+(JSONPath over raw JSON) and model/schema-backed (AJV / typed `CalmCore`). Recursive resolution of a
+node's `detailed-architecture` is opt-in and resolver-controlled: it is governed by a reference
+resolution policy that defaults to shallow, so top-level validation never implicitly fetches
+sub-architectures.
+
+## 1. Objectives
+
+- **O1: One authoritative validator in `shared`.** Validation is a library concern, not a CLI
+  concern. The CLI, CALM Hub (upload), CalmStudio, and any future tool call the same
+  `validate(...)` entry point so guarantees cannot be bypassed by hitting an API directly.
+- **O2: Phased validation.** Run cheap/broad linting (Spectral) and structural schema validation
+  (JSON Schema) as distinct phases, plus semantic/model checks (controls, node-details recursion).
+  A failure in one phase still lets other phases report, so users get a complete picture.
+- **O3: Uniform, machine-readable output.** Every phase emits `ValidationOutput` items aggregated
+  into a single `ValidationOutcome` with stable `code`, `severity`, JSON-pointer `path`, and
+  `source`. Downstream (JUnit/JSON/pretty formatters, Hub UI) depends on this shape.
+- **O4: Cycle- and reference-safe traversal.** Detailed architectures and control configs are
+  references that can form cycles; traversal must terminate and must not re-fetch or re-adapt more
+  than necessary.
+- **O5: Extensibility.** Adding a new check is registering a new `ValidationRule` with the engine;
+  the entry point does not change.
+- **O6: Opt-in deep resolution.** Deep (recursive) validation of referenced sub-architectures is a
+  caller-selected policy, off by default. A shallow validation checks only the supplied document; a
+  caller such as CalmHub opts in to deep validation when it wants sub-architectures resolved and
+  validated too.
+
+## 2. Assumptions
+
+- **A1: Downstream expects the current `ValidationOutcome` contract.** `hasErrors`/`hasWarnings`
+  drive process exit codes (`exitBasedOffOfValidationOutcome`); formatters read `jsonSchema*` and
+  `spectral*` output arrays and each `ValidationOutput` field. Behaviour-preservation applies to this
+  external output *shape*; it does not mandate always-on recursion, which is policy-controlled (O6).
+- **A2: `SchemaDirectory` is the single resolution boundary.** All remote/relative document and
+  schema loading goes through `SchemaDirectory` (backed by a `DocumentLoader`). Validators never
+  fetch directly.
+- **A3: The model owns references.** `Resolvable`/`ResolvableAndAdaptable` (calm-models) are the
+  canonical representation of a `$ref`-like pointer. Raw documents are transient; only adapted model
+  objects persist.
+- **A4: Spectral operates on raw JSON; model checks operate on the typed model.** Spectral rules
+  use JSONPath (`given`/`then`) over the stringified document. Model checks (controls, node-details)
+  operate on `CalmCore`. These are two distinct substrates.
+- **A5: A pattern may be an explicit CALM pattern or the CALM core schema.** The entry point
+  honours the architecture's `$schema` or an explicitly supplied pattern.
+- **A6: Validation is read-only and side-effect-free** apart from logging and cache population in
+  `SchemaDirectory`.
+- **A7: References are resolved lazily, only when necessary.** The calm-model `Resolvable` /
+  `CalmReferenceResolver.canResolve` seam means a reference is fetched only when a caller chooses to
+  dereference it. "When necessary" is therefore a policy decision: the resolution policy decides
+  which references (for example `detailed-architecture` documents) are resolvable in a given run.
+
+## 3. Architecture: `ValidationRule` + `ValidationEngine`
+
+`ValidationRule` is the unit of validation. Each rule declares an `id`, a `phase`
+(`ValidationPhase`), an `appliesTo(context)` predicate (usually a `mode` check), and a
+`run(context)` that returns a `RuleResult`. `ValidationEngine` is constructed with the list of rules;
+on `validate(context)` it:
+
+1. filters rules by `appliesTo(context)`;
+2. runs the survivors in ascending `phase` order (stable; registration order is preserved within a
+   phase);
+3. aggregates each `RuleResult` into a single `ValidationOutcome`, pushing `jsonSchemaOutputs` and
+   `spectralOutputs` into their respective buckets and OR-ing `hasErrors` / `hasWarnings`;
+4. stops early if a rule sets `RuleResult.abort`.
+
+```mermaid
+classDiagram
+    class ValidationEngine {
+        -rules: ValidationRule[]
+        +constructor(rules: ValidationRule[])
+        +validate(context) Promise~ValidationOutcome~
+    }
+    class ValidationRule {
+        <<interface>>
+        +id: string
+        +description: string
+        +phase: ValidationPhase
+        +appliesTo(context) boolean
+        +run(context) Promise~RuleResult~
+    }
+    class SpectralValidationRule
+    class JsonSchemaValidationRule
+    class ControlsValidationRule
+    class NodeDetailsValidationRule
+
+    ValidationEngine o-- ValidationRule : registers
+    ValidationRule <|.. SpectralValidationRule
+    ValidationRule <|.. JsonSchemaValidationRule
+    ValidationRule <|.. ControlsValidationRule
+    ValidationRule <|.. NodeDetailsValidationRule
+```
+
+## 4. Context and result types
+
+`ValidationContext` is the single input passed to every rule; `RuleResult` is the per-rule output;
+`ValidationOutcome` is the aggregated external contract (A1).
+
+```mermaid
+classDiagram
+    class ValidationContext {
+        +mode: ValidationMode
+        +architecture?: object
+        +pattern?: object
+        +timeline?: object
+        +schemaDirectory?: SchemaDirectory
+        +references: CachingTrackingResolver
+        +debug: boolean
+        +engine: ValidationEngine
+    }
+    class RuleResult {
+        +jsonSchemaOutputs: ValidationOutput[]
+        +spectralOutputs: ValidationOutput[]
+        +hasErrors: boolean
+        +hasWarnings: boolean
+        +abort?: boolean
+    }
+    class ValidationOutcome {
+        +jsonSchemaValidationOutputs: ValidationOutput[]
+        +spectralSchemaValidationOutputs: ValidationOutput[]
+        +hasErrors: boolean
+        +hasWarnings: boolean
+    }
+    class ValidationPhase {
+        <<enumeration>>
+        LINT
+        STRUCTURAL
+        SEMANTIC
+        RECURSIVE
+    }
+
+    ValidationEngine ..> ValidationContext : consumes
+    ValidationRule ..> RuleResult : produces
+    ValidationEngine ..> ValidationOutcome : aggregates
+    ValidationRule ..> ValidationPhase
+```
+
+## 5. Rules
+
+Rules fall into two families; all implement the same `ValidationRule` interface (no shared base
+class).
+
+- **Spectral-backed**: `SpectralValidationRule` adapts a Spectral `RulesetDefinition` (raw-JSON /
+  JSONPath rules). Three are registered: `spectral-pattern`, `spectral-architecture`,
+  `spectral-timeline`. Custom checks such as `idsAreUnique`, `nodeIdExists`,
+  `interfaceIdExistsOnNode`, `sequenceNumbersAreUnique` are Spectral custom functions over JSONPath.
+- **Model/schema-backed**: reason over the parsed `CalmCore` model or an AJV schema:
+  `JsonSchemaValidationRule` (STRUCTURAL, AJV), `ControlsValidationRule` (SEMANTIC, via
+  `iterateControls`), and `NodeDetailsValidationRule` (RECURSIVE, node iteration). Node-details
+  tracks visited references through the `CachingTrackingResolver` on the context. `ModelWalker` is
+  the shared cycle-safe traversal available to model-backed rules.
+
+`NodeDetailsValidationRule.run` builds a child `ValidationContext` (a forked `SchemaDirectory` for
+AJV schema-id isolation, plus the shared `CachingTrackingResolver`) and calls `engine.validate`
+again for each detailed sub-architecture; the resolver's visited-reference tracking guarantees each
+sub-architecture is validated once and terminates on cycles.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Engine as ValidationEngine
+    participant Rules as Registered rules
+    Caller->>Engine: validate(context)
+    Note over Engine,Rules: filter by appliesTo, stable-sort by phase
+    Engine->>Rules: run(context) per rule in phase order
+    Rules-->>Engine: RuleResult (outputs, flags, abort?)
+    Note over Engine: OR flags, bucket outputs, stop on abort
+    Engine-->>Caller: aggregated ValidationOutcome
+```
+
+## 6. Reference resolution, caching and cycle safety
+
+The CALM model is *lazily* dereferenced: a `ResolvableAndAdaptable<CalmCoreSchema, CalmCore>`
+only calls `resolve(ref)` when a caller chooses to dereference it, and the resolve function returns
+the **raw** `CalmCoreSchema` before it is adapted to `CalmCore`. Node-details validation needs that
+raw document (for Spectral + JSON-Schema), so the resolve seam is the natural place to centralise:
+
+- **caching**: a reference is fetched at most once; repeat requests return the cached raw document;
+- **tracking**: every attempted reference is recorded, giving dedupe ("validate each
+  detailed-architecture once") and cycle safety without each caller keeping its own `Set`.
+
+`CachingTrackingResolver` is a **decorator** that `implements CalmReferenceResolver`, wrapping any
+inner resolver. This is the single resolver interface used by both the model dereference path and
+validation:
+
+```mermaid
+classDiagram
+    class CalmReferenceResolver {
+        <<interface>>
+        +canResolve(ref) boolean
+        +resolve(ref) Promise
+    }
+    class CachingTrackingResolver {
+        -delegate: CalmReferenceResolver
+        -cache: Map~string, unknown~
+        -seen: Set~string~
+        +canResolve(ref) boolean
+        +resolve(ref) Promise
+        +has(ref) boolean
+        +get(ref) unknown
+        +markSeen(ref) void
+        +resolvedReferences: ReadonlySet~string~
+    }
+    class SchemaDirectoryReferenceResolver {
+        -schemaDirectory: SchemaDirectory
+        +canResolve(ref) boolean
+        +resolve(ref) Promise
+    }
+    CalmReferenceResolver <|.. CachingTrackingResolver
+    CalmReferenceResolver <|.. SchemaDirectoryReferenceResolver
+    CachingTrackingResolver o-- CalmReferenceResolver : decorates
+```
+
+A reference is marked *seen* before the underlying load is awaited, so a failed load still counts as
+seen (a sibling referencing the same failing URL is not retried), matching the
+`visitedUrls.add`-before-load behaviour originally implemented in PR #2778
+(https://github.com/finos/architecture-as-code/pull/2778). Only successful loads populate the value
+cache. In
+validation the decorator wraps a `SchemaDirectoryReferenceResolver` (which loads architecture
+documents via `schemaDirectory.loadDocument(ref, 'architecture')`); in docify the **caller**
+(`TemplateProcessor`) composes the decorator around its resolver (`Mapped` → `Composite`) so repeated
+references are fetched once. Both `DereferencingVisitor` and `ModelWalker` are agnostic: they
+dereference through whatever `CalmReferenceResolver` they are given; caching/tracking is purely the
+caller's composition choice.
+
+### Resolution policy (design intent)
+
+Whether a given reference is resolvable is governed by a `ReferenceResolutionPolicy`, consulted in
+`canResolve`. The policy is a constructor input to the resolver adapter; the `CalmReferenceResolver`
+interface is unchanged. Two variants:
+
+- **shallow (default):** `canResolve` returns `false` for `detailed-architecture` document
+  references, so a shallow run never fetches or recurses into sub-architectures.
+- **deep (opt-in):** `canResolve` allows those references, so the node-details rule resolves and
+  validates each referenced sub-architecture (see §7).
+
+Because only the node-details rule uses `ValidationContext.references` (schemas load via
+`SchemaDirectory.getSchema` directly), the policy affects recursion alone. Child validation contexts
+reuse the same resolver, so the policy is inherited at every level of recursion. This is design
+intent; the policy type, its resolver wiring and the entry-point option are pending implementation.
+
+## 7. Phased validation
+
+For an architecture-against-pattern validation the phases are:
+
+```mermaid
+flowchart TD
+    A[validate entry] --> B[LINT: SpectralValidationRule x3<br/>pattern + architecture + timeline rulesets]
+    B --> C[STRUCTURAL: JsonSchemaValidationRule<br/>compile pattern, validate architecture]
+    C --> D[SEMANTIC: ControlsValidationRule<br/>iterateControls -> requirement schema -> AJV]
+    D --> E[RECURSIVE: NodeDetailsValidationRule<br/>recurse detailed-architecture per sub-arch]
+    E --> F[Aggregate -> ValidationOutcome]
+    F --> G[exitBasedOffOfValidationOutcome / formatOutput]
+```
+
+- **LINT: Spectral (`SpectralValidationRule`).** Runs the `rules-pattern`, `rules-architecture`
+  and `rules-timeline` rulesets. Custom checks such as `idsAreUnique`, `nodeIdExists`,
+  `interfaceIdExistsOnNode`, `sequenceNumbersAreUnique` are Spectral custom functions over JSONPath.
+- **STRUCTURAL: JSON Schema (`JsonSchemaValidationRule`).** Compiles the pattern/core schema with
+  AJV (async schema loading via `SchemaDirectory`) and validates the architecture.
+- **SEMANTIC: Controls (`ControlsValidationRule`).** Enumerates controls via `iterateControls`,
+  resolves each requirement schema (URL or `#`-pointer into the pattern) and validates the control
+  config against it with AJV.
+- **RECURSIVE: Node details (`NodeDetailsValidationRule`).** For every node that carries a
+  `details.detailed-architecture` reference *that the resolution policy permits* (deep runs only; see
+  §6), loads that sub-architecture document through the shared `CachingTrackingResolver`, discovers
+  its pattern (`required-pattern` URL, else the document's `$schema`, else none) and re-enters the
+  whole engine on the sub-architecture, with mode `architecture-with-pattern` or `architecture-only`
+  depending on whether a pattern was found. Because re-entry runs every applicable phase, including
+  this one, the traversal is depth-first: a sub-architecture whose own nodes reference further
+  detailed-architectures recurses again. The shared resolver guarantees each referenced document is
+  validated at most once and that cycles terminate (an already-seen reference is skipped). Under the
+  shallow (default) policy no sub-architecture is resolvable, so the rule finds nothing to recurse
+  into and only the supplied document is validated; a reference the policy forbids is skipped
+  cleanly and does not produce an error.
+
+The SEMANTIC and RECURSIVE rules only apply when a `SchemaDirectory` is available.
+
+### Aggregated outcome
+
+Every phase, at every resolved depth, contributes to a single flat `ValidationOutcome`. There is no
+nested result tree: findings from recursed sub-architectures are merged into the same two arrays as
+the top-level findings (`jsonSchemaValidationOutputs`, `spectralSchemaValidationOutputs`), and
+`hasErrors`/`hasWarnings` are OR-ed across all of them. Under a shallow run the outcome contains the
+top-level findings only. Depth is preserved only in each output's `path`, which is prefixed with the
+referencing node's `/nodes/{i}/details/detailed-architecture` at each level of recursion. So a
+JSON-Schema error two levels deep appears in the top-level outcome with a compound path such as:
+
+```text
+/nodes/0/details/detailed-architecture/nodes/2/details/detailed-architecture/relationships/1
+```
+
+A sub-architecture reference the policy permits but that cannot be loaded or validated is reported as
+a single `node-details-validation` error at the referencing node's
+`/nodes/{i}/details/detailed-architecture` path. A reference the policy forbids is not an error.
+
+### Callers and CalmHub
+
+The resolution policy is chosen by the caller. The CLI defaults to deep (with a shallow opt-out flag)
+to preserve its existing behaviour, while the calm-server route and CalmHub default to shallow and
+opt in to deep when a recursive validation is wanted. CalmHub is the primary driver of deep runs,
+resolving and validating sub-architectures on demand. The caller wiring is design intent and pending
+implementation.
+
+## 8. Open questions and future direction
+
+The following are known gaps and directions the current design does not yet cover. They are recorded
+as design intent, not settled behaviour.
+
+- **Default traversal and resolution policies.** By default, validation recurses into a node's
+  `detailed-architecture`. This rewrite still suffers from the same concern raised on
+  https://github.com/finos/architecture-as-code/pull/2778: the traversal is effectively always-on.
+  Making it configurable through a resolution policy, rather than always-on, is worth considering so
+  callers can decide when a deep run happens. The mechanism is left open here.
+- **Custom rules versus the default traversal.** Custom or organisation-specific rules may apply only
+  to specific documents or specific document types, which the generic default traversal does not
+  model. It is an open question how a caller such as CalmHub tells the calm-server which
+  organisation-specific rules to run, and how differing rule sets across a large organisation are
+  catered for. See
+  https://github.com/finos/architecture-as-code/issues/2716#issuecomment-4868731836 and issue #2566.
+- **Typed CALM document input.** `validate()` currently accepts four loosely-typed positional inputs
+  (`architecture`, `patternOrSchema`, `timeline`, `schemaDirectory`) and infers a mode from their
+  combination. A future direction is to accept a single typed CALM document from `calm-models` instead,
+  standardising the document type in one place. See issue #2770.
+- **CLI versus CalmHub.** Validation may work differently depending on the caller. The CLI is
+  user-driven and would default to recursive (deep) traversal to preserve its existing behaviour,
+  whereas CalmHub validates documents on upload and would decide when a deep validation is performed,
+  for example defaulting to a shallow run and opting in to a deep run only when needed.

--- a/shared/src/commands/validate/calm-core-parse.spec.ts
+++ b/shared/src/commands/validate/calm-core-parse.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { tryParseCalmCore } from './calm-core-parse';
+import { Logger } from '../../logger';
+
+function fakeLogger(): Logger {
+    return {
+        info: vi.fn(),
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    } as unknown as Logger;
+}
+
+describe('tryParseCalmCore', () => {
+    it('parses a valid architecture into a CalmCore', () => {
+        const logger = fakeLogger();
+        const arch = { nodes: [{ 'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D' }], relationships: [] };
+        const core = tryParseCalmCore(arch, logger);
+        expect(core).toBeDefined();
+        expect(core!.nodes).toHaveLength(1);
+        expect(logger.debug).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined and logs at debug when the architecture cannot be parsed', () => {
+        const logger = fakeLogger();
+        const core = tryParseCalmCore(null as unknown as object, logger);
+        expect(core).toBeUndefined();
+        expect(logger.debug).toHaveBeenCalledOnce();
+    });
+});

--- a/shared/src/commands/validate/calm-core-parse.ts
+++ b/shared/src/commands/validate/calm-core-parse.ts
@@ -1,0 +1,20 @@
+import { CalmCore } from '@finos/calm-models/model';
+import { CalmCoreSchema } from '@finos/calm-models/types';
+import { Logger } from '../../logger.js';
+import { getErrorMessage } from '../../error-utils.js';
+
+/**
+ * Parse a raw architecture object into a {@link CalmCore} model, returning `undefined`
+ * (and logging at debug level) if it cannot be parsed.
+ *
+ * Shared by the node-details and controls validators so the parse guard and its debug
+ * message live in exactly one place.
+ */
+export function tryParseCalmCore(architecture: object, logger: Logger): CalmCore | undefined {
+    try {
+        return CalmCore.fromSchema(architecture as CalmCoreSchema);
+    } catch (err) {
+        logger.debug(`Could not parse architecture with CalmCore.fromSchema: ${getErrorMessage(err)}`);
+        return undefined;
+    }
+}

--- a/shared/src/commands/validate/rules/controls-rule.ts
+++ b/shared/src/commands/validate/rules/controls-rule.ts
@@ -1,0 +1,28 @@
+import { validateAllControls } from '../validate-controls.js';
+import { RuleResult, ValidationContext, ValidationPhase, ValidationRule } from '../validation-rule.js';
+import { hasArchitectureAndDirectory } from './json-schema-rule.js';
+
+/**
+ * A model-backed {@link ValidationRule}: validates every control config against its requirement
+ * schema. This is the "custom-on-model" side of the two-implementation design — it reasons over
+ * the parsed CALM model rather than JSONPath. Only runs when a SchemaDirectory is available.
+ */
+export class ControlsValidationRule implements ValidationRule {
+    readonly id = 'controls';
+    readonly description = 'Validate control configurations against their requirement schemas';
+    readonly phase = ValidationPhase.SEMANTIC;
+
+    appliesTo(context: ValidationContext): boolean {
+        return hasArchitectureAndDirectory(context);
+    }
+
+    async run(context: ValidationContext): Promise<RuleResult> {
+        const result = await validateAllControls(context.architecture!, context.pattern, context.schemaDirectory!, context.debug);
+        return {
+            jsonSchemaOutputs: result.jsonSchemaOutputs,
+            spectralOutputs: [],
+            hasErrors: result.hasErrors,
+            hasWarnings: result.hasWarnings
+        };
+    }
+}

--- a/shared/src/commands/validate/rules/json-schema-rule.ts
+++ b/shared/src/commands/validate/rules/json-schema-rule.ts
@@ -1,0 +1,152 @@
+import { initLogger, Logger } from '../../../logger.js';
+import { getErrorMessage } from '../../../error-utils.js';
+import { SchemaDirectory } from '../../../schema-directory.js';
+import { JsonSchemaValidator } from '../json-schema-validator.js';
+import { ValidationOutput } from '../validation.output.js';
+import {
+    applyArchitectureOptionsToPattern,
+    convertJsonSchemaIssuesToValidationOutputs,
+    findLatestCalmCoreSchemaUrl,
+    prettifyJson
+} from '../validation-helpers.js';
+import { emptyRuleResult, RuleResult, ValidationContext, ValidationPhase, ValidationRule } from '../validation-rule.js';
+
+/**
+ * Structural (JSON-Schema / AJV) validation. Encapsulates the four historical mode-specific
+ * behaviours verbatim so the observable output is unchanged:
+ *  - architecture-with-pattern: compile the (option-resolved) pattern and validate the architecture;
+ *    a compile failure aborts the remaining phases (controls/node-details).
+ *  - architecture-only: discover the latest CALM core schema and validate against it; a compile
+ *    failure records an error but does NOT abort subsequent phases.
+ *  - pattern-only: compile the pattern to prove it is a valid schema (no instance validation).
+ *  - timeline: compile the timeline schema and validate the timeline (compile errors propagate).
+ */
+export class JsonSchemaValidationRule implements ValidationRule {
+    readonly id = 'json-schema';
+    readonly description = 'Validate the document against its JSON Schema (pattern / core / timeline)';
+    readonly phase = ValidationPhase.STRUCTURAL;
+
+    appliesTo(): boolean {
+        return true;
+    }
+
+    async run(context: ValidationContext): Promise<RuleResult> {
+        const logger = initLogger(context.debug, 'calm-validate');
+        switch (context.mode) {
+        case 'architecture-with-pattern':
+            return this.runArchitectureWithPattern(context, logger);
+        case 'architecture-only':
+            return this.runArchitectureOnly(context, logger);
+        case 'pattern-only':
+            return this.runPatternOnly(context);
+        case 'timeline':
+            return this.runTimeline(context, logger);
+        }
+    }
+
+    private async runArchitectureWithPattern(context: ValidationContext, logger: Logger): Promise<RuleResult> {
+        const architecture = context.architecture!;
+        const schemaDirectory = context.schemaDirectory!;
+        const patternResolved = applyArchitectureOptionsToPattern(architecture, context.pattern!, context.debug);
+
+        let jsonSchemaValidator: JsonSchemaValidator;
+        try {
+            jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, patternResolved, context.debug);
+            await jsonSchemaValidator.initialize();
+        } catch (error) {
+            const errorMessage = getErrorMessage(error);
+            logger.error(`JSON Schema compilation failed: ${errorMessage}`);
+            return {
+                jsonSchemaOutputs: [ValidationOutput.error('json-schema', errorMessage, '/', { source: 'pattern' })],
+                spectralOutputs: [],
+                hasErrors: true,
+                hasWarnings: false,
+                abort: true
+            };
+        }
+
+        const schemaErrors = jsonSchemaValidator.validate(architecture);
+        if (schemaErrors.length > 0) {
+            logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
+            return {
+                ...emptyRuleResult(),
+                jsonSchemaOutputs: convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'architecture'),
+                hasErrors: true
+            };
+        }
+        return emptyRuleResult();
+    }
+
+    private async runArchitectureOnly(context: ValidationContext, logger: Logger): Promise<RuleResult> {
+        const architecture = context.architecture!;
+        const schemaDirectory = context.schemaDirectory;
+
+        const coreSchemaUrl = schemaDirectory ? findLatestCalmCoreSchemaUrl(schemaDirectory) : undefined;
+        const coreSchema = (schemaDirectory && coreSchemaUrl) ? await schemaDirectory.getSchema(coreSchemaUrl) : undefined;
+        if (!schemaDirectory || !coreSchema) {
+            logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
+            return emptyRuleResult();
+        }
+
+        logger.debug(`Validating architecture against CALM core schema: ${coreSchemaUrl}`);
+        try {
+            const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, coreSchema, context.debug);
+            await jsonSchemaValidator.initialize();
+            const schemaErrors = jsonSchemaValidator.validate(architecture);
+            if (schemaErrors.length > 0) {
+                logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
+                return {
+                    ...emptyRuleResult(),
+                    jsonSchemaOutputs: convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'architecture'),
+                    hasErrors: true
+                };
+            }
+            return emptyRuleResult();
+        } catch (error) {
+            const errorMessage = getErrorMessage(error);
+            logger.error(`JSON Schema compilation failed: ${errorMessage}`);
+            return {
+                ...emptyRuleResult(),
+                jsonSchemaOutputs: [ValidationOutput.error('json-schema', errorMessage, '/', { source: 'architecture' })],
+                hasErrors: true
+            };
+        }
+    }
+
+    private async runPatternOnly(context: ValidationContext): Promise<RuleResult> {
+        try {
+            // Compile pattern as a schema to check if it's valid
+            const jsonSchemaValidator = new JsonSchemaValidator(context.schemaDirectory!, context.pattern!, context.debug);
+            await jsonSchemaValidator.initialize();
+        } catch (error) {
+            return {
+                ...emptyRuleResult(),
+                jsonSchemaOutputs: [ValidationOutput.error('json-schema', getErrorMessage(error), '/', { source: 'pattern' })],
+                hasErrors: true
+            };
+        }
+        return emptyRuleResult();
+    }
+
+    private async runTimeline(context: ValidationContext, logger: Logger): Promise<RuleResult> {
+        // A compile failure here intentionally propagates (matches the historical timeline flow).
+        const jsonSchemaValidator = new JsonSchemaValidator(context.schemaDirectory!, context.pattern!, context.debug);
+        await jsonSchemaValidator.initialize();
+
+        const schemaErrors = jsonSchemaValidator.validate(context.timeline!);
+        if (schemaErrors.length > 0) {
+            logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
+            return {
+                ...emptyRuleResult(),
+                jsonSchemaOutputs: convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'timeline'),
+                hasErrors: true
+            };
+        }
+        return emptyRuleResult();
+    }
+}
+
+/** Convenience predicate for rules that only run when a SchemaDirectory + architecture exist. */
+export function hasArchitectureAndDirectory(context: ValidationContext): context is ValidationContext & { architecture: object, schemaDirectory: SchemaDirectory } {
+    return context.architecture !== undefined && context.schemaDirectory !== undefined;
+}

--- a/shared/src/commands/validate/rules/node-details-rule.ts
+++ b/shared/src/commands/validate/rules/node-details-rule.ts
@@ -1,0 +1,53 @@
+import { SchemaDirectory } from '../../../schema-directory.js';
+import { validateNodeDetails, ArchitectureValidator } from '../validate-node-details.js';
+import { RuleResult, ValidationContext, ValidationPhase, ValidationRule } from '../validation-rule.js';
+import { hasArchitectureAndDirectory } from './json-schema-rule.js';
+import { CachingTrackingResolver } from '../../../resolver/caching-tracking-resolver.js';
+
+/**
+ * A model-backed, recursive {@link ValidationRule}: validates each node's referenced
+ * detailed-architecture by re-entering the engine for the sub-architecture. The shared
+ * {@link CachingTrackingResolver} caches loaded documents and tracks visited references, providing
+ * cycle safety across the recursion.
+ */
+export class NodeDetailsValidationRule implements ValidationRule {
+    readonly id = 'node-details';
+    readonly description = 'Recursively validate referenced detailed-architecture sub-documents';
+    readonly phase = ValidationPhase.RECURSIVE;
+
+    appliesTo(context: ValidationContext): boolean {
+        return hasArchitectureAndDirectory(context);
+    }
+
+    async run(context: ValidationContext): Promise<RuleResult> {
+        // Re-enter the engine for each sub-architecture, threading the shared caching/tracking
+        // resolver and deriving the mode from whether a pattern was resolved — reproducing the
+        // historical dispatch between the with-pattern and pattern-less flows.
+        const recursiveValidator: ArchitectureValidator = (arch, pattern, dir: SchemaDirectory, dbg, references: CachingTrackingResolver) =>
+            context.engine.validate({
+                architecture: arch,
+                pattern,
+                timeline: undefined,
+                mode: pattern !== undefined ? 'architecture-with-pattern' : 'architecture-only',
+                schemaDirectory: dir,
+                references,
+                debug: dbg,
+                engine: context.engine
+            });
+
+        const result = await validateNodeDetails(
+            context.architecture!,
+            context.schemaDirectory!,
+            context.debug,
+            recursiveValidator,
+            context.references
+        );
+
+        return {
+            jsonSchemaOutputs: result.jsonSchemaOutputs,
+            spectralOutputs: result.spectralOutputs,
+            hasErrors: result.hasErrors,
+            hasWarnings: result.hasWarnings
+        };
+    }
+}

--- a/shared/src/commands/validate/rules/rules.spec.ts
+++ b/shared/src/commands/validate/rules/rules.spec.ts
@@ -1,0 +1,134 @@
+import validationRulesForArchitecture from '../../../spectral/rules-architecture';
+import { SpectralValidationRule } from './spectral-rule';
+import { ControlsValidationRule } from './controls-rule';
+import { NodeDetailsValidationRule } from './node-details-rule';
+import { JsonSchemaValidationRule } from './json-schema-rule';
+import { ValidationContext, ValidationMode } from '../validation-rule';
+import { SchemaDirectory } from '../../../schema-directory';
+import { ValidationEngine } from '../validation-engine';
+import { validateAllControls } from '../validate-controls';
+import { validateNodeDetails } from '../validate-node-details';
+import { JsonSchemaValidator } from '../json-schema-validator';
+import { CachingTrackingResolver } from '../../../resolver/caching-tracking-resolver';
+
+vi.mock('../../../logger.js', () => ({
+    initLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+vi.mock('../validate-controls.js', () => ({ validateAllControls: vi.fn() }));
+vi.mock('../validate-node-details.js', () => ({ validateNodeDetails: vi.fn() }));
+vi.mock('../json-schema-validator.js', () => ({ JsonSchemaValidator: vi.fn() }));
+
+const fakeDir = {} as unknown as SchemaDirectory;
+
+function ctx(overrides: Partial<ValidationContext>): ValidationContext {
+    return {
+        mode: 'architecture-only',
+        references: new CachingTrackingResolver({ canResolve: () => false, resolve: () => Promise.reject(new Error('unused')) }),
+        debug: false,
+        engine: undefined as unknown as ValidationEngine,
+        ...overrides
+    };
+}
+
+describe('SpectralValidationRule.appliesTo', () => {
+    const patternRule = new SpectralValidationRule(
+        'spectral-pattern', 'pattern', validationRulesForArchitecture, 'pattern',
+        c => (c.pattern ? JSON.stringify(c.pattern) : undefined),
+        c => c.mode === 'architecture-with-pattern' || c.mode === 'pattern-only'
+    );
+
+    it('applies only when mode allows AND the selected document is present', () => {
+        expect(patternRule.appliesTo(ctx({ mode: 'pattern-only', pattern: {} }))).toBe(true);
+        expect(patternRule.appliesTo(ctx({ mode: 'architecture-with-pattern', pattern: {} }))).toBe(true);
+    });
+
+    it('does not apply when the mode is excluded', () => {
+        expect(patternRule.appliesTo(ctx({ mode: 'architecture-only', pattern: {} }))).toBe(false);
+        expect(patternRule.appliesTo(ctx({ mode: 'timeline', pattern: {} }))).toBe(false);
+    });
+
+    it('does not apply when the selected document is absent', () => {
+        expect(patternRule.appliesTo(ctx({ mode: 'pattern-only', pattern: undefined }))).toBe(false);
+    });
+});
+
+describe('ControlsValidationRule', () => {
+    const rule = new ControlsValidationRule();
+
+    it('applies only when architecture AND schemaDirectory are present', () => {
+        expect(rule.appliesTo(ctx({ architecture: {}, schemaDirectory: fakeDir }))).toBe(true);
+        expect(rule.appliesTo(ctx({ architecture: {} }))).toBe(false);
+        expect(rule.appliesTo(ctx({ schemaDirectory: fakeDir }))).toBe(false);
+    });
+
+    it('delegates to validateAllControls and maps the result', async () => {
+        vi.mocked(validateAllControls).mockResolvedValue({
+            jsonSchemaOutputs: [{ code: 'c' } as never],
+            hasErrors: true,
+            hasWarnings: false
+        });
+
+        const result = await rule.run(ctx({ architecture: { a: 1 }, pattern: { p: 1 }, schemaDirectory: fakeDir }));
+
+        expect(validateAllControls).toHaveBeenCalledWith({ a: 1 }, { p: 1 }, fakeDir, false);
+        expect(result.jsonSchemaOutputs).toEqual([{ code: 'c' }]);
+        expect(result.spectralOutputs).toEqual([]);
+        expect(result.hasErrors).toBe(true);
+    });
+});
+
+describe('NodeDetailsValidationRule', () => {
+    const rule = new NodeDetailsValidationRule();
+
+    it('applies only when architecture AND schemaDirectory are present', () => {
+        expect(rule.appliesTo(ctx({ architecture: {}, schemaDirectory: fakeDir }))).toBe(true);
+        expect(rule.appliesTo(ctx({ architecture: {} }))).toBe(false);
+    });
+
+    it('delegates to validateNodeDetails, threading the shared visited set', async () => {
+        vi.mocked(validateNodeDetails).mockResolvedValue({
+            jsonSchemaOutputs: [{ code: 'n' } as never],
+            spectralOutputs: [{ code: 's' } as never],
+            hasErrors: false,
+            hasWarnings: true
+        });
+        const references = new CachingTrackingResolver({ canResolve: () => false, resolve: () => Promise.reject(new Error('unused')) });
+        references.markSeen('seen');
+
+        const result = await rule.run(ctx({ architecture: { a: 1 }, schemaDirectory: fakeDir, references }));
+
+        expect(validateNodeDetails).toHaveBeenCalledWith({ a: 1 }, fakeDir, false, expect.any(Function), references);
+        expect(result.jsonSchemaOutputs).toEqual([{ code: 'n' }]);
+        expect(result.spectralOutputs).toEqual([{ code: 's' }]);
+        expect(result.hasWarnings).toBe(true);
+    });
+});
+
+describe('JsonSchemaValidationRule compile-failure short-circuit', () => {
+    const rule = new JsonSchemaValidationRule();
+
+    beforeEach(() => {
+        vi.mocked(JsonSchemaValidator).mockImplementation(() => ({
+            initialize: vi.fn().mockRejectedValue(new Error('bad schema')),
+            validate: vi.fn().mockReturnValue([])
+        }) as unknown as JsonSchemaValidator);
+    });
+
+    it('aborts subsequent phases when the pattern fails to compile (architecture-with-pattern)', async () => {
+        const result = await rule.run(ctx({ mode: 'architecture-with-pattern' as ValidationMode, architecture: {}, pattern: {}, schemaDirectory: fakeDir }));
+
+        expect(result.abort).toBe(true);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].source).toBe('pattern');
+    });
+
+    it('does NOT abort when the core schema fails to compile (architecture-only)', async () => {
+        const dir = { getLoadedSchemas: () => ['https://calm.finos.org/release/1.2/meta/core.json'], getSchema: vi.fn().mockResolvedValue({ type: 'object' }) } as unknown as SchemaDirectory;
+
+        const result = await rule.run(ctx({ mode: 'architecture-only' as ValidationMode, architecture: {}, schemaDirectory: dir }));
+
+        expect(result.abort).toBeUndefined();
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].source).toBe('architecture');
+    });
+});

--- a/shared/src/commands/validate/rules/spectral-rule.ts
+++ b/shared/src/commands/validate/rules/spectral-rule.ts
@@ -1,0 +1,43 @@
+import { RulesetDefinition } from '@stoplight/spectral-core';
+import { initLogger } from '../../../logger.js';
+import { runSpectralValidations } from '../validation-helpers.js';
+import { RuleResult, ValidationContext, ValidationPhase, ValidationRule } from '../validation-rule.js';
+
+/**
+ * Selects and serialises the document a Spectral rule should lint from the context.
+ * Returns undefined when the required document is absent (rule then contributes nothing).
+ */
+export type DocumentSelector = (context: ValidationContext) => string | undefined;
+
+/**
+ * A {@link ValidationRule} backed by a Spectral ruleset. This is the "Spectral implementation" of
+ * the two-implementation design: declarative JSONPath rules over the raw JSON document.
+ */
+export class SpectralValidationRule implements ValidationRule {
+    readonly phase = ValidationPhase.LINT;
+
+    constructor(
+        readonly id: string,
+        readonly description: string,
+        private readonly ruleset: RulesetDefinition,
+        private readonly source: string,
+        private readonly selectDocument: DocumentSelector,
+        private readonly applies: (context: ValidationContext) => boolean
+    ) {}
+
+    appliesTo(context: ValidationContext): boolean {
+        return this.applies(context) && this.selectDocument(context) !== undefined;
+    }
+
+    async run(context: ValidationContext): Promise<RuleResult> {
+        const logger = initLogger(context.debug, 'calm-validate');
+        const document = this.selectDocument(context)!;
+        const result = await runSpectralValidations(document, this.ruleset, this.source, logger);
+        return {
+            jsonSchemaOutputs: [],
+            spectralOutputs: result.spectralIssues,
+            hasErrors: result.errors,
+            hasWarnings: result.warnings
+        };
+    }
+}

--- a/shared/src/commands/validate/validate-controls.spec.ts
+++ b/shared/src/commands/validate/validate-controls.spec.ts
@@ -1,0 +1,456 @@
+import { validateAllControls } from './validate-controls';
+import { SchemaDirectory } from '../../schema-directory';
+
+const mocks = vi.hoisted(() => ({
+    jsonSchemaValidate: vi.fn().mockReturnValue([]),
+    jsonSchemaValidatorConstructor: vi.fn().mockImplementation(function () {
+        return {
+            validate: mocks.jsonSchemaValidate,
+            initialize: vi.fn().mockResolvedValue(undefined),
+        };
+    })
+}));
+
+vi.mock('./json-schema-validator', () => ({
+    JsonSchemaValidator: mocks.jsonSchemaValidatorConstructor
+}));
+
+vi.mock('../../logger.js', () => ({
+    initLogger: () => ({
+        info: vi.fn(),
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    })
+}));
+
+const requirementSchema = {
+    $id: 'https://example.com/requirement.json',
+    type: 'object',
+    required: ['control-id', 'name'],
+    properties: {
+        'control-id': { type: 'string' },
+        name: { type: 'string' }
+    }
+};
+
+function makeSchemaDirectory(getSchemaResult: object | undefined = requirementSchema): SchemaDirectory {
+    return {
+        getSchema: vi.fn().mockResolvedValue(getSchemaResult),
+        loadDocument: vi.fn(),
+        fork: vi.fn(),
+        loadSchemas: vi.fn(),
+        storeDocument: vi.fn(),
+        getLoadedSchemas: vi.fn().mockReturnValue([]),
+    } as unknown as SchemaDirectory;
+}
+
+const inlineConfig = { 'control-id': 'sec-001', name: 'Security Control' };
+
+function architectureWithNodeControl(config?: object, requirementUrl = 'https://example.com/requirement.json') {
+    const requirement: Record<string, unknown> = { 'requirement-url': requirementUrl };
+    if (config !== undefined) {
+        requirement['config'] = config;
+    }
+    return {
+        nodes: [{
+            'unique-id': 'node-1',
+            'node-type': 'service',
+            name: 'Node 1',
+            description: 'Test node',
+            controls: {
+                security: {
+                    description: 'Security controls',
+                    requirements: [requirement]
+                }
+            }
+        }]
+    };
+}
+
+describe('validateAllControls', () => {
+    beforeEach(() => {
+        mocks.jsonSchemaValidate.mockReturnValue([]);
+        mocks.jsonSchemaValidatorConstructor.mockClear();
+    });
+
+    it('returns empty outputs when architecture has no controls', async () => {
+        const arch = { nodes: [{ 'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D' }] };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(result.hasErrors).toBe(false);
+        expect(result.hasWarnings).toBe(false);
+    });
+
+    it('validates node control with valid inline config and emits no errors', async () => {
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(mocks.jsonSchemaValidatorConstructor).toHaveBeenCalledOnce();
+    });
+
+    it('emits errors with correct path when node control config is invalid', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            instancePath: '/name',
+            schemaPath: '#/properties/name/type',
+            keyword: 'type',
+            params: {},
+            message: 'must be string'
+        }]);
+        const arch = architectureWithNodeControl({ 'control-id': 'sec-001', name: 42 });
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs).toHaveLength(1);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/controls/security/requirements/0/name');
+    });
+
+    it('uses controlPath as path when instancePath is empty (root error)', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: { missingProperty: 'name' },
+            message: 'must have required property \'name\''
+        }]);
+        const arch = architectureWithNodeControl({ 'control-id': 'sec-001' });
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/controls/security/requirements/0');
+    });
+
+    it('assigns correct path prefix for relationship controls', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: {},
+            message: 'missing required'
+        }]);
+        const arch = {
+            relationships: [{
+                'unique-id': 'rel-1',
+                'relationship-type': { connects: { source: { node: 'a' }, destination: { node: 'b' } } },
+                controls: {
+                    auth: {
+                        description: 'Auth controls',
+                        requirements: [{ 'requirement-url': 'https://example.com/requirement.json', config: { 'control-id': 'auth-001', name: 'Auth' } }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/relationships/0/controls/auth/requirements/0');
+    });
+
+    it('assigns correct path prefix for flow controls', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: {},
+            message: 'missing required'
+        }]);
+        const arch = {
+            flows: [{
+                'unique-id': 'flow-1',
+                name: 'Flow',
+                description: 'A flow',
+                transitions: [],
+                controls: {
+                    data: {
+                        description: 'Data controls',
+                        requirements: [{ 'requirement-url': 'https://example.com/requirement.json', config: { 'control-id': 'd-001', name: 'Data' } }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/flows/0/controls/data/requirements/0');
+    });
+
+    it('assigns correct path prefix for top-level controls', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: {},
+            message: 'missing required'
+        }]);
+        const arch = {
+            controls: {
+                global: {
+                    description: 'Global controls',
+                    requirements: [{ 'requirement-url': 'https://example.com/requirement.json', config: { 'control-id': 'g-001', name: 'Global' } }]
+                }
+            }
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/controls/global/requirements/0');
+    });
+
+    it('resolves requirement-url starting with # as JSON pointer into pattern', async () => {
+        const pattern = {
+            defs: {
+                myRequirement: requirementSchema
+            }
+        };
+        const arch = architectureWithNodeControl(inlineConfig, '#/defs/myRequirement');
+        const result = await validateAllControls(arch, pattern, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(false);
+        // JsonSchemaValidator should have been called with the resolved requirement schema
+        expect(mocks.jsonSchemaValidatorConstructor).toHaveBeenCalledWith(
+            expect.anything(),
+            requirementSchema,
+            false
+        );
+    });
+
+    it('emits error when requirement-url is JSON pointer but pattern is undefined', async () => {
+        const arch = architectureWithNodeControl(inlineConfig, '#/defs/myRequirement');
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].code).toBe('control-requirement-validation');
+        expect(result.jsonSchemaOutputs[0].message).toContain('JSON pointer');
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('emits error when JSON pointer path does not exist in pattern', async () => {
+        const pattern = { defs: {} };
+        const arch = architectureWithNodeControl(inlineConfig, '#/defs/nonExistent');
+        const result = await validateAllControls(arch, pattern, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('Could not resolve');
+    });
+
+    it('loads config via getSchema when config-url is present', async () => {
+        const schemaDir = makeSchemaDirectory(requirementSchema);
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(requirementSchema)   // first call: requirement schema
+            .mockResolvedValueOnce(inlineConfig);        // second call: config doc
+
+        const arch = {
+            nodes: [{
+                'unique-id': 'node-1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                controls: {
+                    security: {
+                        description: 'Security',
+                        requirements: [{
+                            'requirement-url': 'https://example.com/requirement.json',
+                            'config-url': 'https://example.com/config.json'
+                        }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(false);
+        expect(schemaDir.getSchema).toHaveBeenCalledWith('https://example.com/config.json');
+    });
+
+    it('skips control detail when neither config nor config-url is present', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'node-1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                controls: {
+                    security: {
+                        description: 'Security',
+                        requirements: [{ 'requirement-url': 'https://example.com/requirement.json' }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(false);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('emits error when requirement schema cannot be loaded', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].code).toBe('control-requirement-validation');
+        expect(result.jsonSchemaOutputs[0].message).toContain('not found');
+    });
+
+    it('emits warning when architecture contains legacy control-requirement-url naming', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'node-1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                controls: {
+                    security: {
+                        description: 'Security',
+                        requirements: [{
+                            'control-requirement-url': 'https://example.com/requirement.json',
+                            'control-config-url': 'https://example.com/config.json'
+                        }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasWarnings).toBe(true);
+        const warning = result.jsonSchemaOutputs.find(o => o.code === 'control-legacy-naming');
+        expect(warning).toBeDefined();
+        expect(warning?.severity).toBe('warning');
+    });
+
+    it('emits error when getSchema throws for requirement-url', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network error'));
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('network error');
+    });
+
+    it('returns no outputs when architecture cannot be parsed as CalmCore', async () => {
+        const result = await validateAllControls(null as unknown as object, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(result.hasErrors).toBe(false);
+        expect(result.hasWarnings).toBe(false);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('skips validation when in-pattern JSON pointer resolves to an undefined schema', async () => {
+        const pattern = { defs: { myRequirement: undefined } };
+        const arch = architectureWithNodeControl(inlineConfig, '#/defs/myRequirement');
+        const result = await validateAllControls(arch, pattern, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('emits error when config-url document fails to load', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(requirementSchema)                 // requirement schema
+            .mockRejectedValueOnce(new Error('config fetch failed')); // config-url
+        const arch = {
+            nodes: [{
+                'unique-id': 'node-1', 'node-type': 'service', name: 'N', description: 'D',
+                controls: {
+                    security: {
+                        description: 'Security',
+                        requirements: [{
+                            'requirement-url': 'https://example.com/requirement.json',
+                            'config-url': 'https://example.com/config.json'
+                        }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('config fetch failed');
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('skips validation when config-url document is not found', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(requirementSchema)  // requirement schema
+            .mockResolvedValueOnce(undefined);         // config-url -> not found
+        const arch = {
+            nodes: [{
+                'unique-id': 'node-1', 'node-type': 'service', name: 'N', description: 'D',
+                controls: {
+                    security: {
+                        description: 'Security',
+                        requirements: [{
+                            'requirement-url': 'https://example.com/requirement.json',
+                            'config-url': 'https://example.com/missing-config.json'
+                        }]
+                    }
+                }
+            }]
+        };
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(mocks.jsonSchemaValidatorConstructor).not.toHaveBeenCalled();
+    });
+
+    it('emits error when the requirement schema cannot be compiled', async () => {
+        mocks.jsonSchemaValidatorConstructor.mockImplementationOnce(function () {
+            return {
+                validate: mocks.jsonSchemaValidate,
+                initialize: vi.fn().mockRejectedValue(new Error('invalid schema'))
+            };
+        });
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('Could not compile');
+        expect(result.jsonSchemaOutputs[0].message).toContain('invalid schema');
+    });
+
+    it('ignores relationships and flows that have no controls', async () => {
+        const arch = {
+            nodes: [{ 'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D' }],
+            relationships: [{
+                'unique-id': 'rel-1',
+                'relationship-type': { connects: { source: { node: 'a' }, destination: { node: 'b' } } }
+            }],
+            flows: [{ 'unique-id': 'flow-1', name: 'Flow', description: 'A flow', transitions: [] }]
+        };
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(result.hasErrors).toBe(false);
+    });
+
+    it('handles validation errors with missing instancePath and message', async () => {
+        mocks.jsonSchemaValidate.mockReturnValue([{
+            schemaPath: '#/required',
+            keyword: 'required',
+            params: {}
+        }]);
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, makeSchemaDirectory(), false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/controls/security/requirements/0');
+        expect(result.jsonSchemaOutputs[0].message).toBe('');
+    });
+
+    it('coerces a non-Error string thrown while loading the requirement schema', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain string failure');
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('plain string failure');
+    });
+
+    // Note: this codebase uses the shared getErrorMessage util (String(error)) rather than
+    // JSON.stringify, so a non-Error object throw is coerced to '[object Object]'. The behaviour
+    // under test is that a non-Error throw is handled gracefully (an error output, no crash).
+    it('coerces a non-Error object thrown while loading the requirement schema', async () => {
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ code: 500 });
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('[object Object]');
+    });
+
+    it('does not throw when a non-stringifiable (circular) value is thrown while loading the requirement schema', async () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockRejectedValueOnce(circular);
+        const arch = architectureWithNodeControl(inlineConfig);
+        const result = await validateAllControls(arch, undefined, schemaDir, false);
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('[object Object]');
+    });
+});

--- a/shared/src/commands/validate/validate-controls.ts
+++ b/shared/src/commands/validate/validate-controls.ts
@@ -1,0 +1,217 @@
+import pointer from 'json-pointer';
+import { CalmControlDetail } from '@finos/calm-models/model';
+import { ErrorObject } from 'ajv/dist/2020.js';
+import { SchemaDirectory } from '../../schema-directory.js';
+import { JsonSchemaValidator } from './json-schema-validator.js';
+import { ValidationOutput } from './validation.output.js';
+import { initLogger, Logger } from '../../logger.js';
+import { getErrorMessage } from '../../error-utils.js';
+import { iterateControls } from '../../controls/control-iteration.js';
+import { tryParseCalmCore } from './calm-core-parse.js';
+
+type ControlDetailResult = { outputs: ValidationOutput[], hasErrors: boolean };
+
+/**
+ * Validate all control requirements in the architecture against their requirement schemas.
+ *
+ * Controls are enumerated once via the {@link iterateControls} helper. For each control detail
+ * with a config, the requirement schema is loaded and the config validated against it via AJV.
+ *
+ * If a requirement-url starts with '#', it is treated as a JSON pointer into the pattern
+ * document, allowing control requirement schemas to be embedded in the pattern itself.
+ *
+ * @param architecture     Raw architecture object.
+ * @param pattern          Pattern document (needed for '#'-prefixed requirement-url resolution).
+ * @param schemaDirectory  For loading requirement schemas and configs by URL.
+ * @param debug            Enable debug logging.
+ */
+export async function validateAllControls(
+    architecture: object,
+    pattern: object | undefined,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean
+): Promise<{ jsonSchemaOutputs: ValidationOutput[], hasErrors: boolean, hasWarnings: boolean }> {
+    const logger = initLogger(debug, 'validate-controls');
+    const outputs: ValidationOutput[] = [];
+    let hasErrors = false;
+    let hasWarnings = false;
+
+    if (JSON.stringify(architecture).includes('"control-requirement-url"')) {
+        outputs.push(legacyNamingWarning());
+        hasWarnings = true;
+    }
+
+    const calmCore = tryParseCalmCore(architecture, logger);
+    if (!calmCore) {
+        return { jsonSchemaOutputs: outputs, hasErrors, hasWarnings };
+    }
+
+    for (const location of iterateControls(calmCore)) {
+        for (const [reqIdx, detail] of location.control.requirements.entries()) {
+            const controlPath = `${location.pathPrefix}/${location.controlId}/requirements/${reqIdx}`;
+            const result = await validateControlDetail(detail, controlPath, pattern, schemaDirectory, debug);
+            outputs.push(...result.outputs);
+            if (result.hasErrors) hasErrors = true;
+        }
+    }
+
+    return { jsonSchemaOutputs: outputs, hasErrors, hasWarnings };
+}
+
+async function validateControlDetail(
+    detail: CalmControlDetail,
+    controlPath: string,
+    pattern: object | undefined,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean
+): Promise<ControlDetailResult> {
+    const logger = initLogger(debug, 'validate-controls');
+    const requirementUrl = detail.requirement.reference;
+
+    if (!requirementUrl) {
+        logger.debug(`Skipping control at ${controlPath}: requirement-url is missing (possible legacy naming)`);
+        return nothing();
+    }
+
+    const { schema: requirementSchema, error: schemaError } = await resolveRequirementSchema(requirementUrl, controlPath, pattern, schemaDirectory);
+    if (schemaError) return fail(schemaError);
+    if (!requirementSchema) return nothing();
+
+    const { config, error: configError } = await resolveConfig(detail, controlPath, schemaDirectory, logger);
+    if (configError) return fail(configError);
+    if (!config) return nothing();
+
+    return runSchemaValidation(config, requirementSchema, requirementUrl, controlPath, schemaDirectory, debug);
+}
+
+async function resolveRequirementSchema(
+    requirementUrl: string,
+    controlPath: string,
+    pattern: object | undefined,
+    schemaDirectory: SchemaDirectory
+): Promise<{ schema?: object, error?: ValidationOutput }> {
+    if (requirementUrl.startsWith('#')) {
+        // resolve an in-pattern ref (i.e. inline control requirement schema)
+        return resolvePointerInPattern(requirementUrl, controlPath, pattern);
+    }
+    return loadSchemaFromDirectory(requirementUrl, controlPath, schemaDirectory);
+}
+
+/**
+ * Resolve an in-pattern requirement schema reference (JSON pointer) to the actual schema definition.
+ * This is how inline control requirement schemas are supported in patterns.
+ */
+function resolvePointerInPattern(
+    requirementUrl: string,
+    controlPath: string,
+    pattern: object | undefined
+): { schema?: object, error?: ValidationOutput } {
+    if (!pattern) {
+        return { error: controlError(controlPath, `requirement-url '${requirementUrl}' is a JSON pointer but no pattern document is available`) };
+    }
+    try {
+        return { schema: pointer.get(pattern, requirementUrl.slice(1)) as object };
+    } catch {
+        return { error: controlError(controlPath, `Could not resolve requirement-url '${requirementUrl}' as a JSON pointer in the pattern document`) };
+    }
+}
+
+async function loadSchemaFromDirectory(
+    requirementUrl: string,
+    controlPath: string,
+    schemaDirectory: SchemaDirectory
+): Promise<{ schema?: object, error?: ValidationOutput }> {
+    let schema: object | undefined;
+    try {
+        schema = await schemaDirectory.getSchema(requirementUrl);
+    } catch (err) {
+        return { error: controlError(controlPath, `Could not load requirement schema from '${requirementUrl}': ${getErrorMessage(err)}`) };
+    }
+    if (!schema) {
+        return { error: controlError(controlPath, `Requirement schema not found: '${requirementUrl}'`) };
+    }
+    return { schema };
+}
+
+/**
+ * Resolve a control's config. Prefers an inline `config`; otherwise loads the `config-url`
+ * document directly via the SchemaDirectory. Returns an empty result if neither is present
+ * or the config document could not be found.
+ */
+async function resolveConfig(
+    detail: CalmControlDetail,
+    controlPath: string,
+    schemaDirectory: SchemaDirectory,
+    logger: Logger
+): Promise<{ config?: Record<string, unknown>, error?: ValidationOutput }> {
+    if (detail.config) {
+        return { config: detail.config };
+    }
+    if (!detail.configUrl) {
+        logger.debug(`No config for control requirement at ${controlPath}, skipping`);
+        return {};
+    }
+
+    const configUrl = detail.configUrl.reference;
+    try {
+        const config = await schemaDirectory.getSchema(configUrl) as Record<string, unknown> | undefined;
+        if (!config) {
+            logger.debug(`Config document not found at '${configUrl}', skipping validation`);
+            return {};
+        }
+        return { config };
+    } catch (err) {
+        return { error: controlError(controlPath, `Could not load config from '${configUrl}': ${getErrorMessage(err)}`) };
+    }
+}
+
+async function runSchemaValidation(
+    config: Record<string, unknown>,
+    requirementSchema: object,
+    requirementUrl: string,
+    controlPath: string,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean
+): Promise<ControlDetailResult> {
+    let validator: JsonSchemaValidator;
+    try {
+        validator = new JsonSchemaValidator(schemaDirectory, requirementSchema, debug);
+        await validator.initialize();
+    } catch (err) {
+        return fail(controlError(controlPath, `Could not compile requirement schema from '${requirementUrl}': ${getErrorMessage(err)}`));
+    }
+    const errors = validator.validate(config);
+    return { outputs: controlErrorsToValidationOutputs(errors, controlPath), hasErrors: errors.length > 0 };
+}
+
+function controlErrorsToValidationOutputs(errors: ErrorObject[], controlPath: string): ValidationOutput[] {
+    return errors.map(error => {
+        const rawPath = error.instancePath ?? '';
+        const path = rawPath === '' ? controlPath : controlPath + rawPath;
+        return ValidationOutput.error('control-requirement-validation', error.message ?? '', path, {
+            schemaPath: error.schemaPath,
+            source: 'architecture'
+        });
+    });
+}
+
+function legacyNamingWarning(): ValidationOutput {
+    return ValidationOutput.warning(
+        'control-legacy-naming',
+        'Architecture contains legacy control naming (control-requirement-url). Migrate to requirement-url. Controls with legacy naming were not validated.',
+        '/',
+        { source: 'architecture' }
+    );
+}
+
+function controlError(path: string, message: string): ValidationOutput {
+    return ValidationOutput.error('control-requirement-validation', message, path, { source: 'architecture' });
+}
+
+function nothing(): ControlDetailResult {
+    return { outputs: [], hasErrors: false };
+}
+
+function fail(output: ValidationOutput): ControlDetailResult {
+    return { outputs: [output], hasErrors: true };
+}

--- a/shared/src/commands/validate/validate-node-details.e2e.spec.ts
+++ b/shared/src/commands/validate/validate-node-details.e2e.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'path';
+import { validate } from './validate.js';
+import { FileSystemDocumentLoader } from '../../document-loader/file-system-document-loader.js';
+import { InMemoryDocumentLoader } from '../../test/in-memory-document-loader.js';
+import { SchemaDirectory } from '../../schema-directory.js';
+
+const schemaDir_12 = path.join(__dirname, '../../../../calm/release/1.2/meta/');
+
+const CYCLIC_ARCH_URL = 'https://calm.example.com/cyclic-arch.json';
+const NESTED_ARCH_URL = 'https://calm.example.com/nested-arch.json';
+
+function nodeWithDetail(detailUrl: string) {
+    return {
+        'unique-id': 'svc',
+        'node-type': 'service',
+        name: 'Service',
+        description: 'a service with detailed architecture',
+        details: { 'detailed-architecture': detailUrl }
+    };
+}
+
+const topArchWithCycle = {
+    'unique-id': 'top-cyclic',
+    nodes: [nodeWithDetail(CYCLIC_ARCH_URL)],
+    relationships: []
+};
+
+// The sub-architecture references itself, forming a cycle.
+const cyclicSubArch = {
+    'unique-id': 'cyclic-sub',
+    nodes: [nodeWithDetail(CYCLIC_ARCH_URL)],
+    relationships: []
+};
+
+const topArchNested = {
+    'unique-id': 'top-nested',
+    nodes: [nodeWithDetail(NESTED_ARCH_URL)],
+    relationships: []
+};
+
+// A well-formed nested sub-architecture (no cycle, no errors).
+const nestedSubArch = {
+    'unique-id': 'nested-sub',
+    nodes: [
+        { 'unique-id': 'db', 'node-type': 'database', name: 'DB', description: 'a database' }
+    ],
+    relationships: []
+};
+
+describe('validate node-details E2E', () => {
+    function schemaDirectoryWith(docs: Record<string, object>): SchemaDirectory {
+        const fsLoader = new FileSystemDocumentLoader([schemaDir_12], false);
+        return new SchemaDirectory(new InMemoryDocumentLoader(docs, fsLoader));
+    }
+
+    let schemaDirectory: SchemaDirectory;
+
+    beforeEach(async () => {
+        schemaDirectory = schemaDirectoryWith({
+            [CYCLIC_ARCH_URL]: cyclicSubArch,
+            [NESTED_ARCH_URL]: nestedSubArch
+        });
+        await schemaDirectory.loadSchemas();
+    });
+
+    it('terminates (does not hang or overflow) on a cyclic detailed-architecture', async () => {
+        // Regression guard for the cycle bug: a pattern-less architecture whose
+        // detailed-architecture references itself must terminate.
+        const outcome = await validate(topArchWithCycle, undefined, undefined, schemaDirectory, false);
+        expect(outcome).toBeDefined();
+        // The cycle is detected and skipped, so validation completes without a stack overflow.
+        expect(Array.isArray(outcome.jsonSchemaValidationOutputs)).toBe(true);
+    }, 10000);
+
+    it('recursively validates a well-formed nested detailed-architecture', async () => {
+        const outcome = await validate(topArchNested, undefined, undefined, schemaDirectory, false);
+        expect(outcome).toBeDefined();
+        expect(outcome.hasErrors).toBe(false);
+    });
+
+    it('surfaces errors from an invalid nested detailed-architecture with a prefixed path', async () => {
+        const invalidNested = {
+            'unique-id': 'invalid-sub',
+            nodes: [
+                // node-type is required by the core schema; omit it to force an error
+                { 'unique-id': 'broken', name: 'Broken', description: 'missing node-type' }
+            ],
+            relationships: []
+        };
+        schemaDirectory = schemaDirectoryWith({ [NESTED_ARCH_URL]: invalidNested });
+        await schemaDirectory.loadSchemas();
+
+        const outcome = await validate(topArchNested, undefined, undefined, schemaDirectory, false);
+        expect(outcome.hasErrors).toBe(true);
+        const prefixed = outcome.jsonSchemaValidationOutputs.some(o =>
+            o.path.startsWith('/nodes/0/details/detailed-architecture')
+        );
+        expect(prefixed).toBe(true);
+    });
+});

--- a/shared/src/commands/validate/validate-node-details.spec.ts
+++ b/shared/src/commands/validate/validate-node-details.spec.ts
@@ -254,6 +254,35 @@ describe('validateNodeDetails', () => {
         expect(result.jsonSchemaOutputs[1].path).toBe('/nodes/1/details/detailed-architecture/y');
     });
 
+    // Reproduces rocketstack-matt's review comment on PR #2805:
+    // https://github.com/finos/architecture-as-code/pull/2805#discussion_r3576885169
+    // Asserts the DESIRED behaviour (both nodes report); expected to FAIL against current code,
+    // which returns only one error. Left red pending clarification before fixing.
+    it('reports a load error for every node sharing the same broken detailed-architecture reference', async () => {
+        const brokenUrl = 'https://example.com/missing-shared.json';
+        const arch = {
+            nodes: [
+                {
+                    'unique-id': 'n1', 'node-type': 'service', name: 'N1', description: 'D',
+                    details: { 'detailed-architecture': brokenUrl }
+                },
+                {
+                    'unique-id': 'n2', 'node-type': 'service', name: 'N2', description: 'D',
+                    details: { 'detailed-architecture': brokenUrl }
+                }
+            ]
+        };
+        const schemaDir = makeSchemaDirectory({
+            loadDocument: vi.fn().mockRejectedValue(new Error('not found'))
+        });
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.jsonSchemaOutputs).toHaveLength(2);
+        expect(result.jsonSchemaOutputs.map(o => o.path)).toEqual([
+            '/nodes/0/details/detailed-architecture',
+            '/nodes/1/details/detailed-architecture'
+        ]);
+    });
+
     it('propagates hasWarnings from sub-architecture outcome', async () => {
         const arch = {
             nodes: [{

--- a/shared/src/commands/validate/validate-node-details.spec.ts
+++ b/shared/src/commands/validate/validate-node-details.spec.ts
@@ -1,0 +1,420 @@
+import { validateNodeDetails, ArchitectureValidator } from './validate-node-details';
+import { SchemaDirectory } from '../../schema-directory';
+import { ValidationOutput, ValidationOutcome } from './validation.output';
+import { CachingTrackingResolver } from '../../resolver/caching-tracking-resolver';
+
+function makeResolver(dir: SchemaDirectory): CachingTrackingResolver {
+    return new CachingTrackingResolver({
+        canResolve: () => true,
+        resolve: (url: string) => dir.loadDocument(url, 'architecture')
+    });
+}
+
+vi.mock('../../logger.js', () => ({
+    initLogger: () => ({
+        info: vi.fn(),
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    })
+}));
+
+const subArchitecture = {
+    '$schema': 'https://example.com/pattern.json',
+    nodes: [{ 'unique-id': 'sub-node', 'node-type': 'service', name: 'Sub Node', description: 'Sub' }],
+    relationships: []
+};
+
+const patternDoc = { $id: 'https://example.com/pattern.json', type: 'object' };
+
+function makeSchemaDirectory(overrides: Partial<{
+    loadDocument: ReturnType<typeof vi.fn>,
+    getSchema: ReturnType<typeof vi.fn>,
+    fork: ReturnType<typeof vi.fn>,
+    loadSchemas: ReturnType<typeof vi.fn>,
+}> = {}): SchemaDirectory {
+    const freshDir = {
+        getSchema: vi.fn().mockResolvedValue(undefined),
+        loadDocument: vi.fn(),
+        fork: vi.fn(),
+        loadSchemas: vi.fn().mockResolvedValue(undefined),
+        storeDocument: vi.fn(),
+        getLoadedSchemas: vi.fn().mockReturnValue([]),
+    };
+    return {
+        getSchema: vi.fn().mockResolvedValue(patternDoc),
+        loadDocument: overrides.loadDocument ?? vi.fn().mockResolvedValue(subArchitecture),
+        fork: overrides.fork ?? vi.fn().mockReturnValue(freshDir),
+        loadSchemas: vi.fn().mockResolvedValue(undefined),
+        storeDocument: vi.fn(),
+        getLoadedSchemas: vi.fn().mockReturnValue([]),
+    } as unknown as SchemaDirectory;
+}
+
+function emptyOutcome(): ValidationOutcome {
+    return new ValidationOutcome([], [], false, false);
+}
+
+function errorOutcome(path: string): ValidationOutcome {
+    return new ValidationOutcome(
+        [new ValidationOutput('json-schema', 'error', 'sub-arch error', path, undefined)],
+        [],
+        true,
+        false
+    );
+}
+
+const noop: ArchitectureValidator = vi.fn().mockResolvedValue(emptyOutcome());
+
+describe('validateNodeDetails', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (noop as ReturnType<typeof vi.fn>).mockResolvedValue(emptyOutcome());
+    });
+
+    it('returns empty outputs when architecture has no node details', async () => {
+        const arch = { nodes: [{ 'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D' }] };
+        const dir = makeSchemaDirectory();
+        const result = await validateNodeDetails(arch, dir, false, noop, makeResolver(dir));
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(result.hasErrors).toBe(false);
+        expect(noop).not.toHaveBeenCalled();
+    });
+
+    it('loads sub-architecture and calls recursiveValidator when node has detailed-architecture', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(schemaDir.loadDocument).toHaveBeenCalledWith('https://example.com/sub-arch.json', 'architecture');
+        expect(noop).toHaveBeenCalledOnce();
+        expect(result.hasErrors).toBe(false);
+    });
+
+    it('discovers pattern from $schema of sub-architecture when required-pattern is not set', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        // schemaDir.getSchema should have been called with the $schema URL from subArchitecture
+        expect(schemaDir.getSchema).toHaveBeenCalledWith('https://example.com/pattern.json');
+        expect(noop).toHaveBeenCalledWith(
+            subArchitecture,
+            patternDoc,
+            expect.anything(),  // fresh schema dir
+            false,
+            expect.any(CachingTrackingResolver)
+        );
+    });
+
+    it('uses required-pattern when it is set on the node details', async () => {
+        const explicitPatternUrl = 'https://example.com/explicit-pattern.json';
+        const explicitPattern = { $id: explicitPatternUrl, type: 'object' };
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: {
+                    'detailed-architecture': 'https://example.com/sub-arch.json',
+                    'required-pattern': explicitPatternUrl
+                }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockResolvedValue(explicitPattern);
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(noop).toHaveBeenCalledWith(
+            subArchitecture,
+            explicitPattern,
+            expect.anything(),
+            false,
+            expect.any(CachingTrackingResolver)
+        );
+    });
+
+    it('emits error at correct path when sub-architecture cannot be loaded', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/missing-sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory({
+            loadDocument: vi.fn().mockRejectedValue(new Error('not found'))
+        });
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs).toHaveLength(1);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/details/detailed-architecture');
+        expect(result.jsonSchemaOutputs[0].message).toContain('not found');
+        expect(noop).not.toHaveBeenCalled();
+    });
+
+    it('prefixes sub-architecture errors with node path', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (noop as ReturnType<typeof vi.fn>).mockResolvedValue(errorOutcome('/nodes/0'));
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs).toHaveLength(1);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/details/detailed-architecture/nodes/0');
+    });
+
+    it('prefixes root path "/" from sub-architecture as just the node path prefix', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (noop as ReturnType<typeof vi.fn>).mockResolvedValue(errorOutcome('/'));
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/details/detailed-architecture');
+    });
+
+    it('skips already-visited architecture URL (cycle detection)', async () => {
+        const archUrl = 'https://example.com/sub-arch.json';
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': archUrl }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        const references = makeResolver(schemaDir);
+        references.markSeen(archUrl);
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, references);
+        expect(noop).not.toHaveBeenCalled();
+        expect(result.hasErrors).toBe(false);
+        expect(schemaDir.loadDocument).not.toHaveBeenCalled();
+    });
+
+    it('validates both nodes when two nodes have detailed-architecture', async () => {
+        const arch = {
+            nodes: [
+                {
+                    'unique-id': 'n1',
+                    'node-type': 'service',
+                    name: 'N1',
+                    description: 'D',
+                    details: { 'detailed-architecture': 'https://example.com/sub-arch-1.json' }
+                },
+                {
+                    'unique-id': 'n2',
+                    'node-type': 'service',
+                    name: 'N2',
+                    description: 'D',
+                    details: { 'detailed-architecture': 'https://example.com/sub-arch-2.json' }
+                }
+            ]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (noop as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(errorOutcome('/x'))
+            .mockResolvedValueOnce(errorOutcome('/y'));
+
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(noop).toHaveBeenCalledTimes(2);
+        expect(result.jsonSchemaOutputs).toHaveLength(2);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/details/detailed-architecture/x');
+        expect(result.jsonSchemaOutputs[1].path).toBe('/nodes/1/details/detailed-architecture/y');
+    });
+
+    it('propagates hasWarnings from sub-architecture outcome', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        const warningOutcome = new ValidationOutcome([], [], false, true);
+        (noop as ReturnType<typeof vi.fn>).mockResolvedValue(warningOutcome);
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasWarnings).toBe(true);
+        expect(result.hasErrors).toBe(false);
+    });
+
+    it('returns empty outputs when architecture cannot be parsed as CalmCore', async () => {
+        const result = await validateNodeDetails(null as unknown as object, makeSchemaDirectory(), false, noop, new CachingTrackingResolver({ canResolve: () => false, resolve: () => Promise.reject(new Error('unused')) }));
+        expect(result.jsonSchemaOutputs).toHaveLength(0);
+        expect(result.hasErrors).toBe(false);
+        expect(noop).not.toHaveBeenCalled();
+    });
+
+    it('emits error at node path when recursiveValidator throws', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (noop as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('validator exploded'));
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs).toHaveLength(1);
+        expect(result.jsonSchemaOutputs[0].path).toBe('/nodes/0/details/detailed-architecture');
+        expect(result.jsonSchemaOutputs[0].message).toContain('validator exploded');
+    });
+
+    it('validates with undefined pattern when sub-architecture has no $schema and no required-pattern', async () => {
+        const subArchNoSchema = {
+            nodes: [{ 'unique-id': 'sub-node', 'node-type': 'service', name: 'Sub', description: 'Sub' }],
+            relationships: []
+        };
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory({ loadDocument: vi.fn().mockResolvedValue(subArchNoSchema) });
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(schemaDir.getSchema).not.toHaveBeenCalled();
+        expect(noop).toHaveBeenCalledWith(subArchNoSchema, undefined, expect.anything(), false, expect.any(CachingTrackingResolver));
+    });
+
+    it('falls back to $schema when required-pattern cannot be resolved', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: {
+                    'detailed-architecture': 'https://example.com/sub-arch.json',
+                    'required-pattern': 'https://example.com/explicit-pattern.json'
+                }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce(undefined)  // required-pattern -> not found
+            .mockResolvedValue(patternDoc);    // $schema fallback
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(noop).toHaveBeenCalledWith(subArchitecture, patternDoc, expect.anything(), false, expect.any(CachingTrackingResolver));
+    });
+
+    it('validates with undefined pattern when $schema lookup throws', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory();
+        (schemaDir.getSchema as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('schema lookup failed'));
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(noop).toHaveBeenCalledWith(subArchitecture, undefined, expect.anything(), false, expect.any(CachingTrackingResolver));
+    });
+
+    it('coerces a non-Error string thrown while loading the sub-architecture', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory({ loadDocument: vi.fn().mockRejectedValue('string load failure') });
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('string load failure');
+    });
+
+    // Note: this codebase uses the shared getErrorMessage util (String(error)) rather than
+    // JSON.stringify, so a non-Error object throw is coerced to '[object Object]'. The behaviour
+    // under test is that a non-Error throw is handled gracefully (an error output, no crash).
+    it('coerces a non-Error object thrown while loading the sub-architecture', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory({ loadDocument: vi.fn().mockRejectedValue({ status: 404 }) });
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('[object Object]');
+    });
+
+    it('does not throw when a non-stringifiable (circular) value is thrown while loading the sub-architecture', async () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1', 'node-type': 'service', name: 'N', description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const schemaDir = makeSchemaDirectory({ loadDocument: vi.fn().mockRejectedValue(circular) });
+        const result = await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(result.hasErrors).toBe(true);
+        expect(result.jsonSchemaOutputs[0].message).toContain('[object Object]');
+    });
+
+    it('uses a fresh schema directory (fork) for each sub-architecture', async () => {
+        const arch = {
+            nodes: [{
+                'unique-id': 'n1',
+                'node-type': 'service',
+                name: 'N',
+                description: 'D',
+                details: { 'detailed-architecture': 'https://example.com/sub-arch.json' }
+            }]
+        };
+        const freshDir = {
+            getSchema: vi.fn().mockResolvedValue(undefined),
+            loadDocument: vi.fn(),
+            fork: vi.fn(),
+            loadSchemas: vi.fn().mockResolvedValue(undefined),
+            storeDocument: vi.fn(),
+        };
+        const schemaDir = makeSchemaDirectory({ fork: vi.fn().mockReturnValue(freshDir) });
+        await validateNodeDetails(arch, schemaDir, false, noop, makeResolver(schemaDir));
+        expect(schemaDir.fork).toHaveBeenCalledOnce();
+        // The cache-seeding fork() means the fresh dir is used directly (no re-load of schemas);
+        // the recursiveValidator must receive that forked dir.
+        expect(noop).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            freshDir,
+            false,
+            expect.any(CachingTrackingResolver)
+        );
+    });
+});

--- a/shared/src/commands/validate/validate-node-details.spec.ts
+++ b/shared/src/commands/validate/validate-node-details.spec.ts
@@ -254,10 +254,10 @@ describe('validateNodeDetails', () => {
         expect(result.jsonSchemaOutputs[1].path).toBe('/nodes/1/details/detailed-architecture/y');
     });
 
-    // Reproduces rocketstack-matt's review comment on PR #2805:
+    // Covers rocketstack-matt's review comment on PR #2805:
     // https://github.com/finos/architecture-as-code/pull/2805#discussion_r3576885169
-    // Asserts the DESIRED behaviour (both nodes report); expected to FAIL against current code,
-    // which returns only one error. Left red pending clarification before fixing.
+    // A failed reference is re-reported at every node that references it, rather than being skipped
+    // as a cycle after the first occurrence.
     it('reports a load error for every node sharing the same broken detailed-architecture reference', async () => {
         const brokenUrl = 'https://example.com/missing-shared.json';
         const arch = {

--- a/shared/src/commands/validate/validate-node-details.ts
+++ b/shared/src/commands/validate/validate-node-details.ts
@@ -1,0 +1,223 @@
+import { CalmCore } from '@finos/calm-models/model';
+import { SchemaDirectory } from '../../schema-directory.js';
+import { ValidationOutput, ValidationOutcome } from './validation.output.js';
+import { initLogger, Logger } from '../../logger.js';
+import { getErrorMessage } from '../../error-utils.js';
+import { tryParseCalmCore } from './calm-core-parse.js';
+import { CachingTrackingResolver } from '../../resolver/caching-tracking-resolver.js';
+
+type CalmNode = CalmCore['nodes'][number];
+
+type NodeDetailResult = {
+    jsonSchemaOutputs: ValidationOutput[],
+    spectralOutputs: ValidationOutput[],
+    hasErrors: boolean,
+    hasWarnings: boolean
+};
+
+/**
+ * Injectable recursive validator — allows validate-node-details to call back into the
+ * main validation pipeline (two-phase Spectral + JSON-Schema) without creating a circular
+ * module dependency with validate.ts.
+ *
+ * The single {@link CachingTrackingResolver} is threaded through unchanged so reference
+ * caching and cycle/dedupe tracking are owned in exactly one place regardless of whether a
+ * sub-architecture is validated with or without a pattern.
+ */
+export type ArchitectureValidator = (
+    architecture: object,
+    pattern: object | undefined,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean,
+    references: CachingTrackingResolver
+) => Promise<ValidationOutcome>;
+
+/**
+ * Validate all node details in an architecture by recursively loading and validating any
+ * referenced detailed-architecture sub-architectures.
+ *
+ * The raw sub-architecture document is loaded through the shared {@link CachingTrackingResolver},
+ * which caches each document and records which references have been visited. Cycle safety and
+ * "validate each sub-architecture once" both come from that tracking, so a cyclic
+ * detailed-architecture terminates instead of recursing unbounded.
+ *
+ * Pattern resolution priority per node:
+ *  1. `details.required-pattern` URL
+ *  2. `$schema` field of the detailed-architecture document
+ *  3. Neither found → recursiveValidator is called with an undefined pattern
+ */
+export async function validateNodeDetails(
+    architecture: object,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean,
+    recursiveValidator: ArchitectureValidator,
+    references: CachingTrackingResolver
+): Promise<NodeDetailResult> {
+    const logger = initLogger(debug, 'validate-node-details');
+    const jsonSchemaOutputs: ValidationOutput[] = [];
+    const spectralOutputs: ValidationOutput[] = [];
+    let hasErrors = false;
+    let hasWarnings = false;
+
+    const calmCore = tryParseCalmCore(architecture, logger);
+    if (!calmCore) {
+        return { jsonSchemaOutputs, spectralOutputs, hasErrors, hasWarnings };
+    }
+
+    for (const [nodeIdx, node] of calmCore.nodes.entries()) {
+        const result = await validateNodeDetail(node, nodeIdx, schemaDirectory, debug, recursiveValidator, references);
+        jsonSchemaOutputs.push(...result.jsonSchemaOutputs);
+        spectralOutputs.push(...result.spectralOutputs);
+        if (result.hasErrors) hasErrors = true;
+        if (result.hasWarnings) hasWarnings = true;
+    }
+
+    return { jsonSchemaOutputs, spectralOutputs, hasErrors, hasWarnings };
+}
+
+async function validateNodeDetail(
+    node: CalmNode,
+    nodeIdx: number,
+    schemaDirectory: SchemaDirectory,
+    debug: boolean,
+    recursiveValidator: ArchitectureValidator,
+    references: CachingTrackingResolver
+): Promise<NodeDetailResult> {
+    const logger = initLogger(debug, 'validate-node-details');
+    const detailedArchitecture = node.details?.detailedArchitecture;
+    const archUrl = detailedArchitecture?.reference;
+
+    if (!detailedArchitecture || !archUrl) return emptyNodeResult();
+
+    if (references.has(archUrl)) {
+        logger.debug(`Cycle detected: skipping already-visited architecture '${archUrl}'`);
+        return emptyNodeResult();
+    }
+
+    const detailsPrefix = `/nodes/${nodeIdx}/details/detailed-architecture`;
+
+    const { subArch, error: loadError } = await loadSubArchitecture(references, archUrl, detailsPrefix);
+    if (loadError) return nodeError(loadError);
+
+    const pattern = await resolvePattern(node, subArch!, schemaDirectory, logger);
+
+    // A cache-seeded fork isolates AJV schema-id compilation for the sub-architecture while
+    // still reusing the parent's already-loaded base schemas (no redundant re-fetch).
+    const freshDir = schemaDirectory.fork();
+
+    const { outcome, error: validationError } = await runRecursiveValidator(
+        subArch!, pattern, freshDir, debug, references, recursiveValidator, archUrl, detailsPrefix
+    );
+    if (validationError) return nodeError(validationError);
+
+    return prefixedNodeResult(outcome!, detailsPrefix);
+}
+
+/**
+ * Load the raw sub-architecture document through the shared {@link CachingTrackingResolver}.
+ * Validation needs the raw JSON document (for Spectral + JSON-Schema), and the resolver both
+ * caches it and records the reference as visited.
+ */
+async function loadSubArchitecture(
+    references: CachingTrackingResolver,
+    archUrl: string,
+    detailsPrefix: string
+): Promise<{ subArch?: object, error?: ValidationOutput }> {
+    try {
+        const subArch = await references.resolve(archUrl) as object;
+        return { subArch };
+    } catch (err) {
+        return { error: nodeDetailsError(detailsPrefix, `Could not load detailed-architecture '${archUrl}': ${getErrorMessage(err)}`) };
+    }
+}
+
+async function resolvePattern(
+    node: CalmNode,
+    subArch: object,
+    schemaDirectory: SchemaDirectory,
+    logger: Logger
+): Promise<object | undefined> {
+    if (node.details?.requiredPattern?.reference) {
+        const pattern = await tryLoadSchema(node.details.requiredPattern.reference, schemaDirectory, logger, 'required-pattern');
+        if (pattern) return pattern;
+    }
+
+    const schemaRef = (subArch as Record<string, unknown>)['$schema'] as string | undefined;
+    if (schemaRef) {
+        return tryLoadSchema(schemaRef, schemaDirectory, logger, '$schema');
+    }
+
+    return undefined;
+}
+
+async function tryLoadSchema(
+    url: string,
+    schemaDirectory: SchemaDirectory,
+    logger: Logger,
+    label: string
+): Promise<object | undefined> {
+    try {
+        const schema = await schemaDirectory.getSchema(url);
+        if (!schema) logger.debug(`Pattern from ${label} '${url}' not found in schema directory`);
+        return schema;
+    } catch (err) {
+        logger.debug(`Could not load pattern from ${label} '${url}': ${getErrorMessage(err)}`);
+        return undefined;
+    }
+}
+
+async function runRecursiveValidator(
+    subArch: object,
+    pattern: object | undefined,
+    freshDir: SchemaDirectory,
+    debug: boolean,
+    references: CachingTrackingResolver,
+    recursiveValidator: ArchitectureValidator,
+    archUrl: string,
+    detailsPrefix: string
+): Promise<{ outcome?: ValidationOutcome, error?: ValidationOutput }> {
+    try {
+        return { outcome: await recursiveValidator(subArch, pattern, freshDir, debug, references) };
+    } catch (err) {
+        return { error: nodeDetailsError(detailsPrefix, `Validation of detailed-architecture '${archUrl}' failed: ${getErrorMessage(err)}`) };
+    }
+}
+
+function prefixedNodeResult(outcome: ValidationOutcome, prefix: string): NodeDetailResult {
+    return {
+        jsonSchemaOutputs: prefixOutputs(outcome.jsonSchemaValidationOutputs, prefix),
+        spectralOutputs: prefixOutputs(outcome.spectralSchemaValidationOutputs, prefix),
+        hasErrors: outcome.hasErrors,
+        hasWarnings: outcome.hasWarnings
+    };
+}
+
+function prefixOutputs(outputs: ValidationOutput[], prefix: string): ValidationOutput[] {
+    return outputs.map(output => {
+        const newPath = output.path === '/' ? prefix : prefix + output.path;
+        return new ValidationOutput(
+            output.code,
+            output.severity,
+            output.message,
+            newPath,
+            output.schemaPath,
+            output.line_start,
+            output.line_end,
+            output.character_start,
+            output.character_end,
+            output.source
+        );
+    });
+}
+
+function emptyNodeResult(): NodeDetailResult {
+    return { jsonSchemaOutputs: [], spectralOutputs: [], hasErrors: false, hasWarnings: false };
+}
+
+function nodeError(output: ValidationOutput): NodeDetailResult {
+    return { jsonSchemaOutputs: [output], spectralOutputs: [], hasErrors: true, hasWarnings: false };
+}
+
+function nodeDetailsError(path: string, message: string): ValidationOutput {
+    return ValidationOutput.error('node-details-validation', message, path, { source: 'architecture' });
+}

--- a/shared/src/commands/validate/validate-node-details.ts
+++ b/shared/src/commands/validate/validate-node-details.ts
@@ -89,8 +89,13 @@ async function validateNodeDetail(
 
     if (!detailedArchitecture || !archUrl) return emptyNodeResult();
 
-    if (references.has(archUrl)) {
-        logger.debug(`Cycle detected: skipping already-visited architecture '${archUrl}'`);
+    // A reference already resolved (or currently being resolved higher up the traversal) is skipped:
+    // this both dedupes "validate each detailed-architecture once" and keeps cyclic references safe.
+    // A reference whose previous load FAILED is deliberately not skipped, so the load error is
+    // re-reported at every node that references it (the resolver returns the cached failure, so the
+    // delegate is not re-fetched).
+    if (references.has(archUrl) && !references.hasFailed(archUrl)) {
+        logger.debug(`Skipping already-resolved architecture '${archUrl}'`);
         return emptyNodeResult();
     }
 

--- a/shared/src/commands/validate/validate.ts
+++ b/shared/src/commands/validate/validate.ts
@@ -1,18 +1,27 @@
-import { ErrorObject } from 'ajv/dist/2020.js';
-import { Spectral, ISpectralDiagnostic, RulesetDefinition } from '@stoplight/spectral-core';
+import { RulesetDefinition } from '@stoplight/spectral-core';
 
-import validationRulesForPattern from '../../spectral/rules-pattern';
-import validationRulesForArchitecture from '../../spectral/rules-architecture';
-import validationRulesForTimeline from '../../spectral/rules-timeline';
-import { DiagnosticSeverity } from '@stoplight/types';
+import validationRulesForPattern from '../../spectral/rules-pattern.js';
+import validationRulesForArchitecture from '../../spectral/rules-architecture.js';
 import { initLogger, Logger } from '../../logger.js';
-import { ValidationOutput, ValidationOutcome } from './validation.output.js';
-import { SpectralResult } from './spectral.result.js';
+import { ValidationOutcome } from './validation.output.js';
 import createJUnitReport from './output-formats/junit-output.js';
 import prettyFormat from './output-formats/pretty-output.js';
 import { SchemaDirectory } from '../../schema-directory.js';
-import { JsonSchemaValidator } from './json-schema-validator.js';
-import { selectChoices, CalmChoice } from '../generate/components/options.js';
+import { ValidationContext, ValidationMode } from './validation-rule.js';
+import { createDefaultValidationEngine, ValidationEngine } from './validation-engine.js';
+import { prettifyJson } from './validation-helpers.js';
+import { CachingTrackingResolver } from '../../resolver/caching-tracking-resolver.js';
+import { SchemaDirectoryReferenceResolver } from '../../resolver/schema-directory-reference-resolver.js';
+
+// Re-export the shared helpers from their new home so existing importers/tests keep working.
+export {
+    applyArchitectureOptionsToPattern,
+    extractChoicesFromArchitecture,
+    stripRefs,
+    sortSpectralIssueBySeverity,
+    convertJsonSchemaIssuesToValidationOutputs,
+    convertSpectralDiagnosticToValidationOutputs
+} from './validation-helpers.js';
 
 let logger: Logger; // defined later at startup
 
@@ -65,37 +74,6 @@ export function formatOutput(
     }
 }
 
-
-async function runSpectralValidations(
-    schema: string,
-    spectralRuleset: RulesetDefinition,
-    source: string
-): Promise<SpectralResult> {
-    let errors = false;
-    let warnings = false;
-    let spectralIssues: ValidationOutput[] = [];
-    const spectral = new Spectral();
-
-    spectral.setRuleset(spectralRuleset);
-    const issues = await spectral.run(schema);
-
-    if (issues && issues.length > 0) {
-        logger.debug(`Spectral raw output: ${prettifyJson(issues)}`);
-        sortSpectralIssueBySeverity(issues);
-        spectralIssues = convertSpectralDiagnosticToValidationOutputs(issues, source);
-        if (issues.filter(issue => issue.severity === 0).length > 0) {
-            logger.debug('Spectral output contains errors');
-            errors = true;
-        }
-        if (issues.filter(issue => issue.severity === 1).length > 0) {
-            logger.debug('Spectral output contains warnings');
-            warnings = true;
-        }
-    }
-    return new SpectralResult(warnings, errors, spectralIssues);
-}
-
-
 /**
  * Asserts that a schema directory was provided. Validating a pattern, a timeline,
  * or an architecture against a pattern all require schema resolution, so a missing
@@ -109,6 +87,11 @@ function assertSchemaDirectory(schemaDirectory: SchemaDirectory | undefined): as
 
 /**
  * Validation - with simple input parameters and output validation outcomes.
+ *
+ * The input combination is resolved to a {@link ValidationMode} and a {@link ValidationContext},
+ * which the {@link ValidationEngine} runs through the registered rules (Spectral linting,
+ * JSON-Schema, controls and recursive node-details).
+ *
  * @param architecture The architecture as a JS object, or undefined if not provided
  * @param patternOrSchema The pattern (or schema) as a JS object, or undefined if not provided
  * @param timeline The timeline as a JS object, or undefined if not provided
@@ -126,32 +109,9 @@ export async function validate(
     logger = initLogger(debug, 'calm-validate');
 
     try {
-        if (timeline) {
-            if (architecture) {
-                throw new Error('You cannot provide an architecture when validating a timeline');
-            }
-            if (!patternOrSchema) {
-                throw new Error('You must provide a schema to validate the timeline against, or the timeline must reference it internally');
-            }
-            // It is acceptable, in fact desired, for `patternOrSchema` to be set, and be the CALM timeline schema.
-            assertSchemaDirectory(schemaDirectory);
-            return await validateTimeline(timeline, patternOrSchema, schemaDirectory, debug);
-        } else if (architecture && patternOrSchema) {
-            // Note that patternOrSchema may be a CALM pattern, or might be the CALM core schema.
-            // The caller is responsible for honoring the architecture's `$schema`, or using an explicitly provided pattern.
-            // In either case, we validate the architecture against it.
-            assertSchemaDirectory(schemaDirectory);
-            return await validateArchitectureAgainstPattern(architecture, patternOrSchema, schemaDirectory, debug);
-        } else if (patternOrSchema) {
-            // `patternOrSchema` should really be a CALM pattern in this case.
-            assertSchemaDirectory(schemaDirectory);
-            return await validatePatternOnly(patternOrSchema, schemaDirectory, debug);
-        } else if (architecture) {
-            return await validateArchitectureOnly(architecture, schemaDirectory, debug);
-        } else {
-            logger.debug('You must provide an architecture, a pattern, or a timeline');
-            throw new Error('You must provide an architecture, a pattern, or a timeline');
-        }
+        const engine = createDefaultValidationEngine();
+        const context = buildValidationContext(architecture, patternOrSchema, timeline, schemaDirectory, debug, engine);
+        return await engine.validate(context);
     } catch (error) {
         logger.error('An error occurred:' + error);
         throw error;
@@ -159,223 +119,44 @@ export async function validate(
 }
 
 /**
- * Run the spectral rules for the pattern and the architecture, and then compile the pattern and validate the architecture against it.
- *
- * @param architecture - the architecture to validate.
- * @param pattern - the pattern to validate against.
- * @param schemaDirectory - the SchemaDirectory instance to use for schema resolution.
- * @param debug - the flag to enable debug logging.
- * @returns the validation outcome with the results of the spectral and json schema validations.
+ * Resolve the input combination to a mode + context, preserving the historical caller-error
+ * throws for invalid combinations.
  */
-async function validateArchitectureAgainstPattern(architecture: object, pattern: object, schemaDirectory: SchemaDirectory, debug: boolean): Promise<ValidationOutcome> {
-    const spectralResultForPattern: SpectralResult = await runSpectralValidations(stripRefs(pattern), validationRulesForPattern, 'pattern');
-    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(JSON.stringify(architecture), validationRulesForArchitecture, 'architecture');
+function buildValidationContext(
+    architecture: object | undefined,
+    patternOrSchema: object | undefined,
+    timeline: object | undefined,
+    schemaDirectory: SchemaDirectory | undefined,
+    debug: boolean,
+    engine: ValidationEngine
+): ValidationContext {
+    const references = new CachingTrackingResolver(new SchemaDirectoryReferenceResolver(schemaDirectory));
+    const base = { references, debug, engine };
 
-    const spectralResult = mergeSpectralResults(spectralResultForPattern, spectralResultForArchitecture);
-
-    let errors = spectralResult.errors;
-    const warnings = spectralResult.warnings;
-
-    const patternResolved = applyArchitectureOptionsToPattern(architecture, pattern, debug);
-
-    let jsonSchemaValidations: ValidationOutput[] = [];
-    let jsonSchemaValidator: JsonSchemaValidator;
-    try {
-        jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, patternResolved, debug);
-        await jsonSchemaValidator.initialize();
-    } catch (error) {
-        const errorMessage = toErrorMessage(error);
-        logger.error(`JSON Schema compilation failed: ${errorMessage}`);
-        jsonSchemaValidations = [
-            new ValidationOutput('json-schema', 'error', errorMessage, '/', undefined, undefined, undefined, undefined, undefined, 'pattern')
-        ];
-        return new ValidationOutcome(jsonSchemaValidations, spectralResult.spectralIssues, true, warnings);
-    }
-
-    const schemaErrors = jsonSchemaValidator.validate(architecture);
-    if (schemaErrors.length > 0) {
-        logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
-        errors = true;
-        jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'architecture');
-    }
-
-    return new ValidationOutcome(jsonSchemaValidations, spectralResult.spectralIssues, errors, warnings);
-}
-
-
-/**
- * Run validations for the case where only the pattern is provided.
- * This essentially runs the spectral validations and tries to compile the pattern.
- *
- * @param pattern - the pattern to validate.
- * @param schemaDirectory - the SchemaDirectory instance to use for schema resolution.
- * @param debug - the flag to enable debug logging.
- * @returns the validation outcome with the results of the spectral validation and the pattern compilation.
- */
-async function validatePatternOnly(pattern: object, schemaDirectory: SchemaDirectory, debug: boolean): Promise<ValidationOutcome> {
-    logger.debug('Architecture was not provided, only the Pattern Schema will be validated');
-    const spectralValidationResults: SpectralResult = await runSpectralValidations(stripRefs(pattern), validationRulesForPattern, 'pattern');
-
-    let errors = spectralValidationResults.errors;
-    const warnings = spectralValidationResults.warnings;
-    const jsonSchemaErrors = [];
-
-    try {
-        // Compile pattern as a schema to check if it's valid
-        const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, pattern, debug);
-        await jsonSchemaValidator.initialize();
-    } catch (error) {
-        errors = true;
-        jsonSchemaErrors.push(new ValidationOutput('json-schema', 'error', toErrorMessage(error), '/', undefined, undefined, undefined, undefined, undefined, 'pattern'));
-    }
-
-    return new ValidationOutcome(jsonSchemaErrors, spectralValidationResults.spectralIssues, errors, warnings);// added spectral to return object
-}
-
-/**
- * Run the spectral and JSON schema validations for the case where only the architecture is provided.
- * Discovers the most recent available CALM core schema from the schema directory and validates against it.
- *
- * @param architecture - The architecture, as a JS object.
- * @param schemaDirectory - SchemaDirectory instance for schema resolution.
- * @param debug - Whether to log at debug level.
- * @returns the validation outcome with the results of the spectral and JSON schema validations.
- **/
-async function validateArchitectureOnly(architecture: object, schemaDirectory: SchemaDirectory | undefined, debug: boolean): Promise<ValidationOutcome> {
-    logger.debug('Pattern was not provided, validating Architecture against the most recent loaded CALM core schema');
-
-    const spectralResultForArchitecture: SpectralResult = await runSpectralValidations(JSON.stringify(architecture), validationRulesForArchitecture, 'architecture');
-
-    let jsonSchemaValidations: ValidationOutput[] = [];
-    let errors = spectralResultForArchitecture.errors;
-    const warnings = spectralResultForArchitecture.warnings;
-
-    const coreSchemaUrl = schemaDirectory ? findLatestCalmCoreSchemaUrl(schemaDirectory) : undefined;
-    const coreSchema = (schemaDirectory && coreSchemaUrl) ? await schemaDirectory.getSchema(coreSchemaUrl) : undefined;
-    if (!schemaDirectory || !coreSchema) {
-        logger.warn('No CALM core schema found in schema directory — skipping JSON schema validation');
-    } else {
-        logger.debug(`Validating architecture against CALM core schema: ${coreSchemaUrl}`);
-        try {
-            const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, coreSchema, debug);
-            await jsonSchemaValidator.initialize();
-            const schemaErrors = jsonSchemaValidator.validate(architecture);
-            if (schemaErrors.length > 0) {
-                logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
-                errors = true;
-                jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'architecture');
-            }
-        } catch (error) {
-            const errorMessage = toErrorMessage(error);
-            logger.error(`JSON Schema compilation failed: ${errorMessage}`);
-            jsonSchemaValidations = [
-                new ValidationOutput('json-schema', 'error', errorMessage, '/', undefined, undefined, undefined, undefined, undefined, 'architecture')
-            ];
-            errors = true;
+    if (timeline) {
+        if (architecture) {
+            throw new Error('You cannot provide an architecture when validating a timeline');
         }
+        if (!patternOrSchema) {
+            throw new Error('You must provide a schema to validate the timeline against, or the timeline must reference it internally');
+        }
+        // It is acceptable, in fact desired, for `patternOrSchema` to be set, and be the CALM timeline schema.
+        assertSchemaDirectory(schemaDirectory);
+        return { ...base, mode: 'timeline' as ValidationMode, timeline, pattern: patternOrSchema, schemaDirectory };
+    } else if (architecture && patternOrSchema) {
+        // Note that patternOrSchema may be a CALM pattern, or might be the CALM core schema.
+        assertSchemaDirectory(schemaDirectory);
+        return { ...base, mode: 'architecture-with-pattern' as ValidationMode, architecture, pattern: patternOrSchema, schemaDirectory };
+    } else if (patternOrSchema) {
+        // `patternOrSchema` should really be a CALM pattern in this case.
+        assertSchemaDirectory(schemaDirectory);
+        return { ...base, mode: 'pattern-only' as ValidationMode, pattern: patternOrSchema, schemaDirectory };
+    } else if (architecture) {
+        return { ...base, mode: 'architecture-only' as ValidationMode, architecture, schemaDirectory };
     }
 
-    logger.debug(`Returning validation outcome with ${jsonSchemaValidations.length} JSON schema validations, errors: ${errors}`);
-    return new ValidationOutcome(jsonSchemaValidations, spectralResultForArchitecture.spectralIssues, errors, warnings);
-}
-
-/**
- * Finds the URL of the most recent CALM core schema loaded in the schema directory.
- *
- * Precedence: release > draft. Within each tier, URLs are compared with a
- * numeric-aware locale sort so that 1.10 > 1.9 > 1.2 (lexicographic order
- * would get this wrong).
- *
- * Note: localeCompare with { numeric: true } treats runs of digits as numbers,
- * which works correctly for all current CALM version formats (1.x, 2026-03).
- * A version segment containing non-numeric characters (e.g. 1.2-beta) could
- * sort unexpectedly — if pre-release versions are ever published, revisit this.
- *
- * Returns undefined if no CALM core schema is loaded.
- */
-function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string | undefined {
-    const coreSchemaPattern = /calm\.finos\.org\/.*\/meta\/core\.json$/;
-    const matches = schemaDirectory.getLoadedSchemas()
-        .filter(id => coreSchemaPattern.test(id));
-
-    if (matches.length === 0) return undefined;
-
-    return matches.sort((a, b) => {
-        const isRelease = (url: string) => url.includes('/release/');
-        if (isRelease(a) !== isRelease(b)) return isRelease(a) ? -1 : 1;
-        return b.localeCompare(a, undefined, { numeric: true });
-    })[0];
-}
-
-/**
- * Run validations for a timeline.
- * This essentially runs the spectral validations and tries to compile the timeline.
- *
- * @param timeline - the timeline to validate.
- * @param schema - the schema to validate against. This should be the CALM timeline schema.
- * @param schemaDirectory - the SchemaDirectory instance to use for schema resolution.
- * @param debug - the flag to enable debug logging.
- * @returns the validation outcome with the results of the spectral validation and the timeline compilation.
- */
-async function validateTimeline(timeline: object, schema: object, schemaDirectory: SchemaDirectory, debug: boolean): Promise<ValidationOutcome> {
-    logger.debug('Timeline will be validated');
-    const spectralValidationResults: SpectralResult = await runSpectralValidations(stripRefs(timeline), validationRulesForTimeline, 'timeline');
-
-    let errors = spectralValidationResults.errors;
-    const warnings = spectralValidationResults.warnings;
-
-    const jsonSchemaValidator = new JsonSchemaValidator(schemaDirectory, schema, debug);
-    await jsonSchemaValidator.initialize();
-
-    let jsonSchemaValidations: ValidationOutput[] = [];
-
-    const schemaErrors = jsonSchemaValidator.validate(timeline);
-    if (schemaErrors.length > 0) {
-        logger.debug(`JSON Schema validation raw output: ${prettifyJson(schemaErrors)}`);
-        errors = true;
-        jsonSchemaValidations = convertJsonSchemaIssuesToValidationOutputs(schemaErrors, 'timeline');
-    }
-
-    return new ValidationOutcome(jsonSchemaValidations, spectralValidationResults.spectralIssues, errors, warnings);
-}
-
-/**
- * If a pattern contains objects, we need to apply the chosen options recorded
- * in the architecture to the pattern to produce a JSON schema pattern that can
- * be used for validation.
- * @param architecture Architecture which may contain options.
- * @param pattern Pattern which may contain options.
- * @param debug - the flag to enable debug logging.
- * @returns Pattern with options applied and flattened.
- */
-export function applyArchitectureOptionsToPattern(architecture: object, pattern: object, debug: boolean): object {
-
-    const choices: CalmChoice[] = extractChoicesFromArchitecture(architecture);
-    if (choices.length === 0) {
-        return pattern;
-    }
-
-    return selectChoices(pattern, choices, debug);
-}
-
-export function extractChoicesFromArchitecture(architecture: object): CalmChoice[] {
-    if (!architecture || !Object.prototype.hasOwnProperty.call(architecture, 'relationships')) {
-        return [];
-    }
-
-    // architecture is unvalidated CALM JSON traversed via nested property access,
-    // so a permissive index type is used here.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const relationships = (architecture as Record<string, any>)['relationships'] as Record<string, any>[];
-
-    return relationships
-        .filter((rel) => rel['relationship-type'] && Object.prototype.hasOwnProperty.call(rel['relationship-type'], 'options'))
-        .map((rel) => rel['relationship-type']['options'][0])
-        .map((rel) => ({
-            description: rel['description'],
-            nodes: rel['nodes'] || [],
-            relationships: rel['relationships'] || []
-        }));
+    logger.debug('You must provide an architecture, a pattern, or a timeline');
+    throw new Error('You must provide an architecture, a pattern, or a timeline');
 }
 
 function extractSpectralRuleNames(): string[] {
@@ -386,138 +167,4 @@ function extractSpectralRuleNames(): string[] {
 
 function getRuleNamesFromRuleset(ruleset: RulesetDefinition): string[] {
     return Object.keys((ruleset as { rules: Record<string, unknown> }).rules);
-}
-
-function prettifyJson(json: unknown) {
-    return JSON.stringify(json, null, 4);
-}
-
-function toErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-    if (typeof error === 'string') {
-        return error;
-    }
-    try {
-        return JSON.stringify(error);
-    } catch {
-        return 'Unknown error';
-    }
-}
-
-export function stripRefs(obj: object): string {
-    return JSON.stringify(obj).replaceAll('$ref', 'ref');
-}
-
-export function sortSpectralIssueBySeverity(issues: ISpectralDiagnostic[]): void {
-    issues.sort((issue1: ISpectralDiagnostic, issue2: ISpectralDiagnostic) =>
-        issue1.severity.valueOf() - issue2.severity.valueOf()
-    );
-}
-
-export function convertJsonSchemaIssuesToValidationOutputs(jsonSchemaIssues: ErrorObject[], source: string): ValidationOutput[] {
-    return jsonSchemaIssues.map(issue => {
-        const rawPath = issue.instancePath ?? '';
-        const path = rawPath === '' ? '/' : rawPath;
-        return new ValidationOutput(
-            'json-schema',
-            'error',
-            appendExpected(issue),
-            path,
-            issue.schemaPath,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            source
-        );
-    });
-}
-
-export function convertSpectralDiagnosticToValidationOutputs(spectralIssues: ISpectralDiagnostic[], source: string): ValidationOutput[] {
-    const validationOutput: ValidationOutput[] = [];
-
-    spectralIssues.forEach(issue => {
-        const startRange = issue.range.start;
-        const endRange = issue.range.end;
-        const formattedIssue = new ValidationOutput(
-            issue.code,
-            getSeverity(issue.severity),
-            issue.message,
-            '/' + issue.path.join('/'),
-            '',
-            startRange.line,
-            endRange.line,
-            startRange.character,
-            endRange.character,
-            source
-        );
-        validationOutput.push(formattedIssue);
-    });
-
-    return validationOutput;
-}
-
-
-function getSeverity(spectralSeverity: DiagnosticSeverity): string {
-    switch (spectralSeverity) {
-    case 0:
-        return 'error';
-    case 1:
-        return 'warning';
-    case 2:
-        return 'info';
-    case 3:
-        return 'hint';
-    default:
-        throw Error('The spectralSeverity does not match the known values');
-    }
-}
-
-function appendExpected(issue: ErrorObject): string {
-    if (!issue || !issue.params) {
-        return issue?.message ?? '';
-    }
-
-    const params = issue.params as Record<string, unknown>;
-
-    // const keyword: prefer params.allowedValue, fall back to schema (AJV sets schema to the const value)
-    if (issue.keyword === 'const') {
-        const allowed = 'allowedValue' in params ? params['allowedValue'] : (issue as unknown as { schema?: unknown }).schema;
-        if (allowed !== undefined) {
-            return `${issue.message} (expected ${safeStringify(allowed)})`;
-        }
-    }
-
-    // enum keyword: prefer params.allowedValues, fall back to schema array
-    if (issue.keyword === 'enum') {
-        const allowedValues = 'allowedValues' in params ? params['allowedValues'] : (issue as unknown as { schema?: unknown }).schema;
-        if (Array.isArray(allowedValues)) {
-            return `${issue.message} (expected one of ${safeStringify(allowedValues)})`;
-        }
-    }
-
-    return issue.message ?? '';
-}
-
-function safeStringify(value: unknown): string {
-    try {
-        return JSON.stringify(value);
-    } catch (_) {
-        return String(value);
-    }
-}
-
-/**
- * Merge the results from two Spectral validations together, combining any errors/warnings.
- * @param spectralResultPattern Spectral results from the pattern validation
- * @param spectralResultArchitecture Spectral results from the architecture validation
- * @returns A new SpectralResult with the error/warning status propagated and the results concatenated.
- */
-function mergeSpectralResults(spectralResultPattern: SpectralResult, spectralResultArchitecture: SpectralResult): SpectralResult {
-    const errors: boolean = spectralResultPattern.errors || spectralResultArchitecture.errors;
-    const warnings: boolean = spectralResultPattern.warnings || spectralResultArchitecture.warnings;
-    const spectralValidations = spectralResultPattern.spectralIssues.concat(spectralResultArchitecture.spectralIssues);
-    return new SpectralResult(warnings, errors, spectralValidations);
 }

--- a/shared/src/commands/validate/validation-engine.spec.ts
+++ b/shared/src/commands/validate/validation-engine.spec.ts
@@ -1,0 +1,133 @@
+import { ValidationEngine } from './validation-engine';
+import { RuleResult, ValidationContext, ValidationPhase, ValidationRule } from './validation-rule';
+import { CachingTrackingResolver } from '../../resolver/caching-tracking-resolver';
+
+function ctx(overrides: Partial<ValidationContext> = {}): ValidationContext {
+    return {
+        mode: 'architecture-only',
+        references: new CachingTrackingResolver({ canResolve: () => false, resolve: () => Promise.reject(new Error('unused')) }),
+        debug: false,
+        // engine is only used by recursive rules; fake rules here don't touch it.
+        engine: undefined as unknown as ValidationEngine,
+        ...overrides
+    };
+}
+
+function fakeRule(
+    id: string,
+    phase: ValidationPhase,
+    result: Partial<RuleResult>,
+    opts: { applies?: boolean, calls?: string[] } = {}
+): ValidationRule {
+    return {
+        id,
+        description: id,
+        phase,
+        appliesTo: () => opts.applies ?? true,
+        run: async () => {
+            opts.calls?.push(id);
+            return {
+                jsonSchemaOutputs: [],
+                spectralOutputs: [],
+                hasErrors: false,
+                hasWarnings: false,
+                ...result
+            };
+        }
+    };
+}
+
+function output(code: string) {
+    return { code, severity: 'error', message: code, path: '/', schemaPath: undefined } as never;
+}
+
+describe('ValidationEngine', () => {
+    it('aggregates json-schema and spectral outputs into separate buckets', async () => {
+        const engine = new ValidationEngine([
+            fakeRule('a', ValidationPhase.LINT, { spectralOutputs: [output('spec-a')] }),
+            fakeRule('b', ValidationPhase.STRUCTURAL, { jsonSchemaOutputs: [output('json-b')] })
+        ]);
+
+        const outcome = await engine.validate(ctx());
+
+        expect(outcome.spectralSchemaValidationOutputs.map(o => o.code)).toEqual(['spec-a']);
+        expect(outcome.jsonSchemaValidationOutputs.map(o => o.code)).toEqual(['json-b']);
+    });
+
+    it('runs rules in ascending phase order regardless of registration order', async () => {
+        const calls: string[] = [];
+        const engine = new ValidationEngine([
+            fakeRule('recursive', ValidationPhase.RECURSIVE, {}, { calls }),
+            fakeRule('lint', ValidationPhase.LINT, {}, { calls }),
+            fakeRule('semantic', ValidationPhase.SEMANTIC, {}, { calls }),
+            fakeRule('structural', ValidationPhase.STRUCTURAL, {}, { calls })
+        ]);
+
+        await engine.validate(ctx());
+
+        expect(calls).toEqual(['lint', 'structural', 'semantic', 'recursive']);
+    });
+
+    it('preserves registration order for rules within the same phase', async () => {
+        const calls: string[] = [];
+        const engine = new ValidationEngine([
+            fakeRule('pattern', ValidationPhase.LINT, {}, { calls }),
+            fakeRule('architecture', ValidationPhase.LINT, {}, { calls })
+        ]);
+
+        await engine.validate(ctx());
+
+        expect(calls).toEqual(['pattern', 'architecture']);
+    });
+
+    it('skips rules that do not apply', async () => {
+        const calls: string[] = [];
+        const engine = new ValidationEngine([
+            fakeRule('applies', ValidationPhase.LINT, {}, { calls, applies: true }),
+            fakeRule('skipped', ValidationPhase.STRUCTURAL, {}, { calls, applies: false })
+        ]);
+
+        await engine.validate(ctx());
+
+        expect(calls).toEqual(['applies']);
+    });
+
+    it('ORs the error and warning flags across rules', async () => {
+        const engine = new ValidationEngine([
+            fakeRule('warn', ValidationPhase.LINT, { hasWarnings: true }),
+            fakeRule('err', ValidationPhase.STRUCTURAL, { hasErrors: true })
+        ]);
+
+        const outcome = await engine.validate(ctx());
+
+        expect(outcome.hasErrors).toBe(true);
+        expect(outcome.hasWarnings).toBe(true);
+    });
+
+    it('short-circuits remaining rules when a rule aborts', async () => {
+        const calls: string[] = [];
+        const engine = new ValidationEngine([
+            fakeRule('structural', ValidationPhase.STRUCTURAL, { jsonSchemaOutputs: [output('json')], hasErrors: true, abort: true }, { calls }),
+            fakeRule('semantic', ValidationPhase.SEMANTIC, { jsonSchemaOutputs: [output('should-not-run')] }, { calls })
+        ]);
+
+        const outcome = await engine.validate(ctx());
+
+        expect(calls).toEqual(['structural']);
+        expect(outcome.jsonSchemaValidationOutputs.map(o => o.code)).toEqual(['json']);
+        expect(outcome.hasErrors).toBe(true);
+    });
+
+    it('returns an empty passing outcome when no rules apply', async () => {
+        const engine = new ValidationEngine([
+            fakeRule('skipped', ValidationPhase.LINT, {}, { applies: false })
+        ]);
+
+        const outcome = await engine.validate(ctx());
+
+        expect(outcome.jsonSchemaValidationOutputs).toEqual([]);
+        expect(outcome.spectralSchemaValidationOutputs).toEqual([]);
+        expect(outcome.hasErrors).toBe(false);
+        expect(outcome.hasWarnings).toBe(false);
+    });
+});

--- a/shared/src/commands/validate/validation-engine.ts
+++ b/shared/src/commands/validate/validation-engine.ts
@@ -1,0 +1,87 @@
+import validationRulesForPattern from '../../spectral/rules-pattern.js';
+import validationRulesForArchitecture from '../../spectral/rules-architecture.js';
+import validationRulesForTimeline from '../../spectral/rules-timeline.js';
+import { ValidationOutcome } from './validation.output.js';
+import { ValidationContext, ValidationRule } from './validation-rule.js';
+import { stripRefs } from './validation-helpers.js';
+import { SpectralValidationRule } from './rules/spectral-rule.js';
+import { JsonSchemaValidationRule } from './rules/json-schema-rule.js';
+import { ControlsValidationRule } from './rules/controls-rule.js';
+import { NodeDetailsValidationRule } from './rules/node-details-rule.js';
+
+/**
+ * Runs a set of {@link ValidationRule}s over a {@link ValidationContext} and aggregates their
+ * contributions into a single {@link ValidationOutcome}.
+ *
+ * Rules run in ascending {@link ValidationPhase} order; ties keep registration order (so pattern
+ * linting precedes architecture linting). JSON-Schema and Spectral outputs are collected into
+ * separate buckets and the error/warning flags are OR-ed — preserving the historical external
+ * contract exactly. A rule may set `abort` to short-circuit the remaining rules.
+ */
+export class ValidationEngine {
+    private readonly rules: ValidationRule[];
+
+    constructor(rules: ValidationRule[]) {
+        this.rules = rules;
+    }
+
+    async validate(context: ValidationContext): Promise<ValidationOutcome> {
+        const applicable = this.rules
+            .filter(rule => rule.appliesTo(context))
+            .sort((a, b) => a.phase - b.phase);
+
+        const jsonSchemaOutputs = [];
+        const spectralOutputs = [];
+        let hasErrors = false;
+        let hasWarnings = false;
+
+        for (const rule of applicable) {
+            const result = await rule.run(context);
+            jsonSchemaOutputs.push(...result.jsonSchemaOutputs);
+            spectralOutputs.push(...result.spectralOutputs);
+            hasErrors = hasErrors || result.hasErrors;
+            hasWarnings = hasWarnings || result.hasWarnings;
+            if (result.abort) {
+                break;
+            }
+        }
+
+        return new ValidationOutcome(jsonSchemaOutputs, spectralOutputs, hasErrors, hasWarnings);
+    }
+}
+
+/**
+ * Build the engine wired with the standard CALM validation rules, in phase order:
+ * Spectral (pattern, architecture, timeline) -> JSON-Schema -> Controls -> Node-details.
+ */
+export function createDefaultValidationEngine(): ValidationEngine {
+    return new ValidationEngine([
+        new SpectralValidationRule(
+            'spectral-pattern',
+            'Lint the pattern with the CALM pattern Spectral ruleset',
+            validationRulesForPattern,
+            'pattern',
+            context => (context.pattern ? stripRefs(context.pattern) : undefined),
+            context => context.mode === 'architecture-with-pattern' || context.mode === 'pattern-only'
+        ),
+        new SpectralValidationRule(
+            'spectral-architecture',
+            'Lint the architecture with the CALM architecture Spectral ruleset',
+            validationRulesForArchitecture,
+            'architecture',
+            context => (context.architecture ? JSON.stringify(context.architecture) : undefined),
+            context => context.mode === 'architecture-with-pattern' || context.mode === 'architecture-only'
+        ),
+        new SpectralValidationRule(
+            'spectral-timeline',
+            'Lint the timeline with the CALM timeline Spectral ruleset',
+            validationRulesForTimeline,
+            'timeline',
+            context => (context.timeline ? stripRefs(context.timeline) : undefined),
+            context => context.mode === 'timeline'
+        ),
+        new JsonSchemaValidationRule(),
+        new ControlsValidationRule(),
+        new NodeDetailsValidationRule()
+    ]);
+}

--- a/shared/src/commands/validate/validation-helpers.ts
+++ b/shared/src/commands/validate/validation-helpers.ts
@@ -1,0 +1,197 @@
+import { ErrorObject } from 'ajv/dist/2020.js';
+import { Spectral, ISpectralDiagnostic, RulesetDefinition } from '@stoplight/spectral-core';
+import { DiagnosticSeverity } from '@stoplight/types';
+import { ValidationOutput } from './validation.output.js';
+import { SpectralResult } from './spectral.result.js';
+import { SchemaDirectory } from '../../schema-directory.js';
+import { selectChoices, CalmChoice } from '../generate/components/options.js';
+import { initLogger, Logger } from '../../logger.js';
+
+/**
+ * Pure, stateless helpers shared by the validation orchestrator (`validate.ts`) and the
+ * individual {@link ValidationRule} implementations. Kept in a dependency-free module so the
+ * rules can import them without creating an import cycle back through `validate.ts`.
+ */
+
+export function prettifyJson(json: unknown): string {
+    return JSON.stringify(json, null, 4);
+}
+
+export function stripRefs(obj: object): string {
+    return JSON.stringify(obj).replaceAll('$ref', 'ref');
+}
+
+export function sortSpectralIssueBySeverity(issues: ISpectralDiagnostic[]): void {
+    issues.sort((issue1: ISpectralDiagnostic, issue2: ISpectralDiagnostic) =>
+        issue1.severity.valueOf() - issue2.severity.valueOf()
+    );
+}
+
+/**
+ * Run a single Spectral ruleset against a stringified document.
+ */
+export async function runSpectralValidations(
+    schema: string,
+    spectralRuleset: RulesetDefinition,
+    source: string,
+    logger: Logger = initLogger(false, 'calm-validate')
+): Promise<SpectralResult> {
+    let errors = false;
+    let warnings = false;
+    let spectralIssues: ValidationOutput[] = [];
+    const spectral = new Spectral();
+
+    spectral.setRuleset(spectralRuleset);
+    const issues = await spectral.run(schema);
+
+    if (issues && issues.length > 0) {
+        logger.debug(`Spectral raw output: ${prettifyJson(issues)}`);
+        sortSpectralIssueBySeverity(issues);
+        spectralIssues = convertSpectralDiagnosticToValidationOutputs(issues, source);
+        if (issues.filter(issue => issue.severity === 0).length > 0) {
+            logger.debug('Spectral output contains errors');
+            errors = true;
+        }
+        if (issues.filter(issue => issue.severity === 1).length > 0) {
+            logger.debug('Spectral output contains warnings');
+            warnings = true;
+        }
+    }
+    return new SpectralResult(warnings, errors, spectralIssues);
+}
+
+/**
+ * If a pattern contains options, apply the chosen options recorded in the architecture to the
+ * pattern to produce a JSON schema pattern that can be used for validation.
+ */
+export function applyArchitectureOptionsToPattern(architecture: object, pattern: object, debug: boolean): object {
+    const choices: CalmChoice[] = extractChoicesFromArchitecture(architecture);
+    if (choices.length === 0) {
+        return pattern;
+    }
+    return selectChoices(pattern, choices, debug);
+}
+
+export function extractChoicesFromArchitecture(architecture: object): CalmChoice[] {
+    if (!architecture || !Object.prototype.hasOwnProperty.call(architecture, 'relationships')) {
+        return [];
+    }
+
+    // architecture is unvalidated CALM JSON traversed via nested property access,
+    // so a permissive index type is used here.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const relationships = (architecture as Record<string, any>)['relationships'] as Record<string, any>[];
+
+    return relationships
+        .filter((rel) => rel['relationship-type'] && Object.prototype.hasOwnProperty.call(rel['relationship-type'], 'options'))
+        .map((rel) => rel['relationship-type']['options'][0])
+        .map((rel) => ({
+            description: rel['description'],
+            nodes: rel['nodes'] || [],
+            relationships: rel['relationships'] || []
+        }));
+}
+
+/**
+ * Finds the URL of the most recent CALM core schema loaded in the schema directory.
+ *
+ * Precedence: release > draft. Within each tier, URLs are compared with a numeric-aware locale
+ * sort so that 1.10 > 1.9 > 1.2. Returns undefined if no CALM core schema is loaded.
+ */
+export function findLatestCalmCoreSchemaUrl(schemaDirectory: SchemaDirectory): string | undefined {
+    const coreSchemaPattern = /calm\.finos\.org\/.*\/meta\/core\.json$/;
+    const matches = schemaDirectory.getLoadedSchemas()
+        .filter(id => coreSchemaPattern.test(id));
+
+    if (matches.length === 0) return undefined;
+
+    return matches.sort((a, b) => {
+        const isRelease = (url: string) => url.includes('/release/');
+        if (isRelease(a) !== isRelease(b)) return isRelease(a) ? -1 : 1;
+        return b.localeCompare(a, undefined, { numeric: true });
+    })[0];
+}
+
+export function convertJsonSchemaIssuesToValidationOutputs(jsonSchemaIssues: ErrorObject[], source: string): ValidationOutput[] {
+    return jsonSchemaIssues.map(issue => {
+        const rawPath = issue.instancePath ?? '';
+        const path = rawPath === '' ? '/' : rawPath;
+        return ValidationOutput.error('json-schema', appendExpected(issue), path, {
+            schemaPath: issue.schemaPath,
+            source
+        });
+    });
+}
+
+export function convertSpectralDiagnosticToValidationOutputs(spectralIssues: ISpectralDiagnostic[], source: string): ValidationOutput[] {
+    const validationOutput: ValidationOutput[] = [];
+
+    spectralIssues.forEach(issue => {
+        const startRange = issue.range.start;
+        const endRange = issue.range.end;
+        const formattedIssue = new ValidationOutput(
+            issue.code,
+            getSeverity(issue.severity),
+            issue.message,
+            '/' + issue.path.join('/'),
+            '',
+            startRange.line,
+            endRange.line,
+            startRange.character,
+            endRange.character,
+            source
+        );
+        validationOutput.push(formattedIssue);
+    });
+
+    return validationOutput;
+}
+
+function getSeverity(spectralSeverity: DiagnosticSeverity): string {
+    switch (spectralSeverity) {
+    case 0:
+        return 'error';
+    case 1:
+        return 'warning';
+    case 2:
+        return 'info';
+    case 3:
+        return 'hint';
+    default:
+        throw Error('The spectralSeverity does not match the known values');
+    }
+}
+
+function appendExpected(issue: ErrorObject): string {
+    if (!issue || !issue.params) {
+        return issue?.message ?? '';
+    }
+
+    const params = issue.params as Record<string, unknown>;
+
+    // const keyword: prefer params.allowedValue, fall back to schema (AJV sets schema to the const value)
+    if (issue.keyword === 'const') {
+        const allowed = 'allowedValue' in params ? params['allowedValue'] : (issue as unknown as { schema?: unknown }).schema;
+        if (allowed !== undefined) {
+            return `${issue.message} (expected ${safeStringify(allowed)})`;
+        }
+    }
+
+    // enum keyword: prefer params.allowedValues, fall back to schema array
+    if (issue.keyword === 'enum') {
+        const allowedValues = 'allowedValues' in params ? params['allowedValues'] : (issue as unknown as { schema?: unknown }).schema;
+        if (Array.isArray(allowedValues)) {
+            return `${issue.message} (expected one of ${safeStringify(allowedValues)})`;
+        }
+    }
+
+    return issue.message ?? '';
+}
+
+function safeStringify(value: unknown): string {
+    try {
+        return JSON.stringify(value);
+    } catch (_) {
+        return String(value);
+    }
+}

--- a/shared/src/commands/validate/validation-rule.ts
+++ b/shared/src/commands/validate/validation-rule.ts
@@ -1,0 +1,84 @@
+import { SchemaDirectory } from '../../schema-directory.js';
+import { ValidationOutput } from './validation.output.js';
+import { CachingTrackingResolver } from '../../resolver/caching-tracking-resolver.js';
+import type { ValidationEngine } from './validation-engine.js';
+
+/**
+ * The input combination determines which rules apply. It mirrors the four historical dispatch
+ * branches of `validate()`.
+ */
+export type ValidationMode =
+    | 'architecture-with-pattern'
+    | 'architecture-only'
+    | 'pattern-only'
+    | 'timeline';
+
+/**
+ * Coarse ordering of validation phases. Rules run in ascending phase order; within a phase,
+ * registration order is preserved (so pattern linting precedes architecture linting).
+ */
+export enum ValidationPhase {
+    /** Spectral linting over the raw JSON document(s). */
+    LINT = 0,
+    /** JSON-Schema (AJV) structural validation. */
+    STRUCTURAL = 1,
+    /** Semantic checks over the parsed CALM model (e.g. controls). */
+    SEMANTIC = 2,
+    /** Recursive validation of referenced sub-architectures. */
+    RECURSIVE = 3,
+}
+
+/**
+ * The fragment a single rule contributes to the aggregate {@link ValidationOutcome}. JSON-Schema
+ * and Spectral outputs are kept in separate buckets to preserve the external output contract.
+ */
+export interface RuleResult {
+    jsonSchemaOutputs: ValidationOutput[];
+    spectralOutputs: ValidationOutput[];
+    hasErrors: boolean;
+    hasWarnings: boolean;
+    /**
+     * When true, the engine stops running subsequent rules. Used to reproduce the historical
+     * behaviour where a failed pattern compilation short-circuits controls/node-details in the
+     * architecture-with-pattern flow.
+     */
+    abort?: boolean;
+}
+
+export function emptyRuleResult(): RuleResult {
+    return { jsonSchemaOutputs: [], spectralOutputs: [], hasErrors: false, hasWarnings: false };
+}
+
+/**
+ * Everything a rule needs to run. A rule reads only what its mode guarantees is present
+ * (checked via {@link ValidationRule.appliesTo}).
+ */
+export interface ValidationContext {
+    architecture?: object;
+    pattern?: object;
+    timeline?: object;
+    mode: ValidationMode;
+    schemaDirectory?: SchemaDirectory;
+    /**
+     * Shared caching/tracking resolver threaded through recursive node-details validation. It
+     * caches each loaded sub-architecture and records which references have been visited, providing
+     * both dedupe ("validate each sub-architecture once") and cycle safety.
+     */
+    references: CachingTrackingResolver;
+    debug: boolean;
+    /** The engine, so recursive rules can re-enter the pipeline for sub-architectures. */
+    engine: ValidationEngine;
+}
+
+/**
+ * A single, self-contained unit of validation. Two families exist: Spectral-backed rules that
+ * lint the raw JSON, and model-backed rules that reason over the parsed CALM model.
+ */
+export interface ValidationRule {
+    readonly id: string;
+    readonly description: string;
+    readonly phase: ValidationPhase;
+    /** Whether this rule should run for the given context (typically a mode/input check). */
+    appliesTo(context: ValidationContext): boolean;
+    run(context: ValidationContext): Promise<RuleResult>;
+}

--- a/shared/src/commands/validate/validation.output.spec.ts
+++ b/shared/src/commands/validate/validation.output.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ValidationOutput } from './validation.output';
+
+describe('ValidationOutput factories', () => {
+    it('error() builds an error-severity output with no line/character fields', () => {
+        const out = ValidationOutput.error('my-code', 'boom', '/nodes/0');
+        expect(out.code).toBe('my-code');
+        expect(out.severity).toBe('error');
+        expect(out.message).toBe('boom');
+        expect(out.path).toBe('/nodes/0');
+        expect(out.schemaPath).toBeUndefined();
+        expect(out.source).toBeUndefined();
+        expect(out.line_start).toBeUndefined();
+        expect(out.line_end).toBeUndefined();
+        expect(out.character_start).toBeUndefined();
+        expect(out.character_end).toBeUndefined();
+    });
+
+    it('error() applies schemaPath and source options', () => {
+        const out = ValidationOutput.error('c', 'm', '/p', { schemaPath: '#/required', source: 'architecture' });
+        expect(out.schemaPath).toBe('#/required');
+        expect(out.source).toBe('architecture');
+    });
+
+    it('warning() builds a warning-severity output', () => {
+        const out = ValidationOutput.warning('legacy', 'deprecated', '/', { source: 'architecture' });
+        expect(out.severity).toBe('warning');
+        expect(out.code).toBe('legacy');
+        expect(out.message).toBe('deprecated');
+        expect(out.path).toBe('/');
+        expect(out.source).toBe('architecture');
+    });
+});

--- a/shared/src/commands/validate/validation.output.ts
+++ b/shared/src/commands/validate/validation.output.ts
@@ -23,6 +23,24 @@ export class ValidationOutput {
         this.character_end = character_end;
         this.source = source;
     }
+
+    /**
+     * Build an `error`-severity output without the positional `line`/`character` noise.
+     * @param opts.schemaPath optional JSON-schema path.
+     * @param opts.source     optional source label (e.g. 'architecture' or 'pattern').
+     */
+    static error(code: string | number, message: string, path: string, opts: { schemaPath?: string, source?: string } = {}): ValidationOutput {
+        return new ValidationOutput(code, 'error', message, path, opts.schemaPath, undefined, undefined, undefined, undefined, opts.source);
+    }
+
+    /**
+     * Build a `warning`-severity output without the positional `line`/`character` noise.
+     * @param opts.schemaPath optional JSON-schema path.
+     * @param opts.source     optional source label (e.g. 'architecture' or 'pattern').
+     */
+    static warning(code: string | number, message: string, path: string, opts: { schemaPath?: string, source?: string } = {}): ValidationOutput {
+        return new ValidationOutput(code, 'warning', message, path, opts.schemaPath, undefined, undefined, undefined, undefined, opts.source);
+    }
 }
 
 export class ValidationOutcome {

--- a/shared/src/controls/control-iteration.spec.ts
+++ b/shared/src/controls/control-iteration.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { iterateControls } from './control-iteration.js';
+import { CalmCore } from '@finos/calm-models/model';
+import { CalmCoreSchema } from '@finos/calm-models/types';
+
+const control = (desc: string) => ({
+    description: desc,
+    requirements: [{ 'requirement-url': 'https://calm.example.com/req.json', config: {} }]
+});
+
+const arch: CalmCoreSchema = {
+    '$schema': 'https://calm.finos.org/release/1.2/meta/calm.json',
+    'unique-id': 'arch',
+    controls: { 'top-level': control('top') },
+    nodes: [
+        { 'unique-id': 'node-1', 'node-type': 'system', name: 'n1', description: 'd', controls: { 'node-ctrl': control('node') } }
+    ],
+    relationships: [
+        {
+            'unique-id': 'rel-1',
+            'relationship-type': { connects: { source: { node: 'node-1' }, destination: { node: 'node-1' } } },
+            controls: { 'rel-ctrl': control('rel') }
+        }
+    ],
+    flows: [
+        { 'unique-id': 'flow-1', name: 'f', description: 'flow', transitions: [], controls: { 'flow-ctrl': control('flow') } }
+    ]
+} as unknown as CalmCoreSchema;
+
+describe('iterateControls', () => {
+    it('enumerates controls across all scopes in document order', () => {
+        const core = CalmCore.fromSchema(arch);
+        const locations = [...iterateControls(core)];
+
+        expect(locations.map(l => ({ scope: l.scope, pathPrefix: l.pathPrefix, appliedTo: l.appliedTo, controlId: l.controlId }))).toEqual([
+            { scope: 'Architecture', pathPrefix: '/controls', appliedTo: '', controlId: 'top-level' },
+            { scope: 'Node', pathPrefix: '/nodes/0/controls', appliedTo: 'node-1', controlId: 'node-ctrl' },
+            { scope: 'Relationship', pathPrefix: '/relationships/0/controls', appliedTo: 'rel-1', controlId: 'rel-ctrl' },
+            { scope: 'Flow', pathPrefix: '/flows/0/controls', appliedTo: 'flow-1', controlId: 'flow-ctrl' }
+        ]);
+    });
+
+    it('yields nothing for an architecture with no controls', () => {
+        const bare = CalmCore.fromSchema({
+            '$schema': 'https://calm.finos.org/release/1.2/meta/calm.json',
+            'unique-id': 'bare',
+            nodes: [],
+            relationships: []
+        } as unknown as CalmCoreSchema);
+        expect([...iterateControls(bare)]).toHaveLength(0);
+    });
+});

--- a/shared/src/controls/control-iteration.ts
+++ b/shared/src/controls/control-iteration.ts
@@ -1,0 +1,64 @@
+import { Architecture, CalmControl } from '@finos/calm-models/model';
+
+/**
+ * The scope at which a control is applied within an architecture.
+ */
+export type ControlScope = 'Architecture' | 'Node' | 'Relationship' | 'Flow';
+
+/**
+ * A single control location within an architecture, together with everything needed
+ * to both validate it (index-based `pathPrefix`) and index it (`scope`/`appliedTo`).
+ *
+ * This is the single place the CALM control hierarchy (top-level / nodes / relationships /
+ * flows) is enumerated for control validation.
+ */
+export interface ControlLocation {
+    /** JSON-pointer-style prefix to the control, e.g. `/nodes/0/controls`. */
+    pathPrefix: string;
+    /** The scope at which the control is applied. */
+    scope: ControlScope;
+    /** The unique-id of the owning node/relationship/flow (empty for top-level). */
+    appliedTo: string;
+    /** The control identifier (key within the controls object). */
+    controlId: string;
+    /** The control itself. */
+    control: CalmControl;
+}
+
+function* controlsAt(
+    controls: { data: Record<string, CalmControl> } | undefined,
+    pathPrefix: string,
+    scope: ControlScope,
+    appliedTo: string
+): Generator<ControlLocation> {
+    if (!controls) {
+        return;
+    }
+    for (const [controlId, control] of Object.entries(controls.data)) {
+        yield { pathPrefix, scope, appliedTo, controlId, control };
+    }
+}
+
+/**
+ * Enumerate every control in an architecture across all scopes in document order:
+ * top-level, then nodes, then relationships, then flows.
+ */
+export function* iterateControls(architecture: Architecture): Generator<ControlLocation> {
+    yield* controlsAt(architecture.controls, '/controls', 'Architecture', '');
+
+    for (let nodeIdx = 0; nodeIdx < architecture.nodes.length; nodeIdx++) {
+        const node = architecture.nodes[nodeIdx];
+        yield* controlsAt(node.controls, `/nodes/${nodeIdx}/controls`, 'Node', node.uniqueId);
+    }
+
+    for (let relIdx = 0; relIdx < architecture.relationships.length; relIdx++) {
+        const relationship = architecture.relationships[relIdx];
+        yield* controlsAt(relationship.controls, `/relationships/${relIdx}/controls`, 'Relationship', relationship.uniqueId);
+    }
+
+    const flows = architecture.flows ?? [];
+    for (let flowIdx = 0; flowIdx < flows.length; flowIdx++) {
+        const flow = flows[flowIdx];
+        yield* controlsAt(flow.controls, `/flows/${flowIdx}/controls`, 'Flow', flow.uniqueId);
+    }
+}

--- a/shared/src/model-visitor/dereference-visitor.ts
+++ b/shared/src/model-visitor/dereference-visitor.ts
@@ -1,41 +1,38 @@
-import {CalmReferenceResolver} from '../resolver/calm-reference-resolver';
-import {Resolvable,ResolvableAndAdaptable} from '@finos/calm-models/model';
-import {CalmModelVisitor} from './calm-model-visitor';
-import {getErrorMessage} from '../error-utils';
+import { CalmReferenceResolver } from '../resolver/calm-reference-resolver';
+import { CalmModelVisitor } from './calm-model-visitor';
+import { ModelWalker } from './model-walker.js';
+import { initLogger, Logger } from '../logger.js';
 
+/**
+ * Dereferences every unresolved `Resolvable`/`ResolvableAndAdaptable` in the model.
+ *
+ * Traversal, dereferencing, cycle safety and error collection are all owned by the shared
+ * {@link ModelWalker}, which drives dereferencing through the injected {@link CalmReferenceResolver}.
+ * The visitor is agnostic to the resolver's behaviour — if caching or reference-tracking is wanted,
+ * the caller composes a {@link import('../resolver/caching-tracking-resolver').CachingTrackingResolver}
+ * (or any other decorator) around the resolver it passes in.
+ */
 export class DereferencingVisitor implements CalmModelVisitor {
-    private resolver: CalmReferenceResolver;
+    private static _logger: Logger | undefined;
 
-    constructor(resolver: CalmReferenceResolver) {
-        this.resolver = resolver;
+    constructor(private readonly resolver: CalmReferenceResolver) {}
+
+    private static get logger(): Logger {
+        if (!this._logger) {
+            this._logger = initLogger(process.env.DEBUG === 'true', DereferencingVisitor.name);
+        }
+        return this._logger;
     }
 
     async visit(obj: unknown): Promise<void> {
-        if (!obj || typeof obj !== 'object') return;
+        const walker = new ModelWalker(this.resolver);
 
-        if (obj instanceof Resolvable || obj instanceof ResolvableAndAdaptable) {
-            if (!obj.isResolved && obj.reference) {
-                try {
-                    await obj.dereference(this.resolver.resolve.bind(this.resolver));
-                } catch (err) {
-                    console.warn('Failed to dereference Resolvable:', obj.reference, getErrorMessage(err));
-                }
-            }
-            if (obj.isResolved) {
-                //allows for recursive dereferencing
-                await this.visit(obj.value);
-            }
-            return;
-        }
+        await walker.walk(obj);
 
-        if (Array.isArray(obj)) {
-            await Promise.all(obj.map(item => this.visit(item)));
-            return;
-        }
-
-        const values = Object.values(obj);
-        for (const value of values) {
-            await this.visit(value);
+        for (const error of walker.errors) {
+            DereferencingVisitor.logger.warn(
+                `Failed to dereference Resolvable: ${error.reference} ${error.message}`
+            );
         }
     }
 }

--- a/shared/src/model-visitor/model-walker.spec.ts
+++ b/shared/src/model-visitor/model-walker.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Resolvable, ResolvableAndAdaptable } from '@finos/calm-models/model';
+import { ModelWalker, ResolvableHook } from './model-walker';
+import { CalmReferenceResolver, InMemoryResolver } from '../resolver/calm-reference-resolver';
+
+/** A resolver that never dereferences — for tests that pre-resolve their nodes and only observe. */
+const noopResolver: CalmReferenceResolver = {
+    canResolve: () => false,
+    resolve: async () => ({})
+};
+
+function recordingHook(): { hook: ResolvableHook, visits: { reference: string, path: string[] }[] } {
+    const visits: { reference: string, path: string[] }[] = [];
+    const hook: ResolvableHook = {
+        onResolvable: async (node, path) => {
+            visits.push({ reference: node.reference, path: [...path] });
+        }
+    };
+    return { hook, visits };
+}
+
+describe('ModelWalker', () => {
+    it('propagates the path to nested resolvables through objects and arrays', async () => {
+        const inner = new Resolvable<object>('inner-ref', { leaf: true });
+        const obj = { nodes: [{ details: inner }] };
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(noopResolver, hook).walk(obj);
+
+        expect(visits).toHaveLength(1);
+        expect(visits[0].reference).toBe('inner-ref');
+        expect(visits[0].path).toEqual(['nodes', '[0]', 'details']);
+    });
+
+    it('dereferences unresolved resolvables through the injected resolver', async () => {
+        const resolve = vi.fn().mockResolvedValue({ leaf: true });
+        const resolver: CalmReferenceResolver = { canResolve: () => true, resolve };
+        const node = new Resolvable<object>('to-resolve');
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(resolver, hook).walk({ item: node });
+
+        expect(resolve).toHaveBeenCalledWith('to-resolve');
+        expect(node.isResolved).toBe(true);
+        expect(visits).toHaveLength(1);
+        expect(visits[0].reference).toBe('to-resolve');
+    });
+
+    it('records a resolver failure as a walk error instead of throwing', async () => {
+        const resolver: CalmReferenceResolver = {
+            canResolve: () => true,
+            resolve: vi.fn().mockRejectedValue(new Error('load failed'))
+        };
+        const node = new Resolvable<object>('bad-ref');
+
+        const walker = new ModelWalker(resolver);
+        await walker.walk({ item: node });
+
+        expect(walker.errors).toHaveLength(1);
+        expect(walker.errors[0].reference).toBe('bad-ref');
+        expect(walker.errors[0].message).toContain('load failed');
+    });
+
+    it('terminates on a self-referential cycle and visits the reference once', async () => {
+        const selfRef = new Resolvable<object>('self-ref');
+        // resolve it to a structure that contains itself
+        await selfRef.dereference(async () => ({ child: selfRef }));
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(noopResolver, hook).walk(selfRef);
+
+        expect(visits.filter(v => v.reference === 'self-ref')).toHaveLength(1);
+    });
+
+    it('terminates on a mutual (A -> B -> A) cycle', async () => {
+        const a = new Resolvable<object>('a-ref');
+        const b = new Resolvable<object>('b-ref');
+        await a.dereference(async () => ({ next: b }));
+        await b.dereference(async () => ({ next: a }));
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(noopResolver, hook).walk(a);
+
+        expect(visits.map(v => v.reference).sort()).toEqual(['a-ref', 'b-ref']);
+    });
+
+    it('visits legitimate duplicate references in sibling branches (not treated as a cycle)', async () => {
+        const shared1 = new Resolvable<object>('shared-ref', { leaf: 1 });
+        const shared2 = new Resolvable<object>('shared-ref', { leaf: 2 });
+        const obj = { nodes: [{ ref: shared1 }, { ref: shared2 }] };
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(noopResolver, hook).walk(obj);
+
+        expect(visits.filter(v => v.reference === 'shared-ref')).toHaveLength(2);
+    });
+
+    it('collects hook errors instead of throwing, keying them by reference and path', async () => {
+        const boom = new Resolvable<object>('boom-ref');
+        const obj = { a: { b: boom } };
+
+        const hook: ResolvableHook = {
+            onResolvable: async () => {
+                throw new Error('kaboom');
+            }
+        };
+        const walker = new ModelWalker(noopResolver, hook);
+        await walker.walk(obj);
+
+        expect(walker.errors).toHaveLength(1);
+        expect(walker.errors[0].reference).toBe('boom-ref');
+        expect(walker.errors[0].path).toEqual(['a', 'b']);
+        expect(walker.errors[0].message).toContain('kaboom');
+    });
+
+    it('ignores primitives and null without invoking the hook', async () => {
+        const { hook, visits } = recordingHook();
+        const walker = new ModelWalker(noopResolver, hook);
+
+        await walker.walk(null);
+        await walker.walk(42);
+        await walker.walk('a string');
+        await walker.walk({ a: 1, b: 'two', c: null });
+
+        expect(visits).toHaveLength(0);
+        expect(walker.errors).toHaveLength(0);
+    });
+
+    it('walks ResolvableAndAdaptable nodes', async () => {
+        const adaptable = new ResolvableAndAdaptable<object, { adapted: boolean }>(
+            'adaptable-ref',
+            () => ({ adapted: true }),
+            { adapted: true }
+        );
+
+        const { hook, visits } = recordingHook();
+        await new ModelWalker(noopResolver, hook).walk({ item: adaptable });
+
+        expect(visits).toHaveLength(1);
+        expect(visits[0].reference).toBe('adaptable-ref');
+    });
+
+    it('can be driven end-to-end by an InMemoryResolver', async () => {
+        const resolver = new InMemoryResolver({ 'x-ref': { leaf: true } });
+        const node = new Resolvable<object>('x-ref');
+
+        await new ModelWalker(resolver).walk({ item: node });
+
+        expect(node.isResolved).toBe(true);
+        expect(node.value).toEqual({ leaf: true });
+    });
+});

--- a/shared/src/model-visitor/model-walker.ts
+++ b/shared/src/model-visitor/model-walker.ts
@@ -1,0 +1,99 @@
+import { Resolvable, ResolvableAndAdaptable, AnyResolvable } from '@finos/calm-models/model';
+import { getErrorMessage } from '../error-utils.js';
+import { CalmReferenceResolver } from '../resolver/calm-reference-resolver.js';
+
+/**
+ * An error encountered while walking the model. Rather than swallowing failures
+ * (the original sample visitor logged them with `console.warn`), the walk collects
+ * them so callers can surface them however they need to.
+ */
+export interface ModelWalkError {
+    path: string[];
+    reference: string;
+    message: string;
+}
+
+/**
+ * Optional per-consumer behaviour invoked once per resolvable, after the walk has dereferenced it.
+ * Implementations decide what extra to do at each resolvable (validate, index, ...) — the walk
+ * itself owns traversal, dereferencing (via the injected {@link CalmReferenceResolver}), cycle
+ * detection and error collection.
+ */
+export interface ResolvableHook {
+    /**
+     * Called once per resolvable reference encountered on the current traversal path.
+     * The walk guarantees a reference cannot appear twice on the same path (a cycle),
+     * so hooks do not need their own cycle guard.
+     */
+    onResolvable(node: AnyResolvable, path: string[]): Promise<void>;
+}
+
+function isResolvable(obj: unknown): obj is AnyResolvable {
+    return obj instanceof Resolvable || obj instanceof ResolvableAndAdaptable;
+}
+
+/**
+ * A single, cycle-safe traversal of the CALM model.
+ *
+ * This promotes the original {@link import('./dereference-visitor').DereferencingVisitor}
+ * (which began life as a sample of how to visit the model) into shared infrastructure:
+ *  - it dereferences each unresolved resolvable through the injected {@link CalmReferenceResolver},
+ *    so callers share one resolver abstraction (and can layer caching/tracking on it);
+ *  - it tracks the references on the *current* traversal path, so a reference that is
+ *    reachable from itself (a cycle) terminates instead of recursing unbounded, while
+ *    legitimate duplicate references in sibling branches are each still visited;
+ *  - it collects resolution failures rather than logging and discarding them;
+ *  - consumers may supply an optional {@link ResolvableHook} to observe each resolvable
+ *    (validation, indexing, ...) while sharing exactly one walk.
+ *
+ * The active-path set is threaded down the recursion immutably (a fresh set is created when
+ * descending through a resolvable) so that concurrently-walked array branches never observe
+ * one another's in-progress references.
+ */
+export class ModelWalker {
+    readonly errors: ModelWalkError[] = [];
+
+    constructor(
+        private readonly resolver: CalmReferenceResolver,
+        private readonly hook?: ResolvableHook
+    ) {}
+
+    async walk(obj: unknown, path: string[] = [], activeRefs: ReadonlySet<string> = new Set()): Promise<void> {
+        if (!obj || typeof obj !== 'object') {
+            return;
+        }
+
+        if (isResolvable(obj)) {
+            const ref = obj.reference;
+            if (ref && activeRefs.has(ref)) {
+                return;
+            }
+            const nextActive = ref ? new Set(activeRefs).add(ref) : activeRefs;
+            try {
+                if (!obj.isResolved && ref && this.resolver.canResolve(ref)) {
+                    await obj.dereference(this.resolver.resolve.bind(this.resolver));
+                }
+                await this.hook?.onResolvable(obj, path);
+            } catch (err) {
+                this.errors.push({
+                    path,
+                    reference: ref,
+                    message: getErrorMessage(err)
+                });
+            }
+            if (obj.isResolved) {
+                await this.walk(obj.value, path, nextActive);
+            }
+            return;
+        }
+
+        if (Array.isArray(obj)) {
+            await Promise.all(obj.map((item, i) => this.walk(item, [...path, `[${i}]`], activeRefs)));
+            return;
+        }
+
+        for (const [key, value] of Object.entries(obj)) {
+            await this.walk(value, [...path, key], activeRefs);
+        }
+    }
+}

--- a/shared/src/resolver/caching-tracking-resolver.spec.ts
+++ b/shared/src/resolver/caching-tracking-resolver.spec.ts
@@ -58,6 +58,20 @@ describe('CachingTrackingResolver', () => {
         expect(resolver.get('a')).toBeUndefined();
     });
 
+    // Reproduces rocketstack-matt's review comment on PR #2805:
+    // https://github.com/finos/architecture-as-code/pull/2805#discussion_r3576885163
+    // Asserts the DESIRED behaviour (delegate attempted once); expected to FAIL against current
+    // code, which retries the delegate. Left red pending clarification before fixing.
+    it('does not retry the delegate for a reference whose first load failed', async () => {
+        const resolve = vi.fn().mockRejectedValue(new Error('boom'));
+        const resolver = new CachingTrackingResolver(fakeResolver({ resolve }));
+
+        await expect(resolver.resolve('a')).rejects.toThrow('boom');
+        await expect(resolver.resolve('a')).rejects.toThrow('boom');
+
+        expect(resolve).toHaveBeenCalledTimes(1);
+    });
+
     it('supports pre-seeding seen references via markSeen()', () => {
         const resolver = new CachingTrackingResolver(fakeResolver());
 

--- a/shared/src/resolver/caching-tracking-resolver.spec.ts
+++ b/shared/src/resolver/caching-tracking-resolver.spec.ts
@@ -58,10 +58,10 @@ describe('CachingTrackingResolver', () => {
         expect(resolver.get('a')).toBeUndefined();
     });
 
-    // Reproduces rocketstack-matt's review comment on PR #2805:
+    // Covers rocketstack-matt's review comment on PR #2805:
     // https://github.com/finos/architecture-as-code/pull/2805#discussion_r3576885163
-    // Asserts the DESIRED behaviour (delegate attempted once); expected to FAIL against current
-    // code, which retries the delegate. Left red pending clarification before fixing.
+    // A failed load is cached, so a second resolve() re-throws the cached error without re-hitting
+    // the delegate.
     it('does not retry the delegate for a reference whose first load failed', async () => {
         const resolve = vi.fn().mockRejectedValue(new Error('boom'));
         const resolver = new CachingTrackingResolver(fakeResolver({ resolve }));

--- a/shared/src/resolver/caching-tracking-resolver.spec.ts
+++ b/shared/src/resolver/caching-tracking-resolver.spec.ts
@@ -1,0 +1,68 @@
+import { CachingTrackingResolver } from './caching-tracking-resolver';
+import { CalmReferenceResolver } from './calm-reference-resolver';
+
+function fakeResolver(overrides: Partial<CalmReferenceResolver> = {}): CalmReferenceResolver {
+    return {
+        canResolve: overrides.canResolve ?? vi.fn().mockReturnValue(true),
+        resolve: overrides.resolve ?? vi.fn().mockResolvedValue({})
+    };
+}
+
+describe('CachingTrackingResolver', () => {
+    it('loads a reference once and caches the result', async () => {
+        const resolve = vi.fn().mockResolvedValue({ doc: 1 });
+        const resolver = new CachingTrackingResolver(fakeResolver({ resolve }));
+
+        const first = await resolver.resolve('a');
+        const second = await resolver.resolve('a');
+
+        expect(first).toEqual({ doc: 1 });
+        expect(second).toBe(first);
+        expect(resolve).toHaveBeenCalledTimes(1);
+    });
+
+    it('delegates canResolve to the inner resolver', () => {
+        const canResolve = vi.fn().mockReturnValue(false);
+        const resolver = new CachingTrackingResolver(fakeResolver({ canResolve }));
+
+        expect(resolver.canResolve('a')).toBe(false);
+        expect(canResolve).toHaveBeenCalledWith('a');
+    });
+
+    it('tracks resolved references via has() and resolvedReferences', async () => {
+        const resolver = new CachingTrackingResolver(fakeResolver());
+
+        expect(resolver.has('a')).toBe(false);
+        await resolver.resolve('a');
+
+        expect(resolver.has('a')).toBe(true);
+        expect([...resolver.resolvedReferences]).toEqual(['a']);
+    });
+
+    it('exposes the cached raw document via get()', async () => {
+        const resolver = new CachingTrackingResolver(fakeResolver({ resolve: vi.fn().mockResolvedValue({ raw: true }) }));
+
+        await resolver.resolve('a');
+
+        expect(resolver.get('a')).toEqual({ raw: true });
+        expect(resolver.get('missing')).toBeUndefined();
+    });
+
+    it('marks a reference as seen even when the load fails (no retry for siblings)', async () => {
+        const resolve = vi.fn().mockRejectedValue(new Error('boom'));
+        const resolver = new CachingTrackingResolver(fakeResolver({ resolve }));
+
+        await expect(resolver.resolve('a')).rejects.toThrow('boom');
+
+        expect(resolver.has('a')).toBe(true);
+        expect(resolver.get('a')).toBeUndefined();
+    });
+
+    it('supports pre-seeding seen references via markSeen()', () => {
+        const resolver = new CachingTrackingResolver(fakeResolver());
+
+        resolver.markSeen('a');
+
+        expect(resolver.has('a')).toBe(true);
+    });
+});

--- a/shared/src/resolver/caching-tracking-resolver.ts
+++ b/shared/src/resolver/caching-tracking-resolver.ts
@@ -1,0 +1,58 @@
+import { CalmReferenceResolver } from './calm-reference-resolver.js';
+
+/**
+ * A caching, tracking {@link CalmReferenceResolver} decorator.
+ *
+ * The CALM model is lazily dereferenced — callers choose which references to resolve. This resolver
+ * wraps any inner {@link CalmReferenceResolver} and centralises the two concerns that would
+ * otherwise be re-implemented per caller:
+ *  - **caching**: a reference is fetched at most once; repeat requests return the cached document;
+ *  - **tracking**: every attempted reference is recorded, so callers can dedupe work
+ *    (e.g. "validate each detailed-architecture once") and detect cycles without their own set.
+ *
+ * A reference is marked as *seen* before the underlying load is awaited, so a failed load still
+ * counts as seen (a sibling referencing the same failing URL is not retried) — matching the
+ * historical `visitedUrls` semantics. Only successful loads populate the value cache.
+ */
+export class CachingTrackingResolver implements CalmReferenceResolver {
+    private readonly cache = new Map<string, unknown>();
+    private readonly seen = new Set<string>();
+
+    constructor(private readonly delegate: CalmReferenceResolver) {}
+
+    /** Delegates to the wrapped resolver. */
+    canResolve(reference: string): boolean {
+        return this.delegate.canResolve(reference);
+    }
+
+    /** Whether the reference has been resolved or attempted (used for dedupe / cycle checks). */
+    has(reference: string): boolean {
+        return this.seen.has(reference);
+    }
+
+    /** The cached raw document for a reference, or undefined if never successfully loaded. */
+    get(reference: string): unknown {
+        return this.cache.get(reference);
+    }
+
+    /** Mark a reference as already seen without loading it (e.g. to seed cycle state). */
+    markSeen(reference: string): void {
+        this.seen.add(reference);
+    }
+
+    /** All references that have been resolved or attempted. */
+    get resolvedReferences(): ReadonlySet<string> {
+        return this.seen;
+    }
+
+    /** Resolve a reference, returning the cached document if already loaded. */
+    async resolve(reference: string): Promise<unknown> {
+        if (this.cache.has(reference)) {
+            return this.cache.get(reference);
+        }
+        this.seen.add(reference);
+        const document = await this.delegate.resolve(reference);
+        this.cache.set(reference, document);
+        return document;
+    }
+}

--- a/shared/src/resolver/caching-tracking-resolver.ts
+++ b/shared/src/resolver/caching-tracking-resolver.ts
@@ -11,11 +11,14 @@ import { CalmReferenceResolver } from './calm-reference-resolver.js';
  *    (e.g. "validate each detailed-architecture once") and detect cycles without their own set.
  *
  * A reference is marked as *seen* before the underlying load is awaited, so a failed load still
- * counts as seen (a sibling referencing the same failing URL is not retried) — matching the
- * historical `visitedUrls` semantics. Only successful loads populate the value cache.
+ * counts as seen (a sibling referencing the same failing URL is not retried) matching the
+ * historical `visitedUrls` semantics. Successful loads populate the value cache; failed loads cache
+ * the rejection instead, so a repeat {@link resolve} for a known-bad reference re-throws the cached
+ * error without re-hitting the delegate. Callers can tell the two apart via {@link hasFailed}.
  */
 export class CachingTrackingResolver implements CalmReferenceResolver {
     private readonly cache = new Map<string, unknown>();
+    private readonly failures = new Map<string, unknown>();
     private readonly seen = new Set<string>();
 
     constructor(private readonly delegate: CalmReferenceResolver) {}
@@ -28,6 +31,11 @@ export class CachingTrackingResolver implements CalmReferenceResolver {
     /** Whether the reference has been resolved or attempted (used for dedupe / cycle checks). */
     has(reference: string): boolean {
         return this.seen.has(reference);
+    }
+
+    /** Whether a previous {@link resolve} for this reference failed to load. */
+    hasFailed(reference: string): boolean {
+        return this.failures.has(reference);
     }
 
     /** The cached raw document for a reference, or undefined if never successfully loaded. */
@@ -50,9 +58,17 @@ export class CachingTrackingResolver implements CalmReferenceResolver {
         if (this.cache.has(reference)) {
             return this.cache.get(reference);
         }
+        if (this.failures.has(reference)) {
+            throw this.failures.get(reference);
+        }
         this.seen.add(reference);
-        const document = await this.delegate.resolve(reference);
-        this.cache.set(reference, document);
-        return document;
+        try {
+            const document = await this.delegate.resolve(reference);
+            this.cache.set(reference, document);
+            return document;
+        } catch (err) {
+            this.failures.set(reference, err);
+            throw err;
+        }
     }
 }

--- a/shared/src/resolver/schema-directory-reference-resolver.spec.ts
+++ b/shared/src/resolver/schema-directory-reference-resolver.spec.ts
@@ -1,0 +1,41 @@
+import { SchemaDirectoryReferenceResolver } from './schema-directory-reference-resolver';
+import { SchemaDirectory } from '../schema-directory';
+
+describe('SchemaDirectoryReferenceResolver', () => {
+    it('canResolve is true when a schema directory is present', () => {
+        const dir = { loadDocument: vi.fn() } as unknown as SchemaDirectory;
+        const resolver = new SchemaDirectoryReferenceResolver(dir);
+        expect(resolver.canResolve('any')).toBe(true);
+    });
+
+    it('canResolve is false when no schema directory is present', () => {
+        const resolver = new SchemaDirectoryReferenceResolver(undefined);
+        expect(resolver.canResolve('any')).toBe(false);
+    });
+
+    it('resolves by loading the document as an architecture by default', async () => {
+        const loadDocument = vi.fn().mockResolvedValue({ doc: true });
+        const dir = { loadDocument } as unknown as SchemaDirectory;
+        const resolver = new SchemaDirectoryReferenceResolver(dir);
+
+        const result = await resolver.resolve('https://example.com/a.json');
+
+        expect(result).toEqual({ doc: true });
+        expect(loadDocument).toHaveBeenCalledWith('https://example.com/a.json', 'architecture');
+    });
+
+    it('honours a custom document type', async () => {
+        const loadDocument = vi.fn().mockResolvedValue({});
+        const dir = { loadDocument } as unknown as SchemaDirectory;
+        const resolver = new SchemaDirectoryReferenceResolver(dir, 'pattern');
+
+        await resolver.resolve('ref');
+
+        expect(loadDocument).toHaveBeenCalledWith('ref', 'pattern');
+    });
+
+    it('rejects when resolving without a schema directory', async () => {
+        const resolver = new SchemaDirectoryReferenceResolver(undefined);
+        await expect(resolver.resolve('ref')).rejects.toThrow('without a schema directory');
+    });
+});

--- a/shared/src/resolver/schema-directory-reference-resolver.ts
+++ b/shared/src/resolver/schema-directory-reference-resolver.ts
@@ -1,0 +1,30 @@
+import { SchemaDirectory } from '../schema-directory.js';
+import { CalmDocumentType } from '../document-loader/document-loader.js';
+import { CalmReferenceResolver } from './calm-reference-resolver.js';
+
+/**
+ * A {@link CalmReferenceResolver} that resolves references by loading raw documents through a
+ * {@link SchemaDirectory}.
+ *
+ * This bridges the `SchemaDirectory.loadDocument(id, type)` seam to the plain `canResolve`/`resolve`
+ * resolver interface, so validation can share the same resolver abstraction (and the
+ * {@link import('./caching-tracking-resolver').CachingTrackingResolver} decorator) as the model
+ * dereference path — rather than passing a bespoke loader lambda.
+ */
+export class SchemaDirectoryReferenceResolver implements CalmReferenceResolver {
+    constructor(
+        private readonly schemaDirectory: SchemaDirectory | undefined,
+        private readonly documentType: CalmDocumentType = 'architecture'
+    ) {}
+
+    canResolve(_reference: string): boolean {
+        return this.schemaDirectory !== undefined;
+    }
+
+    async resolve(reference: string): Promise<unknown> {
+        if (!this.schemaDirectory) {
+            throw new Error(`Cannot resolve reference '${reference}' without a schema directory`);
+        }
+        return this.schemaDirectory.loadDocument(reference, this.documentType);
+    }
+}

--- a/shared/src/schema-directory.ts
+++ b/shared/src/schema-directory.ts
@@ -11,15 +11,17 @@ export class SchemaDirectory {
     private readonly schemas: Map<string, object> = new Map<string, object>();
     private readonly schemaTypes: Map<string, CalmDocumentType> = new Map<string, CalmDocumentType>();
     private readonly logger: Logger;
+    private readonly debug: boolean;
     private readonly PATTERN_CURRENTLY_VALIDATING = 'patternCurrentlyValidating';
     private documentLoader: DocumentLoader;
 
     /**
      * Initialise the SchemaDirectory. Does not load the schemas until loadSchemas is called.
-     * @param directoryPath The directory path from which to load schemas. All JSON and YAML files under this path will be loaded, including subfolders.
+     * @param documentLoader The document loader to use for loading documents.
      * @param debug Whether to log at debug level.
      */
     constructor(documentLoader: DocumentLoader, debug: boolean = false) {
+        this.debug = debug;
         this.logger = initLogger(debug, 'schema-directory');
         this.documentLoader = documentLoader;
     }
@@ -169,5 +171,39 @@ export class SchemaDirectory {
         this.logger.debug(`Storing document with ID ${documentId} of type ${documentType}.`);
         this.schemas.set(documentId, document);
         this.schemaTypes.set(documentId, documentType);
+    }
+
+    /**
+     * Load a CALM document (e.g. an architecture) by reference via the DocumentLoader.
+     * Unlike {@link getSchema}, this does not cache the result in the schema map and
+     * accepts an explicit document type. Used to fetch raw sub-architecture documents
+     * for recursive validation.
+     */
+    public async loadDocument(documentId: string, type: CalmDocumentType): Promise<object> {
+        return this.documentLoader.loadMissingDocument(documentId, type);
+    }
+
+    /**
+     * Return a new SchemaDirectory backed by the same DocumentLoader, pre-seeded with a
+     * copy of this directory's already-loaded schemas.
+     *
+     * Isolation prevents AJV schema-ID collisions between a parent architecture and a
+     * sub-architecture compilation, while reusing the warm cache means the base CALM
+     * schemas are not re-fetched for every sub-architecture. The pattern-currently-
+     * validating entry is intentionally not copied so the fork can load its own pattern.
+     */
+    public fork(): SchemaDirectory {
+        const forked = new SchemaDirectory(this.documentLoader, this.debug);
+        for (const [id, doc] of this.schemas) {
+            if (id === this.PATTERN_CURRENTLY_VALIDATING) {
+                continue;
+            }
+            forked.schemas.set(id, doc);
+            const type = this.schemaTypes.get(id);
+            if (type) {
+                forked.schemaTypes.set(id, type);
+            }
+        }
+        return forked;
     }
 }

--- a/shared/src/template/template-processor.ts
+++ b/shared/src/template/template-processor.ts
@@ -12,6 +12,7 @@ import {
 import { initLogger, Logger } from '../logger.js';
 import { getErrorMessage } from '../error-utils.js';
 import { CompositeReferenceResolver, MappedReferenceResolver } from '../resolver/calm-reference-resolver.js';
+import { CachingTrackingResolver } from '../resolver/caching-tracking-resolver.js';
 import { pathToFileURL } from 'node:url';
 import TemplateDefaultTransformer from './template-default-transformer';
 import { CalmCore } from '@finos/calm-models/model';
@@ -107,9 +108,10 @@ export class TemplateProcessor {
 
 
             const mappedResolver = new MappedReferenceResolver(this.urlToLocalPathMapping, new CompositeReferenceResolver());
+            const cachingResolver = new CachingTrackingResolver(mappedResolver);
             const transformer = await this.loadTransformer(config.transformer, resolvedBundlePath);
             const coreModel = CalmCore.fromSchema(JSON.parse(calmJson));
-            const dereference = new DereferencingVisitor(mappedResolver);
+            const dereference = new DereferencingVisitor(cachingResolver);
             await dereference.visit(coreModel);
             const transformedModel = transformer.getTransformedModel(coreModel);
             const engine = new TemplateEngine(loader, transformer);

--- a/shared/src/test/in-memory-document-loader.ts
+++ b/shared/src/test/in-memory-document-loader.ts
@@ -1,0 +1,41 @@
+import { DocumentLoader, CalmDocumentType, DocumentLoadError } from '../document-loader/document-loader.js';
+import { SchemaDirectory } from '../schema-directory.js';
+
+/**
+ * A minimal in-memory {@link DocumentLoader} for unit tests. Documents are served from a
+ * simple map; unknown references raise a recoverable {@link DocumentLoadError} so that
+ * `SchemaDirectory.getSchema` resolves them to `undefined` (mirroring "not found").
+ *
+ * An optional `fallback` loader can be supplied so that references not present in the map
+ * (e.g. real CALM meta-schemas loaded from disk) are delegated to it. This lets integration
+ * tests combine in-memory architecture documents with on-disk meta schemas.
+ */
+export class InMemoryDocumentLoader implements DocumentLoader {
+    constructor(
+        private readonly docs: Record<string, object>,
+        private readonly fallback?: DocumentLoader
+    ) {}
+
+    async initialise(schemaDirectory: SchemaDirectory): Promise<void> {
+        if (this.fallback) {
+            await this.fallback.initialise(schemaDirectory);
+        }
+    }
+
+    async loadMissingDocument(documentId: string, type: CalmDocumentType): Promise<object> {
+        if (documentId in this.docs) {
+            return this.docs[documentId];
+        }
+        if (this.fallback) {
+            return this.fallback.loadMissingDocument(documentId, type);
+        }
+        throw new DocumentLoadError({
+            name: 'OPERATION_NOT_IMPLEMENTED',
+            message: `Document not found: ${documentId}`
+        });
+    }
+
+    resolvePath(reference: string): string | undefined {
+        return this.fallback?.resolvePath(reference);
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to @willosborne's PR #2778 (finos/architecture-as-code#2778). I believe this starts to
address the concerns raised on that PR and the assumptions we have been making about the validation
framework, by reworking recursive detailed-architecture and control validation into a cycle-safe,
resolver-driven design. Still some open questions but speaking to @willosborne  he thinks likely can be tackled in subsequent PRs and this does handle additional requirements that PR #2778 was adding.

Summary of the design (see
[`shared/src/commands/validate/ValidationTechnicalSpecification.md`](https://github.com/LeighFinegold/architecture-as-code/blob/validation_engine_rewrite/shared/src/commands/validate/ValidationTechnicalSpecification.md)
for detail):

- Validation phases are modelled as first-class `ValidationRule`s run by a `ValidationEngine`, keeping
  the existing `ValidationOutcome` contract (output buckets, ordering, error/warning flags).
- A single cycle-safe, resolver-driven `ModelWalker` owns model traversal, dereferencing and cycle
  detection. This fixes the pattern-less dispatch branch dropping the `visited` set (the self-reference
  heap OOM flagged on #2778).
- Reference resolution is driven through the model's `Resolvable` / `CalmReferenceResolver` seam, with
  a `CachingTrackingResolver` giving fetch-at-most-once and validate-once/cycle-safety in one place.
- Node-details and control validation reuse that seam; error/message helpers are consolidated onto the
  shared `getErrorMessage`.
- `ValidationTechnicalSpecification.md` also records the open questions the framework does not yet
  settle: default recursive traversal vs a caller-selected resolution policy (same always-on concern
  raised on #2778), custom/organisation-specific rules per document, a typed CALM document input
  instead of four positional params, and how validation should differ between the CLI and CalmHub.

This is intended as a discussion PR: it restates the validation design and surfaces the remaining
unknowns rather than claiming to close them.

## Design detail (from the Validation Technical Specification)

> The full write-up lives in
> [`shared/src/commands/validate/ValidationTechnicalSpecification.md`](shared/src/commands/validate/ValidationTechnicalSpecification.md).
> The key parts are inlined below so the design is reviewable directly on the PR.

### Reference resolution, caching and cycle safety

The CALM model is *lazily* dereferenced: a `ResolvableAndAdaptable<CalmCoreSchema, CalmCore>` only
calls `resolve(ref)` when a caller chooses to dereference it, and the resolve function returns the
**raw** `CalmCoreSchema` before it is adapted to `CalmCore`. Node-details validation needs that raw
document (for Spectral + JSON-Schema), so the resolve seam is the natural place to centralise:

- **caching**: a reference is fetched at most once; repeat requests return the cached raw document;
- **tracking**: every attempted reference is recorded, giving dedupe ("validate each
  detailed-architecture once") and cycle safety without each caller keeping its own `Set`.

`CachingTrackingResolver` is a **decorator** that `implements CalmReferenceResolver`, wrapping any
inner resolver. This is the single resolver interface used by both the model dereference path and
validation:

```mermaid
classDiagram
    class CalmReferenceResolver {
        <<interface>>
        +canResolve(ref) boolean
        +resolve(ref) Promise
    }
    class CachingTrackingResolver {
        -delegate: CalmReferenceResolver
        -cache: Map~string, unknown~
        -seen: Set~string~
        +canResolve(ref) boolean
        +resolve(ref) Promise
        +has(ref) boolean
        +get(ref) unknown
        +markSeen(ref) void
        +resolvedReferences: ReadonlySet~string~
    }
    class SchemaDirectoryReferenceResolver {
        -schemaDirectory: SchemaDirectory
        +canResolve(ref) boolean
        +resolve(ref) Promise
    }
    CalmReferenceResolver <|.. CachingTrackingResolver
    CalmReferenceResolver <|.. SchemaDirectoryReferenceResolver
    CachingTrackingResolver o-- CalmReferenceResolver : decorates
```

A reference is marked *seen* before the underlying load is awaited, so a failed load still counts as
seen (a sibling referencing the same failing URL is not retried), matching the `visitedUrls.add`
-before-load behaviour originally implemented in PR #2778
(finos/architecture-as-code#2778). Only successful loads populate the value cache. In validation the
decorator wraps a `SchemaDirectoryReferenceResolver` (which loads architecture documents via
`schemaDirectory.loadDocument(ref, 'architecture')`); in docify the **caller** (`TemplateProcessor`)
composes the decorator around its resolver (`Mapped` -> `Composite`) so repeated references are
fetched once. Both `DereferencingVisitor` and `ModelWalker` are agnostic: they dereference through
whatever `CalmReferenceResolver` they are given; caching/tracking is purely the caller's composition
choice.

### Resolution policy (design intent)

Whether a given reference is resolvable is governed by a `ReferenceResolutionPolicy`, consulted in
`canResolve`. The policy is a constructor input to the resolver adapter; the `CalmReferenceResolver`
interface is unchanged. Two variants:

- **shallow (default):** `canResolve` returns `false` for `detailed-architecture` document
  references, so a shallow run never fetches or recurses into sub-architectures.
- **deep (opt-in):** `canResolve` allows those references, so the node-details rule resolves and
  validates each referenced sub-architecture.

Because only the node-details rule uses `ValidationContext.references` (schemas load via
`SchemaDirectory.getSchema` directly), the policy affects recursion alone. Child validation contexts
reuse the same resolver, so the policy is inherited at every level of recursion. This is design
intent; the policy type, its resolver wiring and the entry-point option are pending implementation.

### Open questions / Out of Scope

These are recorded in the specification as design intent, not settled behaviour:

- **Default traversal and resolution policies.** By default, validation recurses into a node's
  `detailed-architecture`. This rewrite still suffers from the same always-on concern raised on
  finos/architecture-as-code#2778; making it a caller-selected resolution policy is worth considering.
- **Custom rules versus the default traversal.** Organisation-specific rules may apply only to
  specific documents or document types, which the generic traversal does not model. It is an open
  question how a caller such as CalmHub tells the calm-server which rules to run, and how differing
  rule sets across a large organisation are catered for (see
  finos/architecture-as-code#2716 and #2566).
- **Typed CALM document input.** `validate()` currently takes four loosely-typed positional inputs and
  infers a mode; a single typed CALM document from `calm-models` (finos/architecture-as-code#2770)
  would be cleaner.
- **CLI versus CalmHub.** The CLI is user-driven and would default to recursive (deep) traversal;
  CalmHub validates on upload and would decide when a deep run is performed.
