### PR TITLE
feat(calm-hub): diagram thumbnails and type icons on browse cards

### DIFF
--- a/calm-hub-ui/AGENTS.md
+++ b/calm-hub-ui/AGENTS.md
@@ -58,14 +58,26 @@ src/
 │   ├── helpers/          # Pure helpers (e.g. set-functions)
 │   └── services/         # e.g. node-position-service
 ├── diff/                 # Architecture diff view (components, model, fixtures)
+├── render/               # Chrome-free /#/render route (RenderView), driven headlessly by calm-server for card thumbnails
 ├── components/           # Shared/common components
 ├── fixtures/             # Test fixtures
-└── theme/                # Theme configuration
+└── theme/                # Theme configuration + resource-type registry
 ```
 
 The `visualizer/contracts/*-contracts.ts` files hold the typed interfaces shared
 across the visualiser (nodes, edges, decorators, panels, etc.); add new
 visualiser-facing types there rather than inline.
+
+`src/render/RenderView.tsx` backs the `/#/render` route: it reads the
+`window.__CALM_RENDER_DATA` payload injected by calm-server's thumbnail endpoint and
+mounts the architecture/pattern graph in a `chromeless` mode (no Controls/MiniMap/search
+chrome, whole-graph fit) that sets `data-render-ready` once layout settles so the
+headless browser knows when to screenshot. There is no fetch fallback — the injected
+payload is the only supported path.
+
+`src/theme/resource-type-meta.ts` is the single registry for per-resource-type
+presentation (label, colors, icon) used by browse cards, type tabs and search group
+headers — extend it there rather than hardcoding per-type values in components.
 
 ## Conventions
 

--- a/calm-hub-ui/src/App.tsx
+++ b/calm-hub-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { NamespacesPanel } from './admin/panels/NamespacesPanel.js';
 import { DomainsPanel } from './admin/panels/DomainsPanel.js';
 import { EntitlementsPanel } from './admin/panels/EntitlementsPanel.js';
 import { UserAccessProvider } from './admin/context/UserAccessContext.js';
+import { RenderView } from './render/RenderView.js';
 
 function App() {
     //TODO: The artifacts route will eventually need to be changed/replaced once we create a unique identifier for resources that can be used across CalmHubs.
@@ -18,6 +19,8 @@ function App() {
                     <Route path="/search" element={<Hub />} />
                     {/* The standalone /visualizer page was removed; redirect old links to the hub. */}
                     <Route path="/visualizer" element={<Navigate to="/" replace />} />
+                    {/* Chrome-free diagram page driven headlessly by calm-server for thumbnails. */}
+                    <Route path="/render" element={<RenderView />} />
                     <Route path="/namespace/:ns" element={<Hub />} />
                     <Route path="/domain/:domain" element={<Hub />} />
                     <Route path="/:namespace/:type/:id/:version" element={<Hub />} />

--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.test.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.test.tsx
@@ -25,6 +25,14 @@ const mockResults: GroupedSearchResults = {
     adrs: [],
 };
 
+// One group with a registry icon (flows) and one visual type without (architectures),
+// so the header-icon test can assert both treatments in a single result set.
+const iconGroupResults: GroupedSearchResults = {
+    ...emptyResults,
+    architectures: [{ namespace: 'finos', id: 1, name: 'Test Architecture', description: 'A test architecture' }],
+    flows: [{ namespace: 'finos', id: 3, name: 'Trade Flow', description: 'A test flow' }],
+};
+
 function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
     return { search: searchFn } as unknown as SearchService;
 }
@@ -89,6 +97,25 @@ describe('ExplorerSearch', () => {
         expect(screen.getByText('Test Pattern')).toBeInTheDocument();
         expect(screen.getByText('Architectures')).toBeInTheDocument();
         expect(screen.getByText('Patterns')).toBeInTheDocument();
+    });
+
+    it('shows the registry type icon on group headers that have one, label-only otherwise', async () => {
+        const searchFn = vi.fn().mockResolvedValue(iconGroupResults);
+        renderSearch(createMockSearchService(searchFn));
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        // Flows carries its registry glyph in the group header...
+        expect(screen.getByTestId('search-group-icon-flows')).toBeInTheDocument();
+        // ...but Architectures (a visual type with no registry icon) stays label-only.
+        expect(screen.getByText('Architectures')).toBeInTheDocument();
+        expect(screen.queryByTestId('search-group-icon-architectures')).not.toBeInTheDocument();
     });
 
     it('notifies the parent when a search becomes active and inactive', async () => {

--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
@@ -6,7 +6,7 @@ import { AdrService } from '../../service/adr-service/adr-service.js';
 import { SearchResult } from '../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../hooks/useCatalogueSearch.js';
-import { getSearchGroupIcon } from '../../theme/resource-type-meta.js';
+import { SearchGroupIcon } from '../search-group-icon.js';
 
 interface ExplorerSearchProps {
     searchService?: SearchService;
@@ -85,15 +85,6 @@ export function ExplorerSearch({
         [active, flatResults, selectedIndex, moveSelection, navigateToResult, handleClear]
     );
 
-    // Registry type glyph for a group header; the visual types (architectures /
-    // patterns) have none and their headers stay label-only. Inherits the
-    // header's muted text colour via currentColor.
-    const renderGroupIcon = (type: string) => {
-        const GroupIcon = getSearchGroupIcon(type);
-        if (!GroupIcon) return null;
-        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
-    };
-
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-3 text-sm text-error">Search failed, please try again</div>;
@@ -112,7 +103,7 @@ export function ExplorerSearch({
         return groups.map(([type, items]) => (
             <div key={type}>
                 <div className="flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-base-content/50 uppercase tracking-wide bg-base-200">
-                    {renderGroupIcon(type)}
+                    <SearchGroupIcon type={type} />
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
+++ b/calm-hub-ui/src/components/navbar/ExplorerSearch.tsx
@@ -6,6 +6,7 @@ import { AdrService } from '../../service/adr-service/adr-service.js';
 import { SearchResult } from '../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../hooks/useCatalogueSearch.js';
+import { getSearchGroupIcon } from '../../theme/resource-type-meta.js';
 
 interface ExplorerSearchProps {
     searchService?: SearchService;
@@ -84,6 +85,15 @@ export function ExplorerSearch({
         [active, flatResults, selectedIndex, moveSelection, navigateToResult, handleClear]
     );
 
+    // Registry type glyph for a group header; the visual types (architectures /
+    // patterns) have none and their headers stay label-only. Inherits the
+    // header's muted text colour via currentColor.
+    const renderGroupIcon = (type: string) => {
+        const GroupIcon = getSearchGroupIcon(type);
+        if (!GroupIcon) return null;
+        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
+    };
+
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-3 text-sm text-error">Search failed, please try again</div>;
@@ -101,7 +111,8 @@ export function ExplorerSearch({
 
         return groups.map(([type, items]) => (
             <div key={type}>
-                <div className="px-3 py-1 text-xs font-semibold text-base-content/50 uppercase tracking-wide bg-base-200">
+                <div className="flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-base-content/50 uppercase tracking-wide bg-base-200">
+                    {renderGroupIcon(type)}
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.test.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.test.tsx
@@ -44,6 +44,20 @@ const duplicateNameResults: GroupedSearchResults = {
     adrs: [],
 };
 
+// One group with a registry icon (flows) and one visual type without (architectures),
+// so the header-icon test can assert both treatments in a single dropdown.
+const iconGroupResults: GroupedSearchResults = {
+    architectures: [
+        { namespace: 'finos', id: 1, name: 'Test Architecture', description: 'A test architecture' },
+    ],
+    patterns: [],
+    flows: [{ namespace: 'finos', id: 3, name: 'Trade Flow', description: 'A test flow' }],
+    standards: [],
+    interfaces: [],
+    controls: [],
+    adrs: [],
+};
+
 function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
     return { search: searchFn } as unknown as SearchService;
 }
@@ -173,6 +187,26 @@ describe('GlobalSearchBar', () => {
         const chips = screen.getAllByTestId('result-namespace-chip');
         const chipText = chips.map((c) => c.textContent).sort();
         expect(chipText).toEqual(['finos', 'traderx']);
+    });
+
+    it('shows the registry type icon on group headers that have one, label-only otherwise', async () => {
+        const searchFn = vi.fn().mockResolvedValue(iconGroupResults);
+        const service = createMockSearchService(searchFn);
+        renderSearchBar(service);
+
+        const input = screen.getByPlaceholderText('Search CALM Hub...');
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        // Flows carries its registry glyph in the group header...
+        expect(screen.getByTestId('search-group-icon-flows')).toBeInTheDocument();
+        // ...but Architectures (a visual type with no registry icon) stays label-only.
+        expect(screen.getByText('Architectures')).toBeInTheDocument();
+        expect(screen.queryByTestId('search-group-icon-architectures')).not.toBeInTheDocument();
     });
 
     it('shows no results message when search returns empty', async () => {

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
@@ -7,7 +7,7 @@ import { AdrService } from '../../service/adr-service/adr-service.js';
 import { SearchResult } from '../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../hooks/useCatalogueSearch.js';
-import { getSearchGroupIcon } from '../../theme/resource-type-meta.js';
+import { SearchGroupIcon } from '../search-group-icon.js';
 import { colors } from '../../theme/colors.js';
 
 interface GlobalSearchBarProps {
@@ -95,15 +95,6 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [closeDropdown]);
 
-    // Registry type glyph for a group header; the visual types (architectures /
-    // patterns) have none and their headers stay label-only. Inherits the
-    // header's muted text colour via currentColor.
-    const renderGroupIcon = (type: string) => {
-        const GroupIcon = getSearchGroupIcon(type);
-        if (!GroupIcon) return null;
-        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
-    };
-
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-3 text-sm text-error">Search failed, please try again</div>;
@@ -127,7 +118,7 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
                     className="flex items-center gap-1.5 px-3 py-1 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
                     style={{ color: colors.redesign.faintAlt, backgroundColor: colors.redesign.surface }}
                 >
-                    {renderGroupIcon(type)}
+                    <SearchGroupIcon type={type} />
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
+++ b/calm-hub-ui/src/components/navbar/GlobalSearchBar.tsx
@@ -7,6 +7,7 @@ import { AdrService } from '../../service/adr-service/adr-service.js';
 import { SearchResult } from '../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../hooks/useCatalogueSearch.js';
+import { getSearchGroupIcon } from '../../theme/resource-type-meta.js';
 import { colors } from '../../theme/colors.js';
 
 interface GlobalSearchBarProps {
@@ -94,6 +95,15 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [closeDropdown]);
 
+    // Registry type glyph for a group header; the visual types (architectures /
+    // patterns) have none and their headers stay label-only. Inherits the
+    // header's muted text colour via currentColor.
+    const renderGroupIcon = (type: string) => {
+        const GroupIcon = getSearchGroupIcon(type);
+        if (!GroupIcon) return null;
+        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
+    };
+
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-3 text-sm text-error">Search failed, please try again</div>;
@@ -114,9 +124,10 @@ export function GlobalSearchBar({ searchService, calmService: calmServiceProp, a
         return groups.map(([type, items]) => (
             <div key={type}>
                 <div
-                    className="px-3 py-1 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
+                    className="flex items-center gap-1.5 px-3 py-1 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
                     style={{ color: colors.redesign.faintAlt, backgroundColor: colors.redesign.surface }}
                 >
+                    {renderGroupIcon(type)}
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/components/search-group-icon.tsx
+++ b/calm-hub-ui/src/components/search-group-icon.tsx
@@ -1,0 +1,18 @@
+import { getSearchGroupIcon } from '../theme/resource-type-meta.js';
+
+interface SearchGroupIconProps {
+    /** The search group key, e.g. `flows` (a `GroupedSearchResults` key). */
+    type: string;
+}
+
+/**
+ * Registry type glyph for a search group header. The visual types
+ * (architectures / patterns) have no registry icon and render nothing, keeping
+ * their headers label-only. Inherits the header's muted text colour via
+ * currentColor.
+ */
+export function SearchGroupIcon({ type }: SearchGroupIconProps) {
+    const GroupIcon = getSearchGroupIcon(type);
+    if (!GroupIcon) return null;
+    return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
+}

--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.test.tsx
@@ -38,6 +38,11 @@ describe('ControlCard', () => {
         expect(screen.getByTestId('control-card')).toHaveAttribute('aria-pressed', 'false');
     });
 
+    it('renders the shield glyph in the thumbnail header (from the type registry)', () => {
+        render(<ControlCard name="Encryption" controlId={5} onActivate={vi.fn()} />);
+        expect(screen.getByTestId('thumbnail-type-icon')).toBeInTheDocument();
+    });
+
     it('renders without a description', () => {
         render(<ControlCard name="Audit Logging" controlId={9} onActivate={vi.fn()} />);
 

--- a/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/ControlCard.tsx
@@ -1,5 +1,3 @@
-import { IoShieldCheckmarkOutline } from 'react-icons/io5';
-import { colors } from '../../../theme/colors.js';
 import { ItemCard } from '../namespace-page/ItemCard.js';
 
 interface ControlCardProps {
@@ -20,8 +18,9 @@ interface ControlCardProps {
  * item cards.
  *
  * Control-specific bits are passed through: the `Controls` type paints the blue
- * thumbnail + "Control" pill, a shield glyph marks the header, the mono footer shows
- * the control id (`#5`), and `active` drives the selected treatment + `aria-pressed`.
+ * thumbnail + "Control" pill and the registry's shield glyph in the header, the mono
+ * footer shows the control id (`#5`), and `active` drives the selected treatment +
+ * `aria-pressed`.
  */
 export function ControlCard({ name, description, controlId, active = false, onActivate }: ControlCardProps) {
     return (
@@ -30,14 +29,6 @@ export function ControlCard({ name, description, controlId, active = false, onAc
             description={description}
             type="Controls"
             meta={`#${controlId}`}
-            thumbnailIcon={
-                <IoShieldCheckmarkOutline
-                    size={30}
-                    // Same control-type accent the striped header and pill use, so the
-                    // shield can't drift if the control colours are adjusted independently.
-                    style={{ color: colors.resourceTypes.control.accentText, opacity: 0.55 }}
-                />
-            }
             active={active}
             testId="control-card"
             onActivate={onActivate}

--- a/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
@@ -5,6 +5,7 @@ import { ControlService } from '../../../service/control-service.js';
 import { ControlData, ControlDetail } from '../../../model/control.js';
 import { colors } from '../../../theme/colors.js';
 import { ControlCard } from './ControlCard.js';
+import { CARD_GRID_CLASS } from '../namespace-page/ItemCard.js';
 
 interface DomainPageProps {
     domain: string;
@@ -89,7 +90,7 @@ export function DomainPage({ domain, controlCount, onControlLoad, selectedContro
                         No controls in this domain yet.
                     </p>
                 ) : (
-                    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-w-[1240px]">
+                    <div className={`${CARD_GRID_CLASS} max-w-[1240px]`}>
                         {controls.map((control) => (
                             <ControlCard
                                 key={control.id}

--- a/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
+++ b/calm-hub-ui/src/hub/components/domain-page/DomainPage.tsx
@@ -89,7 +89,7 @@ export function DomainPage({ domain, controlCount, onControlLoad, selectedContro
                         No controls in this domain yet.
                     </p>
                 ) : (
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-w-[1240px]">
                         {controls.map((control) => (
                             <ControlCard
                                 key={control.id}

--- a/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.test.tsx
@@ -22,6 +22,14 @@ const controlResults: GroupedSearchResults = {
     controls: [{ namespace: 'security', id: 7, name: 'PCI-DSS', description: 'Encryption at rest' }],
 };
 
+// One group with a registry icon (flows) and one visual type without (architectures),
+// so the header-icon test can assert both treatments in a single dropdown.
+const iconGroupResults: GroupedSearchResults = {
+    ...emptyResults,
+    architectures: [{ namespace: 'finos', id: 1, name: 'Test Architecture', description: 'A test architecture' }],
+    flows: [{ namespace: 'finos', id: 3, name: 'Trade Flow', description: 'A test flow' }],
+};
+
 function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
     return { search: searchFn } as unknown as SearchService;
 }
@@ -95,5 +103,23 @@ describe('IntroSearchBar', () => {
         fireEvent.mouseDown(screen.getByText('PCI-DSS'));
 
         expect(screen.getByTestId('location')).toHaveTextContent('/security/controls/PCI-DSS/detail');
+    });
+
+    it('shows the registry type icon on group headers that have one, label-only otherwise', async () => {
+        renderBar(createMockSearchService(vi.fn().mockResolvedValue(iconGroupResults)));
+
+        const input = screen.getByLabelText('Search the architecture catalogue');
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'test' } });
+        });
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(300);
+        });
+
+        // Flows carries its registry glyph in the group header...
+        expect(screen.getByTestId('search-group-icon-flows')).toBeInTheDocument();
+        // ...but Architectures (a visual type with no registry icon) stays label-only.
+        expect(screen.getByText('Architectures')).toBeInTheDocument();
+        expect(screen.queryByTestId('search-group-icon-architectures')).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.tsx
+++ b/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.tsx
@@ -5,6 +5,7 @@ import { SearchService } from '../../../service/search-service.js';
 import { SearchResult } from '../../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../../hooks/useCatalogueSearch.js';
+import { getSearchGroupIcon } from '../../../theme/resource-type-meta.js';
 import { colors } from '../../../theme/colors.js';
 
 interface IntroSearchBarProps {
@@ -93,6 +94,15 @@ export function IntroSearchBar({ searchService }: IntroSearchBarProps) {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [closeDropdown]);
 
+    // Registry type glyph for a group header; the visual types (architectures /
+    // patterns) have none and their headers stay label-only. Inherits the
+    // header's muted text colour via currentColor.
+    const renderGroupIcon = (type: string) => {
+        const GroupIcon = getSearchGroupIcon(type);
+        if (!GroupIcon) return null;
+        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
+    };
+
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-4 text-sm text-error">Search failed, please try again</div>;
@@ -111,9 +121,10 @@ export function IntroSearchBar({ searchService }: IntroSearchBarProps) {
         return groups.map(([type, items]) => (
             <div key={type}>
                 <div
-                    className="px-4 py-1.5 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
+                    className="flex items-center gap-1.5 px-4 py-1.5 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
                     style={{ color: colors.redesign.faintAlt, backgroundColor: colors.redesign.surface }}
                 >
+                    {renderGroupIcon(type)}
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.tsx
+++ b/calm-hub-ui/src/hub/components/intro-screen/IntroSearchBar.tsx
@@ -5,7 +5,7 @@ import { SearchService } from '../../../service/search-service.js';
 import { SearchResult } from '../../../model/search.js';
 import { FlatResult, TYPE_LABELS, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
 import { useCatalogueSearch } from '../../../hooks/useCatalogueSearch.js';
-import { getSearchGroupIcon } from '../../../theme/resource-type-meta.js';
+import { SearchGroupIcon } from '../../../components/search-group-icon.js';
 import { colors } from '../../../theme/colors.js';
 
 interface IntroSearchBarProps {
@@ -94,15 +94,6 @@ export function IntroSearchBar({ searchService }: IntroSearchBarProps) {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [closeDropdown]);
 
-    // Registry type glyph for a group header; the visual types (architectures /
-    // patterns) have none and their headers stay label-only. Inherits the
-    // header's muted text colour via currentColor.
-    const renderGroupIcon = (type: string) => {
-        const GroupIcon = getSearchGroupIcon(type);
-        if (!GroupIcon) return null;
-        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
-    };
-
     const renderGroupedResults = () => {
         if (error) {
             return <div className="p-4 text-sm text-error">Search failed, please try again</div>;
@@ -124,7 +115,7 @@ export function IntroSearchBar({ searchService }: IntroSearchBarProps) {
                     className="flex items-center gap-1.5 px-4 py-1.5 font-mono-jb text-[10px] uppercase tracking-[0.1em]"
                     style={{ color: colors.redesign.faintAlt, backgroundColor: colors.redesign.surface }}
                 >
-                    {renderGroupIcon(type)}
+                    <SearchGroupIcon type={type} />
                     {TYPE_LABELS[type] ?? type}
                 </div>
                 {(items as SearchResult[]).map((item) => {

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import { ItemCard } from './ItemCard.js';
 
@@ -196,5 +197,73 @@ describe('ItemCard', () => {
     it('renders no thumbnail image when thumbnailUrl is unset', () => {
         render(<ItemCard name="TraderX" type="Architectures" onActivate={() => {}} />);
         expect(screen.queryByTestId('item-card-thumbnail')).not.toBeInTheDocument();
+    });
+
+    it('defaults the header to 96px for icon/stripe-only cards (no thumbnailUrl)', () => {
+        const { container } = render(<ItemCard name="No Thumb" type="Flows" onActivate={() => {}} />);
+        expect(container.querySelector('article > div')).toHaveStyle({ height: '96px' });
+    });
+
+    it('defaults the header to 160px when a thumbnailUrl is set', () => {
+        const { container } = render(
+            <ItemCard
+                name="With Thumb"
+                type="Architectures"
+                thumbnailUrl="/api/calm/namespaces/finos/architectures/1/thumbnail"
+                onActivate={() => {}}
+            />
+        );
+        expect(container.querySelector('article > div')).toHaveStyle({ height: '160px' });
+    });
+
+    it('lets an explicit thumbnailHeight win over both defaults', () => {
+        const { container, rerender } = render(
+            <ItemCard name="Explicit" type="Flows" thumbnailHeight={72} onActivate={() => {}} />
+        );
+        expect(container.querySelector('article > div')).toHaveStyle({ height: '72px' });
+
+        rerender(
+            <ItemCard
+                name="Explicit"
+                type="Architectures"
+                thumbnailHeight={72}
+                thumbnailUrl="/api/calm/namespaces/finos/architectures/1/thumbnail"
+                onActivate={() => {}}
+            />
+        );
+        expect(container.querySelector('article > div')).toHaveStyle({ height: '72px' });
+    });
+
+    it('describes the activation button with the description and meta chip', () => {
+        // The search-results shape: description + namespace meta chip both present.
+        render(
+            <ItemCard
+                name="Test Architecture"
+                description="A test architecture"
+                type="Architectures"
+                meta="finos"
+                onActivate={() => {}}
+            />
+        );
+        expect(screen.getByTestId('item-card')).toHaveAccessibleDescription('A test architecture finos');
+    });
+
+    it('describes the activation element with just the chip when there is no description', () => {
+        render(<ItemCard name="Chip Only" type="Architectures" customId="chip-only" onActivate={() => {}} />);
+        expect(screen.getByTestId('item-card')).toHaveAccessibleDescription('chip-only');
+    });
+
+    it('carries no accessible description when neither description nor chip exists', () => {
+        render(<ItemCard name="Bare" type="Architectures" onActivate={() => {}} />);
+        expect(screen.getByTestId('item-card')).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('describes the Link form of the card too', () => {
+        render(
+            <MemoryRouter>
+                <ItemCard name="Linked" description="Goes somewhere" type="Architectures" href="/namespace/finos" />
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('item-card')).toHaveAccessibleDescription('Goes somewhere');
     });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
@@ -133,4 +133,28 @@ describe('ItemCard', () => {
         );
         expect(screen.getByTestId('thumb-icon')).toBeInTheDocument();
     });
+
+    it('derives the registry type icon for a type that has one', () => {
+        render(<ItemCard name="Trade Flow" type="Flows" onActivate={() => {}} />);
+        expect(screen.getByTestId('thumbnail-type-icon')).toBeInTheDocument();
+    });
+
+    it('leaves the thumbnail a plain stripe for the visual types (no registry icon)', () => {
+        render(<ItemCard name="TraderX" type="Architectures" onActivate={() => {}} />);
+        expect(screen.queryByTestId('thumbnail-type-icon')).not.toBeInTheDocument();
+    });
+
+    it('lets an explicit thumbnailIcon override the registry icon', () => {
+        // Controls has a registry icon, so the explicit prop must win over it.
+        render(
+            <ItemCard
+                name="Override"
+                type="Controls"
+                thumbnailIcon={<svg data-testid="custom-thumb-icon" />}
+                onActivate={() => {}}
+            />
+        );
+        expect(screen.getByTestId('custom-thumb-icon')).toBeInTheDocument();
+        expect(screen.queryByTestId('thumbnail-type-icon')).not.toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.test.tsx
@@ -157,4 +157,44 @@ describe('ItemCard', () => {
         expect(screen.getByTestId('custom-thumb-icon')).toBeInTheDocument();
         expect(screen.queryByTestId('thumbnail-type-icon')).not.toBeInTheDocument();
     });
+
+    it('renders a lazy cover image in the header when thumbnailUrl is set', () => {
+        render(
+            <ItemCard
+                name="TraderX"
+                type="Architectures"
+                thumbnailUrl="/api/calm/namespaces/traderx/architectures/1/thumbnail"
+                onActivate={() => {}}
+            />
+        );
+        const img = screen.getByTestId('item-card-thumbnail');
+        expect(img).toHaveAttribute('src', '/api/calm/namespaces/traderx/architectures/1/thumbnail');
+        expect(img).toHaveAttribute('loading', 'lazy');
+        expect(img).toHaveAttribute('alt', '');
+        expect(img.className).toContain('object-cover');
+    });
+
+    it('falls back to the stripe(+icon) header when the thumbnail image fails to load', () => {
+        // Flows has a registry icon, so the error fallback must restore it.
+        render(
+            <ItemCard
+                name="Trade Flow"
+                type="Flows"
+                thumbnailUrl="/api/calm/namespaces/traderx/flows/1/thumbnail"
+                onActivate={() => {}}
+            />
+        );
+        // While loading, the image replaces the icon.
+        expect(screen.queryByTestId('thumbnail-type-icon')).not.toBeInTheDocument();
+
+        fireEvent.error(screen.getByTestId('item-card-thumbnail'));
+
+        expect(screen.queryByTestId('item-card-thumbnail')).not.toBeInTheDocument();
+        expect(screen.getByTestId('thumbnail-type-icon')).toBeInTheDocument();
+    });
+
+    it('renders no thumbnail image when thumbnailUrl is unset', () => {
+        render(<ItemCard name="TraderX" type="Architectures" onActivate={() => {}} />);
+        expect(screen.queryByTestId('item-card-thumbnail')).not.toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -1,9 +1,16 @@
-import { useState, type ReactNode } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { TypeBadge } from './TypeBadge.js';
 import { type CardResourceType, getResourceTypeColors, getResourceTypeIcon } from '../../../theme/resource-type-meta.js';
+
+/**
+ * Shared responsive card grid for the browse surfaces (namespace, domain, search
+ * results). `min(280px,100%)` keeps a single column from overflowing containers
+ * narrower than the 280px card minimum.
+ */
+export const CARD_GRID_CLASS = 'grid gap-4 grid-cols-[repeat(auto-fill,minmax(min(280px,100%),1fr))]';
 
 interface ItemCardProps {
     name: string;
@@ -23,7 +30,13 @@ interface ItemCardProps {
      * When unset the footer falls back to the "N versions" scent or {@link customId}.
      */
     meta?: string;
-    /** Thumbnail header height in px. The tall default gives rendered diagram thumbnails enough vertical space that the cover-fit crop stays modest. */
+    /**
+     * Thumbnail header height in px. An explicit value always wins; otherwise the
+     * default is 160 when {@link thumbnailUrl} is set (rendered diagram thumbnails
+     * need the vertical space so the cover-fit crop stays modest) and 96 when not
+     * (icon/stripe-only headers shouldn't burn it). Every browse surface shows one
+     * type at a time, so the per-type default can't misalign a row.
+     */
     thumbnailHeight?: number;
     /**
      * URL of a rendered diagram thumbnail (architectures/patterns). When set, an
@@ -74,7 +87,7 @@ export function ItemCard({
     customId,
     versionCount,
     meta,
-    thumbnailHeight = 160,
+    thumbnailHeight,
     thumbnailUrl,
     thumbnailIcon,
     active,
@@ -87,6 +100,10 @@ export function ItemCard({
     // changed thumbnailUrl naturally retries without an effect to reset state.
     const [failedThumbnailUrl, setFailedThumbnailUrl] = useState<string | undefined>(undefined);
     const showThumbnailImage = thumbnailUrl !== undefined && thumbnailUrl !== failedThumbnailUrl;
+
+    // Explicit prop wins; otherwise diagram-thumbnail cards get the tall header and
+    // icon/stripe-only cards the short one (see the thumbnailHeight prop JSDoc).
+    const headerHeight = thumbnailHeight ?? (thumbnailUrl !== undefined ? 160 : 96);
 
     const { accent, accentText, tint } = getResourceTypeColors(type);
     // Registry-derived type glyph for the thumbnail; an explicit thumbnailIcon
@@ -129,6 +146,16 @@ export function ItemCard({
               ? `${versionCount} ${versionCount === 1 ? 'version' : 'versions'}`
               : customId;
 
+    // The activation element's accessible name is just the item name; the description
+    // paragraph and footer chip become its accessible description via aria-describedby
+    // so screen readers announce them with the control.
+    const descriptionId = useId();
+    const chipId = useId();
+    const describedByIds = [description ? descriptionId : undefined, chip !== undefined ? chipId : undefined]
+        .filter(Boolean)
+        .join(' ');
+    const describedBy = describedByIds === '' ? undefined : describedByIds;
+
     return (
         <article
             className="group relative rounded-[12px] overflow-hidden bg-base-100 hover:-translate-y-0.5 hover:shadow-md"
@@ -142,7 +169,7 @@ export function ItemCard({
         >
             <div
                 className={!showThumbnailImage && headerIcon ? 'flex items-center justify-center' : undefined}
-                style={{ height: thumbnailHeight, background: stripes }}
+                style={{ height: headerHeight, background: stripes }}
             >
                 {showThumbnailImage ? (
                     // Rendered diagram thumbnail on top of the stripe background; on
@@ -166,7 +193,13 @@ export function ItemCard({
             </div>
             <div className="p-[14px]">
                 {href ? (
-                    <Link to={href} data-testid={testId} className={activationClass} style={{ color: colors.redesign.ink }}>
+                    <Link
+                        to={href}
+                        data-testid={testId}
+                        aria-describedby={describedBy}
+                        className={activationClass}
+                        style={{ color: colors.redesign.ink }}
+                    >
                         {name}
                     </Link>
                 ) : (
@@ -176,6 +209,7 @@ export function ItemCard({
                         // Only forwarded when `active` is defined, so plain browse cards
                         // (which don't pass it) carry no aria-pressed and aren't toggles.
                         aria-pressed={active}
+                        aria-describedby={describedBy}
                         onClick={onActivate}
                         className={activationClass}
                         style={{ color: colors.redesign.ink }}
@@ -185,6 +219,7 @@ export function ItemCard({
                 )}
                 {description && (
                     <p
+                        id={descriptionId}
                         className="text-[12px] leading-[1.45] mt-[5px] mb-[11px] line-clamp-2"
                         style={{ color: colors.redesign.mutedAlt }}
                     >
@@ -197,6 +232,7 @@ export function ItemCard({
                     <TypeBadge type={type} />
                     {chip !== undefined && (
                         <span
+                            id={chipId}
                             className="font-mono-jb text-[10.5px] ml-auto truncate"
                             style={{ color: colors.redesign.mutedAlt }}
                         >

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { TypeBadge } from './TypeBadge.js';
-import { type CardResourceType, getResourceTypeColors } from './resource-type-meta.js';
+import { type CardResourceType, getResourceTypeColors, getResourceTypeIcon } from '../../../theme/resource-type-meta.js';
 
 interface ItemCardProps {
     name: string;
@@ -26,8 +26,10 @@ interface ItemCardProps {
     /** Thumbnail header height in px (default 96; landing highlights use a shorter one). */
     thumbnailHeight?: number;
     /**
-     * Optional glyph centred in the striped thumbnail (e.g. a shield for a control).
-     * Namespace cards leave the header a plain stripe; only control-style cards set it.
+     * Overrides the glyph centred in the striped thumbnail. Pass a non-null node
+     * to override; when unset or `null` the type's registry icon
+     * ({@link getResourceTypeIcon}) is used, and types without one
+     * (Architectures / Patterns) keep the plain stripe.
      */
     thumbnailIcon?: ReactNode;
     /**
@@ -72,7 +74,21 @@ export function ItemCard({
     href,
     onActivate,
 }: ItemCardProps) {
-    const { accent, tint } = getResourceTypeColors(type);
+    const { accent, accentText, tint } = getResourceTypeColors(type);
+    // Registry-derived type glyph for the thumbnail; an explicit thumbnailIcon
+    // prop still wins so callers can override the header treatment.
+    const TypeIcon = getResourceTypeIcon(type);
+    const headerIcon =
+        thumbnailIcon ??
+        (TypeIcon ? (
+            <TypeIcon
+                size={30}
+                data-testid="thumbnail-type-icon"
+                // The type's own accent in its text/icon role, so the glyph
+                // can't drift if the type colours are adjusted independently.
+                style={{ color: accentText, opacity: 0.55 }}
+            />
+        ) : undefined);
     // Selected treatment mirrors the diagram's selected-node style: an interaction-blue
     // outline + elevated shadow while the item's detail panel is open. Uses the brand
     // interaction blue (not the type accent) so selection reads consistently. Only the
@@ -111,10 +127,10 @@ export function ItemCard({
             }}
         >
             <div
-                className={thumbnailIcon ? 'flex items-center justify-center' : undefined}
+                className={headerIcon ? 'flex items-center justify-center' : undefined}
                 style={{ height: thumbnailHeight, background: stripes }}
             >
-                {thumbnailIcon}
+                {headerIcon}
             </div>
             <div className="p-[14px]">
                 {href ? (

--- a/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/ItemCard.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
@@ -23,8 +23,15 @@ interface ItemCardProps {
      * When unset the footer falls back to the "N versions" scent or {@link customId}.
      */
     meta?: string;
-    /** Thumbnail header height in px (default 96; landing highlights use a shorter one). */
+    /** Thumbnail header height in px. The tall default gives rendered diagram thumbnails enough vertical space that the cover-fit crop stays modest. */
     thumbnailHeight?: number;
+    /**
+     * URL of a rendered diagram thumbnail (architectures/patterns). When set, an
+     * `<img>` fills the thumbnail header on top of the stripe background; if the
+     * image fails to load (e.g. no thumbnail rendered yet — the endpoint 404s)
+     * the header falls back to exactly the stripe(+icon) rendering.
+     */
+    thumbnailUrl?: string;
     /**
      * Overrides the glyph centred in the striped thumbnail. Pass a non-null node
      * to override; when unset or `null` the type's registry icon
@@ -67,13 +74,20 @@ export function ItemCard({
     customId,
     versionCount,
     meta,
-    thumbnailHeight = 96,
+    thumbnailHeight = 160,
+    thumbnailUrl,
     thumbnailIcon,
     active,
     testId = 'item-card',
     href,
     onActivate,
 }: ItemCardProps) {
+    // Tracks the thumbnail URL that failed to load, so the header falls back to
+    // the stripe(+icon) treatment; keying on the URL (not a boolean) means a
+    // changed thumbnailUrl naturally retries without an effect to reset state.
+    const [failedThumbnailUrl, setFailedThumbnailUrl] = useState<string | undefined>(undefined);
+    const showThumbnailImage = thumbnailUrl !== undefined && thumbnailUrl !== failedThumbnailUrl;
+
     const { accent, accentText, tint } = getResourceTypeColors(type);
     // Registry-derived type glyph for the thumbnail; an explicit thumbnailIcon
     // prop still wins so callers can override the header treatment.
@@ -127,10 +141,28 @@ export function ItemCard({
             }}
         >
             <div
-                className={headerIcon ? 'flex items-center justify-center' : undefined}
+                className={!showThumbnailImage && headerIcon ? 'flex items-center justify-center' : undefined}
                 style={{ height: thumbnailHeight, background: stripes }}
             >
-                {headerIcon}
+                {showThumbnailImage ? (
+                    // Rendered diagram thumbnail on top of the stripe background; on
+                    // load failure fall back to the stripe(+icon) treatment below.
+                    // object-cover so the header is always fully filled (no letterbox
+                    // gaps); the image is clipped server-side to the diagram's own
+                    // bounds, so what the cover crop discards is real margin-free
+                    // content overflow, kept small by the taller header and the
+                    // near-card-shaped render stage.
+                    <img
+                        src={thumbnailUrl}
+                        alt=""
+                        loading="lazy"
+                        data-testid="item-card-thumbnail"
+                        className="h-full w-full object-cover"
+                        onError={() => setFailedThumbnailUrl(thumbnailUrl)}
+                    />
+                ) : (
+                    headerIcon
+                )}
             </div>
             <div className="p-[14px]">
                 {href ? (

--- a/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.test.tsx
@@ -163,6 +163,21 @@ describe('NamespacePage', () => {
         });
     });
 
+    it('renders architecture cards with the latest-version thumbnail image', async () => {
+        renderPage();
+        await screen.findByText('Arch One');
+        expect(screen.getByTestId('item-card-thumbnail')).toHaveAttribute(
+            'src',
+            '/api/calm/namespaces/traderx/architectures/1/thumbnail'
+        );
+    });
+
+    it('renders interface cards without a thumbnail image', async () => {
+        renderPage(['/namespace/traderx?type=interfaces']);
+        await screen.findByText('My Interface');
+        expect(screen.queryByTestId('item-card-thumbnail')).not.toBeInTheDocument();
+    });
+
     it('wires the tabpanel to the active tab (aria-controls / aria-labelledby)', async () => {
         renderPage();
         const panel = screen.getByRole('tabpanel');

--- a/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
@@ -6,7 +6,7 @@ import { NamespaceCounts } from '../../../model/counts.js';
 import { resolveResourceDetailPath } from '../tree-navigation/navigation-loaders.js';
 import { NamespacePageHeader } from './NamespacePageHeader.js';
 import { SegmentedTypeTabs } from './SegmentedTypeTabs.js';
-import { ItemCard } from './ItemCard.js';
+import { CARD_GRID_CLASS, ItemCard } from './ItemCard.js';
 import { EmptyState } from './EmptyState.js';
 import { useNamespaceItems } from './useNamespaceItems.js';
 import { useActiveType } from './useActiveType.js';
@@ -89,7 +89,7 @@ export function NamespacePage({ namespace, counts }: NamespacePageProps) {
                         message={`No ${getResourceTypeMeta(active).pluralLabel} in this namespace yet`}
                     />
                 ) : (
-                    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-w-[1240px]">
+                    <div className={`${CARD_GRID_CLASS} max-w-[1240px]`}>
                         {activeItems.map((item) => (
                             <ItemCard
                                 key={`${active}-${item.id}`}

--- a/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
@@ -89,7 +89,7 @@ export function NamespacePage({ namespace, counts }: NamespacePageProps) {
                         message={`No ${getResourceTypeMeta(active).pluralLabel} in this namespace yet`}
                     />
                 ) : (
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-w-[1240px]">
                         {activeItems.map((item) => (
                             <ItemCard
                                 key={`${active}-${item.id}`}
@@ -98,6 +98,7 @@ export function NamespacePage({ namespace, counts }: NamespacePageProps) {
                                 type={active}
                                 customId={item.customId}
                                 versionCount={item.versionCount}
+                                thumbnailUrl={item.thumbnailUrl}
                                 onActivate={() => openItem(active, item.id)}
                             />
                         ))}

--- a/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/NamespacePage.tsx
@@ -15,7 +15,7 @@ import {
     getResourceTypeMeta,
     tabId,
     TYPE_PANEL_ID,
-} from './resource-type-meta.js';
+} from '../../../theme/resource-type-meta.js';
 
 interface NamespacePageProps {
     namespace: string;

--- a/calm-hub-ui/src/hub/components/namespace-page/SegmentedTypeTabs.test.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/SegmentedTypeTabs.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { SegmentedTypeTabs, type TypeTab } from './SegmentedTypeTabs.js';
-import { TYPE_PANEL_ID } from './resource-type-meta.js';
+import { TYPE_PANEL_ID } from '../../../theme/resource-type-meta.js';
 import { colors } from '../../../theme/colors.js';
 
 /** Drive `useIsMobile()` via window.matchMedia. Returns a restore function. */

--- a/calm-hub-ui/src/hub/components/namespace-page/SegmentedTypeTabs.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/SegmentedTypeTabs.tsx
@@ -3,7 +3,7 @@ import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { CountBadge } from '../explore-rail/CountBadge.js';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
-import { type NamespaceResourceType, tabId, TYPE_PANEL_ID } from './resource-type-meta.js';
+import { type NamespaceResourceType, tabId, TYPE_PANEL_ID } from '../../../theme/resource-type-meta.js';
 
 export interface TypeTab {
     type: NamespaceResourceType;

--- a/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.tsx
+++ b/calm-hub-ui/src/hub/components/namespace-page/TypeBadge.tsx
@@ -2,7 +2,7 @@ import {
     type CardResourceType,
     getResourceTypeColors,
     getResourceTypeMeta,
-} from './resource-type-meta.js';
+} from '../../../theme/resource-type-meta.js';
 
 interface TypeBadgeProps {
     /** Resource type whose accent / tint and singular label the pill shows. */

--- a/calm-hub-ui/src/hub/components/namespace-page/useActiveType.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useActiveType.ts
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { NamespaceCounts } from '../../../model/counts.js';
 import { mapTypeInUIToTypeInUrl } from '../tree-navigation/navigation-loaders.js';
 import { type TypeTab } from './SegmentedTypeTabs.js';
-import { NAMESPACE_RESOURCE_TYPES, type NamespaceResourceType, COUNT_FIELD } from './resource-type-meta.js';
+import { NAMESPACE_RESOURCE_TYPES, type NamespaceResourceType, COUNT_FIELD } from '../../../theme/resource-type-meta.js';
 
 /**
  * Resolves the `?type=` param to a valid browse type, defaulting deterministically,

--- a/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.test.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.test.ts
@@ -65,6 +65,27 @@ describe('useNamespaceItems', () => {
         ]);
     });
 
+    it('builds a latest-version thumbnail URL for architectures from the numeric id', async () => {
+        const { result } = renderHook(() => useNamespaceItems('traderx'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const arch = result.current.groups.find((g) => g.type === 'Architectures');
+        // The numeric summary id (1), not the customId slug, addresses the storage API.
+        expect(arch?.items[0].thumbnailUrl).toBe('/api/calm/namespaces/traderx/architectures/1/thumbnail');
+    });
+
+    it('sets no thumbnail URL on non-diagram types', async () => {
+        const { result } = renderHook(() => useNamespaceItems('traderx'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        for (const type of ['Flows', 'Standards', 'ADRs', 'Interfaces'] as const) {
+            const group = result.current.groups.find((g) => g.type === type);
+            for (const item of group?.items ?? []) {
+                expect(item.thumbnailUrl).toBeUndefined();
+            }
+        }
+    });
+
     it('labels ADRs with title and status, and keeps numeric interface ids', async () => {
         const { result } = renderHook(() => useNamespaceItems('traderx'));
         await waitFor(() => expect(result.current.loading).toBe(false));

--- a/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
@@ -3,6 +3,7 @@ import { CalmService } from '../../../service/calm-service.js';
 import { InterfaceService } from '../../../service/interface-service.js';
 import { AdrService } from '../../../service/adr-service/adr-service.js';
 import { ResourceSummary } from '../../../model/calm.js';
+import { latestThumbnailUrl } from '../../../service/thumbnail-url.js';
 import { type TypeInUI } from '../tree-navigation/navigation-loaders.js';
 
 export interface NamespaceItem {
@@ -46,7 +47,7 @@ const summaryToThumbnailItem = (
     typePath: 'architectures' | 'patterns'
 ): NamespaceItem => ({
     ...summaryToItem(s),
-    thumbnailUrl: `/api/calm/namespaces/${encodeURIComponent(namespace)}/${typePath}/${encodeURIComponent(String(s.id))}/thumbnail`,
+    thumbnailUrl: latestThumbnailUrl(namespace, typePath, s.id),
 });
 
 /**

--- a/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
@@ -14,6 +14,12 @@ export interface NamespaceItem {
     customId?: string;
     /** Stored-version count for the version-map types; drives the "N versions" scent. */
     versionCount?: number;
+    /**
+     * Latest-version thumbnail endpoint, set only for architectures and patterns
+     * (the diagram types calm-hub renders thumbnails for). The card's `<img>`
+     * falls back to the stripe header when the endpoint 404s.
+     */
+    thumbnailUrl?: string;
 }
 
 export interface NamespaceItemGroup {
@@ -27,6 +33,20 @@ const summaryToItem = (s: ResourceSummary): NamespaceItem => ({
     description: s.description,
     customId: s.customId,
     versionCount: s.versionCount,
+});
+
+/**
+ * Maps an architecture/pattern summary to an item carrying its latest-version
+ * thumbnail URL. Built on the numeric-ID storage API (the same base path the
+ * summary fetches use), so it uses the summary's numeric `id`, not the slug.
+ */
+const summaryToThumbnailItem = (
+    s: ResourceSummary,
+    namespace: string,
+    typePath: 'architectures' | 'patterns'
+): NamespaceItem => ({
+    ...summaryToItem(s),
+    thumbnailUrl: `/api/calm/namespaces/${encodeURIComponent(namespace)}/${typePath}/${encodeURIComponent(String(s.id))}/thumbnail`,
 });
 
 /**
@@ -58,8 +78,8 @@ export function useNamespaceItems(namespace: string): { groups: NamespaceItemGro
         ]).then(([architectures, patterns, flows, standards, adrs, interfaces]) => {
             if (cancelled) return;
             setGroups([
-                { type: 'Architectures', items: architectures.map(summaryToItem) },
-                { type: 'Patterns', items: patterns.map(summaryToItem) },
+                { type: 'Architectures', items: architectures.map((s) => summaryToThumbnailItem(s, namespace, 'architectures')) },
+                { type: 'Patterns', items: patterns.map((s) => summaryToThumbnailItem(s, namespace, 'patterns')) },
                 { type: 'Flows', items: flows.map(summaryToItem) },
                 { type: 'Standards', items: standards.map(summaryToItem) },
                 {

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
@@ -129,6 +129,8 @@ describe('SearchResultsPage', () => {
         // ...while the unknown group and its items are dropped entirely.
         expect(screen.queryByText('Mystery Widget')).not.toBeInTheDocument();
         expect(screen.queryByText(/widgets/i)).not.toBeInTheDocument();
+        // The headline count covers only the rendered (known) groups.
+        expect(screen.getByText('2 results')).toBeInTheDocument();
     });
 
     it('shows an empty state when nothing matches', async () => {

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
@@ -99,6 +99,38 @@ describe('SearchResultsPage', () => {
         expect(screen.queryByTestId('search-group-icon-architectures')).not.toBeInTheDocument();
     });
 
+    it('renders results as browse cards: thumbnails for architectures, meta namespace chip', async () => {
+        renderPage('/search?q=test', createMockSearchService(vi.fn().mockResolvedValue(iconGroupResults)));
+
+        expect(await screen.findByText('Test Architecture')).toBeInTheDocument();
+        // Both results render as shared ItemCards...
+        expect(screen.getAllByTestId('item-card')).toHaveLength(2);
+        // ...the architecture card carries its latest-version thumbnail image...
+        const img = screen.getByTestId('item-card-thumbnail');
+        expect(img).toHaveAttribute('src', '/api/calm/namespaces/finos/architectures/1/thumbnail');
+        // ...while the flow card has no thumbnail (registry icon instead).
+        expect(screen.getByTestId('thumbnail-type-icon')).toBeInTheDocument();
+        // The namespace rides in the card's footer meta chip.
+        expect(screen.getAllByText('finos')).toHaveLength(2);
+    });
+
+    it('drops result groups the registry does not know instead of crashing', async () => {
+        // A newer backend may return group keys this UI predates; those groups must
+        // be dropped before ItemCard's non-null type assertion, not rendered.
+        const withUnknownGroup = {
+            ...iconGroupResults,
+            widgets: [{ namespace: 'finos', id: 9, name: 'Mystery Widget', description: 'Unknown group' }],
+        } as unknown as GroupedSearchResults;
+        renderPage('/search?q=test', createMockSearchService(vi.fn().mockResolvedValue(withUnknownGroup)));
+
+        // The known groups still render...
+        expect(await screen.findByText('Test Architecture')).toBeInTheDocument();
+        expect(screen.getByText('Trade Flow')).toBeInTheDocument();
+        // ...while the unknown group and its items are dropped entirely.
+        expect(screen.queryByText('Mystery Widget')).not.toBeInTheDocument();
+        expect(screen.queryByText(/widgets/i)).not.toBeInTheDocument();
+    });
+
     it('shows an empty state when nothing matches', async () => {
         renderPage('/search?q=zzz', createMockSearchService(vi.fn().mockResolvedValue(emptyResults)));
         expect(await screen.findByText(/No results found for/i)).toBeInTheDocument();

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.test.tsx
@@ -20,6 +20,14 @@ const controlResults: GroupedSearchResults = {
     controls: [{ namespace: 'security', id: 7, name: 'PCI-DSS', description: 'Encryption at rest' }],
 };
 
+// One group with a registry icon (flows) and one visual type without (architectures),
+// so the header-icon test can assert both treatments on a single page.
+const iconGroupResults: GroupedSearchResults = {
+    ...emptyResults,
+    architectures: [{ namespace: 'finos', id: 1, name: 'Test Architecture', description: 'A test architecture' }],
+    flows: [{ namespace: 'finos', id: 3, name: 'Trade Flow', description: 'A test flow' }],
+};
+
 function createMockSearchService(searchFn: (q: string) => Promise<GroupedSearchResults>) {
     return { search: searchFn } as unknown as SearchService;
 }
@@ -78,6 +86,17 @@ describe('SearchResultsPage', () => {
         await waitFor(() =>
             expect(screen.getByTestId('location')).toHaveTextContent('/security/controls/PCI-DSS/detail')
         );
+    });
+
+    it('shows the registry type icon on group headers that have one, label-only otherwise', async () => {
+        renderPage('/search?q=test', createMockSearchService(vi.fn().mockResolvedValue(iconGroupResults)));
+
+        expect(await screen.findByText('Trade Flow')).toBeInTheDocument();
+        // Flows carries its registry glyph in the group header...
+        expect(screen.getByTestId('search-group-icon-flows')).toBeInTheDocument();
+        // ...but Architectures (a visual type with no registry icon) stays label-only.
+        expect(screen.getByText(/Architectures \(1\)/)).toBeInTheDocument();
+        expect(screen.queryByTestId('search-group-icon-architectures')).not.toBeInTheDocument();
     });
 
     it('shows an empty state when nothing matches', async () => {

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
@@ -3,7 +3,8 @@ import { useSearchParams } from 'react-router-dom';
 import { SearchService } from '../../../service/search-service.js';
 import { GroupedSearchResults, SearchResult } from '../../../model/search.js';
 import { TYPE_LABELS, flattenResults, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
-import { getSearchGroupIcon } from '../../../theme/resource-type-meta.js';
+import { getSearchGroupIcon, getSearchGroupType } from '../../../theme/resource-type-meta.js';
+import { ItemCard } from '../namespace-page/ItemCard.js';
 import { colors } from '../../../theme/colors.js';
 
 interface SearchResultsPageProps {
@@ -63,8 +64,13 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
         return () => controller.abort();
     }, [query, service]);
 
+    // Groups the registry doesn't know are dropped rather than rendered with a
+    // guessed card type; the model's GroupedSearchResults keys make this a no-op
+    // until the backend grows a new group.
     const groups = results
-        ? Object.entries(results).filter(([, items]) => (items as SearchResult[]).length > 0)
+        ? Object.entries(results).filter(
+              ([type, items]) => (items as SearchResult[]).length > 0 && getSearchGroupType(type) !== undefined
+          )
         : [];
     const totalCount = results ? flattenResults(results).length : 0;
 
@@ -79,7 +85,7 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
 
     return (
         <div className="h-full overflow-auto bg-base-100" style={{ padding: '44px 48px' }}>
-            <div className="max-w-[880px] mx-auto flex flex-col gap-8">
+            <div className="max-w-[1240px] mx-auto flex flex-col gap-8">
                 <header>
                     <h1 className="text-[28px] font-bold" style={{ color: colors.redesign.ink }}>
                         {query ? (
@@ -133,41 +139,21 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
                                     {renderGroupIcon(type)}
                                     {TYPE_LABELS[type] ?? type} ({(items as SearchResult[]).length})
                                 </div>
-                                <div className="flex flex-col gap-2">
+                                <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
                                     {(items as SearchResult[]).map((item) => (
-                                        <button
+                                        <ItemCard
                                             key={`${type}-${item.namespace}-${item.id}`}
-                                            className="w-full text-left rounded-xl px-4 py-3 hover:bg-base-200 transition-colors cursor-pointer"
-                                            style={{ border: `1px solid ${colors.redesign.border}` }}
-                                            onClick={() => navigateToResult({ type, result: item })}
-                                        >
-                                            <div className="flex items-center gap-2">
-                                                <span
-                                                    className="font-medium truncate min-w-0"
-                                                    style={{ color: colors.redesign.ink }}
-                                                >
-                                                    {item.name}
-                                                </span>
-                                                <span
-                                                    data-testid="result-namespace-chip"
-                                                    className="ml-auto shrink-0 font-mono-jb text-[10px] rounded-[6px] px-1.5 py-0.5"
-                                                    style={{
-                                                        backgroundColor: colors.redesign.badgeBg,
-                                                        color: colors.redesign.mutedAlt,
-                                                    }}
-                                                >
-                                                    {item.namespace}
-                                                </span>
-                                            </div>
-                                            {item.description && (
-                                                <div
-                                                    className="text-sm mt-1"
-                                                    style={{ color: colors.redesign.muted }}
-                                                >
-                                                    {item.description}
-                                                </div>
-                                            )}
-                                        </button>
+                                            name={item.name}
+                                            description={item.description}
+                                            type={getSearchGroupType(type)!}
+                                            meta={item.namespace}
+                                            thumbnailUrl={
+                                                type === 'architectures' || type === 'patterns'
+                                                    ? `/api/calm/namespaces/${encodeURIComponent(item.namespace)}/${type}/${encodeURIComponent(String(item.id))}/thumbnail`
+                                                    : undefined
+                                            }
+                                            onActivate={() => navigateToResult({ type, result: item })}
+                                        />
                                     ))}
                                 </div>
                             </section>

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { SearchService } from '../../../service/search-service.js';
 import { GroupedSearchResults, SearchResult } from '../../../model/search.js';
 import { TYPE_LABELS, flattenResults, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
+import { getSearchGroupIcon } from '../../../theme/resource-type-meta.js';
 import { colors } from '../../../theme/colors.js';
 
 interface SearchResultsPageProps {
@@ -67,6 +68,15 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
         : [];
     const totalCount = results ? flattenResults(results).length : 0;
 
+    // Registry type glyph for a group header; the visual types (architectures /
+    // patterns) have none and their headers stay label-only. Inherits the
+    // header's muted text colour via currentColor.
+    const renderGroupIcon = (type: string) => {
+        const GroupIcon = getSearchGroupIcon(type);
+        if (!GroupIcon) return null;
+        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
+    };
+
     return (
         <div className="h-full overflow-auto bg-base-100" style={{ padding: '44px 48px' }}>
             <div className="max-w-[880px] mx-auto flex flex-col gap-8">
@@ -117,9 +127,10 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
                         {groups.map(([type, items]) => (
                             <section key={type}>
                                 <div
-                                    className="font-mono-jb text-[11px] uppercase tracking-[0.1em] mb-3"
+                                    className="flex items-center gap-1.5 font-mono-jb text-[11px] uppercase tracking-[0.1em] mb-3"
                                     style={{ color: colors.redesign.faintAlt }}
                                 >
+                                    {renderGroupIcon(type)}
                                     {TYPE_LABELS[type] ?? type} ({(items as SearchResult[]).length})
                                 </div>
                                 <div className="flex flex-col gap-2">

--- a/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
+++ b/calm-hub-ui/src/hub/components/search-results/SearchResultsPage.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SearchService } from '../../../service/search-service.js';
 import { GroupedSearchResults, SearchResult } from '../../../model/search.js';
-import { TYPE_LABELS, flattenResults, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
-import { getSearchGroupIcon, getSearchGroupType } from '../../../theme/resource-type-meta.js';
-import { ItemCard } from '../namespace-page/ItemCard.js';
+import { TYPE_LABELS, useSearchNavigation } from '../../../hooks/useSearchNavigation.js';
+import { getSearchGroupType } from '../../../theme/resource-type-meta.js';
+import { SearchGroupIcon } from '../../../components/search-group-icon.js';
+import { CARD_GRID_CLASS, ItemCard } from '../namespace-page/ItemCard.js';
+import { latestThumbnailUrl } from '../../../service/thumbnail-url.js';
 import { colors } from '../../../theme/colors.js';
 
 interface SearchResultsPageProps {
@@ -72,16 +74,9 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
               ([type, items]) => (items as SearchResult[]).length > 0 && getSearchGroupType(type) !== undefined
           )
         : [];
-    const totalCount = results ? flattenResults(results).length : 0;
-
-    // Registry type glyph for a group header; the visual types (architectures /
-    // patterns) have none and their headers stay label-only. Inherits the
-    // header's muted text colour via currentColor.
-    const renderGroupIcon = (type: string) => {
-        const GroupIcon = getSearchGroupIcon(type);
-        if (!GroupIcon) return null;
-        return <GroupIcon size={12} className="shrink-0" data-testid={`search-group-icon-${type}`} />;
-    };
+    // Counted over the FILTERED groups, so the headline count never includes items
+    // from unknown groups that are dropped from rendering.
+    const totalCount = groups.reduce((n, [, items]) => n + (items as SearchResult[]).length, 0);
 
     return (
         <div className="h-full overflow-auto bg-base-100" style={{ padding: '44px 48px' }}>
@@ -136,10 +131,10 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
                                     className="flex items-center gap-1.5 font-mono-jb text-[11px] uppercase tracking-[0.1em] mb-3"
                                     style={{ color: colors.redesign.faintAlt }}
                                 >
-                                    {renderGroupIcon(type)}
+                                    <SearchGroupIcon type={type} />
                                     {TYPE_LABELS[type] ?? type} ({(items as SearchResult[]).length})
                                 </div>
-                                <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+                                <div className={CARD_GRID_CLASS}>
                                     {(items as SearchResult[]).map((item) => (
                                         <ItemCard
                                             key={`${type}-${item.namespace}-${item.id}`}
@@ -149,7 +144,7 @@ export function SearchResultsPage({ searchService }: SearchResultsPageProps) {
                                             meta={item.namespace}
                                             thumbnailUrl={
                                                 type === 'architectures' || type === 'patterns'
-                                                    ? `/api/calm/namespaces/${encodeURIComponent(item.namespace)}/${type}/${encodeURIComponent(String(item.id))}/thumbnail`
+                                                    ? latestThumbnailUrl(item.namespace, type, item.id)
                                                     : undefined
                                             }
                                             onActivate={() => navigateToResult({ type, result: item })}

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -12,7 +12,7 @@ import { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
 import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { CountBadge } from '../explore-rail/CountBadge.js';
-import { COUNT_FIELD, type NamespaceResourceType } from '../namespace-page/resource-type-meta.js';
+import { COUNT_FIELD, type NamespaceResourceType } from '../../../theme/resource-type-meta.js';
 import {
     type TypeInUI,
     mapTypeInUIToTypeInUrl,

--- a/calm-hub-ui/src/render/RenderView.test.tsx
+++ b/calm-hub-ui/src/render/RenderView.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RenderView } from './RenderView.js';
+import type { CalmRenderData } from './RenderView.js';
+
+// The graphs themselves are heavy ReactFlow components that don't lay out in
+// jsdom; RenderView's job is choosing the right one, passing chromeless, and
+// carrying data-render-container — which is what these stubs let us assert.
+vi.mock('../visualizer/components/reactflow/ArchitectureGraph.js', () => ({
+    ArchitectureGraph: (props: Record<string, unknown>) => (
+        <div data-testid="architecture-graph" data-chromeless={String(props.chromeless)} />
+    ),
+}));
+
+vi.mock('../visualizer/components/reactflow/PatternGraph.js', () => ({
+    PatternGraph: (props: Record<string, unknown>) => (
+        <div data-testid="pattern-graph" data-chromeless={String(props.chromeless)} />
+    ),
+}));
+
+describe('RenderView', () => {
+    beforeEach(() => {
+        delete window.__CALM_RENDER_DATA;
+    });
+
+    afterEach(() => {
+        delete window.__CALM_RENDER_DATA;
+    });
+
+    it('shows an error state when no render data has been injected', () => {
+        render(<RenderView />);
+        expect(screen.getByTestId('render-view-error')).toBeInTheDocument();
+        expect(screen.queryByTestId('render-view-container')).not.toBeInTheDocument();
+    });
+
+    it('shows an error state when the injected documentType is not supported', () => {
+        window.__CALM_RENDER_DATA = {
+            documentType: 'flow',
+            document: {},
+        } as unknown as CalmRenderData;
+        render(<RenderView />);
+        expect(screen.getByTestId('render-view-error')).toBeInTheDocument();
+    });
+
+    it('shows an error state when the injected document is missing', () => {
+        window.__CALM_RENDER_DATA = { documentType: 'architecture' } as unknown as CalmRenderData;
+        render(<RenderView />);
+        expect(screen.getByTestId('render-view-error')).toBeInTheDocument();
+    });
+
+    it('renders an architecture document in the chromeless architecture graph', () => {
+        window.__CALM_RENDER_DATA = {
+            documentType: 'architecture',
+            document: { nodes: [], relationships: [] },
+        };
+        render(<RenderView />);
+        expect(screen.getByTestId('architecture-graph')).toHaveAttribute('data-chromeless', 'true');
+        expect(screen.queryByTestId('pattern-graph')).not.toBeInTheDocument();
+    });
+
+    it('renders a pattern document in the chromeless pattern graph', () => {
+        window.__CALM_RENDER_DATA = {
+            documentType: 'pattern',
+            document: { properties: {} },
+        };
+        render(<RenderView />);
+        expect(screen.getByTestId('pattern-graph')).toHaveAttribute('data-chromeless', 'true');
+        expect(screen.queryByTestId('architecture-graph')).not.toBeInTheDocument();
+    });
+
+    it('wraps the graph in a full-viewport data-render-container element', () => {
+        window.__CALM_RENDER_DATA = {
+            documentType: 'architecture',
+            document: { nodes: [] },
+        };
+        render(<RenderView />);
+        const container = screen.getByTestId('render-view-container');
+        expect(container).toHaveAttribute('data-render-container');
+        expect(container).toHaveStyle({ width: '100vw', height: '100vh' });
+    });
+});

--- a/calm-hub-ui/src/render/RenderView.tsx
+++ b/calm-hub-ui/src/render/RenderView.tsx
@@ -1,0 +1,66 @@
+import { CalmArchitectureSchema } from '@finos/calm-models/types';
+import { ArchitectureGraph } from '../visualizer/components/reactflow/ArchitectureGraph.js';
+import { PatternGraph } from '../visualizer/components/reactflow/PatternGraph.js';
+
+/**
+ * Render payload injected by calm-server (via Playwright `addInitScript`) before
+ * any page script runs. The injected path is the only supported production path
+ * for this route — there is deliberately no fetch-based fallback.
+ */
+export interface CalmRenderData {
+    documentType: 'architecture' | 'pattern';
+    document: Record<string, unknown>;
+}
+
+declare global {
+    interface Window {
+        __CALM_RENDER_DATA?: CalmRenderData;
+    }
+}
+
+function readRenderData(): CalmRenderData | undefined {
+    const data = window.__CALM_RENDER_DATA;
+    if (
+        !data ||
+        (data.documentType !== 'architecture' && data.documentType !== 'pattern') ||
+        !data.document ||
+        typeof data.document !== 'object'
+    ) {
+        return undefined;
+    }
+    return data;
+}
+
+/**
+ * Chrome-free diagram render page for the `/#/render` route. Driven by
+ * calm-server's thumbnail endpoint: a headless browser injects
+ * `window.__CALM_RENDER_DATA`, loads this route, waits for
+ * `[data-render-ready="true"]` (set by the chromeless graph once layout has
+ * settled) and screenshots the `[data-render-container]` element.
+ */
+export function RenderView() {
+    const renderData = readRenderData();
+
+    if (!renderData) {
+        return (
+            <div data-testid="render-view-error" style={{ padding: '16px', fontFamily: 'monospace' }}>
+                No CALM render data available. This route is driven by calm-server, which injects
+                window.__CALM_RENDER_DATA before the page loads.
+            </div>
+        );
+    }
+
+    return (
+        <div
+            data-render-container
+            data-testid="render-view-container"
+            style={{ width: '100vw', height: '100vh', margin: 0, padding: 0, background: '#ffffff' }}
+        >
+            {renderData.documentType === 'pattern' ? (
+                <PatternGraph patternData={renderData.document} chromeless />
+            ) : (
+                <ArchitectureGraph jsonData={renderData.document as CalmArchitectureSchema} chromeless />
+            )}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/service/thumbnail-url.ts
+++ b/calm-hub-ui/src/service/thumbnail-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Latest-version thumbnail endpoint on the numeric-ID storage API, for the two
+ * diagram types calm-hub renders thumbnails for. Cards' `<img>`s fall back to
+ * the stripe header when the endpoint 404s (no thumbnail rendered yet).
+ */
+export function latestThumbnailUrl(
+    namespace: string,
+    typePath: 'architectures' | 'patterns',
+    id: string | number
+): string {
+    return `/api/calm/namespaces/${encodeURIComponent(namespace)}/${typePath}/${encodeURIComponent(String(id))}/thumbnail`;
+}

--- a/calm-hub-ui/src/theme/resource-type-meta.ts
+++ b/calm-hub-ui/src/theme/resource-type-meta.ts
@@ -1,6 +1,15 @@
-import { colors } from '../../../theme/colors.js';
-import { type TypeInUI } from '../tree-navigation/navigation-loaders.js';
-import { NamespaceCounts } from '../../../model/counts.js';
+import { type IconType } from 'react-icons';
+import {
+    IoDocumentTextOutline,
+    IoGitBranchOutline,
+    IoGitCommitOutline,
+    IoLinkOutline,
+    IoShieldCheckmarkOutline,
+} from 'react-icons/io5';
+import { colors } from './colors.js';
+import { type TypeInUI } from '../hub/components/tree-navigation/navigation-loaders.js';
+import { NamespaceCounts } from '../model/counts.js';
+import { type GroupedSearchResults } from '../model/search.js';
 
 /**
  * The resource types shown on the namespace browse page: every UI type except
@@ -37,6 +46,13 @@ interface ResourceTypeMeta {
     pluralLabel: string;
     /** Key into `colors.resourceTypes` for the accent / tint pair. */
     colorKey: ResourceTypeKey;
+    /**
+     * Type glyph shown on card thumbnails and search group headers. Only the
+     * non-visual types carry one; Architectures and Patterns are deliberately
+     * absent — they keep the plain striped placeholder until they get real
+     * diagram thumbnails.
+     */
+    icon?: IconType;
 }
 
 /**
@@ -54,11 +70,11 @@ interface ResourceTypeMeta {
 const RESOURCE_TYPE_META: Record<CardResourceType, ResourceTypeMeta> = {
     Architectures: { label: 'Architecture', pluralLabel: 'architectures', colorKey: 'architecture' },
     Patterns: { label: 'Pattern', pluralLabel: 'patterns', colorKey: 'pattern' },
-    Flows: { label: 'Flow', pluralLabel: 'flows', colorKey: 'flow' },
-    Standards: { label: 'Standard', pluralLabel: 'standards', colorKey: 'standard' },
-    ADRs: { label: 'ADR', pluralLabel: 'ADRs', colorKey: 'adr' },
-    Interfaces: { label: 'Interface', pluralLabel: 'interfaces', colorKey: 'interface' },
-    Controls: { label: 'Control', pluralLabel: 'controls', colorKey: 'control' },
+    Flows: { label: 'Flow', pluralLabel: 'flows', colorKey: 'flow', icon: IoGitBranchOutline },
+    Standards: { label: 'Standard', pluralLabel: 'standards', colorKey: 'standard', icon: IoDocumentTextOutline },
+    ADRs: { label: 'ADR', pluralLabel: 'ADRs', colorKey: 'adr', icon: IoGitCommitOutline },
+    Interfaces: { label: 'Interface', pluralLabel: 'interfaces', colorKey: 'interface', icon: IoLinkOutline },
+    Controls: { label: 'Control', pluralLabel: 'controls', colorKey: 'control', icon: IoShieldCheckmarkOutline },
 };
 
 /**
@@ -106,4 +122,41 @@ export function getResourceTypeColors(type: CardResourceType): {
     tint: string;
 } {
     return colors.resourceTypes[RESOURCE_TYPE_META[type].colorKey];
+}
+
+/**
+ * The type glyph for a browse (or control) card resource type, or `undefined`
+ * for the visual types (Architectures / Patterns) that keep a plain thumbnail.
+ */
+export function getResourceTypeIcon(type: CardResourceType): IconType | undefined {
+    return RESOURCE_TYPE_META[type].icon;
+}
+
+/**
+ * Maps a lowercase search group key (the `GroupedSearchResults` / `TYPE_LABELS`
+ * key, e.g. `'flows'`, `'adrs'`) back to its {@link CardResourceType}, so the
+ * search surfaces can pull the type icon from this registry rather than keeping
+ * their own copy of the mapping. Keyed on `keyof GroupedSearchResults`, so a new
+ * backend group fails to compile here instead of silently rendering icon-less.
+ */
+const SEARCH_GROUP_TYPE: Record<keyof GroupedSearchResults, CardResourceType> = {
+    architectures: 'Architectures',
+    patterns: 'Patterns',
+    flows: 'Flows',
+    standards: 'Standards',
+    adrs: 'ADRs',
+    interfaces: 'Interfaces',
+    controls: 'Controls',
+};
+
+/**
+ * The type glyph for a search result group header, keyed by the lowercase
+ * group key. `undefined` for unknown keys and for the icon-less visual types,
+ * whose headers render label-only.
+ */
+export function getSearchGroupIcon(groupKey: string): IconType | undefined {
+    // Callers hold plain-string keys (Object.entries); unknown keys miss the
+    // map and fall out as undefined at runtime, hence the narrowing cast.
+    const type: CardResourceType | undefined = SEARCH_GROUP_TYPE[groupKey as keyof GroupedSearchResults];
+    return type === undefined ? undefined : RESOURCE_TYPE_META[type].icon;
 }

--- a/calm-hub-ui/src/theme/resource-type-meta.ts
+++ b/calm-hub-ui/src/theme/resource-type-meta.ts
@@ -150,13 +150,21 @@ const SEARCH_GROUP_TYPE: Record<keyof GroupedSearchResults, CardResourceType> = 
 };
 
 /**
+ * The {@link CardResourceType} behind a lowercase search group key, or `undefined`
+ * for keys this registry doesn't know. Callers hold plain-string keys
+ * (`Object.entries`); unknown keys miss the map and fall out as undefined at
+ * runtime, hence the narrowing cast.
+ */
+export function getSearchGroupType(groupKey: string): CardResourceType | undefined {
+    return SEARCH_GROUP_TYPE[groupKey as keyof GroupedSearchResults];
+}
+
+/**
  * The type glyph for a search result group header, keyed by the lowercase
  * group key. `undefined` for unknown keys and for the icon-less visual types,
  * whose headers render label-only.
  */
 export function getSearchGroupIcon(groupKey: string): IconType | undefined {
-    // Callers hold plain-string keys (Object.entries); unknown keys miss the
-    // map and fall out as undefined at runtime, hence the narrowing cast.
-    const type: CardResourceType | undefined = SEARCH_GROUP_TYPE[groupKey as keyof GroupedSearchResults];
+    const type = getSearchGroupType(groupKey);
     return type === undefined ? undefined : RESOURCE_TYPE_META[type].icon;
 }

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.test.tsx
@@ -21,6 +21,9 @@ vi.mock('reactflow', async () => {
     return {
         ...actual,
         __esModule: true,
+        // Nodes never measure in jsdom (and the stubbed ReactFlow provides no store
+        // context), so report them initialized for the chromeless ready-signal tests.
+        useNodesInitialized: () => true,
         default: (props: Record<string, unknown>) => {
             reactFlowProps.current = props;
             return <div data-testid="react-flow">{props.children as ReactNode}</div>;
@@ -147,6 +150,45 @@ describe('ArchitectureGraph', () => {
             render(<ArchitectureGraph jsonData={mockCalmData} />);
             expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
             expect(screen.getByRole('button', { name: /show minimap/i })).toBeInTheDocument();
+        });
+    });
+
+    describe('chromeless (thumbnail render mode)', () => {
+        it('suppresses the Controls, MiniMap and SearchBar chrome but keeps the Background', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} chromeless />);
+            expect(screen.queryByTestId('rf-controls')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('rf-panel')).not.toBeInTheDocument();
+            expect(screen.getByTestId('rf-background')).toBeInTheDocument();
+        });
+
+        it('always fits the whole graph, dropping below the desktop zoom floor', () => {
+            render(<ArchitectureGraph jsonData={mockCalmData} chromeless />);
+            expect(reactFlowProps.current?.fitView).toBe(true);
+            expect(reactFlowProps.current?.defaultViewport).toBeUndefined();
+            expect(reactFlowProps.current?.fitViewOptions).toEqual({
+                padding: 0.1,
+                minZoom: 0.05,
+                maxZoom: 0.8,
+            });
+        });
+
+        it('sets data-render-ready on the wrapper once nodes initialize and paint settles', async () => {
+            const { container } = render(<ArchitectureGraph jsonData={mockCalmData} chromeless />);
+            // Set asynchronously: one requestAnimationFrame after useNodesInitialized.
+            await vi.waitFor(() => {
+                expect(container.querySelector('[data-render-ready="true"]')).toBeInTheDocument();
+            });
+        });
+
+        it('signals ready immediately for a genuinely empty document', () => {
+            const { container } = render(<ArchitectureGraph jsonData={{}} chromeless />);
+            expect(container.querySelector('[data-render-ready="true"]')).toBeInTheDocument();
+        });
+
+        it('never sets data-render-ready in normal interactive mode', () => {
+            const { container } = render(<ArchitectureGraph jsonData={mockCalmData} />);
+            expect(container.querySelector('[data-render-ready]')).not.toBeInTheDocument();
         });
     });
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
     Node,
     Background,
@@ -18,6 +18,8 @@ import { FloatingEdge } from './FloatingEdge.js';
 import { CustomNode } from './CustomNode.js';
 import { SystemGroupNode } from './SystemGroupNode.js';
 import { RenderReadySignal } from './RenderReadySignal.js';
+import { CHROMELESS_FIT_VIEW_OPTIONS, useChromelessRender } from './chromeless.js';
+import { ChromelessEmptyState } from './ChromelessEmptyState.js';
 import { SearchBar } from './SearchBar.js';
 import { THEME } from './theme.js';
 import { colors } from '../../../theme/colors.js';
@@ -57,17 +59,6 @@ const FIT_VIEW_OPTIONS = { padding: 0.2, minZoom: 0.6, maxZoom: 1.2 } as const;
  */
 const MOBILE_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.1, maxZoom: FIT_VIEW_OPTIONS.maxZoom } as const;
 
-/**
- * Chromeless (thumbnail render) fit: the screenshot must show the whole graph in a
- * fixed wide-and-short viewport (a minimap-style strip), so the zoom floor drops well
- * below the interactive modes' legibility floors — a partially cropped thumbnail is
- * worse than a small one. Padding matches the mobile fit; margins don't matter
- * to framing because the screenshot is clipped to the graph's content server-side.
- * maxZoom sits below the interactive fits so tiny graphs (e.g. two nodes) don't
- * render as oversized strips that overflow the clip's card-aspect expansion.
- */
-const CHROMELESS_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.05, maxZoom: 0.8 } as const;
-
 /** Persist the minimap show/hide choice so it survives a refresh. */
 const MINIMAP_HIDDEN_KEY = 'calmHub.diagramMinimapHidden';
 
@@ -82,11 +73,7 @@ function readMinimapHidden(): boolean {
 export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewportKey, chromeless = false }: ArchitectureGraphProps) {
     const isMobile = useIsMobile();
 
-    // Chromeless render mode: true once nodes are measured and the first paint has
-    // settled (RenderReadySignal), surfaced as data-render-ready on the wrapper so
-    // calm-server's headless browser knows the graph is safe to screenshot.
-    const [renderReady, setRenderReady] = useState(false);
-    const markRenderReady = useCallback(() => setRenderReady(true), []);
+    const { renderReady, markRenderReady } = useChromelessRender();
 
     // The viewport store key is namespaced by device. Mobile fits to a far lower zoom
     // floor (0.1 vs desktop's 0.6), so a viewport saved while mobile must not be
@@ -203,15 +190,10 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
     }, [isMobile]);
 
     if (nodes.length === 0) {
-        const emptyState = <EmptyGraphState message="No architecture data to display. Load a CALM architecture to visualize." />;
-        // A chromeless render of a genuinely empty document must still signal ready,
-        // otherwise calm-server waits out its full render timeout for nothing.
-        return chromeless && parsed ? (
-            <div style={{ height: '100%', width: '100%' }} data-render-ready="true">
-                {emptyState}
-            </div>
-        ) : (
-            emptyState
+        return (
+            <ChromelessEmptyState signalReady={chromeless && parsed}>
+                <EmptyGraphState message="No architecture data to display. Load a CALM architecture to visualize." />
+            </ChromelessEmptyState>
         );
     }
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
     Node,
     Background,
@@ -17,6 +17,7 @@ import { readViewportForKey, saveViewportForKey } from './utils/viewportStore.js
 import { FloatingEdge } from './FloatingEdge.js';
 import { CustomNode } from './CustomNode.js';
 import { SystemGroupNode } from './SystemGroupNode.js';
+import { RenderReadySignal } from './RenderReadySignal.js';
 import { SearchBar } from './SearchBar.js';
 import { THEME } from './theme.js';
 import { colors } from '../../../theme/colors.js';
@@ -56,6 +57,17 @@ const FIT_VIEW_OPTIONS = { padding: 0.2, minZoom: 0.6, maxZoom: 1.2 } as const;
  */
 const MOBILE_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.1, maxZoom: FIT_VIEW_OPTIONS.maxZoom } as const;
 
+/**
+ * Chromeless (thumbnail render) fit: the screenshot must show the whole graph in a
+ * fixed wide-and-short viewport (a minimap-style strip), so the zoom floor drops well
+ * below the interactive modes' legibility floors — a partially cropped thumbnail is
+ * worse than a small one. Padding matches the mobile fit; margins don't matter
+ * to framing because the screenshot is clipped to the graph's content server-side.
+ * maxZoom sits below the interactive fits so tiny graphs (e.g. two nodes) don't
+ * render as oversized strips that overflow the clip's card-aspect expansion.
+ */
+const CHROMELESS_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.05, maxZoom: 0.8 } as const;
+
 /** Persist the minimap show/hide choice so it survives a refresh. */
 const MINIMAP_HIDDEN_KEY = 'calmHub.diagramMinimapHidden';
 
@@ -67,8 +79,14 @@ function readMinimapHidden(): boolean {
     }
 }
 
-export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewportKey }: ArchitectureGraphProps) {
+export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewportKey, chromeless = false }: ArchitectureGraphProps) {
     const isMobile = useIsMobile();
+
+    // Chromeless render mode: true once nodes are measured and the first paint has
+    // settled (RenderReadySignal), surfaced as data-render-ready on the wrapper so
+    // calm-server's headless browser knows the graph is safe to screenshot.
+    const [renderReady, setRenderReady] = useState(false);
+    const markRenderReady = useCallback(() => setRenderReady(true), []);
 
     // The viewport store key is namespaced by device. Mobile fits to a far lower zoom
     // floor (0.1 vs desktop's 0.6), so a viewport saved while mobile must not be
@@ -131,6 +149,10 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
         persistKey: viewportKey,
     });
 
+    // Distinguishes "not parsed yet" (initial empty node state) from a genuinely
+    // empty document, so chromeless mode never signals ready before the parse ran.
+    const [parsed, setParsed] = useState(false);
+
     useEffect(() => {
         const { nodes: parsedNodes, edges: parsedEdges } = parseCALMData(jsonData, onNodeClick);
         sourceNodesRef.current = parsedNodes;
@@ -139,6 +161,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
         setNodes(viewportKey ? applyStoredPositions(viewportKey, parsedNodes) : parsedNodes);
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
+        setParsed(true);
     }, [jsonData, setNodes, setEdges, setAvailableNodeTypes, onNodeClick, viewportKey]);
 
     // Search & filter
@@ -180,19 +203,31 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
     }, [isMobile]);
 
     if (nodes.length === 0) {
-        return <EmptyGraphState message="No architecture data to display. Load a CALM architecture to visualize." />;
+        const emptyState = <EmptyGraphState message="No architecture data to display. Load a CALM architecture to visualize." />;
+        // A chromeless render of a genuinely empty document must still signal ready,
+        // otherwise calm-server waits out its full render timeout for nothing.
+        return chromeless && parsed ? (
+            <div style={{ height: '100%', width: '100%' }} data-render-ready="true">
+                {emptyState}
+            </div>
+        ) : (
+            emptyState
+        );
     }
 
     // One derived config so the device-dependent fit props can't drift out of sync.
-    // Mobile always fits on load (ignoring any persisted viewport) so the whole graph
+    // Chromeless always fits the whole graph (thumbnails must not crop); mobile
+    // always fits on load (ignoring any persisted viewport) so the whole graph
     // fits 390px (redesign problem #10); desktop restores its saved viewport, or fits
     // when there's none.
-    const flowConfig = isMobile
-        ? { fitView: true, defaultViewport: undefined, fitViewOptions: MOBILE_FIT_VIEW_OPTIONS }
-        : { fitView: !savedViewport, defaultViewport: savedViewport, fitViewOptions: FIT_VIEW_OPTIONS };
+    const flowConfig = chromeless
+        ? { fitView: true, defaultViewport: undefined, fitViewOptions: CHROMELESS_FIT_VIEW_OPTIONS }
+        : isMobile
+          ? { fitView: true, defaultViewport: undefined, fitViewOptions: MOBILE_FIT_VIEW_OPTIONS }
+          : { fitView: !savedViewport, defaultViewport: savedViewport, fitViewOptions: FIT_VIEW_OPTIONS };
 
     return (
-        <div style={{ height: '100%', width: '100%' }}>
+        <div style={{ height: '100%', width: '100%' }} data-render-ready={renderReady ? 'true' : undefined}>
             <ReactFlow
                 // Remount when the diagram (resource) changes so a new architecture fits
                 // afresh; switching versions/moments keeps the same key and preserves the view.
@@ -223,7 +258,8 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                     prop into an SVG `fill` presentation attribute, where `var()` does
                     not resolve. */}
                 <Background gap={16} />
-                {!isMobile && (
+                {chromeless && <RenderReadySignal onReady={markRenderReady} />}
+                {!chromeless && !isMobile && (
                     <Controls
                         style={{
                             background: THEME.colors.card,
@@ -244,7 +280,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         </ControlButton>
                     </Controls>
                 )}
-                {isMobile && (
+                {!chromeless && isMobile && (
                     // Mobile gets visible zoom controls (redesign problem #11) —
                     // larger touch cells, bottom-right per Frame F, no minimap
                     // toggle (mobile has no minimap) and no lock cell. Sized via the
@@ -259,7 +295,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         fitViewOptions={MOBILE_FIT_VIEW_OPTIONS}
                     />
                 )}
-                {!isMobile && !minimapHidden && (
+                {!chromeless && !isMobile && !minimapHidden && (
                     <MiniMap
                         data-testid="diagram-minimap"
                         className="calm-minimap-mask-surface"
@@ -289,7 +325,7 @@ export function ArchitectureGraph({ jsonData, onNodeClick, onEdgeClick, viewport
                         maskStrokeWidth={1.5}
                     />
                 )}
-                {!externalSearch && (
+                {!chromeless && !externalSearch && (
                     <Panel position="top-right">
                         <SearchBar
                             searchTerm={searchTerm}

--- a/calm-hub-ui/src/visualizer/components/reactflow/ChromelessEmptyState.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ChromelessEmptyState.tsx
@@ -1,0 +1,24 @@
+import { type ReactNode } from 'react';
+
+interface ChromelessEmptyStateProps {
+    /** True when in chromeless mode AND the document parse has run. */
+    signalReady: boolean;
+    children: ReactNode;
+}
+
+/**
+ * Wraps a graph's empty state so a chromeless render (see chromeless.ts) of a
+ * genuinely empty document still signals ready — otherwise calm-server would
+ * wait out its full render timeout for nothing. Outside chromeless mode the
+ * children render unwrapped, exactly as before.
+ */
+export function ChromelessEmptyState({ signalReady, children }: ChromelessEmptyStateProps) {
+    if (!signalReady) {
+        return <>{children}</>;
+    }
+    return (
+        <div style={{ height: '100%', width: '100%' }} data-render-ready="true">
+            {children}
+        </div>
+    );
+}

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { PatternGraph } from './PatternGraph';
+
+/**
+ * Stub the heavy, DOM-measuring ReactFlow view components (as the
+ * ArchitectureGraph tests do) but keep the real state hooks; capture the props
+ * the chromeless assertions need.
+ */
+const reactFlowProps: { current: Record<string, unknown> | null } = { current: null };
+
+vi.mock('reactflow', async () => {
+    const actual = await vi.importActual<typeof import('reactflow')>('reactflow');
+    return {
+        ...actual,
+        __esModule: true,
+        // Nodes never measure in jsdom (and the stubbed ReactFlow provides no store
+        // context), so report them initialized for the chromeless ready-signal tests.
+        useNodesInitialized: () => true,
+        default: (props: Record<string, unknown>) => {
+            reactFlowProps.current = props;
+            return <div data-testid="react-flow">{props.children as ReactNode}</div>;
+        },
+        Background: () => <div data-testid="rf-background" />,
+        Controls: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-controls">{children}</div>
+        ),
+        MiniMap: () => <div data-testid="diagram-minimap" />,
+        Panel: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-panel">{children}</div>
+        ),
+    };
+});
+
+// A minimal CALM pattern: properties.nodes.prefixItems drives the parsed nodes.
+const mockPatternData: Record<string, unknown> = {
+    properties: {
+        nodes: {
+            prefixItems: [
+                {
+                    properties: {
+                        'unique-id': { const: 'node-1' },
+                        name: { const: 'Service A' },
+                        'node-type': { const: 'service' },
+                    },
+                },
+                {
+                    properties: {
+                        'unique-id': { const: 'node-2' },
+                        name: { const: 'Database B' },
+                        'node-type': { const: 'database' },
+                    },
+                },
+            ],
+        },
+        relationships: { prefixItems: [] },
+    },
+};
+
+describe('PatternGraph', () => {
+    beforeEach(() => {
+        reactFlowProps.current = null;
+        vi.clearAllMocks();
+    });
+
+    it('renders the chrome (controls, minimap, panels) in normal mode', () => {
+        render(<PatternGraph patternData={mockPatternData} />);
+        expect(screen.getByTestId('rf-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('diagram-minimap')).toBeInTheDocument();
+        expect(screen.getAllByTestId('rf-panel').length).toBeGreaterThan(0);
+    });
+
+    describe('chromeless (thumbnail render mode)', () => {
+        it('suppresses the Controls, MiniMap and panel chrome but keeps the Background', () => {
+            render(<PatternGraph patternData={mockPatternData} chromeless />);
+            expect(screen.queryByTestId('rf-controls')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('diagram-minimap')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('rf-panel')).not.toBeInTheDocument();
+            expect(screen.getByTestId('rf-background')).toBeInTheDocument();
+        });
+
+        it('always fits the whole graph with a dropped zoom floor', () => {
+            render(<PatternGraph patternData={mockPatternData} chromeless />);
+            expect(reactFlowProps.current?.fitView).toBe(true);
+            expect(reactFlowProps.current?.defaultViewport).toBeUndefined();
+            expect(reactFlowProps.current?.fitViewOptions).toEqual({
+                padding: 0.1,
+                minZoom: 0.05,
+                maxZoom: 0.8,
+            });
+        });
+
+        it('sets data-render-ready on the wrapper once nodes initialize and paint settles', async () => {
+            const { container } = render(<PatternGraph patternData={mockPatternData} chromeless />);
+            await vi.waitFor(() => {
+                expect(container.querySelector('[data-render-ready="true"]')).toBeInTheDocument();
+            });
+        });
+
+        it('signals ready immediately for a genuinely empty document', () => {
+            const { container } = render(<PatternGraph patternData={{}} chromeless />);
+            expect(container.querySelector('[data-render-ready="true"]')).toBeInTheDocument();
+        });
+
+        it('never sets data-render-ready in normal interactive mode', () => {
+            const { container } = render(<PatternGraph patternData={mockPatternData} />);
+            expect(container.querySelector('[data-render-ready]')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -17,6 +17,8 @@ import { CustomNode } from './CustomNode.js';
 import { SystemGroupNode } from './SystemGroupNode.js';
 import { DecisionGroupNode } from './DecisionGroupNode.js';
 import { RenderReadySignal } from './RenderReadySignal.js';
+import { CHROMELESS_FIT_VIEW_OPTIONS, useChromelessRender } from './chromeless.js';
+import { ChromelessEmptyState } from './ChromelessEmptyState.js';
 import { SearchBar } from './SearchBar.js';
 import { THEME } from './theme.js';
 import { EmptyGraphState } from './EmptyGraphState.js';
@@ -43,17 +45,6 @@ const nodeTypes = {
 };
 const GROUP_NODE_TYPES = ['group', 'decisionGroup'];
 
-/**
- * Chromeless (thumbnail render) fit: the screenshot must show the whole graph in a
- * fixed wide-and-short viewport (a minimap-style strip), so the zoom floor drops
- * below ReactFlow's default — a partially cropped thumbnail is worse than a small
- * one. Margins don't matter to framing because the screenshot is clipped to the
- * graph's content server-side. maxZoom sits below the interactive fit so tiny
- * graphs don't render as oversized strips that overflow the clip's card-aspect
- * expansion.
- */
-const CHROMELESS_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.05, maxZoom: 0.8 } as const;
-
 interface PatternGraphProps {
     patternData: Record<string, unknown>;
     onNodeClick?: (nodeData: Record<string, unknown>) => void;
@@ -74,11 +65,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
         [viewportKey]
     );
 
-    // Chromeless render mode: true once nodes are measured and the first paint has
-    // settled (RenderReadySignal), surfaced as data-render-ready on the wrapper so
-    // calm-server's headless browser knows the graph is safe to screenshot.
-    const [renderReady, setRenderReady] = useState(false);
-    const markRenderReady = useCallback(() => setRenderReady(true), []);
+    const { renderReady, markRenderReady } = useChromelessRender();
 
     // Distinguishes "not parsed yet" (initial empty node state) from a genuinely
     // empty document, so chromeless mode never signals ready before the parse ran.
@@ -197,15 +184,10 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
     }, []);
 
     if (nodes.length === 0) {
-        const emptyState = <EmptyGraphState message="No pattern data to display. Load a CALM pattern to visualize." />;
-        // A chromeless render of a genuinely empty document must still signal ready,
-        // otherwise calm-server waits out its full render timeout for nothing.
-        return chromeless && parsed ? (
-            <div style={{ height: '100%', width: '100%' }} data-render-ready="true">
-                {emptyState}
-            </div>
-        ) : (
-            emptyState
+        return (
+            <ChromelessEmptyState signalReady={chromeless && parsed}>
+                <EmptyGraphState message="No pattern data to display. Load a CALM pattern to visualize." />
+            </ChromelessEmptyState>
         );
     }
 

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -16,6 +16,7 @@ import { FloatingEdge } from './FloatingEdge.js';
 import { CustomNode } from './CustomNode.js';
 import { SystemGroupNode } from './SystemGroupNode.js';
 import { DecisionGroupNode } from './DecisionGroupNode.js';
+import { RenderReadySignal } from './RenderReadySignal.js';
 import { SearchBar } from './SearchBar.js';
 import { THEME } from './theme.js';
 import { EmptyGraphState } from './EmptyGraphState.js';
@@ -42,18 +43,46 @@ const nodeTypes = {
 };
 const GROUP_NODE_TYPES = ['group', 'decisionGroup'];
 
+/**
+ * Chromeless (thumbnail render) fit: the screenshot must show the whole graph in a
+ * fixed wide-and-short viewport (a minimap-style strip), so the zoom floor drops
+ * below ReactFlow's default — a partially cropped thumbnail is worse than a small
+ * one. Margins don't matter to framing because the screenshot is clipped to the
+ * graph's content server-side. maxZoom sits below the interactive fit so tiny
+ * graphs don't render as oversized strips that overflow the clip's card-aspect
+ * expansion.
+ */
+const CHROMELESS_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.05, maxZoom: 0.8 } as const;
+
 interface PatternGraphProps {
     patternData: Record<string, unknown>;
     onNodeClick?: (nodeData: Record<string, unknown>) => void;
     onEdgeClick?: (edgeData: Record<string, unknown>) => void;
     viewportKey?: string;
+    /**
+     * Headless-render mode (the `/render` route driven by calm-server): suppresses
+     * the Controls, MiniMap, DecisionSelector and SearchBar chrome (`<Background>`
+     * stays), fits the whole graph, and sets `data-render-ready="true"` on the graph
+     * wrapper once nodes are measured and the first paint has settled.
+     */
+    chromeless?: boolean;
 }
 
-export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKey }: PatternGraphProps) {
+export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKey, chromeless = false }: PatternGraphProps) {
     const savedViewport = useMemo<Viewport | undefined>(
         () => (viewportKey ? readViewportForKey(viewportKey) : undefined),
         [viewportKey]
     );
+
+    // Chromeless render mode: true once nodes are measured and the first paint has
+    // settled (RenderReadySignal), surfaced as data-render-ready on the wrapper so
+    // calm-server's headless browser knows the graph is safe to screenshot.
+    const [renderReady, setRenderReady] = useState(false);
+    const markRenderReady = useCallback(() => setRenderReady(true), []);
+
+    // Distinguishes "not parsed yet" (initial empty node state) from a genuinely
+    // empty document, so chromeless mode never signals ready before the parse ran.
+    const [parsed, setParsed] = useState(false);
 
     const [nodes, setNodes, onNodesChangeBase] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -95,6 +124,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
         setDecisionPoints(extractDecisionPoints(parsedNodes));
+        setParsed(true);
     }, [patternData, setNodes, setEdges, setAvailableNodeTypes, viewportKey]);
 
     // Search & filter
@@ -167,11 +197,20 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
     }, []);
 
     if (nodes.length === 0) {
-        return <EmptyGraphState message="No pattern data to display. Load a CALM pattern to visualize." />;
+        const emptyState = <EmptyGraphState message="No pattern data to display. Load a CALM pattern to visualize." />;
+        // A chromeless render of a genuinely empty document must still signal ready,
+        // otherwise calm-server waits out its full render timeout for nothing.
+        return chromeless && parsed ? (
+            <div style={{ height: '100%', width: '100%' }} data-render-ready="true">
+                {emptyState}
+            </div>
+        ) : (
+            emptyState
+        );
     }
 
     return (
-        <div style={{ height: '100%', width: '100%' }}>
+        <div style={{ height: '100%', width: '100%' }} data-render-ready={renderReady ? 'true' : undefined}>
             <ReactFlow
                 key={viewportKey}
                 nodes={nodes}
@@ -187,15 +226,16 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                 onMove={(_, viewport) => {
                     if (viewportKey) saveViewportForKey(viewportKey, viewport);
                 }}
-                fitView={!savedViewport}
-                defaultViewport={savedViewport}
-                fitViewOptions={{ padding: 0.2 }}
+                fitView={chromeless || !savedViewport}
+                defaultViewport={chromeless ? undefined : savedViewport}
+                fitViewOptions={chromeless ? CHROMELESS_FIT_VIEW_OPTIONS : { padding: 0.2 }}
                 attributionPosition="bottom-left"
                 style={{ background: THEME.colors.background }}
             >
                 {/* Dot colour lives in index.css — see ArchitectureGraph. */}
                 <Background gap={16} />
-                {!isMobile && (
+                {chromeless && <RenderReadySignal onReady={markRenderReady} />}
+                {!chromeless && !isMobile && (
                     <Controls
                         style={{
                             background: THEME.colors.card,
@@ -204,7 +244,7 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         }}
                     />
                 )}
-                {!isMobile && (
+                {!chromeless && !isMobile && (
                     <MiniMap
                         className="calm-minimap-mask-base"
                         style={{
@@ -214,15 +254,17 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
                         nodeColor={THEME.colors.accent}
                     />
                 )}
-                <Panel position="top-left">
-                    <DecisionSelectorPanel
-                        decisionPoints={decisionPoints}
-                        selections={decisionSelections}
-                        onSelectionChange={handleDecisionSelectionChange}
-                        onReset={handleDecisionReset}
-                    />
-                </Panel>
-                {!externalSearch && (
+                {!chromeless && (
+                    <Panel position="top-left">
+                        <DecisionSelectorPanel
+                            decisionPoints={decisionPoints}
+                            selections={decisionSelections}
+                            onSelectionChange={handleDecisionSelectionChange}
+                            onReset={handleDecisionReset}
+                        />
+                    </Panel>
+                )}
+                {!chromeless && !externalSearch && (
                 <Panel position="top-right">
                     <SearchBar
                         searchTerm={searchTerm}

--- a/calm-hub-ui/src/visualizer/components/reactflow/RenderReadySignal.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/RenderReadySignal.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useNodesInitialized } from 'reactflow';
+
+/**
+ * Signals when the graph is safe to screenshot. Mounted as a `<ReactFlow>` child
+ * (it needs the flow store context) by the chromeless render mode.
+ *
+ * `useNodesInitialized()` turns true once every node has been measured, but edge
+ * paths derive from those measured nodeInternals (see {@link FloatingEdge}), so
+ * we wait one further `requestAnimationFrame` for the paint to settle before
+ * calling {@link RenderReadySignalProps.onReady}.
+ */
+interface RenderReadySignalProps {
+    onReady: () => void;
+}
+
+export function RenderReadySignal({ onReady }: RenderReadySignalProps) {
+    const nodesInitialized = useNodesInitialized();
+
+    useEffect(() => {
+        if (!nodesInitialized) return;
+        const frame = requestAnimationFrame(() => onReady());
+        return () => cancelAnimationFrame(frame);
+    }, [nodesInitialized, onReady]);
+
+    return null;
+}

--- a/calm-hub-ui/src/visualizer/components/reactflow/chromeless.ts
+++ b/calm-hub-ui/src/visualizer/components/reactflow/chromeless.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Shared plumbing for the graphs' chromeless (headless thumbnail render) mode —
+ * see {@link ArchitectureGraph} / {@link PatternGraph} and RenderView. The
+ * empty-state wrapper lives in {@link ChromelessEmptyState}.
+ */
+
+/**
+ * Chromeless fit: the screenshot must show the whole graph in a fixed
+ * card-shaped viewport, so the zoom floor drops well below the interactive
+ * modes' legibility floors — a partially cropped thumbnail is worse than a
+ * small one. maxZoom stays below the interactive cap so a tiny (one/two node)
+ * graph doesn't render as a blown-up close-up in the thumbnail.
+ */
+export const CHROMELESS_FIT_VIEW_OPTIONS = { padding: 0.1, minZoom: 0.05, maxZoom: 0.8 } as const;
+
+/**
+ * Render-readiness state for chromeless mode: `renderReady` turns true when
+ * {@link RenderReadySignal} fires (nodes measured + first paint settled) and is
+ * surfaced as `data-render-ready` on the graph wrapper so calm-server's
+ * headless browser knows the graph is safe to screenshot.
+ */
+export function useChromelessRender() {
+    const [renderReady, setRenderReady] = useState(false);
+    const markRenderReady = useCallback(() => setRenderReady(true), []);
+    return { renderReady, markRenderReady };
+}

--- a/calm-hub-ui/src/visualizer/contracts/visualizer-contracts.ts
+++ b/calm-hub-ui/src/visualizer/contracts/visualizer-contracts.ts
@@ -55,6 +55,14 @@ export interface ArchitectureGraphProps {
     onEdgeClick?: (edge: CalmRelationshipSchema) => void;
     /** Identifies the diagram (namespace/id) so its viewport can be remembered. */
     viewportKey?: string;
+    /**
+     * Headless-render mode (the `/render` route driven by calm-server): suppresses
+     * the Controls, MiniMap and SearchBar chrome (the `<Background>` stays), fits
+     * the whole graph regardless of the desktop zoom floor, and sets
+     * `data-render-ready="true"` on the graph wrapper once nodes are measured and
+     * the first paint has settled. Defaults to false (normal interactive mode).
+     */
+    chromeless?: boolean;
 }
 
 /**

--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -119,6 +119,9 @@ browser. Disabled by default; enabled by configuring the render service URL.
 - `calm.render.timeout-ms` — per-render timeout (default 20000)
 - `calm.render.failure-cache-ttl-ms` — how long a failed render/store is remembered per
   version; GET misses within the window 404 immediately instead of re-rendering (default 60000)
+- `calm.render.max-concurrent-renders` — bound on simultaneous renders (default 2); each
+  render launches a headless browser on the render service. Saturated attempts resolve as
+  a miss (no failure-cache entry) and retry on a later view
 
 **Endpoints** (on `ArchitectureResource`/`PatternResource`, `@PermissionsAllowed(READ)`,
 respond `image/png` or 404):

--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -106,6 +106,38 @@ Resource types are not limited to architectures/patterns/controls — the `resou
 package also covers ADR, Decorator, Domain, Flow, Interface, Standard, Timeline,
 Search, and UserAccess (per-namespace and domain-level access grants).
 
+### Diagram Thumbnails (calm-server render pipeline)
+
+Architecture and pattern versions can carry a rendered PNG thumbnail, produced by an
+external calm-server instance that drives this hub's own UI (`/#/render`) in a headless
+browser. Disabled by default; enabled by configuring the render service URL.
+
+**Configuration** (`application.properties`, unset/commented in all profiles):
+- `calm.render.service-url` — base URL of a calm-server whose `/calm/render/thumbnail`
+  endpoint does the rendering. Unset/empty = feature disabled (thumbnail GETs 404,
+  writes never attempt a render)
+- `calm.render.timeout-ms` — per-render timeout (default 20000)
+- `calm.render.failure-cache-ttl-ms` — how long a failed render/store is remembered per
+  version; GET misses within the window 404 immediately instead of re-rendering (default 60000)
+
+**Endpoints** (on `ArchitectureResource`/`PatternResource`, `@PermissionsAllowed(READ)`,
+respond `image/png` or 404):
+- `GET {namespace}/architectures/{id}/versions/{version}/thumbnail` (patterns likewise)
+- `GET {namespace}/architectures/{id}/thumbnail` — latest version (numeric per-segment
+  version ordering, mirroring the UI's `pickLatestVersion`)
+
+**Flow**: after a successful architecture/pattern write the resource fires an async
+render via `ThumbnailService` (`services/ThumbnailService.java`) — render failures never
+fail the write. A GET for a missing thumbnail attempts a synchronous self-healing render
+(single-flight per `namespace/type/id/version`) before 404ing. Thumbnails are stored
+base64-encoded per version in a `thumbnails` sub-document sibling to `versions` in both
+the Mongo and Nitrite stores, so the version's document value is untouched.
+
+**Deployment caveat**: the pipeline needs the Hub UI and the thumbnail GETs reachable
+without interactive auth (standalone / no-auth / proxy-auth / public-read) — in secure
+OIDC mode the headless browser cannot log in and the browse cards' `<img>` requests
+cannot send bearer tokens, so leave `calm.render.service-url` unset there.
+
 ### Storage Mode Selection
 
 CALM Hub supports pluggable storage backends via CDI Producers:

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Optional;
 
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
@@ -56,7 +54,7 @@ public class ArchitectureResource {
 
     private final ArchitectureStore store;
     private final ArchitectureTimelineService timelineService;
-    private final ThumbnailService thumbnailService;
+    private final ThumbnailEndpointSupport thumbnails;
 
     private final Logger logger = LoggerFactory.getLogger(ArchitectureResource.class);
 
@@ -64,10 +62,10 @@ public class ArchitectureResource {
     Boolean allowPutOperations;
 
     @Inject
-    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService, ThumbnailService thumbnailService) {
+    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService, ThumbnailEndpointSupport thumbnails) {
         this.store = store;
         this.timelineService = timelineService;
-        this.thumbnailService = thumbnailService;
+        this.thumbnails = thumbnails;
     }
 
     /**
@@ -343,78 +341,39 @@ public class ArchitectureResource {
                 .setId(architectureId)
                 .build();
 
-        try {
-            List<String> versions = store.getArchitectureVersions(architecture);
-            Optional<String> latest = ThumbnailService.pickLatestVersion(versions);
-            if (latest.isEmpty()) {
-                return thumbnailNotFoundResponse();
-            }
-            return architectureThumbnailResponse(new Architecture.ArchitectureBuilder()
-                    .setNamespace(namespace)
-                    .setId(architectureId)
-                    .setVersion(latest.get())
-                    .build());
-        } catch (NamespaceNotFoundException | ArchitectureNotFoundException e) {
-            logger.debug("Could not resolve latest version for architecture thumbnail [{}]", architecture, e);
-            return thumbnailNotFoundResponse();
-        }
+        return thumbnails.latestThumbnailResponse(architecture,
+                () -> store.getArchitectureVersions(architecture),
+                version -> architectureThumbnailResponse(new Architecture.ArchitectureBuilder()
+                        .setNamespace(namespace)
+                        .setId(architectureId)
+                        .setVersion(version)
+                        .build()));
     }
 
-    /**
-     * Serves the stored thumbnail for the given architecture version, attempting a
-     * self-healing synchronous render on a miss (single-flight per version). Any
-     * failure resolves to a 404 — thumbnails are best-effort.
-     */
+    /** Thumbnail flow shared with PatternResource — see {@link ThumbnailEndpointSupport}. */
     private Response architectureThumbnailResponse(Architecture architecture) {
-        try {
-            byte[] png = store.getThumbnail(architecture);
-            if (png == null) {
-                png = renderArchitectureThumbnailOnDemand(architecture);
-            }
-            if (png == null) {
-                return thumbnailNotFoundResponse();
-            }
-            return Response.ok(png)
-                    .type("image/png")
-                    .header("Cache-Control", "private, max-age=300")
-                    .build();
-        } catch (NamespaceNotFoundException | ArchitectureNotFoundException | ArchitectureVersionNotFoundException e) {
-            logger.debug("Thumbnail requested for unknown architecture version [{}]", architecture, e);
-            return thumbnailNotFoundResponse();
-        }
-    }
-
-    private byte[] renderArchitectureThumbnailOnDemand(Architecture architecture)
-            throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
-        if (!thumbnailService.isEnabled()) {
-            return null;
-        }
-        String documentJson = store.getArchitectureForVersion(architecture);
-        String key = architecture.getNamespace() + "/architectures/" + architecture.getId() + "/" + architecture.getDotVersion();
-        return thumbnailService.renderSync(key, ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE, documentJson,
-                        bytes -> storeThumbnailQuietly(architecture, bytes))
-                .orElse(null);
+        return thumbnails.thumbnailResponse(
+                thumbnailKey(architecture),
+                ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE,
+                architecture,
+                () -> store.getThumbnail(architecture),
+                () -> store.getArchitectureForVersion(architecture),
+                bytes -> store.storeThumbnail(architecture, bytes));
     }
 
     /** Fire-and-forget render after a successful write; never affects the write response. */
     private void triggerThumbnailRender(Architecture architecture) {
-        String key = architecture.getNamespace() + "/architectures/" + architecture.getId() + "/" + architecture.getDotVersion();
-        thumbnailService.triggerRender(key, ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE, architecture.getArchitectureJson(),
-                bytes -> storeThumbnailQuietly(architecture, bytes));
+        thumbnails.triggerThumbnailRender(
+                thumbnailKey(architecture),
+                ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE,
+                architecture.getArchitectureJson(),
+                architecture,
+                bytes -> store.storeThumbnail(architecture, bytes));
     }
 
-    private void storeThumbnailQuietly(Architecture architecture, byte[] bytes) {
-        try {
-            store.storeThumbnail(architecture, bytes);
-        } catch (NamespaceNotFoundException | ArchitectureNotFoundException | ArchitectureVersionNotFoundException e) {
-            logger.debug("Could not store rendered thumbnail for [{}]", architecture, e);
-        }
-    }
-
-    private Response thumbnailNotFoundResponse() {
-        // Explicit text/plain: the thumbnail endpoints @Produces image/png, and a text
-        // entity must not be negotiated onto the image media type.
-        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").type(MediaType.TEXT_PLAIN).build();
+    /** Single-flight render key: {@code namespace/architectures/id/version}. */
+    private String thumbnailKey(Architecture architecture) {
+        return architecture.getNamespace() + "/architectures/" + architecture.getId() + "/" + architecture.getDotVersion();
     }
 
     private Response architectureWithLocationResponse(Architecture architecture) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -412,7 +412,9 @@ public class ArchitectureResource {
     }
 
     private Response thumbnailNotFoundResponse() {
-        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").build();
+        // Explicit text/plain: the thumbnail endpoints @Produces image/png, and a text
+        // entity must not be negotiated onto the image media type.
+        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").type(MediaType.TEXT_PLAIN).build();
     }
 
     private Response architectureWithLocationResponse(Architecture architecture) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -29,12 +29,15 @@ import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.ArchitectureTimelineService;
+import org.finos.calm.services.ThumbnailService;
 import org.finos.calm.store.ArchitectureStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
 
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
@@ -53,6 +56,7 @@ public class ArchitectureResource {
 
     private final ArchitectureStore store;
     private final ArchitectureTimelineService timelineService;
+    private final ThumbnailService thumbnailService;
 
     private final Logger logger = LoggerFactory.getLogger(ArchitectureResource.class);
 
@@ -60,9 +64,10 @@ public class ArchitectureResource {
     Boolean allowPutOperations;
 
     @Inject
-    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService) {
+    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService, ThumbnailService thumbnailService) {
         this.store = store;
         this.timelineService = timelineService;
+        this.thumbnailService = thumbnailService;
     }
 
     /**
@@ -115,7 +120,9 @@ public class ArchitectureResource {
                 .build();
 
         try {
-            return architectureWithLocationResponse(store.createArchitectureForNamespace(architecture));
+            Architecture persisted = store.createArchitectureForNamespace(architecture);
+            triggerThumbnailRender(persisted);
+            return architectureWithLocationResponse(persisted);
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when creating architecture", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
@@ -207,6 +214,7 @@ public class ArchitectureResource {
 
         try {
             store.createArchitectureForVersion(architecture);
+            triggerThumbnailRender(architecture);
             return architectureWithLocationResponse(architecture);
         } catch (ArchitectureVersionExistsException e) {
             logger.error("Architecture version already exists [{}] when trying to create new architecture", architecture, e);
@@ -252,6 +260,7 @@ public class ArchitectureResource {
 
         try {
             store.updateArchitectureForVersion(architecture);
+            triggerThumbnailRender(architecture);
             return architectureWithLocationResponse(architecture);
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when trying to put architecture", architecture, e);
@@ -293,6 +302,117 @@ public class ArchitectureResource {
             logger.error("Failed to serialise timeline for architecture [{}] in namespace [{}]", architectureId, namespace, e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Failed to build timeline for architecture: " + architectureId).build();
         }
+    }
+
+    @GET
+    @Path("{namespace}/architectures/{architectureId}/versions/{version}/thumbnail")
+    @Produces("image/png")
+    @Operation(
+            summary = "Retrieve the rendered thumbnail for an architecture version",
+            description = "Returns the PNG thumbnail rendered for this architecture version. When absent and a "
+                    + "render service is configured, a synchronous render is attempted before returning 404."
+    )
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getArchitectureThumbnail(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("architectureId") int architectureId,
+            @PathParam("version") @Pattern(regexp = VERSION_REGEX, message = VERSION_MESSAGE) String version) {
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(namespace)
+                .setId(architectureId)
+                .setVersion(version)
+                .build();
+
+        return architectureThumbnailResponse(architecture);
+    }
+
+    @GET
+    @Path("{namespace}/architectures/{architectureId}/thumbnail")
+    @Produces("image/png")
+    @Operation(
+            summary = "Retrieve the rendered thumbnail for an architecture's latest version",
+            description = "Returns the PNG thumbnail of the latest stored version of the architecture. When absent "
+                    + "and a render service is configured, a synchronous render is attempted before returning 404."
+    )
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getLatestArchitectureThumbnail(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("architectureId") int architectureId) {
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(namespace)
+                .setId(architectureId)
+                .build();
+
+        try {
+            List<String> versions = store.getArchitectureVersions(architecture);
+            Optional<String> latest = ThumbnailService.pickLatestVersion(versions);
+            if (latest.isEmpty()) {
+                return thumbnailNotFoundResponse();
+            }
+            return architectureThumbnailResponse(new Architecture.ArchitectureBuilder()
+                    .setNamespace(namespace)
+                    .setId(architectureId)
+                    .setVersion(latest.get())
+                    .build());
+        } catch (NamespaceNotFoundException | ArchitectureNotFoundException e) {
+            logger.debug("Could not resolve latest version for architecture thumbnail [{}]", architecture, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    /**
+     * Serves the stored thumbnail for the given architecture version, attempting a
+     * self-healing synchronous render on a miss (single-flight per version). Any
+     * failure resolves to a 404 — thumbnails are best-effort.
+     */
+    private Response architectureThumbnailResponse(Architecture architecture) {
+        try {
+            byte[] png = store.getThumbnail(architecture);
+            if (png == null) {
+                png = renderArchitectureThumbnailOnDemand(architecture);
+            }
+            if (png == null) {
+                return thumbnailNotFoundResponse();
+            }
+            return Response.ok(png)
+                    .type("image/png")
+                    .header("Cache-Control", "private, max-age=300")
+                    .build();
+        } catch (NamespaceNotFoundException | ArchitectureNotFoundException | ArchitectureVersionNotFoundException e) {
+            logger.debug("Thumbnail requested for unknown architecture version [{}]", architecture, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    private byte[] renderArchitectureThumbnailOnDemand(Architecture architecture)
+            throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        if (!thumbnailService.isEnabled()) {
+            return null;
+        }
+        String documentJson = store.getArchitectureForVersion(architecture);
+        String key = architecture.getNamespace() + "/architectures/" + architecture.getId() + "/" + architecture.getDotVersion();
+        return thumbnailService.renderSync(key, ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE, documentJson,
+                        bytes -> storeThumbnailQuietly(architecture, bytes))
+                .orElse(null);
+    }
+
+    /** Fire-and-forget render after a successful write; never affects the write response. */
+    private void triggerThumbnailRender(Architecture architecture) {
+        String key = architecture.getNamespace() + "/architectures/" + architecture.getId() + "/" + architecture.getDotVersion();
+        thumbnailService.triggerRender(key, ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE, architecture.getArchitectureJson(),
+                bytes -> storeThumbnailQuietly(architecture, bytes));
+    }
+
+    private void storeThumbnailQuietly(Architecture architecture, byte[] bytes) {
+        try {
+            store.storeThumbnail(architecture, bytes);
+        } catch (NamespaceNotFoundException | ArchitectureNotFoundException | ArchitectureVersionNotFoundException e) {
+            logger.debug("Could not store rendered thumbnail for [{}]", architecture, e);
+        }
+    }
+
+    private Response thumbnailNotFoundResponse() {
+        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").build();
     }
 
     private Response architectureWithLocationResponse(Architecture architecture) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -362,7 +362,9 @@ public class PatternResource {
     }
 
     private Response thumbnailNotFoundResponse() {
-        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").build();
+        // Explicit text/plain: the thumbnail endpoints @Produces image/png, and a text
+        // entity must not be negotiated onto the image media type.
+        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").type(MediaType.TEXT_PLAIN).build();
     }
 
     private Response patternWithLocationResponse(Pattern pattern) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -26,8 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Optional;
 
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
@@ -40,7 +38,7 @@ import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX
 public class PatternResource {
 
     private final PatternStore store;
-    private final ThumbnailService thumbnailService;
+    private final ThumbnailEndpointSupport thumbnails;
 
     private final Logger logger = LoggerFactory.getLogger(PatternResource.class);
 
@@ -48,9 +46,9 @@ public class PatternResource {
     Boolean allowPutOperations;
 
     @Inject
-    public PatternResource(PatternStore store, ThumbnailService thumbnailService) {
+    public PatternResource(PatternStore store, ThumbnailEndpointSupport thumbnails) {
         this.store = store;
-        this.thumbnailService = thumbnailService;
+        this.thumbnails = thumbnails;
     }
 
     @GET
@@ -293,78 +291,39 @@ public class PatternResource {
                 .setId(patternId)
                 .build();
 
-        try {
-            List<String> versions = store.getPatternVersions(pattern);
-            Optional<String> latest = ThumbnailService.pickLatestVersion(versions);
-            if (latest.isEmpty()) {
-                return thumbnailNotFoundResponse();
-            }
-            return patternThumbnailResponse(new Pattern.PatternBuilder()
-                    .setNamespace(namespace)
-                    .setId(patternId)
-                    .setVersion(latest.get())
-                    .build());
-        } catch (NamespaceNotFoundException | PatternNotFoundException e) {
-            logger.debug("Could not resolve latest version for pattern thumbnail [{}]", pattern, e);
-            return thumbnailNotFoundResponse();
-        }
+        return thumbnails.latestThumbnailResponse(pattern,
+                () -> store.getPatternVersions(pattern),
+                version -> patternThumbnailResponse(new Pattern.PatternBuilder()
+                        .setNamespace(namespace)
+                        .setId(patternId)
+                        .setVersion(version)
+                        .build()));
     }
 
-    /**
-     * Serves the stored thumbnail for the given pattern version, attempting a
-     * self-healing synchronous render on a miss (single-flight per version). Any
-     * failure resolves to a 404 — thumbnails are best-effort.
-     */
+    /** Thumbnail flow shared with ArchitectureResource — see {@link ThumbnailEndpointSupport}. */
     private Response patternThumbnailResponse(Pattern pattern) {
-        try {
-            byte[] png = store.getThumbnail(pattern);
-            if (png == null) {
-                png = renderPatternThumbnailOnDemand(pattern);
-            }
-            if (png == null) {
-                return thumbnailNotFoundResponse();
-            }
-            return Response.ok(png)
-                    .type("image/png")
-                    .header("Cache-Control", "private, max-age=300")
-                    .build();
-        } catch (NamespaceNotFoundException | PatternNotFoundException | PatternVersionNotFoundException e) {
-            logger.debug("Thumbnail requested for unknown pattern version [{}]", pattern, e);
-            return thumbnailNotFoundResponse();
-        }
-    }
-
-    private byte[] renderPatternThumbnailOnDemand(Pattern pattern)
-            throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
-        if (!thumbnailService.isEnabled()) {
-            return null;
-        }
-        String documentJson = store.getPatternForVersion(pattern);
-        String key = pattern.getNamespace() + "/patterns/" + pattern.getId() + "/" + pattern.getDotVersion();
-        return thumbnailService.renderSync(key, ThumbnailService.DOCUMENT_TYPE_PATTERN, documentJson,
-                        bytes -> storeThumbnailQuietly(pattern, bytes))
-                .orElse(null);
+        return thumbnails.thumbnailResponse(
+                thumbnailKey(pattern),
+                ThumbnailService.DOCUMENT_TYPE_PATTERN,
+                pattern,
+                () -> store.getThumbnail(pattern),
+                () -> store.getPatternForVersion(pattern),
+                bytes -> store.storeThumbnail(pattern, bytes));
     }
 
     /** Fire-and-forget render after a successful write; never affects the write response. */
     private void triggerThumbnailRender(Pattern pattern) {
-        String key = pattern.getNamespace() + "/patterns/" + pattern.getId() + "/" + pattern.getDotVersion();
-        thumbnailService.triggerRender(key, ThumbnailService.DOCUMENT_TYPE_PATTERN, pattern.getPatternJson(),
-                bytes -> storeThumbnailQuietly(pattern, bytes));
+        thumbnails.triggerThumbnailRender(
+                thumbnailKey(pattern),
+                ThumbnailService.DOCUMENT_TYPE_PATTERN,
+                pattern.getPatternJson(),
+                pattern,
+                bytes -> store.storeThumbnail(pattern, bytes));
     }
 
-    private void storeThumbnailQuietly(Pattern pattern, byte[] bytes) {
-        try {
-            store.storeThumbnail(pattern, bytes);
-        } catch (NamespaceNotFoundException | PatternNotFoundException | PatternVersionNotFoundException e) {
-            logger.debug("Could not store rendered thumbnail for [{}]", pattern, e);
-        }
-    }
-
-    private Response thumbnailNotFoundResponse() {
-        // Explicit text/plain: the thumbnail endpoints @Produces image/png, and a text
-        // entity must not be negotiated onto the image media type.
-        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").type(MediaType.TEXT_PLAIN).build();
+    /** Single-flight render key: {@code namespace/patterns/id/version}. */
+    private String thumbnailKey(Pattern pattern) {
+        return pattern.getNamespace() + "/patterns/" + pattern.getId() + "/" + pattern.getDotVersion();
     }
 
     private Response patternWithLocationResponse(Pattern pattern) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -19,12 +19,15 @@ import org.finos.calm.domain.exception.PatternVersionExistsException;
 import org.finos.calm.domain.exception.PatternVersionNotFoundException;
 import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.services.ThumbnailService;
 import org.finos.calm.store.PatternStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
 
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
@@ -37,6 +40,7 @@ import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX
 public class PatternResource {
 
     private final PatternStore store;
+    private final ThumbnailService thumbnailService;
 
     private final Logger logger = LoggerFactory.getLogger(PatternResource.class);
 
@@ -44,8 +48,9 @@ public class PatternResource {
     Boolean allowPutOperations;
 
     @Inject
-    public PatternResource(PatternStore store) {
+    public PatternResource(PatternStore store, ThumbnailService thumbnailService) {
         this.store = store;
+        this.thumbnailService = thumbnailService;
     }
 
     @GET
@@ -84,7 +89,9 @@ public class PatternResource {
             @Valid @NotNull(message = "Request must not be null") CreatePatternRequest patternRequest
     ) throws URISyntaxException {
         try {
-            return patternWithLocationResponse(store.createPatternForNamespace(patternRequest, namespace));
+            Pattern persisted = store.createPatternForNamespace(patternRequest, namespace);
+            triggerThumbnailRender(persisted);
+            return patternWithLocationResponse(persisted);
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when creating pattern", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
@@ -182,6 +189,7 @@ public class PatternResource {
 
         try {
             store.createPatternForVersion(pattern);
+            triggerThumbnailRender(pattern);
             return patternWithLocationResponse(pattern);
         } catch (PatternVersionExistsException e) {
             logger.error("Pattern version already exists [{}] when trying to create new pattern", pattern, e);
@@ -228,6 +236,7 @@ public class PatternResource {
 
         try {
             store.updatePatternForVersion(pattern);
+            triggerThumbnailRender(pattern);
             return patternWithLocationResponse(pattern);
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when trying to put pattern", pattern, e);
@@ -241,6 +250,119 @@ public class PatternResource {
         }
 
 
+    }
+
+    @GET
+    @Path("{namespace}/patterns/{patternId}/versions/{version}/thumbnail")
+    @Produces("image/png")
+    @Operation(
+            summary = "Retrieve the rendered thumbnail for a pattern version",
+            description = "Returns the PNG thumbnail rendered for this pattern version. When absent and a "
+                    + "render service is configured, a synchronous render is attempted before returning 404."
+    )
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getPatternThumbnail(
+            @PathParam("namespace") @jakarta.validation.constraints.Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("patternId") int patternId,
+            @PathParam("version") @jakarta.validation.constraints.Pattern(regexp = VERSION_REGEX, message = VERSION_MESSAGE) String version
+    ) {
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(namespace)
+                .setId(patternId)
+                .setVersion(version)
+                .build();
+
+        return patternThumbnailResponse(pattern);
+    }
+
+    @GET
+    @Path("{namespace}/patterns/{patternId}/thumbnail")
+    @Produces("image/png")
+    @Operation(
+            summary = "Retrieve the rendered thumbnail for a pattern's latest version",
+            description = "Returns the PNG thumbnail of the latest stored version of the pattern. When absent "
+                    + "and a render service is configured, a synchronous render is attempted before returning 404."
+    )
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getLatestPatternThumbnail(
+            @PathParam("namespace") @jakarta.validation.constraints.Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("patternId") int patternId
+    ) {
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(namespace)
+                .setId(patternId)
+                .build();
+
+        try {
+            List<String> versions = store.getPatternVersions(pattern);
+            Optional<String> latest = ThumbnailService.pickLatestVersion(versions);
+            if (latest.isEmpty()) {
+                return thumbnailNotFoundResponse();
+            }
+            return patternThumbnailResponse(new Pattern.PatternBuilder()
+                    .setNamespace(namespace)
+                    .setId(patternId)
+                    .setVersion(latest.get())
+                    .build());
+        } catch (NamespaceNotFoundException | PatternNotFoundException e) {
+            logger.debug("Could not resolve latest version for pattern thumbnail [{}]", pattern, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    /**
+     * Serves the stored thumbnail for the given pattern version, attempting a
+     * self-healing synchronous render on a miss (single-flight per version). Any
+     * failure resolves to a 404 — thumbnails are best-effort.
+     */
+    private Response patternThumbnailResponse(Pattern pattern) {
+        try {
+            byte[] png = store.getThumbnail(pattern);
+            if (png == null) {
+                png = renderPatternThumbnailOnDemand(pattern);
+            }
+            if (png == null) {
+                return thumbnailNotFoundResponse();
+            }
+            return Response.ok(png)
+                    .type("image/png")
+                    .header("Cache-Control", "private, max-age=300")
+                    .build();
+        } catch (NamespaceNotFoundException | PatternNotFoundException | PatternVersionNotFoundException e) {
+            logger.debug("Thumbnail requested for unknown pattern version [{}]", pattern, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    private byte[] renderPatternThumbnailOnDemand(Pattern pattern)
+            throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        if (!thumbnailService.isEnabled()) {
+            return null;
+        }
+        String documentJson = store.getPatternForVersion(pattern);
+        String key = pattern.getNamespace() + "/patterns/" + pattern.getId() + "/" + pattern.getDotVersion();
+        return thumbnailService.renderSync(key, ThumbnailService.DOCUMENT_TYPE_PATTERN, documentJson,
+                        bytes -> storeThumbnailQuietly(pattern, bytes))
+                .orElse(null);
+    }
+
+    /** Fire-and-forget render after a successful write; never affects the write response. */
+    private void triggerThumbnailRender(Pattern pattern) {
+        String key = pattern.getNamespace() + "/patterns/" + pattern.getId() + "/" + pattern.getDotVersion();
+        thumbnailService.triggerRender(key, ThumbnailService.DOCUMENT_TYPE_PATTERN, pattern.getPatternJson(),
+                bytes -> storeThumbnailQuietly(pattern, bytes));
+    }
+
+    private void storeThumbnailQuietly(Pattern pattern, byte[] bytes) {
+        try {
+            store.storeThumbnail(pattern, bytes);
+        } catch (NamespaceNotFoundException | PatternNotFoundException | PatternVersionNotFoundException e) {
+            logger.debug("Could not store rendered thumbnail for [{}]", pattern, e);
+        }
+    }
+
+    private Response thumbnailNotFoundResponse() {
+        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").build();
     }
 
     private Response patternWithLocationResponse(Pattern pattern) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/ThumbnailEndpointSupport.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ThumbnailEndpointSupport.java
@@ -1,0 +1,143 @@
+package org.finos.calm.resources;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.finos.calm.services.ThumbnailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Shared implementation of the thumbnail endpoint flow used by
+ * {@link ArchitectureResource} and {@link PatternResource}: serve the stored
+ * thumbnail, self-heal a miss with a synchronous render, resolve "latest"
+ * versions, and fire the write-path render trigger. The per-type variation
+ * (store lookups, document type, single-flight key, domain exceptions) comes in
+ * as functional parameters; response building (200 png + Cache-Control,
+ * text/plain 404) lives here once.
+ */
+@ApplicationScoped
+public class ThumbnailEndpointSupport {
+
+    private final ThumbnailService thumbnailService;
+    private final Logger logger = LoggerFactory.getLogger(ThumbnailEndpointSupport.class);
+
+    @Inject
+    public ThumbnailEndpointSupport(ThumbnailService thumbnailService) {
+        this.thumbnailService = thumbnailService;
+    }
+
+    /** Store lookup throwing the resource type's checked domain exceptions. */
+    @FunctionalInterface
+    public interface ThumbnailSupplier<T> {
+        T get() throws Exception;
+    }
+
+    /** Store write throwing the resource type's checked domain exceptions. */
+    @FunctionalInterface
+    public interface ThumbnailStore {
+        void store(byte[] png) throws Exception;
+    }
+
+    /**
+     * Serves the stored thumbnail for one resource version, attempting a
+     * self-healing synchronous render on a miss (single-flight per version).
+     * Checked (domain) exceptions resolve to a 404 — thumbnails are best-effort —
+     * while runtime exceptions propagate unchanged.
+     *
+     * @param key                 single-flight key, {@code namespace/type/id/version}
+     * @param documentType        {@link ThumbnailService#DOCUMENT_TYPE_ARCHITECTURE} or
+     *                            {@link ThumbnailService#DOCUMENT_TYPE_PATTERN}
+     * @param logContext          the domain object, logged on failure paths
+     * @param loadStoredThumbnail store lookup for the stored PNG (null = miss)
+     * @param loadDocumentJson    store lookup for the version's raw CALM JSON
+     * @param storeThumbnail      store write for a freshly rendered PNG
+     */
+    public Response thumbnailResponse(String key, String documentType, Object logContext,
+                                      ThumbnailSupplier<byte[]> loadStoredThumbnail,
+                                      ThumbnailSupplier<String> loadDocumentJson,
+                                      ThumbnailStore storeThumbnail) {
+        try {
+            byte[] png = loadStoredThumbnail.get();
+            if (png == null) {
+                png = renderOnDemand(key, documentType, loadDocumentJson, storeThumbnail);
+            }
+            if (png == null) {
+                return thumbnailNotFoundResponse();
+            }
+            return Response.ok(png)
+                    .type("image/png")
+                    .header("Cache-Control", "private, max-age=300")
+                    .build();
+        } catch (RuntimeException e) {
+            // Only the stores' checked domain exceptions mean "no thumbnail here".
+            throw e;
+        } catch (Exception e) {
+            logger.debug("Thumbnail requested for unknown resource version [{}]", logContext, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    /**
+     * Resolves the resource's latest stored version (mirroring the UI's
+     * {@code pickLatestVersion} ordering) and delegates to {@code versionThumbnail}.
+     *
+     * @param logContext       the domain object, logged on failure paths
+     * @param versionsSupplier store lookup for the resource's version list
+     * @param versionThumbnail builds the response for the resolved latest version
+     */
+    public Response latestThumbnailResponse(Object logContext,
+                                            ThumbnailSupplier<List<String>> versionsSupplier,
+                                            Function<String, Response> versionThumbnail) {
+        try {
+            Optional<String> latest = ThumbnailService.pickLatestVersion(versionsSupplier.get());
+            if (latest.isEmpty()) {
+                return thumbnailNotFoundResponse();
+            }
+            return versionThumbnail.apply(latest.get());
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.debug("Could not resolve latest version for thumbnail [{}]", logContext, e);
+            return thumbnailNotFoundResponse();
+        }
+    }
+
+    /** Fire-and-forget render after a successful write; never affects the write response. */
+    public void triggerThumbnailRender(String key, String documentType, String documentJson,
+                                       Object logContext, ThumbnailStore storeThumbnail) {
+        thumbnailService.triggerRender(key, documentType, documentJson,
+                bytes -> storeQuietly(logContext, bytes, storeThumbnail));
+    }
+
+    private byte[] renderOnDemand(String key, String documentType,
+                                  ThumbnailSupplier<String> loadDocumentJson,
+                                  ThumbnailStore storeThumbnail) throws Exception {
+        if (!thumbnailService.isEnabled()) {
+            return null;
+        }
+        String documentJson = loadDocumentJson.get();
+        return thumbnailService.renderSync(key, documentType, documentJson,
+                        bytes -> storeQuietly(key, bytes, storeThumbnail))
+                .orElse(null);
+    }
+
+    private void storeQuietly(Object logContext, byte[] bytes, ThumbnailStore storeThumbnail) {
+        try {
+            storeThumbnail.store(bytes);
+        } catch (Exception e) {
+            logger.debug("Could not store rendered thumbnail for [{}]", logContext, e);
+        }
+    }
+
+    private Response thumbnailNotFoundResponse() {
+        // Explicit text/plain: the thumbnail endpoints @Produces image/png, and a text
+        // entity must not be negotiated onto the image media type.
+        return Response.status(Response.Status.NOT_FOUND).entity("No thumbnail available").type(MediaType.TEXT_PLAIN).build();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
@@ -86,7 +86,9 @@ public class ThumbnailService {
 
     /** Visible-for-testing constructor allowing an injected {@link HttpClient}. */
     ThumbnailService(String renderServiceUrl, String uiBaseUrl, long timeoutMs, long failureCacheTtlMs, HttpClient httpClient) {
-        this.renderServiceUrl = renderServiceUrl == null ? "" : renderServiceUrl.trim();
+        // Trailing slashes are stripped so a configured base URL of "http://host:3000/"
+        // doesn't produce a double-slash render path (mirrors calm-server's uiBaseUrl handling).
+        this.renderServiceUrl = renderServiceUrl == null ? "" : renderServiceUrl.trim().replaceAll("/+$", "");
         this.uiBaseUrl = uiBaseUrl;
         this.timeoutMs = timeoutMs;
         this.failureCacheTtlMs = failureCacheTtlMs;

--- a/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -62,6 +63,17 @@ public class ThumbnailService {
     private final long failureCacheTtlMs;
     private final HttpClient httpClient;
 
+    /**
+     * Bounds concurrent renders ({@code calm.render.max-concurrent-renders}): each render
+     * costs calm-server a full headless-browser launch, so an unbounded burst (a browse
+     * page of misses) could fork dozens of Chrome processes. Only render OWNERS acquire a
+     * permit — joiners just wait on the shared future. Acquisition is non-blocking: when
+     * saturated the attempt resolves empty WITHOUT entering the failure cache, so the next
+     * view retries rather than being 404-pinned for the TTL.
+     */
+    private final Semaphore renderPermits;
+    private final int maxConcurrentRenders;
+
     /** In-flight renders keyed by {@code namespace/type/id/version} (single-flight). */
     private final ConcurrentHashMap<String, CompletableFuture<Optional<byte[]>>> inFlight = new ConcurrentHashMap<>();
 
@@ -78,20 +90,24 @@ public class ThumbnailService {
             @ConfigProperty(name = "calm.render.service-url") Optional<String> renderServiceUrl,
             @ConfigProperty(name = "calm.hub.base-url", defaultValue = "http://localhost:8080") String uiBaseUrl,
             @ConfigProperty(name = "calm.render.timeout-ms", defaultValue = "20000") long timeoutMs,
-            @ConfigProperty(name = "calm.render.failure-cache-ttl-ms", defaultValue = "60000") long failureCacheTtlMs) {
-        this(renderServiceUrl.orElse(""), uiBaseUrl, timeoutMs, failureCacheTtlMs, HttpClient.newBuilder()
+            @ConfigProperty(name = "calm.render.failure-cache-ttl-ms", defaultValue = "60000") long failureCacheTtlMs,
+            @ConfigProperty(name = "calm.render.max-concurrent-renders", defaultValue = "2") int maxConcurrentRenders) {
+        this(renderServiceUrl.orElse(""), uiBaseUrl, timeoutMs, failureCacheTtlMs, maxConcurrentRenders, HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build());
     }
 
     /** Visible-for-testing constructor allowing an injected {@link HttpClient}. */
-    ThumbnailService(String renderServiceUrl, String uiBaseUrl, long timeoutMs, long failureCacheTtlMs, HttpClient httpClient) {
+    ThumbnailService(String renderServiceUrl, String uiBaseUrl, long timeoutMs, long failureCacheTtlMs,
+                     int maxConcurrentRenders, HttpClient httpClient) {
         // Trailing slashes are stripped so a configured base URL of "http://host:3000/"
         // doesn't produce a double-slash render path (mirrors calm-server's uiBaseUrl handling).
         this.renderServiceUrl = renderServiceUrl == null ? "" : renderServiceUrl.trim().replaceAll("/+$", "");
         this.uiBaseUrl = uiBaseUrl;
         this.timeoutMs = timeoutMs;
         this.failureCacheTtlMs = failureCacheTtlMs;
+        this.maxConcurrentRenders = maxConcurrentRenders;
+        this.renderPermits = new Semaphore(maxConcurrentRenders);
         this.httpClient = httpClient;
     }
 
@@ -146,6 +162,15 @@ public class ThumbnailService {
      * collapse onto a single render. On success {@code storeCallback} is invoked with the bytes
      * before they are returned.
      *
+     * <p><b>Stale-render race:</b> a GET-miss that joins an already in-flight render can be
+     * returned a render of content that a concurrent same-version update just replaced, and
+     * that client then pins the stale image for up to the response's Cache-Control max-age
+     * (5 minutes). The write path converges the STORE: {@link #triggerRender}'s non-owner
+     * chase re-renders the new content once the in-flight render completes, so staleness is
+     * bounded to that one client's cache window. The read path deliberately does NOT chase:
+     * concurrent GETs for the same missing thumbnail are the common case this single-flight
+     * exists for, and chasing per joiner would fire N renders for one page of cards.</p>
+     *
      * @param key           single-flight key, {@code namespace/type/id/version}
      * @param documentType  {@link #DOCUMENT_TYPE_ARCHITECTURE} or {@link #DOCUMENT_TYPE_PATTERN}
      * @param documentJson  the raw CALM JSON document as a string
@@ -192,6 +217,15 @@ public class ThumbnailService {
             return new CompletableFuture<>();
         });
         if (owner.get()) {
+            if (!renderPermits.tryAcquire()) {
+                // Saturated: resolve this attempt empty WITHOUT touching the failure
+                // cache — saturation is transient, and the next view should retry
+                // rather than be 404-pinned for the failure TTL.
+                logger.debug("Thumbnail render for [{}] skipped: {} renders already in flight", key, maxConcurrentRenders);
+                inFlight.remove(key);
+                future.complete(Optional.empty());
+                return new RenderAttempt(future, true);
+            }
             sendRenderRequest(documentType, documentJson)
                     .thenApply(png -> {
                         boolean stored = png.isPresent() && safeStore(key, png.get(), storeCallback);
@@ -210,8 +244,12 @@ public class ThumbnailService {
                         return Optional.<byte[]>empty();
                     })
                     .whenComplete((result, t) -> {
-                        // Remove before completing so a caller observing completion
-                        // and re-requesting always triggers a fresh render.
+                        // The async "finally": the permit is released however the
+                        // pipeline ended (sendRenderRequest never throws synchronously —
+                        // it converts failures into a failed future — so this stage
+                        // always runs). Remove before completing so a caller observing
+                        // completion and re-requesting always triggers a fresh render.
+                        renderPermits.release();
                         inFlight.remove(key);
                         future.complete(result == null ? Optional.empty() : result);
                     });

--- a/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/ThumbnailService.java
@@ -1,0 +1,311 @@
+package org.finos.calm.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Client for the calm-server thumbnail render endpoint.
+ *
+ * <p>Asks a configured calm-server instance ({@code calm.render.service-url}) to render a PNG
+ * thumbnail of an architecture or pattern document by driving this hub's own UI in a headless
+ * browser, so the thumbnail is pixel-identical to the diagram users see.</p>
+ *
+ * <p>The feature is disabled gracefully when {@code calm.render.service-url} is unset/empty:
+ * every method becomes a no-op / returns empty. Render failures are never propagated to
+ * callers — a failed render only means a missing thumbnail.</p>
+ *
+ * <p><b>Single-flight:</b> renders are keyed by {@code namespace/type/id/version}; concurrent
+ * requests for the same key (e.g. several browse pages hitting the same missing thumbnail)
+ * collapse onto one in-flight render.</p>
+ *
+ * <p><b>Failure caching:</b> a failed render (or a failed thumbnail store, e.g. in read-only
+ * mode) is remembered per key for {@code calm.render.failure-cache-ttl-ms} (default 60s).
+ * Read-path misses within the TTL return empty immediately instead of re-attempting a doomed
+ * render on every page view; write-path renders are never gated (a new write means new content
+ * worth rendering) and a successful render+store clears the cached failure.</p>
+ */
+@ApplicationScoped
+public class ThumbnailService {
+
+    public static final String DOCUMENT_TYPE_ARCHITECTURE = "architecture";
+    public static final String DOCUMENT_TYPE_PATTERN = "pattern";
+
+    private static final String RENDER_PATH = "/calm/render/thumbnail";
+    /** Extra grace on the whole HTTP exchange beyond the render timeout requested of calm-server. */
+    private static final long TIMEOUT_GRACE_MS = 5000;
+
+    private final Logger logger = LoggerFactory.getLogger(ThumbnailService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String renderServiceUrl;
+    private final String uiBaseUrl;
+    private final long timeoutMs;
+    private final long failureCacheTtlMs;
+    private final HttpClient httpClient;
+
+    /** In-flight renders keyed by {@code namespace/type/id/version} (single-flight). */
+    private final ConcurrentHashMap<String, CompletableFuture<Optional<byte[]>>> inFlight = new ConcurrentHashMap<>();
+
+    /** Recent per-key render/store failures (epoch millis) gating read-path retries. */
+    private final ConcurrentHashMap<String, Long> recentFailures = new ConcurrentHashMap<>();
+
+    /** A single-flight render attempt: the shared future and whether this call started it. */
+    private record RenderAttempt(CompletableFuture<Optional<byte[]>> future, boolean owner) {
+    }
+
+    @Inject
+    public ThumbnailService(
+            // Optional because SmallRye rejects an empty-string defaultValue: absent == disabled.
+            @ConfigProperty(name = "calm.render.service-url") Optional<String> renderServiceUrl,
+            @ConfigProperty(name = "calm.hub.base-url", defaultValue = "http://localhost:8080") String uiBaseUrl,
+            @ConfigProperty(name = "calm.render.timeout-ms", defaultValue = "20000") long timeoutMs,
+            @ConfigProperty(name = "calm.render.failure-cache-ttl-ms", defaultValue = "60000") long failureCacheTtlMs) {
+        this(renderServiceUrl.orElse(""), uiBaseUrl, timeoutMs, failureCacheTtlMs, HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build());
+    }
+
+    /** Visible-for-testing constructor allowing an injected {@link HttpClient}. */
+    ThumbnailService(String renderServiceUrl, String uiBaseUrl, long timeoutMs, long failureCacheTtlMs, HttpClient httpClient) {
+        this.renderServiceUrl = renderServiceUrl == null ? "" : renderServiceUrl.trim();
+        this.uiBaseUrl = uiBaseUrl;
+        this.timeoutMs = timeoutMs;
+        this.failureCacheTtlMs = failureCacheTtlMs;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Whether thumbnail rendering is configured. When false all render methods are no-ops.
+     *
+     * @return true when {@code calm.render.service-url} is set
+     */
+    public boolean isEnabled() {
+        return !renderServiceUrl.isEmpty();
+    }
+
+    /**
+     * Fire-and-forget render used on the document write path. Kicks off an asynchronous render
+     * and invokes {@code storeCallback} with the PNG bytes on success. Failures (including a
+     * throwing callback) are logged and swallowed — this method NEVER throws to the caller, so
+     * a render problem cannot fail a document write.
+     *
+     * @param key           single-flight key, {@code namespace/type/id/version}
+     * @param documentType  {@link #DOCUMENT_TYPE_ARCHITECTURE} or {@link #DOCUMENT_TYPE_PATTERN}
+     * @param documentJson  the raw CALM JSON document as a string
+     * @param storeCallback invoked with the PNG bytes when the render succeeds
+     */
+    public void triggerRender(String key, String documentType, String documentJson, Consumer<byte[]> storeCallback) {
+        if (!isEnabled()) {
+            return;
+        }
+        try {
+            RenderAttempt attempt = renderSingleFlight(key, documentType, documentJson, storeCallback);
+            if (!attempt.owner()) {
+                // A render for this key was already in flight — necessarily of an older
+                // (or at best equal) document, whose result would be stale for this write.
+                // Chain exactly one follow-up render of THIS write's document after the
+                // in-flight one completes. Bounded: the follow-up is itself single-flight,
+                // so writes that join it don't chain off each other indefinitely.
+                attempt.future().whenComplete((result, t) -> {
+                    try {
+                        renderSingleFlight(key, documentType, documentJson, storeCallback);
+                    } catch (Exception e) {
+                        logger.debug("Failed to re-render thumbnail after in-flight render for [{}]", key, e);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to trigger thumbnail render for [{}]", key, e);
+        }
+    }
+
+    /**
+     * Blocking render used by the GET-miss (self-healing) path. Waits for the render to complete,
+     * bounded by {@code calm.render.timeout-ms} (+grace). Concurrent calls for the same key
+     * collapse onto a single render. On success {@code storeCallback} is invoked with the bytes
+     * before they are returned.
+     *
+     * @param key           single-flight key, {@code namespace/type/id/version}
+     * @param documentType  {@link #DOCUMENT_TYPE_ARCHITECTURE} or {@link #DOCUMENT_TYPE_PATTERN}
+     * @param documentJson  the raw CALM JSON document as a string
+     * @param storeCallback invoked with the PNG bytes when the render succeeds
+     * @return the PNG bytes, or empty when disabled, recently failed, or the render failed
+     */
+    public Optional<byte[]> renderSync(String key, String documentType, String documentJson, Consumer<byte[]> storeCallback) {
+        if (!isEnabled()) {
+            return Optional.empty();
+        }
+        if (isRecentlyFailed(key)) {
+            logger.debug("Skipping thumbnail render for [{}]: failed within the last {}ms", key, failureCacheTtlMs);
+            return Optional.empty();
+        }
+        try {
+            return renderSingleFlight(key, documentType, documentJson, storeCallback).future().join();
+        } catch (Exception e) {
+            logger.debug("Thumbnail render failed for [{}]", key, e);
+            return Optional.empty();
+        }
+    }
+
+    private boolean isRecentlyFailed(String key) {
+        Long failedAt = recentFailures.get(key);
+        if (failedAt == null) {
+            return false;
+        }
+        if (System.currentTimeMillis() - failedAt >= failureCacheTtlMs) {
+            recentFailures.remove(key, failedAt);
+            return false;
+        }
+        return true;
+    }
+
+    private RenderAttempt renderSingleFlight(
+            String key, String documentType, String documentJson, Consumer<byte[]> storeCallback) {
+        // The render pipeline must start only AFTER the future is inserted: kicking it
+        // off inside computeIfAbsent's mapping function would let a synchronously
+        // completing render run whenComplete's inFlight.remove during the compute —
+        // a forbidden recursive map modification that silently loses the cleanup.
+        AtomicBoolean owner = new AtomicBoolean(false);
+        CompletableFuture<Optional<byte[]>> future = inFlight.computeIfAbsent(key, k -> {
+            owner.set(true);
+            return new CompletableFuture<>();
+        });
+        if (owner.get()) {
+            sendRenderRequest(documentType, documentJson)
+                    .thenApply(png -> {
+                        boolean stored = png.isPresent() && safeStore(key, png.get(), storeCallback);
+                        if (stored) {
+                            recentFailures.remove(key);
+                        } else {
+                            // Failed render OR failed store (e.g. read-only mode): remember it
+                            // so read-path misses don't re-attempt on every page view.
+                            recentFailures.put(key, System.currentTimeMillis());
+                        }
+                        return png;
+                    })
+                    .exceptionally(t -> {
+                        logger.debug("Thumbnail render request failed for [{}]", key, t);
+                        recentFailures.put(key, System.currentTimeMillis());
+                        return Optional.<byte[]>empty();
+                    })
+                    .whenComplete((result, t) -> {
+                        // Remove before completing so a caller observing completion
+                        // and re-requesting always triggers a fresh render.
+                        inFlight.remove(key);
+                        future.complete(result == null ? Optional.empty() : result);
+                    });
+        }
+        return new RenderAttempt(future, owner.get());
+    }
+
+    private CompletableFuture<Optional<byte[]>> sendRenderRequest(String documentType, String documentJson) {
+        try {
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("uiBaseUrl", uiBaseUrl);
+            body.put("documentType", documentType);
+            body.put("documentJson", documentJson);
+            body.put("timeoutMs", timeoutMs);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(renderServiceUrl + RENDER_PATH))
+                    .timeout(Duration.ofMillis(timeoutMs + TIMEOUT_GRACE_MS))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)))
+                    .build();
+
+            return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofByteArray())
+                    .orTimeout(timeoutMs + TIMEOUT_GRACE_MS, TimeUnit.MILLISECONDS)
+                    .thenApply(response -> {
+                        if (response.statusCode() == 200) {
+                            return Optional.of(response.body());
+                        }
+                        logger.debug("Thumbnail render service returned status [{}]", response.statusCode());
+                        return Optional.empty();
+                    });
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private boolean safeStore(String key, byte[] bytes, Consumer<byte[]> storeCallback) {
+        try {
+            storeCallback.accept(bytes);
+            return true;
+        } catch (Exception e) {
+            logger.debug("Failed to store rendered thumbnail for [{}]", key, e);
+            return false;
+        }
+    }
+
+    /**
+     * Picks the latest version from a list, mirroring the Hub UI's
+     * {@code pickLatestVersion} ordering semantics (calm-hub-ui/src/model/version.ts):
+     * split on dots and compare segment-by-segment, numerically where both segments
+     * are numeric (a missing trailing segment counts as 0), falling back to a string
+     * compare for non-numeric segments.
+     *
+     * @param versions the available dot-format versions
+     * @return the latest version, or empty when the list is empty
+     */
+    public static Optional<String> pickLatestVersion(List<String> versions) {
+        if (versions == null || versions.isEmpty()) {
+            return Optional.empty();
+        }
+        return versions.stream().max(Comparator.comparing(v -> v, ThumbnailService::compareVersions));
+    }
+
+    private static int compareVersions(String a, String b) {
+        String[] segsA = a.split("\\.");
+        String[] segsB = b.split("\\.");
+        int len = Math.max(segsA.length, segsB.length);
+        for (int i = 0; i < len; i++) {
+            String rawA = i < segsA.length ? segsA[i] : "";
+            String rawB = i < segsB.length ? segsB[i] : "";
+            Long numA = parseSegment(rawA, i >= segsA.length);
+            Long numB = parseSegment(rawB, i >= segsB.length);
+            if (numA != null && numB != null) {
+                int cmp = Long.compare(numA, numB);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            } else if (!rawA.equals(rawB)) {
+                return rawA.compareTo(rawB);
+            }
+        }
+        return 0;
+    }
+
+    /** Numeric value of a segment, a missing trailing segment counting as 0; null when non-numeric. */
+    private static Long parseSegment(String raw, boolean missing) {
+        if (missing) {
+            return 0L;
+        }
+        if (raw.isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
@@ -34,4 +34,23 @@ public interface ArchitectureStore {
     String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException;
     Architecture createArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionExistsException;
     Architecture updateArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException;
+
+    /**
+     * Store a rendered PNG thumbnail for the architecture version identified by
+     * {@code architecture} (namespace, id, version). Stored base64-encoded alongside —
+     * never inside — the version's document value, so the document itself is untouched.
+     *
+     * @param architecture the architecture version the thumbnail belongs to
+     * @param png          the PNG bytes to store
+     */
+    void storeThumbnail(Architecture architecture, byte[] png) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException;
+
+    /**
+     * Retrieve the stored thumbnail for the architecture version identified by
+     * {@code architecture} (namespace, id, version).
+     *
+     * @param architecture the architecture version to fetch the thumbnail for
+     * @return the PNG bytes, or {@code null} when no thumbnail is stored for the version
+     */
+    byte[] getThumbnail(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
@@ -36,4 +36,23 @@ public interface PatternStore {
     String getPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;
     Pattern createPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionExistsException;
     Pattern updatePatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException;
+
+    /**
+     * Store a rendered PNG thumbnail for the pattern version identified by
+     * {@code pattern} (namespace, id, version). Stored base64-encoded alongside —
+     * never inside — the version's document value, so the document itself is untouched.
+     *
+     * @param pattern the pattern version the thumbnail belongs to
+     * @param png     the PNG bytes to store
+     */
+    void storeThumbnail(Pattern pattern, byte[] png) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;
+
+    /**
+     * Retrieve the stored thumbnail for the pattern version identified by
+     * {@code pattern} (namespace, id, version).
+     *
+     * @param pattern the pattern version to fetch the thumbnail for
+     * @return the PNG bytes, or {@code null} when no thumbnail is stored for the version
+     */
+    byte[] getThumbnail(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -236,6 +237,41 @@ public class MongoArchitectureStore implements ArchitectureStore {
 
         writeArchitectureToMongo(architecture);
         return architecture;
+    }
+
+    @Override
+    public void storeThumbnail(Architecture architecture, byte[] png) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // Validates namespace, architecture and version existence — no orphan thumbnails.
+        getArchitectureForVersion(architecture);
+
+        // Thumbnails live in a sibling sub-document keyed by dashed version
+        // (thumbnails.<1-0-0>), so the version's document value is untouched.
+        Document filter = new Document("namespace", architecture.getNamespace())
+                .append("architectures.architectureId", architecture.getId());
+        Document update = new Document("$set",
+                new Document("architectures.$.thumbnails." + architecture.getMongoVersion(),
+                        Base64.getEncoder().encodeToString(png)));
+
+        architectureCollection.updateOne(filter, update);
+    }
+
+    @Override
+    public byte[] getThumbnail(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        Document result = retrieveArchitectureVersions(architecture);
+
+        List<Document> architectures = result.getList("architectures", Document.class);
+        for (Document architectureDoc : architectures) {
+            if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
+                Document thumbnails = (Document) architectureDoc.get("thumbnails");
+                if (thumbnails == null) {
+                    return null;
+                }
+                String encoded = thumbnails.getString(architecture.getMongoVersion());
+                return encoded == null ? null : Base64.getDecoder().decode(encoded);
+            }
+        }
+
+        throw new ArchitectureNotFoundException();
     }
 
     private void writeArchitectureToMongo(Architecture architecture) throws ArchitectureNotFoundException, NamespaceNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -232,6 +233,41 @@ public class MongoPatternStore implements PatternStore {
         }
         writePatternToMongo(pattern);
         return pattern;
+    }
+
+    @Override
+    public void storeThumbnail(Pattern pattern, byte[] png) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // Validates namespace, pattern and version existence — no orphan thumbnails.
+        getPatternForVersion(pattern);
+
+        // Thumbnails live in a sibling sub-document keyed by dashed version
+        // (thumbnails.<1-0-0>), so the version's document value is untouched.
+        Document filter = new Document("namespace", pattern.getNamespace())
+                .append("patterns.patternId", pattern.getId());
+        Document update = new Document("$set",
+                new Document("patterns.$.thumbnails." + pattern.getMongoVersion(),
+                        Base64.getEncoder().encodeToString(png)));
+
+        patternCollection.updateOne(filter, update);
+    }
+
+    @Override
+    public byte[] getThumbnail(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        Document result = retrievePatternVersions(pattern);
+
+        List<Document> patterns = result.getList("patterns", Document.class);
+        for (Document patternDoc : patterns) {
+            if (pattern.getId() == patternDoc.getInteger("patternId")) {
+                Document thumbnails = (Document) patternDoc.get("thumbnails");
+                if (thumbnails == null) {
+                    return null;
+                }
+                String encoded = thumbnails.getString(pattern.getMongoVersion());
+                return encoded == null ? null : Base64.getDecoder().decode(encoded);
+            }
+        }
+
+        throw new PatternNotFoundException();
     }
 
     private void writePatternToMongo(Pattern pattern) throws PatternNotFoundException, NamespaceNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -17,6 +17,7 @@ import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.NitriteDocumentMutationResult;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -286,42 +288,63 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         lock.lock();
         try {
-            Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
-            Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
-            if (namespaceDoc == null) {
-                throw new NamespaceNotFoundException();
+            NitriteDocumentMutationResult result = mutateArchitectureDocument(
+                    architecture.getNamespace(), architecture.getId(), architectureDoc -> {
+                        // Thumbnails live in a sibling nested document keyed by dashed
+                        // version, so the version's JSON string value is untouched.
+                        Document thumbnails = architectureDoc.get(THUMBNAILS_FIELD, Document.class);
+                        if (thumbnails == null) {
+                            thumbnails = Document.createDocument();
+                        }
+                        thumbnails.put(architecture.getMongoVersion(), Base64.getEncoder().encodeToString(png));
+                        architectureDoc.put(THUMBNAILS_FIELD, thumbnails);
+                        return true;
+                    });
+            switch (result) {
+                case NAMESPACE_DOCUMENT_MISSING -> throw new NamespaceNotFoundException();
+                case RESOURCE_MISSING, ABORTED -> throw new ArchitectureNotFoundException();
+                case UPDATED -> LOG.debug("Stored thumbnail for version '{}' of architecture {} in namespace '{}'",
+                        architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
             }
-
-            List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
-            if (architectures == null) {
-                throw new ArchitectureNotFoundException();
-            }
-            architectures = new ArrayList<>(architectures); // Make a mutable copy
-
-            for (int i = 0; i < architectures.size(); i++) {
-                Document architectureDoc = architectures.get(i);
-                if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architecture.getId()) {
-                    // Thumbnails live in a sibling nested document keyed by dashed
-                    // version, so the version's JSON string value is untouched.
-                    Document thumbnails = architectureDoc.get(THUMBNAILS_FIELD, Document.class);
-                    if (thumbnails == null) {
-                        thumbnails = Document.createDocument();
-                    }
-                    thumbnails.put(architecture.getMongoVersion(), Base64.getEncoder().encodeToString(png));
-                    architectureDoc.put(THUMBNAILS_FIELD, thumbnails);
-                    architectures.set(i, architectureDoc);
-                    namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
-                    architectureCollection.update(filter, namespaceDoc);
-                    LOG.debug("Stored thumbnail for version '{}' of architecture {} in namespace '{}'",
-                            architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                    return;
-                }
-            }
-
-            throw new ArchitectureNotFoundException();
         } finally {
             lock.unlock();
         }
+    }
+
+    /**
+     * Shared find→mutate→splice→persist sequence for a single architecture document
+     * inside its namespace document, used by the version-write and thumbnail-write
+     * paths. {@code mutation} returns false to abort without persisting. Callers must
+     * hold {@code lock} — this helper does not lock, so the caller's lock scope covers
+     * the whole read-modify-write.
+     */
+    private NitriteDocumentMutationResult mutateArchitectureDocument(
+            String namespace, int architectureId, Function<Document, Boolean> mutation) {
+        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+        Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
+        if (namespaceDoc == null) {
+            return NitriteDocumentMutationResult.NAMESPACE_DOCUMENT_MISSING;
+        }
+
+        List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
+        if (architectures == null) {
+            return NitriteDocumentMutationResult.RESOURCE_MISSING;
+        }
+        architectures = new ArrayList<>(architectures); // Make a mutable copy
+
+        for (int i = 0; i < architectures.size(); i++) {
+            Document architectureDoc = architectures.get(i);
+            if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architectureId) {
+                if (!mutation.apply(architectureDoc)) {
+                    return NitriteDocumentMutationResult.ABORTED;
+                }
+                architectures.set(i, architectureDoc);
+                namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
+                architectureCollection.update(filter, namespaceDoc);
+                return NitriteDocumentMutationResult.UPDATED;
+            }
+        }
+        return NitriteDocumentMutationResult.RESOURCE_MISSING;
     }
 
     @Override
@@ -370,49 +393,26 @@ public class NitriteArchitectureStore implements ArchitectureStore {
             // First verify the architecture exists
             retrieveArchitectureVersions(architecture);
 
-            // Store the architecture JSON as a string directly
-            // No need to parse it to a Document
-
-            // Find the namespace document
-            Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
-            Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc != null) {
-                // Find the architecture document
-                List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
-                if (architectures != null) {
-                    // Create a mutable copy of the list
-                    architectures = new ArrayList<>(architectures);
-                    boolean found = false;
-                    for (int i = 0; i < architectures.size(); i++) {
-                        Document architectureDoc = architectures.get(i);
-                        if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architecture.getId()) {
-                            // Found the architecture, update its version
-                            Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                            if (versions == null) {
-                                throw new ArchitectureNotFoundException();
-                            }
-                            versions.put(architecture.getMongoVersion(), architecture.getArchitectureJson());
-                            architectureDoc.put(NAME_FIELD, architecture.getName());
-                            architectureDoc.put(DESCRIPTION_FIELD, architecture.getDescription());
-                            architectureDoc.put(VERSIONS_FIELD, versions);
-                            architectures.set(i, architectureDoc);
-                            found = true;
-                            break;
+            // Store the architecture JSON as a string directly (no need to parse it
+            // to a Document); shared find/splice/persist sequence lives in the helper.
+            NitriteDocumentMutationResult result = mutateArchitectureDocument(
+                    architecture.getNamespace(), architecture.getId(), architectureDoc -> {
+                        Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                        if (versions == null) {
+                            return false;
                         }
-                    }
+                        versions.put(architecture.getMongoVersion(), architecture.getArchitectureJson());
+                        architectureDoc.put(NAME_FIELD, architecture.getName());
+                        architectureDoc.put(DESCRIPTION_FIELD, architecture.getDescription());
+                        architectureDoc.put(VERSIONS_FIELD, versions);
+                        return true;
+                    });
 
-                    if (found) {
-                        // Update the namespace document with the modified architectures list
-                        namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
-                        architectureCollection.update(filter, namespaceDoc);
-                        LOG.info("Updated version '{}' for architecture {} in namespace '{}'",
-                                architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                        return;
-                    }
-                }
+            if (result == NitriteDocumentMutationResult.UPDATED) {
+                LOG.info("Updated version '{}' for architecture {} in namespace '{}'",
+                        architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
+                return;
             }
-
             LOG.error("Failed to write architecture to Nitrite [{}]", architecture);
             throw new ArchitectureNotFoundException();
         } catch (NamespaceNotFoundException e) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -46,6 +47,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
     private static final String ARCHITECTURE_ID_FIELD = "architectureId";
     private static final String ARCHITECTURES_FIELD = "architectures";
     private static final String VERSIONS_FIELD = "versions";
+    private static final String THUMBNAILS_FIELD = "thumbnails";
     private static final String NAME_FIELD = "name";
     private static final String DESCRIPTION_FIELD = "description";
 
@@ -265,8 +267,80 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         validateArchitectureJson(architecture.getArchitectureJson());
 
-        writeArchitectureToNitrite(architecture);
+        // Locked like the create path: the write is a whole-namespace-document
+        // read-modify-write, so an unlocked update racing another RMW (e.g. an async
+        // storeThumbnail callback) could silently discard this PUT's content.
+        lock.lock();
+        try {
+            writeArchitectureToNitrite(architecture);
+        } finally {
+            lock.unlock();
+        }
         return architecture;
+    }
+
+    @Override
+    public void storeThumbnail(Architecture architecture, byte[] png) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // Validates namespace, architecture and version existence — no orphan thumbnails.
+        getArchitectureForVersion(architecture);
+
+        lock.lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
+            Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
+            if (namespaceDoc == null) {
+                throw new NamespaceNotFoundException();
+            }
+
+            List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
+            if (architectures == null) {
+                throw new ArchitectureNotFoundException();
+            }
+            architectures = new ArrayList<>(architectures); // Make a mutable copy
+
+            for (int i = 0; i < architectures.size(); i++) {
+                Document architectureDoc = architectures.get(i);
+                if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architecture.getId()) {
+                    // Thumbnails live in a sibling nested document keyed by dashed
+                    // version, so the version's JSON string value is untouched.
+                    Document thumbnails = architectureDoc.get(THUMBNAILS_FIELD, Document.class);
+                    if (thumbnails == null) {
+                        thumbnails = Document.createDocument();
+                    }
+                    thumbnails.put(architecture.getMongoVersion(), Base64.getEncoder().encodeToString(png));
+                    architectureDoc.put(THUMBNAILS_FIELD, thumbnails);
+                    architectures.set(i, architectureDoc);
+                    namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
+                    architectureCollection.update(filter, namespaceDoc);
+                    LOG.debug("Stored thumbnail for version '{}' of architecture {} in namespace '{}'",
+                            architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
+                    return;
+                }
+            }
+
+            throw new ArchitectureNotFoundException();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public byte[] getThumbnail(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        Document result = retrieveArchitectureVersions(architecture);
+
+        List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
+        for (Document architectureDoc : architectures) {
+            if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
+                Document thumbnails = architectureDoc.get(THUMBNAILS_FIELD, Document.class);
+                if (thumbnails == null) {
+                    return null;
+                }
+                Object encoded = thumbnails.get(architecture.getMongoVersion());
+                return encoded instanceof String s ? Base64.getDecoder().decode(s) : null;
+            }
+        }
+
+        throw new ArchitectureNotFoundException();
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -47,6 +48,7 @@ public class NitritePatternStore implements PatternStore {
     private static final String PATTERN_ID_FIELD = "patternId";
     private static final String PATTERNS_FIELD = "patterns";
     private static final String VERSIONS_FIELD = "versions";
+    private static final String THUMBNAILS_FIELD = "thumbnails";
     private static final String NAME_FIELD = "name";
     private static final String DESCRIPTION_FIELD = "description";
 
@@ -306,54 +308,130 @@ public class NitritePatternStore implements PatternStore {
 
         validatePatternJson(pattern.getPatternJson());
 
-        Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
-        Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
+        // Locked like the create path: the write is a whole-namespace-document
+        // read-modify-write, so an unlocked update racing another RMW (e.g. an async
+        // storeThumbnail callback) could silently discard this PUT's content.
+        lock.lock();
+        try {
+            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
+            Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
 
-        if (namespaceDocument == null) {
-            LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
-
-        Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-        if (patternDoc == null) {
-            LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
-
-        Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new PatternNotFoundException();
-        }
-        versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
-        patternDoc.put(VERSIONS_FIELD, versions);
-
-        // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
-        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-        if (pattern.getName() != null && !pattern.getName().isBlank()) {
-            patternDoc.put(NAME_FIELD, pattern.getName());
-        }
-        if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
-            patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
-        }
-
-        // Update the pattern in the namespace document
-        List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
-        // Create a mutable copy of the list
-        patterns = new ArrayList<>(patterns);
-        for (int i = 0; i < patterns.size(); i++) {
-            Document doc = patterns.get(i);
-            if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
-                patterns.set(i, patternDoc);
-                break;
+            if (namespaceDocument == null) {
+                LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
+                throw new PatternNotFoundException();
             }
-        }
 
-        namespaceDocument.put(PATTERNS_FIELD, patterns);
-        patternCollection.update(namespaceFilter, namespaceDocument);
+            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+            if (patternDoc == null) {
+                LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+                throw new PatternNotFoundException();
+            }
+
+            Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new PatternNotFoundException();
+            }
+            versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
+            patternDoc.put(VERSIONS_FIELD, versions);
+
+            // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
+            // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
+            if (pattern.getName() != null && !pattern.getName().isBlank()) {
+                patternDoc.put(NAME_FIELD, pattern.getName());
+            }
+            if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
+                patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
+            }
+
+            // Update the pattern in the namespace document
+            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
+            // Create a mutable copy of the list
+            patterns = new ArrayList<>(patterns);
+            for (int i = 0; i < patterns.size(); i++) {
+                Document doc = patterns.get(i);
+                if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
+                    patterns.set(i, patternDoc);
+                    break;
+                }
+            }
+
+            namespaceDocument.put(PATTERNS_FIELD, patterns);
+            patternCollection.update(namespaceFilter, namespaceDocument);
+        } finally {
+            lock.unlock();
+        }
 
         LOG.info("Updated version '{}' for pattern {} in namespace '{}'",
                 pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
         return pattern;
+    }
+
+    @Override
+    public void storeThumbnail(Pattern pattern, byte[] png) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // Validates namespace, pattern and version existence — no orphan thumbnails.
+        getPatternForVersion(pattern);
+
+        lock.lock();
+        try {
+            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
+            Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
+            if (namespaceDocument == null) {
+                throw new NamespaceNotFoundException();
+            }
+
+            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+            if (patternDoc == null) {
+                throw new PatternNotFoundException();
+            }
+
+            // Thumbnails live in a sibling nested document keyed by dashed
+            // version, so the version's JSON string value is untouched.
+            Document thumbnails = patternDoc.get(THUMBNAILS_FIELD, Document.class);
+            if (thumbnails == null) {
+                thumbnails = Document.createDocument();
+            }
+            thumbnails.put(pattern.getMongoVersion(), Base64.getEncoder().encodeToString(png));
+            patternDoc.put(THUMBNAILS_FIELD, thumbnails);
+
+            // Update the pattern in the namespace document
+            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
+            patterns = new ArrayList<>(patterns); // Make a mutable copy
+            for (int i = 0; i < patterns.size(); i++) {
+                Document doc = patterns.get(i);
+                if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
+                    patterns.set(i, patternDoc);
+                    break;
+                }
+            }
+
+            namespaceDocument.put(PATTERNS_FIELD, patterns);
+            patternCollection.update(namespaceFilter, namespaceDocument);
+            LOG.debug("Stored thumbnail for version '{}' of pattern {} in namespace '{}'",
+                    pattern.getDotVersion(), pattern.getId(), pattern.getNamespace());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public byte[] getThumbnail(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        if (!namespaceStore.namespaceExists(pattern.getNamespace())) {
+            LOG.debug("Namespace '{}' not found when retrieving pattern thumbnail", pattern.getNamespace());
+            throw new NamespaceNotFoundException();
+        }
+
+        Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+        if (patternDoc == null) {
+            LOG.debug("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+            throw new PatternNotFoundException();
+        }
+
+        Document thumbnails = patternDoc.get(THUMBNAILS_FIELD, Document.class);
+        if (thumbnails == null) {
+            return null;
+        }
+        Object encoded = thumbnails.get(pattern.getMongoVersion());
+        return encoded instanceof String s ? Base64.getDecoder().decode(s) : null;
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -18,6 +18,7 @@ import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.util.NitriteDocumentMutationResult;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.slf4j.Logger;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -313,50 +315,37 @@ public class NitritePatternStore implements PatternStore {
         // storeThumbnail callback) could silently discard this PUT's content.
         lock.lock();
         try {
-            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
-            Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
+            NitriteDocumentMutationResult result = mutatePatternDocument(
+                    pattern.getNamespace(), pattern.getId(), patternDoc -> {
+                        Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+                        if (versions == null) {
+                            return false;
+                        }
+                        versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
+                        patternDoc.put(VERSIONS_FIELD, versions);
 
-            if (namespaceDocument == null) {
-                LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
-                throw new PatternNotFoundException();
-            }
-
-            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-            if (patternDoc == null) {
-                LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
-                throw new PatternNotFoundException();
-            }
-
-            Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new PatternNotFoundException();
-            }
-            versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
-            patternDoc.put(VERSIONS_FIELD, versions);
-
-            // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
-            // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-            if (pattern.getName() != null && !pattern.getName().isBlank()) {
-                patternDoc.put(NAME_FIELD, pattern.getName());
-            }
-            if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
-                patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
-            }
-
-            // Update the pattern in the namespace document
-            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
-            // Create a mutable copy of the list
-            patterns = new ArrayList<>(patterns);
-            for (int i = 0; i < patterns.size(); i++) {
-                Document doc = patterns.get(i);
-                if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
-                    patterns.set(i, patternDoc);
-                    break;
+                        // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
+                        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
+                        if (pattern.getName() != null && !pattern.getName().isBlank()) {
+                            patternDoc.put(NAME_FIELD, pattern.getName());
+                        }
+                        if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
+                            patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
+                        }
+                        return true;
+                    });
+            switch (result) {
+                case NAMESPACE_DOCUMENT_MISSING -> {
+                    LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
+                    throw new PatternNotFoundException();
                 }
+                case RESOURCE_MISSING -> {
+                    LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+                    throw new PatternNotFoundException();
+                }
+                case ABORTED -> throw new PatternNotFoundException();
+                case UPDATED -> { }
             }
-
-            namespaceDocument.put(PATTERNS_FIELD, patterns);
-            patternCollection.update(namespaceFilter, namespaceDocument);
         } finally {
             lock.unlock();
         }
@@ -366,6 +355,46 @@ public class NitritePatternStore implements PatternStore {
         return pattern;
     }
 
+    /**
+     * Shared find→mutate→splice→persist sequence for a single pattern document
+     * inside its namespace document, used by the version-update and thumbnail-write
+     * paths. {@code mutation} returns false to abort without persisting. Callers must
+     * hold {@code lock} — this helper does not lock, so the caller's lock scope covers
+     * the whole read-modify-write.
+     */
+    private NitriteDocumentMutationResult mutatePatternDocument(
+            String namespace, int patternId, Function<Document, Boolean> mutation) {
+        Filter namespaceFilter = where(NAMESPACE_FIELD).eq(namespace);
+        Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
+        if (namespaceDocument == null) {
+            return NitriteDocumentMutationResult.NAMESPACE_DOCUMENT_MISSING;
+        }
+
+        Document patternDoc = findPatternDocument(namespace, patternId);
+        if (patternDoc == null) {
+            return NitriteDocumentMutationResult.RESOURCE_MISSING;
+        }
+
+        if (!mutation.apply(patternDoc)) {
+            return NitriteDocumentMutationResult.ABORTED;
+        }
+
+        // Splice the mutated pattern back into the namespace document (mutable copy)
+        List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
+        patterns = new ArrayList<>(patterns);
+        for (int i = 0; i < patterns.size(); i++) {
+            Document doc = patterns.get(i);
+            if (doc.get(PATTERN_ID_FIELD, Integer.class) == patternId) {
+                patterns.set(i, patternDoc);
+                break;
+            }
+        }
+
+        namespaceDocument.put(PATTERNS_FIELD, patterns);
+        patternCollection.update(namespaceFilter, namespaceDocument);
+        return NitriteDocumentMutationResult.UPDATED;
+    }
+
     @Override
     public void storeThumbnail(Pattern pattern, byte[] png) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
         // Validates namespace, pattern and version existence — no orphan thumbnails.
@@ -373,41 +402,24 @@ public class NitritePatternStore implements PatternStore {
 
         lock.lock();
         try {
-            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
-            Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
-            if (namespaceDocument == null) {
-                throw new NamespaceNotFoundException();
+            NitriteDocumentMutationResult result = mutatePatternDocument(
+                    pattern.getNamespace(), pattern.getId(), patternDoc -> {
+                        // Thumbnails live in a sibling nested document keyed by dashed
+                        // version, so the version's JSON string value is untouched.
+                        Document thumbnails = patternDoc.get(THUMBNAILS_FIELD, Document.class);
+                        if (thumbnails == null) {
+                            thumbnails = Document.createDocument();
+                        }
+                        thumbnails.put(pattern.getMongoVersion(), Base64.getEncoder().encodeToString(png));
+                        patternDoc.put(THUMBNAILS_FIELD, thumbnails);
+                        return true;
+                    });
+            switch (result) {
+                case NAMESPACE_DOCUMENT_MISSING -> throw new NamespaceNotFoundException();
+                case RESOURCE_MISSING, ABORTED -> throw new PatternNotFoundException();
+                case UPDATED -> LOG.debug("Stored thumbnail for version '{}' of pattern {} in namespace '{}'",
+                        pattern.getDotVersion(), pattern.getId(), pattern.getNamespace());
             }
-
-            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-            if (patternDoc == null) {
-                throw new PatternNotFoundException();
-            }
-
-            // Thumbnails live in a sibling nested document keyed by dashed
-            // version, so the version's JSON string value is untouched.
-            Document thumbnails = patternDoc.get(THUMBNAILS_FIELD, Document.class);
-            if (thumbnails == null) {
-                thumbnails = Document.createDocument();
-            }
-            thumbnails.put(pattern.getMongoVersion(), Base64.getEncoder().encodeToString(png));
-            patternDoc.put(THUMBNAILS_FIELD, thumbnails);
-
-            // Update the pattern in the namespace document
-            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
-            patterns = new ArrayList<>(patterns); // Make a mutable copy
-            for (int i = 0; i < patterns.size(); i++) {
-                Document doc = patterns.get(i);
-                if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
-                    patterns.set(i, patternDoc);
-                    break;
-                }
-            }
-
-            namespaceDocument.put(PATTERNS_FIELD, patterns);
-            patternCollection.update(namespaceFilter, namespaceDocument);
-            LOG.debug("Stored thumbnail for version '{}' of pattern {} in namespace '{}'",
-                    pattern.getDotVersion(), pattern.getId(), pattern.getNamespace());
         } finally {
             lock.unlock();
         }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteDocumentMutationResult.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteDocumentMutationResult.java
@@ -1,0 +1,19 @@
+package org.finos.calm.store.util;
+
+/**
+ * Outcome of a Nitrite store's shared find→mutate→splice→persist sequence on a
+ * single resource document inside its namespace document. Callers map the
+ * non-{@link #UPDATED} outcomes onto their own domain exceptions, which differ
+ * per operation (e.g. a missing namespace document is a namespace error for a
+ * thumbnail write but a resource error for a version update).
+ */
+public enum NitriteDocumentMutationResult {
+    /** The document was mutated and the namespace document persisted. */
+    UPDATED,
+    /** No namespace document exists in the collection; nothing was written. */
+    NAMESPACE_DOCUMENT_MISSING,
+    /** The namespace document has no resource with the requested id; nothing was written. */
+    RESOURCE_MISSING,
+    /** The mutation declined to proceed (returned false); nothing was written. */
+    ABORTED
+}

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -13,6 +13,21 @@ calm.standalone.password=admin
 calm.standalone.init-script-path=mongo/init-mongo.js
 # Read-only mode: when true, opens Nitrite with readOnly(true) and rejects mutating HTTP verbs
 calm.readonly=false
+# Thumbnail rendering: base URL of a calm-server instance whose /calm/render/thumbnail
+# endpoint renders architecture/pattern PNG thumbnails via this hub's UI. Disabled
+# (empty) by default in all profiles; when unset, thumbnail endpoints return 404 and
+# document writes never attempt a render.
+# NOTE: the render pipeline requires a deployment where the Hub UI and the thumbnail
+# GET endpoints are reachable without interactive authentication (standalone, no-auth,
+# proxy-auth, or a public-read setup) — in secure OIDC mode the headless browser cannot
+# log in and the browse cards' <img> requests cannot send bearer tokens, so leave this
+# unset there.
+# calm.render.service-url=http://localhost:3000
+# Per-render timeout in milliseconds passed to (and awaited from) the render service.
+# calm.render.timeout-ms=20000
+# How long a failed render (or failed thumbnail store) is remembered per document version;
+# GET misses within this window return 404 immediately instead of re-attempting the render.
+# calm.render.failure-cache-ttl-ms=60000
 quarkus.mongodb.connection-string = mongodb://localhost:27017
 quarkus.mongodb.database = calmSchemas
 
@@ -58,6 +73,15 @@ quarkus.http.filter.security.methods=GET,HEAD,POST,PUT,DELETE,PATCH
 quarkus.http.filter.security.header."X-Frame-Options"=DENY
 quarkus.http.filter.security.header."X-Content-Type-Options"=nosniff
 quarkus.http.filter.security.header."Referrer-Policy"=no-referrer
+
+# The SPA shell (/ and /index.html) must never be browser-cached: its hashed asset
+# references change every build, and the static handler's default 24h immutable
+# caching pins browsers to a stale bundle across upgrades. no-cache forces
+# revalidation of the shell only; the content-hashed /assets/* files keep the
+# default immutable caching, so repeat loads stay cheap.
+quarkus.http.filter.spa-shell.matches=/(index\\.html)?
+quarkus.http.filter.spa-shell.methods=GET,HEAD
+quarkus.http.filter.spa-shell.header."Cache-Control"=no-cache
 
 # MCP Server Configuration (experimental)
 # Gates MCP tool invocations. When false (the default), every @Tool method

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -28,6 +28,10 @@ calm.readonly=false
 # How long a failed render (or failed thumbnail store) is remembered per document version;
 # GET misses within this window return 404 immediately instead of re-attempting the render.
 # calm.render.failure-cache-ttl-ms=60000
+# Maximum renders in flight at once (each render launches a headless browser on the
+# render service). When saturated, further render attempts resolve as a miss and are
+# retried on a later view rather than queued.
+# calm.render.max-concurrent-renders=2
 quarkus.mongodb.connection-string = mongodb://localhost:27017
 quarkus.mongodb.database = calmSchemas
 

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
@@ -13,6 +13,7 @@ import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.services.ThumbnailService;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.TimelineStore;
@@ -24,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
@@ -33,8 +35,10 @@ import static org.finos.calm.resources.ResourceValidationConstants.OFFSET_MESSAG
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @TestSecurity(authorizationEnabled = false)
@@ -49,6 +53,9 @@ public class TestArchitectureResourceShould {
 
     @InjectMock
     TimelineStore mockTimelineStore;
+
+    @InjectMock
+    ThumbnailService mockThumbnailService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -499,5 +506,165 @@ public class TestArchitectureResourceShould {
                 .body("moments[0].details.'detailed-architecture'",
                         equalTo("/api/calm/namespaces/finos/architectures/42/versions/1.0.0"))
                 .body("moments[1].'unique-id'", equalTo("1.1.0"));
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    @Test
+    void return_stored_thumbnail_bytes_for_an_architecture_version() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenReturn(PNG_BYTES);
+
+        byte[] body = given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png")
+                .header("Cache-Control", equalTo("private, max-age=300"))
+                .extract().asByteArray();
+
+        assertArrayEquals(PNG_BYTES, body);
+        Architecture expected = new Architecture.ArchitectureBuilder()
+                .setNamespace("finos").setId(12).setVersion("1.0.0").build();
+        verify(mockArchitectureStore, times(1)).getThumbnail(expected);
+    }
+
+    @Test
+    void return_a_404_for_a_missing_thumbnail_when_rendering_is_disabled() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenReturn(null);
+        when(mockThumbnailService.isEnabled()).thenReturn(false);
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(404);
+
+        verify(mockThumbnailService, never()).renderSync(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void render_a_missing_thumbnail_on_demand_and_return_it() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        String architectureJson = "{ \"test\": \"json\" }";
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenReturn(null);
+        when(mockArchitectureStore.getArchitectureForVersion(any(Architecture.class))).thenReturn(architectureJson);
+        when(mockThumbnailService.isEnabled()).thenReturn(true);
+        when(mockThumbnailService.renderSync(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Optional.of(PNG_BYTES));
+
+        byte[] body = given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png")
+                .extract().asByteArray();
+
+        assertArrayEquals(PNG_BYTES, body);
+        verify(mockThumbnailService, times(1)).renderSync(
+                eq("finos/architectures/12/1.0.0"), eq("architecture"), eq(architectureJson), any());
+    }
+
+    @Test
+    void return_a_404_when_the_on_demand_thumbnail_render_fails() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenReturn(null);
+        when(mockArchitectureStore.getArchitectureForVersion(any(Architecture.class))).thenReturn("{}");
+        when(mockThumbnailService.isEnabled()).thenReturn(true);
+        when(mockThumbnailService.renderSync(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Optional.empty());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_a_404_for_a_thumbnail_of_an_unknown_architecture_version() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenThrow(new ArchitectureVersionNotFoundException());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/versions/9.9.9/thumbnail")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_the_latest_version_thumbnail_when_no_version_is_specified() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // 10.0.0 is latest under numeric segment comparison (a lexical compare would pick 9.0.0)
+        when(mockArchitectureStore.getArchitectureVersions(any(Architecture.class)))
+                .thenReturn(List.of("1.0.0", "10.0.0", "9.0.0"));
+        when(mockArchitectureStore.getThumbnail(any(Architecture.class))).thenReturn(PNG_BYTES);
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/12/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png");
+
+        Architecture expected = new Architecture.ArchitectureBuilder()
+                .setNamespace("finos").setId(12).setVersion("10.0.0").build();
+        verify(mockArchitectureStore, times(1)).getThumbnail(expected);
+    }
+
+    @Test
+    void return_a_404_for_a_latest_thumbnail_of_an_unknown_architecture() throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        when(mockArchitectureStore.getArchitectureVersions(any(Architecture.class)))
+                .thenThrow(new ArchitectureNotFoundException());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/architectures/99/thumbnail")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void trigger_an_async_thumbnail_render_after_a_successful_version_create() throws ArchitectureNotFoundException, ArchitectureVersionExistsException, NamespaceNotFoundException {
+        String architectureJson = "{ \"test\": \"json\" }";
+        when(mockArchitectureStore.createArchitectureForVersion(any(Architecture.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ArchitectureRequest architectureRequest = new ArchitectureRequest();
+        architectureRequest.setName(TEST_NAME);
+        architectureRequest.setDescription(TEST_DESCRIPTION);
+        architectureRequest.setArchitectureJson(architectureJson);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(architectureRequest)
+                .when()
+                .post("/api/calm/namespaces/test/architectures/20/versions/1.0.1")
+                .then()
+                .statusCode(201);
+
+        verify(mockThumbnailService, times(1)).triggerRender(
+                eq("test/architectures/20/1.0.1"), eq("architecture"), eq(architectureJson), any());
+    }
+
+    @Test
+    void not_trigger_a_thumbnail_render_when_the_version_create_fails() throws ArchitectureNotFoundException, ArchitectureVersionExistsException, NamespaceNotFoundException {
+        when(mockArchitectureStore.createArchitectureForVersion(any(Architecture.class)))
+                .thenThrow(new ArchitectureVersionExistsException());
+
+        ArchitectureRequest architectureRequest = new ArchitectureRequest();
+        architectureRequest.setName(TEST_NAME);
+        architectureRequest.setDescription(TEST_DESCRIPTION);
+        architectureRequest.setArchitectureJson("{ \"test\": \"json\" }");
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(architectureRequest)
+                .when()
+                .post("/api/calm/namespaces/test/architectures/20/versions/1.0.1")
+                .then()
+                .statusCode(409);
+
+        verify(mockThumbnailService, never()).triggerRender(anyString(), anyString(), anyString(), any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
@@ -11,6 +11,7 @@ import org.finos.calm.domain.exception.PatternVersionExistsException;
 import org.finos.calm.domain.exception.PatternVersionNotFoundException;
 import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.services.ThumbnailService;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.PatternStore;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
@@ -31,8 +33,10 @@ import static org.finos.calm.resources.ResourceValidationConstants.OFFSET_MESSAG
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @TestSecurity(authorizationEnabled = false)
@@ -42,6 +46,9 @@ public class TestPatternResourceShould {
 
     @InjectMock
     PatternStore mockPatternStore;
+
+    @InjectMock
+    ThumbnailService mockThumbnailService;
 
     @Test
     void return_a_404_when_an_invalid_namespace_is_provided_on_get_patterns() throws NamespaceNotFoundException {
@@ -422,5 +429,154 @@ public class TestPatternResourceShould {
                 .put("/api/calm/namespaces/test/patterns/20/versions/1.0.1")
                 .then()
                 .statusCode(403);
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    @Test
+    void return_stored_thumbnail_bytes_for_a_pattern_version() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        when(mockPatternStore.getThumbnail(any(Pattern.class))).thenReturn(PNG_BYTES);
+
+        byte[] body = given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png")
+                .header("Cache-Control", equalTo("private, max-age=300"))
+                .extract().asByteArray();
+
+        assertArrayEquals(PNG_BYTES, body);
+        Pattern expected = new Pattern.PatternBuilder()
+                .setNamespace("finos").setId(12).setVersion("1.0.0").build();
+        verify(mockPatternStore, times(1)).getThumbnail(expected);
+    }
+
+    @Test
+    void return_a_404_for_a_missing_pattern_thumbnail_when_rendering_is_disabled() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        when(mockPatternStore.getThumbnail(any(Pattern.class))).thenReturn(null);
+        when(mockThumbnailService.isEnabled()).thenReturn(false);
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(404);
+
+        verify(mockThumbnailService, never()).renderSync(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void render_a_missing_pattern_thumbnail_on_demand_and_return_it() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        String patternJson = "{ \"test\": \"json\" }";
+        when(mockPatternStore.getThumbnail(any(Pattern.class))).thenReturn(null);
+        when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenReturn(patternJson);
+        when(mockThumbnailService.isEnabled()).thenReturn(true);
+        when(mockThumbnailService.renderSync(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Optional.of(PNG_BYTES));
+
+        byte[] body = given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png")
+                .extract().asByteArray();
+
+        assertArrayEquals(PNG_BYTES, body);
+        verify(mockThumbnailService, times(1)).renderSync(
+                eq("finos/patterns/12/1.0.0"), eq("pattern"), eq(patternJson), any());
+    }
+
+    @Test
+    void return_a_404_when_the_on_demand_pattern_thumbnail_render_fails() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        when(mockPatternStore.getThumbnail(any(Pattern.class))).thenReturn(null);
+        when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenReturn("{}");
+        when(mockThumbnailService.isEnabled()).thenReturn(true);
+        when(mockThumbnailService.renderSync(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Optional.empty());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/12/versions/1.0.0/thumbnail")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_the_latest_version_pattern_thumbnail_when_no_version_is_specified() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // 10.0.0 is latest under numeric segment comparison (a lexical compare would pick 9.0.0)
+        when(mockPatternStore.getPatternVersions(any(Pattern.class)))
+                .thenReturn(List.of("1.0.0", "10.0.0", "9.0.0"));
+        when(mockPatternStore.getThumbnail(any(Pattern.class))).thenReturn(PNG_BYTES);
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/12/thumbnail")
+                .then()
+                .statusCode(200)
+                .contentType("image/png");
+
+        Pattern expected = new Pattern.PatternBuilder()
+                .setNamespace("finos").setId(12).setVersion("10.0.0").build();
+        verify(mockPatternStore, times(1)).getThumbnail(expected);
+    }
+
+    @Test
+    void return_a_404_for_a_latest_thumbnail_of_an_unknown_pattern() throws NamespaceNotFoundException, PatternNotFoundException {
+        when(mockPatternStore.getPatternVersions(any(Pattern.class)))
+                .thenThrow(new PatternNotFoundException());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/99/thumbnail")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void trigger_an_async_thumbnail_render_after_a_successful_pattern_version_create() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionExistsException {
+        String patternJson = "{ \"test\": \"json\" }";
+        when(mockPatternStore.createPatternForVersion(any(Pattern.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CreatePatternRequest patternRequest = new CreatePatternRequest();
+        patternRequest.setName("test-pattern");
+        patternRequest.setDescription("test description");
+        patternRequest.setPatternJson(patternJson);
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(patternRequest)
+                .when()
+                .post("/api/calm/namespaces/test/patterns/20/versions/1.0.1")
+                .then()
+                .statusCode(201);
+
+        verify(mockThumbnailService, times(1)).triggerRender(
+                eq("test/patterns/20/1.0.1"), eq("pattern"), eq(patternJson), any());
+    }
+
+    @Test
+    void not_trigger_a_thumbnail_render_when_the_pattern_version_create_fails() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionExistsException {
+        when(mockPatternStore.createPatternForVersion(any(Pattern.class)))
+                .thenThrow(new PatternVersionExistsException());
+
+        CreatePatternRequest patternRequest = new CreatePatternRequest();
+        patternRequest.setName("test-pattern");
+        patternRequest.setDescription("test description");
+        patternRequest.setPatternJson("{ \"test\": \"json\" }");
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(patternRequest)
+                .when()
+                .post("/api/calm/namespaces/test/patterns/20/versions/1.0.1")
+                .then()
+                .statusCode(409);
+
+        verify(mockThumbnailService, never()).triggerRender(anyString(), anyString(), anyString(), any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestThumbnailEndpointSupportShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestThumbnailEndpointSupportShould.java
@@ -1,0 +1,257 @@
+package org.finos.calm.resources;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
+import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.services.ThumbnailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestThumbnailEndpointSupportShould {
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+    private static final String KEY = "finos/architectures/12/1.0.0";
+    private static final String DOCUMENT_TYPE = ThumbnailService.DOCUMENT_TYPE_ARCHITECTURE;
+    private static final String DOCUMENT_JSON = "{\"nodes\": []}";
+    private static final String LOG_CONTEXT = "architecture-12";
+
+    @Mock
+    private ThumbnailService thumbnailService;
+
+    private ThumbnailEndpointSupport support;
+
+    @BeforeEach
+    public void setup() {
+        support = new ThumbnailEndpointSupport(thumbnailService);
+    }
+
+    // --- thumbnailResponse ---
+
+    @Test
+    public void return_the_stored_thumbnail_with_private_caching_on_a_hit() throws Exception {
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> PNG_BYTES,
+                () -> DOCUMENT_JSON,
+                png -> { });
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getMediaType().toString(), is("image/png"));
+        assertThat(response.getHeaderString("Cache-Control"), is("private, max-age=300"));
+        assertArrayEquals(PNG_BYTES, (byte[]) response.getEntity());
+        verify(thumbnailService, never()).renderSync(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    public void return_a_text_plain_404_on_a_miss_when_rendering_is_disabled() {
+        when(thumbnailService.isEnabled()).thenReturn(false);
+
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> null,
+                () -> DOCUMENT_JSON,
+                png -> { });
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.getMediaType(), is(MediaType.TEXT_PLAIN_TYPE));
+        assertThat(response.getEntity(), is("No thumbnail available"));
+        verify(thumbnailService, never()).renderSync(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void render_on_demand_and_store_the_result_on_a_miss() {
+        when(thumbnailService.isEnabled()).thenReturn(true);
+        when(thumbnailService.renderSync(eq(KEY), eq(DOCUMENT_TYPE), eq(DOCUMENT_JSON), any()))
+                .thenAnswer(invocation -> {
+                    // The render service invokes the store callback with the fresh bytes.
+                    invocation.getArgument(3, Consumer.class).accept(PNG_BYTES);
+                    return Optional.of(PNG_BYTES);
+                });
+        AtomicReference<byte[]> stored = new AtomicReference<>();
+
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> null,
+                () -> DOCUMENT_JSON,
+                stored::set);
+
+        assertThat(response.getStatus(), is(200));
+        assertArrayEquals(PNG_BYTES, (byte[]) response.getEntity());
+        // The fresh render was persisted through the store seam.
+        assertArrayEquals(PNG_BYTES, stored.get());
+    }
+
+    @Test
+    public void return_a_404_when_the_on_demand_render_fails() {
+        when(thumbnailService.isEnabled()).thenReturn(true);
+        when(thumbnailService.renderSync(eq(KEY), eq(DOCUMENT_TYPE), eq(DOCUMENT_JSON), any()))
+                .thenReturn(Optional.empty());
+
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> null,
+                () -> DOCUMENT_JSON,
+                png -> { });
+
+        assertThat(response.getStatus(), is(404));
+    }
+
+    @Test
+    public void return_a_404_when_the_stored_thumbnail_lookup_throws_a_domain_exception() {
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> {
+                    throw new NamespaceNotFoundException();
+                },
+                () -> DOCUMENT_JSON,
+                png -> { });
+
+        assertThat(response.getStatus(), is(404));
+    }
+
+    @Test
+    public void return_a_404_when_the_document_load_throws_a_domain_exception() {
+        when(thumbnailService.isEnabled()).thenReturn(true);
+
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> null,
+                () -> {
+                    throw new ArchitectureVersionNotFoundException();
+                },
+                png -> { });
+
+        assertThat(response.getStatus(), is(404));
+        verify(thumbnailService, never()).renderSync(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    public void propagate_a_runtime_exception_from_the_thumbnail_lookup() {
+        assertThrows(IllegalStateException.class, () -> support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> {
+                    throw new IllegalStateException("store blew up");
+                },
+                () -> DOCUMENT_JSON,
+                png -> { }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void swallow_a_store_failure_from_the_on_demand_render_and_still_serve_the_bytes() {
+        when(thumbnailService.isEnabled()).thenReturn(true);
+        when(thumbnailService.renderSync(eq(KEY), eq(DOCUMENT_TYPE), eq(DOCUMENT_JSON), any()))
+                .thenAnswer(invocation -> {
+                    invocation.getArgument(3, Consumer.class).accept(PNG_BYTES);
+                    return Optional.of(PNG_BYTES);
+                });
+
+        Response response = support.thumbnailResponse(KEY, DOCUMENT_TYPE, LOG_CONTEXT,
+                () -> null,
+                () -> DOCUMENT_JSON,
+                png -> {
+                    throw new ArchitectureNotFoundException();
+                });
+
+        assertThat(response.getStatus(), is(200));
+        assertArrayEquals(PNG_BYTES, (byte[]) response.getEntity());
+    }
+
+    // --- latestThumbnailResponse ---
+
+    @Test
+    public void resolve_the_latest_version_numerically_and_delegate_to_the_version_response() {
+        Response expected = Response.ok().build();
+        AtomicReference<String> resolvedVersion = new AtomicReference<>();
+
+        Response response = support.latestThumbnailResponse(LOG_CONTEXT,
+                // 10.0.0 is latest under numeric segment comparison (lexical would pick 9.0.0)
+                () -> List.of("1.0.0", "10.0.0", "9.0.0"),
+                version -> {
+                    resolvedVersion.set(version);
+                    return expected;
+                });
+
+        assertThat(response, is(expected));
+        assertThat(resolvedVersion.get(), is("10.0.0"));
+    }
+
+    @Test
+    public void return_a_404_when_there_are_no_versions_to_resolve() {
+        Response response = support.latestThumbnailResponse(LOG_CONTEXT,
+                List::of,
+                version -> Response.ok().build());
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.getMediaType(), is(MediaType.TEXT_PLAIN_TYPE));
+    }
+
+    @Test
+    public void return_a_404_when_the_version_lookup_throws_a_domain_exception() {
+        Response response = support.latestThumbnailResponse(LOG_CONTEXT,
+                () -> {
+                    throw new ArchitectureNotFoundException();
+                },
+                version -> Response.ok().build());
+
+        assertThat(response.getStatus(), is(404));
+    }
+
+    @Test
+    public void propagate_a_runtime_exception_from_the_version_lookup() {
+        assertThrows(IllegalStateException.class, () -> support.latestThumbnailResponse(LOG_CONTEXT,
+                () -> {
+                    throw new IllegalStateException("store blew up");
+                },
+                version -> Response.ok().build()));
+    }
+
+    // --- triggerThumbnailRender ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void trigger_an_async_render_and_store_the_result_through_the_seam() {
+        AtomicReference<byte[]> stored = new AtomicReference<>();
+
+        support.triggerThumbnailRender(KEY, DOCUMENT_TYPE, DOCUMENT_JSON, LOG_CONTEXT, stored::set);
+
+        ArgumentCaptor<Consumer<byte[]>> callback = ArgumentCaptor.forClass(Consumer.class);
+        verify(thumbnailService, times(1)).triggerRender(eq(KEY), eq(DOCUMENT_TYPE), eq(DOCUMENT_JSON), callback.capture());
+
+        // Simulate the async render completing: the callback persists via the store seam.
+        callback.getValue().accept(PNG_BYTES);
+        assertArrayEquals(PNG_BYTES, stored.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void swallow_a_store_failure_from_the_async_render_callback() {
+        support.triggerThumbnailRender(KEY, DOCUMENT_TYPE, DOCUMENT_JSON, LOG_CONTEXT, png -> {
+            throw new NamespaceNotFoundException();
+        });
+
+        ArgumentCaptor<Consumer<byte[]>> callback = ArgumentCaptor.forClass(Consumer.class);
+        verify(thumbnailService, times(1)).triggerRender(eq(KEY), eq(DOCUMENT_TYPE), eq(DOCUMENT_JSON), callback.capture());
+
+        assertDoesNotThrow(() -> callback.getValue().accept(PNG_BYTES));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
@@ -73,6 +73,7 @@ public class TestThumbnailServiceShould {
 
     private HttpServer server;
     private final AtomicReference<String> capturedBody = new AtomicReference<>();
+    private final AtomicReference<String> capturedPath = new AtomicReference<>();
     private final AtomicInteger responseStatus = new AtomicInteger(200);
     private final AtomicInteger requestCount = new AtomicInteger(0);
 
@@ -81,6 +82,7 @@ public class TestThumbnailServiceShould {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/calm/render/thumbnail", exchange -> {
             requestCount.incrementAndGet();
+            capturedPath.set(exchange.getRequestURI().getPath());
             capturedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             int status = responseStatus.get();
             byte[] payload = status == 200 ? PNG_BYTES : "{\"error\":\"render failed\"}".getBytes(StandardCharsets.UTF_8);
@@ -105,6 +107,21 @@ public class TestThumbnailServiceShould {
     private ThumbnailService serviceAgainstFixture(long failureCacheTtlMs) {
         String url = "http://127.0.0.1:" + server.getAddress().getPort();
         return new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, failureCacheTtlMs, HttpClient.newHttpClient());
+    }
+
+    @Test
+    void normalise_a_trailing_slash_on_the_render_service_url() throws Exception {
+        // A configured base URL of "http://host:3000/" must not produce a
+        // "//calm/render/thumbnail" request path.
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        ThumbnailService service = new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, HttpClient.newHttpClient());
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        Optional<byte[]> result = service.renderSync("finos/architectures/1/1.0.0", "architecture", DOCUMENT_JSON, callback);
+
+        assertTrue(result.isPresent());
+        assertThat(capturedPath.get(), is("/calm/render/thumbnail"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
@@ -1,0 +1,395 @@
+package org.finos.calm.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestThumbnailServiceShould {
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+    private static final String UI_BASE_URL = "http://localhost:8080";
+    private static final long TIMEOUT_MS = 20000;
+    private static final long FAILURE_TTL_MS = 60000;
+    private static final String DOCUMENT_JSON = "{\"nodes\": []}";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // --- Disabled mode ---
+
+    @Test
+    void be_disabled_and_never_call_the_render_service_when_no_url_is_configured() {
+        HttpClient mockClient = mock(HttpClient.class);
+        ThumbnailService service = new ThumbnailService("", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+
+        assertThat(service.isEnabled(), is(false));
+
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+        assertDoesNotThrow(() -> service.triggerRender("k", "architecture", DOCUMENT_JSON, callback));
+
+        verify(mockClient, never()).sendAsync(any(), any());
+        verify(callback, never()).accept(any());
+    }
+
+    // --- Contract against a real HTTP server ---
+
+    private HttpServer server;
+    private final AtomicReference<String> capturedBody = new AtomicReference<>();
+    private final AtomicInteger responseStatus = new AtomicInteger(200);
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/calm/render/thumbnail", exchange -> {
+            requestCount.incrementAndGet();
+            capturedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            int status = responseStatus.get();
+            byte[] payload = status == 200 ? PNG_BYTES : "{\"error\":\"render failed\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", status == 200 ? "image/png" : "application/json");
+            exchange.sendResponseHeaders(status, payload.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(payload);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private ThumbnailService serviceAgainstFixture() {
+        return serviceAgainstFixture(FAILURE_TTL_MS);
+    }
+
+    private ThumbnailService serviceAgainstFixture(long failureCacheTtlMs) {
+        String url = "http://127.0.0.1:" + server.getAddress().getPort();
+        return new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, failureCacheTtlMs, HttpClient.newHttpClient());
+    }
+
+    @Test
+    void post_the_render_contract_body_and_return_the_png_bytes() throws Exception {
+        ThumbnailService service = serviceAgainstFixture();
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        Optional<byte[]> result = service.renderSync("finos/architectures/1/1.0.0", "architecture", DOCUMENT_JSON, callback);
+
+        assertTrue(result.isPresent());
+        assertArrayEquals(PNG_BYTES, result.get());
+        verify(callback, times(1)).accept(PNG_BYTES);
+
+        // Contract 1: uiBaseUrl + documentType + documentJson (string) + timeoutMs
+        JsonNode body = objectMapper.readTree(capturedBody.get());
+        assertThat(body.get("uiBaseUrl").asText(), is(UI_BASE_URL));
+        assertThat(body.get("documentType").asText(), is("architecture"));
+        assertThat(body.get("documentJson").asText(), is(DOCUMENT_JSON));
+        assertThat(body.get("timeoutMs").asLong(), is(TIMEOUT_MS));
+    }
+
+    @Test
+    void return_empty_and_skip_the_store_callback_when_the_render_service_errors() {
+        responseStatus.set(500);
+        ThumbnailService service = serviceAgainstFixture();
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        Optional<byte[]> result = service.renderSync("k", "pattern", DOCUMENT_JSON, callback);
+
+        assertThat(result, is(Optional.empty()));
+        verify(callback, never()).accept(any());
+    }
+
+    @Test
+    void return_empty_rather_than_throw_when_the_render_service_is_unreachable() {
+        // A closed port: connection refused must resolve to empty, not an exception.
+        server.stop(0);
+        ThumbnailService service = serviceAgainstFixture();
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+        verify(callback, never()).accept(any());
+    }
+
+    @Test
+    void still_return_the_bytes_when_the_store_callback_throws() {
+        ThumbnailService service = serviceAgainstFixture();
+
+        Optional<byte[]> result = service.renderSync("k", "architecture", DOCUMENT_JSON, bytes -> {
+            throw new IllegalStateException("store blew up");
+        });
+
+        assertTrue(result.isPresent());
+        assertArrayEquals(PNG_BYTES, result.get());
+    }
+
+    @Test
+    void never_throw_from_the_async_trigger_when_the_render_fails() throws Exception {
+        responseStatus.set(500);
+        ThumbnailService service = serviceAgainstFixture();
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        assertDoesNotThrow(() -> service.triggerRender("k", "architecture", DOCUMENT_JSON, callback));
+
+        // Wait for the async request to land, then confirm the failure was swallowed.
+        awaitRequests(1);
+        verify(callback, never()).accept(any());
+    }
+
+    @Test
+    void invoke_the_store_callback_from_the_async_trigger_on_success() throws Exception {
+        ThumbnailService service = serviceAgainstFixture();
+        CountDownLatch stored = new CountDownLatch(1);
+        AtomicReference<byte[]> storedBytes = new AtomicReference<>();
+
+        service.triggerRender("k", "pattern", DOCUMENT_JSON, bytes -> {
+            storedBytes.set(bytes);
+            stored.countDown();
+        });
+
+        assertTrue(stored.await(10, TimeUnit.SECONDS), "store callback was not invoked");
+        assertArrayEquals(PNG_BYTES, storedBytes.get());
+        JsonNode body = objectMapper.readTree(capturedBody.get());
+        assertThat(body.get("documentType").asText(), is("pattern"));
+    }
+
+    private void awaitRequests(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10000;
+        while (requestCount.get() < expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+        assertThat(requestCount.get(), is(expected));
+    }
+
+    // --- Single-flight ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void collapse_concurrent_renders_for_the_same_key_onto_one_request() throws Exception {
+        HttpClient mockClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = (HttpResponse<byte[]>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(PNG_BYTES);
+
+        // A slow fake renderer: the future is only completed once both callers are waiting.
+        CompletableFuture<HttpResponse<byte[]>> slowRender = new CompletableFuture<>();
+        when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(slowRender);
+
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        AtomicInteger storeCount = new AtomicInteger(0);
+        Consumer<byte[]> callback = bytes -> storeCount.incrementAndGet();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            CountDownLatch bothStarted = new CountDownLatch(2);
+            Future<Optional<byte[]>> first = executor.submit(() -> {
+                bothStarted.countDown();
+                return service.renderSync("same/key", "architecture", DOCUMENT_JSON, callback);
+            });
+            Future<Optional<byte[]>> second = executor.submit(() -> {
+                bothStarted.countDown();
+                return service.renderSync("same/key", "architecture", DOCUMENT_JSON, callback);
+            });
+
+            // Give both callers time to join the in-flight render, then complete it.
+            assertTrue(bothStarted.await(10, TimeUnit.SECONDS));
+            Thread.sleep(200);
+            slowRender.complete(response);
+
+            assertArrayEquals(PNG_BYTES, first.get(10, TimeUnit.SECONDS).orElseThrow());
+            assertArrayEquals(PNG_BYTES, second.get(10, TimeUnit.SECONDS).orElseThrow());
+        } finally {
+            executor.shutdownNow();
+        }
+
+        // One render and one store despite two concurrent callers.
+        verify(mockClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertThat(storeCount.get(), is(1));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_again_for_the_same_key_once_the_previous_render_completed() {
+        HttpClient mockClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = (HttpResponse<byte[]>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(PNG_BYTES);
+        when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        Consumer<byte[]> callback = bytes -> { };
+
+        service.renderSync("same/key", "architecture", DOCUMENT_JSON, callback);
+        service.renderSync("same/key", "architecture", DOCUMENT_JSON, callback);
+
+        // The single-flight map is cleaned on completion, so a later miss re-renders.
+        verify(mockClient, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    // --- Latest-version selection (mirrors calm-hub-ui/src/model/version.ts) ---
+
+    @Test
+    void pick_the_highest_version_comparing_segments_numerically() {
+        assertThat(ThumbnailService.pickLatestVersion(List.of("1.0.0", "2.1.0", "2.0.0")), is(Optional.of("2.1.0")));
+        // Numeric per-segment compare: 10 > 9 (a lexical compare would pick 9.0.0).
+        assertThat(ThumbnailService.pickLatestVersion(List.of("9.0.0", "10.0.0")), is(Optional.of("10.0.0")));
+        assertThat(ThumbnailService.pickLatestVersion(List.of("3.4.5")), is(Optional.of("3.4.5")));
+    }
+
+    @Test
+    void treat_missing_trailing_segments_as_zero_when_picking_the_latest_version() {
+        // "1.0" and "1.0.0" compare equal; max keeps the first encountered.
+        assertThat(ThumbnailService.pickLatestVersion(List.of("1.0", "1.0.1")), is(Optional.of("1.0.1")));
+    }
+
+    @Test
+    void fall_back_to_string_comparison_for_non_numeric_segments() {
+        assertThat(ThumbnailService.pickLatestVersion(List.of("1.0.0-alpha", "1.0.0-beta")), is(Optional.of("1.0.0-beta")));
+    }
+
+    @Test
+    void return_empty_when_picking_the_latest_of_no_versions() {
+        assertThat(ThumbnailService.pickLatestVersion(List.of()), is(Optional.empty()));
+        assertThat(ThumbnailService.pickLatestVersion(null), is(Optional.empty()));
+    }
+
+    // --- Failure caching ---
+
+    @Test
+    public void skip_the_read_path_render_while_a_recent_failure_is_cached() {
+        responseStatus.set(500);
+        ThumbnailService service = serviceAgainstFixture();
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+        // The second miss within the TTL must not hit the render service again.
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+
+        assertThat(requestCount.get(), is(1));
+        verify(callback, never()).accept(any());
+    }
+
+    @Test
+    public void cache_a_failed_thumbnail_store_like_a_failed_render() {
+        // Render succeeds but the store callback throws (e.g. read-only mode): the
+        // failure must be cached so the next read-path miss doesn't re-render.
+        ThumbnailService service = serviceAgainstFixture();
+        Consumer<byte[]> throwingStore = bytes -> {
+            throw new IllegalStateException("read-only");
+        };
+
+        assertTrue(service.renderSync("k", "architecture", DOCUMENT_JSON, throwingStore).isPresent());
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, throwingStore), is(Optional.empty()));
+
+        assertThat(requestCount.get(), is(1));
+    }
+
+    @Test
+    public void re_attempt_the_render_once_the_failure_cache_ttl_expires() throws Exception {
+        responseStatus.set(500);
+        ThumbnailService service = serviceAgainstFixture(1);
+        @SuppressWarnings("unchecked")
+        Consumer<byte[]> callback = mock(Consumer.class);
+
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+        Thread.sleep(50);
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+
+        assertThat(requestCount.get(), is(2));
+    }
+
+    @Test
+    public void clear_the_cached_failure_after_a_successful_render_and_store() throws Exception {
+        responseStatus.set(500);
+        ThumbnailService service = serviceAgainstFixture();
+
+        // Read-path failure is cached...
+        assertThat(service.renderSync("k", "architecture", DOCUMENT_JSON, bytes -> { }), is(Optional.empty()));
+        assertThat(requestCount.get(), is(1));
+
+        // ...but the write path is never gated, and its success clears the cache.
+        responseStatus.set(200);
+        CountDownLatch stored = new CountDownLatch(1);
+        service.triggerRender("k", "architecture", DOCUMENT_JSON, bytes -> stored.countDown());
+        assertTrue(stored.await(10, TimeUnit.SECONDS), "write-path render did not store");
+
+        // A read-path miss now renders again instead of returning the cached failure.
+        assertTrue(service.renderSync("k", "architecture", DOCUMENT_JSON, bytes -> { }).isPresent());
+        assertThat(requestCount.get(), is(3));
+    }
+
+    // --- Write path re-render after joining an in-flight render ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void re_render_a_write_that_joined_an_in_flight_render_of_an_older_document() {
+        HttpClient mockClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = (HttpResponse<byte[]>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(PNG_BYTES);
+
+        CompletableFuture<HttpResponse<byte[]>> firstRender = new CompletableFuture<>();
+        when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(firstRender)
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        AtomicInteger storeCount = new AtomicInteger(0);
+        Consumer<byte[]> callback = bytes -> storeCount.incrementAndGet();
+
+        // First write starts the render; second write (newer document) joins it and
+        // must chain exactly one follow-up render once the first completes.
+        service.triggerRender("same/key", "architecture", "{\"v\":1}", callback);
+        service.triggerRender("same/key", "architecture", "{\"v\":2}", callback);
+        verify(mockClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+        firstRender.complete(response);
+
+        verify(mockClient, timeout(10000).times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestThumbnailServiceShould.java
@@ -47,6 +47,7 @@ public class TestThumbnailServiceShould {
     private static final String UI_BASE_URL = "http://localhost:8080";
     private static final long TIMEOUT_MS = 20000;
     private static final long FAILURE_TTL_MS = 60000;
+    private static final int MAX_CONCURRENT_RENDERS = 2;
     private static final String DOCUMENT_JSON = "{\"nodes\": []}";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -56,7 +57,7 @@ public class TestThumbnailServiceShould {
     @Test
     void be_disabled_and_never_call_the_render_service_when_no_url_is_configured() {
         HttpClient mockClient = mock(HttpClient.class);
-        ThumbnailService service = new ThumbnailService("", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        ThumbnailService service = new ThumbnailService("", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, MAX_CONCURRENT_RENDERS, mockClient);
 
         assertThat(service.isEnabled(), is(false));
 
@@ -106,7 +107,7 @@ public class TestThumbnailServiceShould {
 
     private ThumbnailService serviceAgainstFixture(long failureCacheTtlMs) {
         String url = "http://127.0.0.1:" + server.getAddress().getPort();
-        return new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, failureCacheTtlMs, HttpClient.newHttpClient());
+        return new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, failureCacheTtlMs, MAX_CONCURRENT_RENDERS, HttpClient.newHttpClient());
     }
 
     @Test
@@ -114,7 +115,7 @@ public class TestThumbnailServiceShould {
         // A configured base URL of "http://host:3000/" must not produce a
         // "//calm/render/thumbnail" request path.
         String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
-        ThumbnailService service = new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, HttpClient.newHttpClient());
+        ThumbnailService service = new ThumbnailService(url, UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, MAX_CONCURRENT_RENDERS, HttpClient.newHttpClient());
         @SuppressWarnings("unchecked")
         Consumer<byte[]> callback = mock(Consumer.class);
 
@@ -235,7 +236,7 @@ public class TestThumbnailServiceShould {
         when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(slowRender);
 
-        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, MAX_CONCURRENT_RENDERS, mockClient);
         AtomicInteger storeCount = new AtomicInteger(0);
         Consumer<byte[]> callback = bytes -> storeCount.incrementAndGet();
 
@@ -277,7 +278,7 @@ public class TestThumbnailServiceShould {
         when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(CompletableFuture.completedFuture(response));
 
-        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, MAX_CONCURRENT_RENDERS, mockClient);
         Consumer<byte[]> callback = bytes -> { };
 
         service.renderSync("same/key", "architecture", DOCUMENT_JSON, callback);
@@ -395,7 +396,7 @@ public class TestThumbnailServiceShould {
                 .thenReturn(firstRender)
                 .thenReturn(CompletableFuture.completedFuture(response));
 
-        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, mockClient);
+        ThumbnailService service = new ThumbnailService("http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, MAX_CONCURRENT_RENDERS, mockClient);
         AtomicInteger storeCount = new AtomicInteger(0);
         Consumer<byte[]> callback = bytes -> storeCount.incrementAndGet();
 
@@ -408,5 +409,58 @@ public class TestThumbnailServiceShould {
         firstRender.complete(response);
 
         verify(mockClient, timeout(10000).times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    // --- Concurrent render bound ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void resolve_empty_without_failure_caching_when_render_permits_are_saturated() {
+        HttpClient mockClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = (HttpResponse<byte[]>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(PNG_BYTES);
+
+        // First render holds the single permit until we complete it; later calls succeed.
+        CompletableFuture<HttpResponse<byte[]>> permitHolder = new CompletableFuture<>();
+        when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(permitHolder)
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        ThumbnailService service = new ThumbnailService(
+                "http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, 1, mockClient);
+        Consumer<byte[]> callback = bytes -> { };
+
+        service.triggerRender("key/a", "architecture", DOCUMENT_JSON, callback);
+
+        // Saturated: the attempt for a different key resolves empty without rendering...
+        assertThat(service.renderSync("key/b", "architecture", DOCUMENT_JSON, callback), is(Optional.empty()));
+        verify(mockClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+        // ...and is NOT failure-cached: once the permit frees, the next view renders.
+        permitHolder.complete(response);
+        assertTrue(service.renderSync("key/b", "architecture", DOCUMENT_JSON, callback).isPresent());
+        verify(mockClient, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void release_the_render_permit_when_a_render_completes() {
+        HttpClient mockClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = (HttpResponse<byte[]>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(PNG_BYTES);
+        when(mockClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        ThumbnailService service = new ThumbnailService(
+                "http://render.example", UI_BASE_URL, TIMEOUT_MS, FAILURE_TTL_MS, 1, mockClient);
+        Consumer<byte[]> callback = bytes -> { };
+
+        // Sequential renders on a single permit: each must reacquire successfully,
+        // proving the permit is released when a render completes (even synchronously).
+        assertTrue(service.renderSync("key/a", "architecture", DOCUMENT_JSON, callback).isPresent());
+        assertTrue(service.renderSync("key/b", "architecture", DOCUMENT_JSON, callback).isPresent());
+        verify(mockClient, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -33,6 +33,7 @@ import java.util.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -514,5 +515,80 @@ public class TestMongoArchitectureStoreShould {
 
         verify(architectureCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
         verify(architectureCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    @Test
+    void store_a_thumbnail_in_a_sibling_thumbnails_sub_document() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        mockSetupArchitectureDocumentWithVersions();
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        mongoArchitectureStore.storeThumbnail(architecture, PNG_BYTES);
+
+        Document expectedFilter = new Document("namespace", NAMESPACE)
+                .append("architectures.architectureId", 42);
+        Document expectedUpdate = new Document("$set",
+                new Document("architectures.$.thumbnails.1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES)));
+
+        verify(architectureCollection).updateOne(eq(expectedFilter), eq(expectedUpdate));
+    }
+
+    @Test
+    void throw_a_version_exception_when_storing_a_thumbnail_for_a_missing_version() {
+        mockSetupArchitectureDocumentWithVersions();
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("9.0.0").build();
+
+        assertThrows(ArchitectureVersionNotFoundException.class,
+                () -> mongoArchitectureStore.storeThumbnail(architecture, PNG_BYTES));
+
+        verify(architectureCollection, Mockito.never()).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void return_null_when_no_thumbnail_is_stored_for_a_version() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        mockSetupArchitectureDocumentWithVersions();
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        assertThat(mongoArchitectureStore.getThumbnail(architecture), is((byte[]) null));
+    }
+
+    @Test
+    void return_stored_thumbnail_bytes_for_a_version() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        Document storedArchitecture = new Document("architectureId", 42)
+                .append("versions", new Document("1-0-0", Document.parse(validJson)))
+                .append("thumbnails", new Document("1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES)));
+        Document namespaceDoc = new Document("namespace", NAMESPACE)
+                .append("architectures", List.of(storedArchitecture));
+
+        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(architectureCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(namespaceDoc);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        assertArrayEquals(PNG_BYTES, mongoArchitectureStore.getThumbnail(architecture));
+    }
+
+    @Test
+    void throw_an_architecture_exception_when_getting_a_thumbnail_for_a_missing_architecture() {
+        mockSetupArchitectureDocumentWithVersions();
+
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(99).setVersion("1.0.0").build();
+
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> mongoArchitectureStore.getThumbnail(architecture));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -54,6 +55,7 @@ public class TestMongoPatternStoreShould {
     MongoNamespaceStore namespaceStore;
 
     private final String validJson = "{\"test\": \"test\"}";
+    private static final String NAMESPACE = "finos";
 
     private MongoPatternStore mongoPatternStore;
     private MongoCollection<Document> patternCollection;
@@ -559,5 +561,80 @@ public class TestMongoPatternStoreShould {
         Document set = (Document) updateCaptor.getValue().get("$set");
         assertThat(set.getString("patterns.$.name"), is("updated"));
         assertThat(set.getString("patterns.$.description"), is("updated desc"));
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    @Test
+    void store_a_thumbnail_in_a_sibling_thumbnails_sub_document() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        mockSetupPatternDocumentWithVersions();
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        mongoPatternStore.storeThumbnail(pattern, PNG_BYTES);
+
+        Document expectedFilter = new Document("namespace", NAMESPACE)
+                .append("patterns.patternId", 42);
+        Document expectedUpdate = new Document("$set",
+                new Document("patterns.$.thumbnails.1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES)));
+
+        verify(patternCollection).updateOne(eq(expectedFilter), eq(expectedUpdate));
+    }
+
+    @Test
+    void throw_a_version_exception_when_storing_a_thumbnail_for_a_missing_version() {
+        mockSetupPatternDocumentWithVersions();
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("9.0.0").build();
+
+        assertThrows(PatternVersionNotFoundException.class,
+                () -> mongoPatternStore.storeThumbnail(pattern, PNG_BYTES));
+
+        verify(patternCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void return_null_when_no_thumbnail_is_stored_for_a_version() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        mockSetupPatternDocumentWithVersions();
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        assertThat(mongoPatternStore.getThumbnail(pattern), is((byte[]) null));
+    }
+
+    @Test
+    void return_stored_thumbnail_bytes_for_a_version() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        Document storedPattern = new Document("patternId", 42)
+                .append("versions", new Document("1-0-0", Document.parse(validJson)))
+                .append("thumbnails", new Document("1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES)));
+        Document namespaceDoc = new Document("namespace", NAMESPACE)
+                .append("patterns", List.of(storedPattern));
+
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(patternCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(namespaceDoc);
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.0").build();
+
+        assertArrayEquals(PNG_BYTES, mongoPatternStore.getThumbnail(pattern));
+    }
+
+    @Test
+    void throw_a_pattern_exception_when_getting_a_thumbnail_for_a_missing_pattern() {
+        mockSetupPatternDocumentWithVersions();
+
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace(NAMESPACE)
+                .setId(99).setVersion("1.0.0").build();
+
+        assertThrows(PatternNotFoundException.class,
+                () -> mongoPatternStore.getThumbnail(pattern));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -13,6 +13,7 @@ import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,11 +22,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -880,5 +883,125 @@ public class TestNitriteArchitectureStoreShould {
         assertThat(result, is(architecture));
         verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
         verify(mockCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    private Document setupNamespaceDocWithVersion(Document extraArchitectureFields) {
+        Document versions = Document.createDocument()
+                .put("1-0-0", VALID_JSON);
+
+        Document architectureDoc = Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID)
+                .put("versions", versions);
+        if (extraArchitectureFields != null) {
+            for (String field : extraArchitectureFields.getFields()) {
+                architectureDoc.put(field, extraArchitectureFields.get(field));
+            }
+        }
+
+        List<Document> architectures = new ArrayList<>();
+        architectures.add(architectureDoc);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("architectures", architectures);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        return namespaceDoc;
+    }
+
+    @Test
+    public void testStoreThumbnail_whenVersionExists_storesBase64InSiblingThumbnailsDocument() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // Arrange
+        Document namespaceDoc = setupNamespaceDocWithVersion(null);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .build();
+
+        // Act
+        architectureStore.storeThumbnail(architecture, PNG_BYTES);
+
+        // Assert
+        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList("architectures");
+        Document thumbnails = architectures.get(0).get("thumbnails", Document.class);
+        assertThat(thumbnails.get("1-0-0"), is(Base64.getEncoder().encodeToString(PNG_BYTES)));
+        // The version's JSON value is untouched by the thumbnail write.
+        assertThat(architectures.get(0).get("versions", Document.class).get("1-0-0"), is(VALID_JSON));
+    }
+
+    @Test
+    public void testStoreThumbnail_whenVersionDoesNotExist_throwsException() {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion("9.0.0")
+                .build();
+
+        // Act & Assert
+        assertThrows(ArchitectureVersionNotFoundException.class,
+                () -> architectureStore.storeThumbnail(architecture, PNG_BYTES));
+        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void testGetThumbnail_whenNoThumbnailStored_returnsNull() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .build();
+
+        // Act & Assert
+        assertThat(architectureStore.getThumbnail(architecture), is((byte[]) null));
+    }
+
+    @Test
+    public void testGetThumbnail_whenThumbnailStored_returnsDecodedBytes() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
+        // Arrange
+        Document thumbnails = Document.createDocument()
+                .put("1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES));
+        setupNamespaceDocWithVersion(Document.createDocument().put("thumbnails", thumbnails));
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(VERSION)
+                .build();
+
+        // Act & Assert
+        assertArrayEquals(PNG_BYTES, architectureStore.getThumbnail(architecture));
+    }
+
+    @Test
+    public void testGetThumbnail_whenArchitectureDoesNotExist_throwsException() {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Architecture architecture = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(999)
+                .setVersion(VERSION)
+                .build();
+
+        // Act & Assert
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> architectureStore.getThumbnail(architecture));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -10,6 +10,7 @@ import org.finos.calm.domain.Pattern;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.finos.calm.domain.exception.PatternVersionExistsException;
 import org.finos.calm.domain.exception.PatternVersionNotFoundException;
 import org.finos.calm.domain.pattern.CreatePatternRequest;
@@ -22,12 +23,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -934,5 +937,125 @@ public class TestNitritePatternStoreShould {
 
         verify(patternDoc).put(eq("name"), eq("updated"));
         verify(patternDoc).put(eq("description"), eq("updated desc"));
+    }
+
+    // --- Thumbnails ---
+
+    private static final byte[] PNG_BYTES = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+
+    private Document setupNamespaceDocWithVersion(Document extraPatternFields) {
+        Document versions = Document.createDocument()
+                .put("1-0-0", PATTERN_JSON);
+
+        Document patternDoc = Document.createDocument()
+                .put("patternId", PATTERN_ID)
+                .put("versions", versions);
+        if (extraPatternFields != null) {
+            for (String field : extraPatternFields.getFields()) {
+                patternDoc.put(field, extraPatternFields.get(field));
+            }
+        }
+
+        List<Document> patterns = new ArrayList<>();
+        patterns.add(patternDoc);
+
+        Document namespaceDoc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("patterns", patterns);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        return namespaceDoc;
+    }
+
+    @Test
+    public void testStoreThumbnail_whenVersionExists_storesBase64InSiblingThumbnailsDocument() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // Arrange
+        Document namespaceDoc = setupNamespaceDocWithVersion(null);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1.0.0")
+                .build();
+
+        // Act
+        patternStore.storeThumbnail(pattern, PNG_BYTES);
+
+        // Assert
+        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList("patterns");
+        Document thumbnails = patterns.get(0).get("thumbnails", Document.class);
+        assertThat(thumbnails.get("1-0-0"), is(Base64.getEncoder().encodeToString(PNG_BYTES)));
+        // The version's JSON value is untouched by the thumbnail write.
+        assertThat(patterns.get(0).get("versions", Document.class).get("1-0-0"), is(PATTERN_JSON));
+    }
+
+    @Test
+    public void testStoreThumbnail_whenVersionDoesNotExist_throwsException() {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("9.0.0")
+                .build();
+
+        // Act & Assert
+        assertThrows(PatternVersionNotFoundException.class,
+                () -> patternStore.storeThumbnail(pattern, PNG_BYTES));
+        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void testGetThumbnail_whenNoThumbnailStored_returnsNull() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1.0.0")
+                .build();
+
+        // Act & Assert
+        assertThat(patternStore.getThumbnail(pattern), is((byte[]) null));
+    }
+
+    @Test
+    public void testGetThumbnail_whenThumbnailStored_returnsDecodedBytes() throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
+        // Arrange
+        Document thumbnails = Document.createDocument()
+                .put("1-0-0", Base64.getEncoder().encodeToString(PNG_BYTES));
+        setupNamespaceDocWithVersion(Document.createDocument().put("thumbnails", thumbnails));
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(PATTERN_ID)
+                .setVersion("1.0.0")
+                .build();
+
+        // Act & Assert
+        assertArrayEquals(PNG_BYTES, patternStore.getThumbnail(pattern));
+    }
+
+    @Test
+    public void testGetThumbnail_whenPatternDoesNotExist_throwsException() {
+        // Arrange
+        setupNamespaceDocWithVersion(null);
+
+        Pattern pattern = new Pattern.PatternBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(999)
+                .setVersion("1.0.0")
+                .build();
+
+        // Act & Assert
+        assertThrows(PatternNotFoundException.class,
+                () -> patternStore.getThumbnail(pattern));
     }
 }

--- a/calm-server/AGENTS.md
+++ b/calm-server/AGENTS.md
@@ -9,7 +9,8 @@ The calm-server provides:
 - **Bundled CALM Schemas** - All CALM schemas (release and draft) are bundled during build
 - **Health Check Endpoint** (`/health`) - Status endpoint for monitoring
 - **Validation Endpoint** (`/calm/validate`) - POST endpoint for validating a CALM architecture. By default it resolves the architecture's `$schema` against the bundled schemas; if the request body also includes an optional `pattern`, the architecture is validated against that runtime-supplied pattern instead. When a pattern is supplied it must include a `$id` field that matches the architecture's `$schema` field
-- **Rate Limiting** - Protects against abuse with 100 requests per 15 minutes per IP
+- **Thumbnail Render Endpoint** (`/calm/render/thumbnail`) - Internal POST endpoint that renders a PNG thumbnail of a CALM architecture or pattern by driving a CALM Hub UI's chrome-free `/#/render` route in a local headless browser (requires a system Chrome or Edge install). Intended to be called by a trusted CALM Hub backend, not end users — it is unauthenticated and not rate limited, so keep calm-server bound to localhost or a private network
+- **Rate Limiting** - Protects against abuse with 100 requests per 15 minutes per IP (validation endpoint; the internal render endpoint is not rate limited)
 
 ## Project Structure
 
@@ -22,7 +23,8 @@ calm-server/
 │   │   └── routes/
 │   │       ├── routes.ts           # Router setup
 │   │       ├── health-route.ts     # Health check endpoint
-│   │       └── validation-route.ts # Architecture validation endpoints (/calm/validate, with optional pattern in the body)
+│   │       ├── validation-route.ts # Architecture validation endpoints (/calm/validate, with optional pattern in the body)
+│   │       └── render-route.ts     # Internal thumbnail render endpoint (/calm/render/thumbnail, drives a local headless Chrome/Edge against a CALM Hub UI)
 │   └── *.spec.ts                   # Unit tests
 ├── dist/                           # (generated) build output
 │   ├── index.js                    # Compiled executable

--- a/calm-server/README.md
+++ b/calm-server/README.md
@@ -9,6 +9,7 @@ The `calm-server` executable provides HTTP endpoints for CALM architecture valid
 - **Bundled CALM Schemas** - All CALM schemas (release and draft) are bundled with the executable
 - **Health Check Endpoint** (`GET /health`) - Status endpoint for monitoring
 - **Validation Endpoint** (`POST /calm/validate`) - Validate CALM architectures against bundled schemas, or against an optional pattern supplied in the request
+- **Thumbnail Render Endpoint** (`POST /calm/render/thumbnail`) - Internal endpoint that renders a PNG thumbnail of a CALM architecture or pattern by driving a CALM Hub UI's chrome-free `/#/render` route in a local headless browser (requires a system Chrome or Edge install). Intended to be called by CALM Hub, not end users
 
 ## Usage
 
@@ -120,6 +121,24 @@ Response (validation errors):
   "hasWarnings":false
 }
 ```
+
+### Render a Thumbnail (internal)
+
+Render a PNG thumbnail of a CALM document by driving a running CALM Hub UI in a local headless browser. This endpoint is intended to be called by a CALM Hub backend (see `calm.render.service-url` in calm-hub), requires a system Chrome or Edge install, and is neither authenticated nor rate limited — keep the server on localhost or a private network:
+
+```bash
+curl -X POST http://localhost:3000/calm/render/thumbnail \
+  -H "Content-Type: application/json" \
+  -o thumbnail.png \
+  -d '{
+    "uiBaseUrl": "http://localhost:8080",
+    "documentType": "architecture",
+    "documentJson": "{\"nodes\":[],\"relationships\":[]}"
+  }'
+```
+
+- `documentType` is `architecture` or `pattern`; `documentJson` is the raw CALM document as a JSON-encoded string; optional `timeoutMs` bounds the render (default 20000, capped at 60000).
+- Responds `200` with `image/png` bytes, `400` for an invalid body, or `500` with a JSON error envelope when the render fails (e.g. no local Chromium-based browser found).
 
 ## Development
 

--- a/calm-server/package.json
+++ b/calm-server/package.json
@@ -33,7 +33,8 @@
         "commander": "^14.0.0",
         "copyfiles": "^2.4.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.5.0"
+        "express-rate-limit": "^8.5.0",
+        "playwright-core": "^1.56.0"
     },
     "devDependencies": {
         "@types/express": "^5.0.0",

--- a/calm-server/src/server/routes/error-response.ts
+++ b/calm-server/src/server/routes/error-response.ts
@@ -1,0 +1,7 @@
+/** JSON error envelope shared by the calm-server routes: `{ "error": "<message>" }`. */
+export class ErrorResponse {
+    error: string;
+    constructor(error: string) {
+        this.error = error;
+    }
+}

--- a/calm-server/src/server/routes/render-route.spec.ts
+++ b/calm-server/src/server/routes/render-route.spec.ts
@@ -55,6 +55,15 @@ const VALID_BODY = {
     documentJson: JSON.stringify({ nodes: [], relationships: [] }),
 };
 
+/**
+ * The navigation and readiness waits share one deadline, so each mocked step
+ * receives the REMAINING budget — near timeoutMs but not an exact value.
+ */
+function timeoutOf(mock: Mock): number {
+    const lastCall = mock.mock.calls.at(-1) as unknown[];
+    return (lastCall[1] as { timeout: number }).timeout;
+}
+
 describe('RenderRouter', () => {
     let app: Application;
 
@@ -123,8 +132,14 @@ describe('RenderRouter', () => {
             documentType: 'architecture',
             document: { nodes: [], relationships: [] },
         });
-        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: 20000 });
-        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 20000 });
+        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: expect.any(Number) });
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: expect.any(Number) });
+        // Both steps draw on ONE shared 20000ms budget (mocks resolve instantly, so
+        // each remaining budget is at most the full default and always positive).
+        for (const stepTimeout of [timeoutOf(fake.page.goto), timeoutOf(fake.page.waitForSelector)]) {
+            expect(stepTimeout).toBeGreaterThan(0);
+            expect(stepTimeout).toBeLessThanOrEqual(20000);
+        }
         // The screenshot is clipped to the diagram's content bounds from the page.
         expect(fake.page.screenshot).toHaveBeenCalledWith({
             type: 'png',
@@ -166,7 +181,10 @@ describe('RenderRouter', () => {
             .post('/calm/render/thumbnail')
             .send({ ...VALID_BODY, timeoutMs: 120000 });
 
-        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 60000 });
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: expect.any(Number) });
+        const stepTimeout = timeoutOf(fake.page.waitForSelector);
+        expect(stepTimeout).toBeGreaterThan(50000); // capped budget, minus instant-mock elapsed time
+        expect(stepTimeout).toBeLessThanOrEqual(60000);
     });
 
     test('should honour a custom timeout below the cap', async () => {
@@ -177,7 +195,10 @@ describe('RenderRouter', () => {
             .post('/calm/render/thumbnail')
             .send({ ...VALID_BODY, timeoutMs: 5000 });
 
-        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 5000 });
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: expect.any(Number) });
+        const stepTimeout = timeoutOf(fake.page.waitForSelector);
+        expect(stepTimeout).toBeGreaterThan(0);
+        expect(stepTimeout).toBeLessThanOrEqual(5000);
     });
 
     test('should return 500 with an error envelope when the browser cannot launch', async () => {
@@ -209,7 +230,7 @@ describe('RenderRouter', () => {
             .post('/calm/render/thumbnail')
             .send({ ...VALID_BODY, uiBaseUrl: ' http://localhost:8080/ ' });
 
-        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: 20000 });
+        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: expect.any(Number) });
     });
 
     test('should accept documents larger than the 100kb express default', async () => {

--- a/calm-server/src/server/routes/render-route.spec.ts
+++ b/calm-server/src/server/routes/render-route.spec.ts
@@ -1,0 +1,322 @@
+import request from 'supertest';
+import express, { Application } from 'express';
+import { vi, Mock } from 'vitest';
+import { RenderRouter, computeDiagramClip } from './render-route';
+import { launchBrowser } from '@finos/calm-shared';
+
+vi.mock('@finos/calm-shared', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@finos/calm-shared')>();
+    return {
+        ...actual,
+        launchBrowser: vi.fn(),
+    };
+});
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+interface FakeBrowser {
+    browser: {
+        newContext: Mock;
+        close: Mock;
+    };
+    page: {
+        addInitScript: Mock;
+        goto: Mock;
+        waitForSelector: Mock;
+        evaluate: Mock;
+        screenshot: Mock;
+        locator: Mock;
+    };
+    screenshot: Mock;
+}
+
+function fakeBrowser(): FakeBrowser {
+    const screenshot = vi.fn().mockResolvedValue(PNG_BYTES);
+    const page = {
+        addInitScript: vi.fn().mockResolvedValue(undefined),
+        goto: vi.fn().mockResolvedValue(undefined),
+        waitForSelector: vi.fn().mockResolvedValue(undefined),
+        // computeDiagramClip result: a content bounding box by default; tests that
+        // exercise the no-content fallback override this to resolve null.
+        evaluate: vi.fn().mockResolvedValue({ x: 10, y: 20, width: 300, height: 150 }),
+        screenshot,
+        locator: vi.fn().mockReturnValue({ screenshot }),
+    };
+    const browser = {
+        newContext: vi.fn().mockResolvedValue({ newPage: vi.fn().mockResolvedValue(page) }),
+        close: vi.fn().mockResolvedValue(undefined),
+    };
+    return { browser, page, screenshot };
+}
+
+const VALID_BODY = {
+    uiBaseUrl: 'http://localhost:8080',
+    documentType: 'architecture',
+    documentJson: JSON.stringify({ nodes: [], relationships: [] }),
+};
+
+describe('RenderRouter', () => {
+    let app: Application;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        app = express();
+        // No app-level express.json(): the RenderRouter mounts its own higher-limit
+        // parser (and server.ts skips the app-level parser for this route).
+        const router: express.Router = express.Router();
+        app.use('/calm/render', router);
+        new RenderRouter(router);
+    });
+
+    test('should return 400 when uiBaseUrl is missing', async () => {
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, uiBaseUrl: undefined });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('uiBaseUrl');
+    });
+
+    test('should return 400 when uiBaseUrl is not an http(s) URL', async () => {
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, uiBaseUrl: 'file:///etc/passwd' });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('uiBaseUrl');
+    });
+
+    test('should return 400 when documentType is invalid', async () => {
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, documentType: 'flow' });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('documentType');
+    });
+
+    test('should return 400 when documentJson is missing', async () => {
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, documentJson: undefined });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('documentJson');
+    });
+
+    test('should return 400 when documentJson is not valid JSON', async () => {
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, documentJson: '{not json' });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('Invalid JSON format');
+    });
+
+    test('should return PNG bytes rendered from the UI render route', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        const response = await request(app).post('/calm/render/thumbnail').send(VALID_BODY);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toContain('image/png');
+        expect(Buffer.from(response.body)).toEqual(PNG_BYTES);
+
+        // Contract 2: data injected before navigation to {uiBaseUrl}/#/render.
+        expect(fake.page.addInitScript).toHaveBeenCalledWith(expect.any(Function), {
+            documentType: 'architecture',
+            document: { nodes: [], relationships: [] },
+        });
+        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: 20000 });
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 20000 });
+        // The screenshot is clipped to the diagram's content bounds from the page.
+        expect(fake.page.screenshot).toHaveBeenCalledWith({
+            type: 'png',
+            clip: { x: 10, y: 20, width: 300, height: 150 },
+        });
+        expect(fake.page.locator).not.toHaveBeenCalled();
+        expect(fake.browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('should fall back to screenshotting the render container when no content bounds exist', async () => {
+        const fake = fakeBrowser();
+        fake.page.evaluate.mockResolvedValue(null);
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        const response = await request(app).post('/calm/render/thumbnail').send(VALID_BODY);
+
+        expect(response.status).toBe(200);
+        expect(fake.page.locator).toHaveBeenCalledWith('[data-render-container]');
+        expect(fake.browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('should use a fixed card-shaped 1000x450 viewport at deviceScaleFactor 2', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        await request(app).post('/calm/render/thumbnail').send(VALID_BODY);
+
+        expect(fake.browser.newContext).toHaveBeenCalledWith({
+            viewport: { width: 1000, height: 450 },
+            deviceScaleFactor: 2,
+        });
+    });
+
+    test('should cap the requested timeout at 60000ms', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, timeoutMs: 120000 });
+
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 60000 });
+    });
+
+    test('should honour a custom timeout below the cap', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, timeoutMs: 5000 });
+
+        expect(fake.page.waitForSelector).toHaveBeenCalledWith('[data-render-ready="true"]', { timeout: 5000 });
+    });
+
+    test('should return 500 with an error envelope when the browser cannot launch', async () => {
+        (launchBrowser as Mock).mockRejectedValue(new Error('no browser found'));
+
+        const response = await request(app).post('/calm/render/thumbnail').send(VALID_BODY);
+
+        expect(response.status).toBe(500);
+        expect(response.body.error).toContain('Failed to render thumbnail');
+    });
+
+    test('should return 500 and still close the browser when the render times out', async () => {
+        const fake = fakeBrowser();
+        fake.page.waitForSelector.mockRejectedValue(new Error('Timeout 20000ms exceeded'));
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        const response = await request(app).post('/calm/render/thumbnail').send(VALID_BODY);
+
+        expect(response.status).toBe(500);
+        expect(response.body.error).toContain('Timeout');
+        expect(fake.browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('should normalize a trailing slash off uiBaseUrl before navigating', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, uiBaseUrl: ' http://localhost:8080/ ' });
+
+        expect(fake.page.goto).toHaveBeenCalledWith('http://localhost:8080/#/render', { timeout: 20000 });
+    });
+
+    test('should accept documents larger than the 100kb express default', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        // ~300kb document — over express.json's default limit, under the render router's 10mb.
+        const bigDocument = { nodes: [{ description: 'x'.repeat(300 * 1024) }] };
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, documentJson: JSON.stringify(bigDocument) });
+
+        expect(response.status).toBe(200);
+        expect(fake.page.addInitScript).toHaveBeenCalledWith(expect.any(Function), {
+            documentType: 'architecture',
+            document: bigDocument,
+        });
+    });
+
+    test('should support pattern documents', async () => {
+        const fake = fakeBrowser();
+        (launchBrowser as Mock).mockResolvedValue({ browser: fake.browser, displayName: 'Fake Chrome' });
+
+        const response = await request(app)
+            .post('/calm/render/thumbnail')
+            .send({ ...VALID_BODY, documentType: 'pattern' });
+
+        expect(response.status).toBe(200);
+        expect(fake.page.addInitScript).toHaveBeenCalledWith(expect.any(Function), {
+            documentType: 'pattern',
+            document: { nodes: [], relationships: [] },
+        });
+    });
+});
+
+// computeDiagramClip runs inside the page via page.evaluate (mocked above), so its
+// branches are exercised here directly against a stubbed DOM.
+describe('computeDiagramClip', () => {
+    interface FakeRect {
+        left: number;
+        top: number;
+        right: number;
+        bottom: number;
+        width: number;
+        height: number;
+    }
+
+    function fakeElement(left: number, top: number, right: number, bottom: number) {
+        const rect: FakeRect = { left, top, right, bottom, width: right - left, height: bottom - top };
+        return { getBoundingClientRect: () => rect };
+    }
+
+    function stubDom(nodes: ReturnType<typeof fakeElement>[], edges: ReturnType<typeof fakeElement>[] = []) {
+        vi.stubGlobal('document', {
+            querySelectorAll: (selector: string) => (selector === '.react-flow__node' ? nodes : edges),
+        });
+        vi.stubGlobal('window', { innerWidth: 1000, innerHeight: 450 });
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('pads the union of node and edge boxes and widens it to the target aspect', () => {
+        // The edge lies inside the node's box, so the union is the node box: content
+        // (200,100)-(300,200) → padded by 16 to (184,84) 132x132, then widened
+        // (aspect 1 < 1.75) by 99 centred: x 184-49.5, width 231.
+        stubDom([fakeElement(200, 100, 300, 200)], [fakeElement(250, 150, 300, 200)]);
+
+        expect(computeDiagramClip()).toEqual({ x: 134.5, y: 84, width: 231, height: 132 });
+    });
+
+    test('expands the height of a very wide content box toward the target aspect', () => {
+        // Padded box 350x82 (aspect ~4.3 > 1.75): height grows to 350/1.75 = 200,
+        // centred (y 184 - 59 = 125); width is untouched.
+        stubDom([fakeElement(300, 200, 618, 250)]);
+
+        expect(computeDiagramClip()).toEqual({ x: 284, y: 125, width: 350, height: 200 });
+    });
+
+    test('expands the width of a tall content box toward the target aspect', () => {
+        // Padded box 132x232 (aspect ~0.57 < 1.75): width grows to 232*1.75 = 406,
+        // centred (x 384 - 137 = 247); height is untouched.
+        stubDom([fakeElement(400, 100, 500, 300)]);
+
+        expect(computeDiagramClip()).toEqual({ x: 247, y: 84, width: 406, height: 232 });
+    });
+
+    test('returns null when the page has no nodes or edges', () => {
+        stubDom([], []);
+
+        expect(computeDiagramClip()).toBeNull();
+    });
+
+    test('returns null when every element has a zero-size rect', () => {
+        // Unmeasured/hidden elements report 0x0 rects and are skipped.
+        stubDom([fakeElement(0, 0, 0, 0)], [fakeElement(0, 0, 0, 0)]);
+
+        expect(computeDiagramClip()).toBeNull();
+    });
+
+    test('clamps a box pushed past the viewport origin by padding and aspect expansion', () => {
+        // Content at the top-left corner: padding takes x/y negative and the aspect
+        // expansion pushes x further left; both clamp to 0 and the width/height
+        // shrink by the clamped amount.
+        stubDom([fakeElement(0, 0, 30, 10)]);
+
+        expect(computeDiagramClip()).toEqual({ x: 0, y: 0, width: 51.75, height: 26 });
+    });
+});

--- a/calm-server/src/server/routes/render-route.ts
+++ b/calm-server/src/server/routes/render-route.ts
@@ -1,0 +1,221 @@
+import { initLogger, launchBrowser } from '@finos/calm-shared';
+import type { Logger } from '@finos/calm-shared';
+import express, { Router, Request, Response } from 'express';
+import type { Browser } from 'playwright-core';
+
+const DEFAULT_TIMEOUT_MS = 20000;
+const MAX_TIMEOUT_MS = 60000;
+
+/**
+ * CALM documents routinely exceed express.json's 100kb default, so the render
+ * router parses its own bodies with a higher limit (the app-level parser skips
+ * this route — see server.ts).
+ */
+const RENDER_BODY_LIMIT = '10mb';
+
+/**
+ * Render stage for the fitView pass, shaped near the browse card's header (~2:1) so
+ * the `object-cover` crop discards little of the diagram. The screenshot is clipped
+ * to the graph's real content bounds (see {@link computeDiagramClip}), so the stage
+ * sets zoom/detail while the clip removes empty margins — the stage size caps
+ * detail, not framing. deviceScaleFactor 2 keeps the (upscaled-on-card) thumbnail
+ * crisp on high-DPI displays; the content clip keeps the payload far below a
+ * full-stage 2x screenshot.
+ */
+const THUMBNAIL_VIEWPORT = { width: 1000, height: 450 };
+const THUMBNAIL_DEVICE_SCALE_FACTOR = 2;
+
+/** Selector the Hub UI's render route sets once the diagram has painted. */
+const RENDER_READY_SELECTOR = '[data-render-ready="true"]';
+/** Element the Hub UI's render route wraps the diagram in; this is what gets screenshotted. */
+const RENDER_CONTAINER_SELECTOR = '[data-render-container]';
+
+const DOCUMENT_TYPES = ['architecture', 'pattern'] as const;
+type RenderDocumentType = (typeof DOCUMENT_TYPES)[number];
+
+interface RenderThumbnailRequest {
+    /** Base URL of a running CALM Hub UI, e.g. http://localhost:8080. */
+    uiBaseUrl: string;
+    documentType: RenderDocumentType;
+    /** The raw CALM JSON document, as a string. */
+    documentJson: string;
+    /** Optional render timeout in ms (default 20000, capped at 60000). */
+    timeoutMs?: number;
+}
+
+function isHttpUrl(value: unknown): value is string {
+    return typeof value === 'string' && /^https?:\/\//i.test(value);
+}
+
+function isDocumentType(value: unknown): value is RenderDocumentType {
+    return typeof value === 'string' && (DOCUMENT_TYPES as readonly string[]).includes(value);
+}
+
+function clampTimeout(timeoutMs: unknown): number {
+    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        return DEFAULT_TIMEOUT_MS;
+    }
+    return Math.min(timeoutMs, MAX_TIMEOUT_MS);
+}
+
+/**
+ * Runs inside the page: the union bounding box of every rendered node and edge,
+ * padded, widened to a minimum aspect ratio and clamped to the viewport, in page
+ * coordinates (the render route fills the viewport from the origin, so client rects
+ * are page coordinates). Returns null when nothing rendered (e.g. an empty document)
+ * — the caller then screenshots the whole render container instead.
+ *
+ * The aspect bound exists for extreme diagram shapes: a two-node architecture clips
+ * to a very wide thin strip, and the browse card's `object-cover` would crop away
+ * both nodes leaving only the middle of the edge. Expanding the box toward the
+ * card header's minimum aspect (~1.75:1) adds empty canvas margin instead, so the
+ * cover crop trims margin — never the diagram.
+ *
+ * Exported for unit tests only. Runtime-safe to export: the function is fully
+ * self-contained (no captured bindings), which `page.evaluate` requires anyway
+ * to serialize it into the page.
+ */
+export function computeDiagramClip(): { x: number; y: number; width: number; height: number } | null {
+    const PAD = 16;
+    // Browse-card headers are at least ~1.75x wider than tall (280px min column /
+    // 160px header). Keeping the clip at or below that aspect means object-cover
+    // scales by width and crops only vertical margin.
+    const TARGET_ASPECT = 1.75;
+    const elements = [
+        ...document.querySelectorAll('.react-flow__node'),
+        ...document.querySelectorAll('.react-flow__edge'),
+    ];
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const element of elements) {
+        const rect = element.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) continue;
+        minX = Math.min(minX, rect.left);
+        minY = Math.min(minY, rect.top);
+        maxX = Math.max(maxX, rect.right);
+        maxY = Math.max(maxY, rect.bottom);
+    }
+    if (!Number.isFinite(minX)) return null;
+    let x = minX - PAD;
+    let y = minY - PAD;
+    let width = maxX - minX + PAD * 2;
+    let height = maxY - minY + PAD * 2;
+    // Expand the tighter dimension toward the target aspect, centred on the content.
+    if (width / height > TARGET_ASPECT) {
+        const grow = width / TARGET_ASPECT - height;
+        y -= grow / 2;
+        height += grow;
+    } else {
+        const grow = height * TARGET_ASPECT - width;
+        x -= grow / 2;
+        width += grow;
+    }
+    const clampedX = Math.max(0, x);
+    const clampedY = Math.max(0, y);
+    const clampedWidth = Math.min(window.innerWidth, x + width) - clampedX;
+    const clampedHeight = Math.min(window.innerHeight, y + height) - clampedY;
+    if (clampedWidth <= 0 || clampedHeight <= 0) return null;
+    return { x: clampedX, y: clampedY, width: clampedWidth, height: clampedHeight };
+}
+
+/**
+ * Renders PNG thumbnails of CALM architecture/pattern documents by driving the
+ * CALM Hub UI's chrome-free `/#/render` route in a headless local browser, so a
+ * thumbnail is pixel-identical to the diagram users see in the Hub UI.
+ *
+ * INTERNAL endpoint: calm-server has no authentication and this route launches a
+ * local browser per request — it is intended to be called by a trusted CALM Hub
+ * backend on a private network (calm-server binds 127.0.0.1 by default).
+ */
+export class RenderRouter {
+    private logger: Logger;
+
+    constructor(router: Router, debug: boolean = false) {
+        this.logger = initLogger(debug, 'calm-server');
+        router.use(express.json({ limit: RENDER_BODY_LIMIT }));
+        router.post('/thumbnail', this.renderThumbnail);
+    }
+
+    private renderThumbnail = async (
+        req: Request<Record<string, never>, Buffer | ErrorResponse, Partial<RenderThumbnailRequest>>,
+        res: Response<Buffer | ErrorResponse>
+    ) => {
+        const { uiBaseUrl, documentType, documentJson } = req.body;
+
+        // Normalize once and validate the EXACT expression that reaches page.goto —
+        // validating a different (re-derived) expression than the sink's has
+        // previously triggered CodeQL js/request-forgery findings in this repo.
+        const base = typeof uiBaseUrl === 'string' ? uiBaseUrl.trim().replace(/\/$/, '') : undefined;
+        if (!isHttpUrl(base)) {
+            return res.status(400).type('json').send(new ErrorResponse('The "uiBaseUrl" field is missing or is not an http(s) URL'));
+        }
+        if (!isDocumentType(documentType)) {
+            return res.status(400).type('json').send(new ErrorResponse('The "documentType" field must be "architecture" or "pattern"'));
+        }
+        if (typeof documentJson !== 'string' || documentJson.trim() === '') {
+            return res.status(400).type('json').send(new ErrorResponse('The "documentJson" field is missing or is not a string'));
+        }
+
+        let document: unknown;
+        try {
+            document = JSON.parse(documentJson);
+        } catch (error) {
+            this.logger.error('Invalid JSON format for documentJson ' + error);
+            return res.status(400).type('json').send(new ErrorResponse('Invalid JSON format for documentJson'));
+        }
+
+        const timeoutMs = clampTimeout(req.body.timeoutMs);
+
+        // Launched per request, disposed in finally — no pooling.
+        let browser: Browser | undefined;
+        try {
+            ({ browser } = await launchBrowser());
+            const context = await browser.newContext({
+                viewport: THUMBNAIL_VIEWPORT,
+                deviceScaleFactor: THUMBNAIL_DEVICE_SCALE_FACTOR,
+            });
+            const page = await context.newPage();
+            // Injected before any page script runs, so the UI's render route sees
+            // the document on first mount (see RenderView in calm-hub-ui).
+            await page.addInitScript(
+                (data) => {
+                    (window as unknown as Record<string, unknown>)['__CALM_RENDER_DATA'] = data;
+                },
+                { documentType, document }
+            );
+            // Navigation bounded by the request timeout, not Playwright's 30s default.
+            await page.goto(`${base}/#/render`, { timeout: timeoutMs });
+            await page.waitForSelector(RENDER_READY_SELECTOR, { timeout: timeoutMs });
+            // Clip to the diagram's real content bounds rather than the fixed viewport:
+            // fitView centres the graph in the strip, so a graph narrower than the frame
+            // would otherwise ship (and later display) large empty margins. The clip is
+            // expanded toward the card header's aspect, so the card's `object-cover`
+            // crop trims only empty margin — never the diagram itself.
+            const clip = await page.evaluate(computeDiagramClip);
+            const png = clip
+                ? await page.screenshot({ type: 'png', clip })
+                : await page.locator(RENDER_CONTAINER_SELECTOR).screenshot({ type: 'png' });
+            return res.status(200).type('image/png').send(png);
+        } catch (error) {
+            this.logger.error('Failed to render thumbnail: ' + error);
+            return res.status(500).type('json').send(new ErrorResponse('Failed to render thumbnail: ' + (error as Error).message));
+        } finally {
+            if (browser) {
+                try {
+                    await browser.close();
+                } catch (error) {
+                    this.logger.debug('Error closing thumbnail render browser: ' + error);
+                }
+            }
+        }
+    };
+}
+
+class ErrorResponse {
+    error: string;
+    constructor(error: string) {
+        this.error = error;
+    }
+}

--- a/calm-server/src/server/routes/render-route.ts
+++ b/calm-server/src/server/routes/render-route.ts
@@ -2,6 +2,7 @@ import { initLogger, launchBrowser } from '@finos/calm-shared';
 import type { Logger } from '@finos/calm-shared';
 import express, { Router, Request, Response } from 'express';
 import type { Browser } from 'playwright-core';
+import { ErrorResponse } from './error-response';
 
 const DEFAULT_TIMEOUT_MS = 20000;
 const MAX_TIMEOUT_MS = 60000;
@@ -181,6 +182,11 @@ export class RenderRouter {
         }
 
         const timeoutMs = clampTimeout(req.body.timeoutMs);
+        // One deadline shared by the navigation and readiness waits: giving each step
+        // the full budget could take ~2x timeoutMs — longer than the hub client waits
+        // (timeoutMs + grace), which would failure-cache a healthy-but-slow render.
+        const deadline = Date.now() + timeoutMs;
+        const remainingBudget = () => Math.max(1, deadline - Date.now());
 
         // Launched per request, disposed in finally — no pooling.
         let browser: Browser | undefined;
@@ -199,9 +205,9 @@ export class RenderRouter {
                 },
                 { documentType, document }
             );
-            // Navigation bounded by the request timeout, not Playwright's 30s default.
-            await page.goto(`${base}/#/render`, { timeout: timeoutMs });
-            await page.waitForSelector(RENDER_READY_SELECTOR, { timeout: timeoutMs });
+            // Each step bounded by the shared deadline, not Playwright's 30s default.
+            await page.goto(`${base}/#/render`, { timeout: remainingBudget() });
+            await page.waitForSelector(RENDER_READY_SELECTOR, { timeout: remainingBudget() });
             // Clip to the diagram's real content bounds rather than the fixed viewport:
             // fitView centres the graph in the strip, so a graph narrower than the frame
             // would otherwise ship (and later display) large empty margins. The clip is
@@ -225,11 +231,4 @@ export class RenderRouter {
             }
         }
     };
-}
-
-class ErrorResponse {
-    error: string;
-    constructor(error: string) {
-        this.error = error;
-    }
 }

--- a/calm-server/src/server/routes/render-route.ts
+++ b/calm-server/src/server/routes/render-route.ts
@@ -58,6 +58,20 @@ function clampTimeout(timeoutMs: unknown): number {
     return Math.min(timeoutMs, MAX_TIMEOUT_MS);
 }
 
+/*
+ * Minimal shapes of the two browser globals {@link computeDiagramClip} touches.
+ * The function executes inside the page via `page.evaluate`, but calm-server is a
+ * Node service whose tsconfig deliberately excludes the DOM lib — these local
+ * declarations keep the in-page function type-checked without dragging DOM typings
+ * into the rest of the server.
+ */
+declare const document: {
+    querySelectorAll(selector: string): Iterable<{
+        getBoundingClientRect(): { left: number; top: number; right: number; bottom: number; width: number; height: number };
+    }>;
+};
+declare const window: { innerWidth: number; innerHeight: number };
+
 /**
  * Runs inside the page: the union bounding box of every rendered node and edge,
  * padded, widened to a minimum aspect ratio and clamped to the viewport, in page

--- a/calm-server/src/server/routes/routes.spec.ts
+++ b/calm-server/src/server/routes/routes.spec.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { ServerRoutes } from './routes';
 import { ValidationRouter } from './validation-route';
 import { HealthRouter } from './health-route';
+import { RenderRouter } from './render-route';
 import { SchemaDirectory } from '@finos/calm-shared';
 
 vi.mock('express', () => ({
@@ -20,6 +21,12 @@ vi.mock('./health-route', () => {
     };
 });
 
+vi.mock('./render-route', () => {
+    return {
+        RenderRouter: vi.fn()
+    };
+});
+
 vi.mock('@finos/calm-shared', () => {
     return {
         SchemaDirectory: vi.fn()
@@ -31,17 +38,20 @@ describe('ServerRoutes', () => {
     let mainRouter: Router;
     let validateRouter: Router;
     let healthRouter: Router;
+    let renderRouter: Router;
 
     beforeEach(() => {
         mainRouter = { use: vi.fn() } as unknown as Router;
         validateRouter = { use: vi.fn() } as unknown as Router;
         healthRouter = { use: vi.fn() } as unknown as Router;
+        renderRouter = { use: vi.fn() } as unknown as Router;
         const routerMock = Router as unknown as vi.Mock;
         routerMock.mockReset();
         routerMock
             .mockImplementationOnce(() => mainRouter)
             .mockImplementationOnce(() => validateRouter)
-            .mockImplementationOnce(() => healthRouter);
+            .mockImplementationOnce(() => healthRouter)
+            .mockImplementationOnce(() => renderRouter);
         serverRoutes = new ServerRoutes(schemaDirectory);
         void serverRoutes;
     });
@@ -58,5 +68,10 @@ describe('ServerRoutes', () => {
     it('should set up health route', () => {
         expect(mainRouter.use).toHaveBeenCalledWith('/health', healthRouter);
         expect(HealthRouter).toHaveBeenCalledWith(healthRouter);
+    });
+
+    it('should set up render route', () => {
+        expect(mainRouter.use).toHaveBeenCalledWith('/calm/render', renderRouter);
+        expect(RenderRouter).toHaveBeenCalledWith(renderRouter, false);
     });
 });

--- a/calm-server/src/server/routes/routes.ts
+++ b/calm-server/src/server/routes/routes.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import { ValidationRouter } from './validation-route';
 import { HealthRouter } from './health-route';
+import { RenderRouter } from './render-route';
 import { SchemaDirectory } from '@finos/calm-shared';
 
 const HEALTH_ROUTE_PATH = '/health';
 const VALIDATE_ROUTE_PATH = '/calm/validate';
+const RENDER_ROUTE_PATH = '/calm/render';
 
 export class ServerRoutes {
     router: Router;
@@ -23,5 +25,11 @@ export class ServerRoutes {
         const healthRouter = Router();
         this.router.use(HEALTH_ROUTE_PATH, healthRouter);
         new HealthRouter(healthRouter);
+
+        // Internal render endpoint — no rate limiting: calm-server has no auth and is
+        // expected to be reachable only by a trusted CALM Hub on a private network.
+        const renderRouter = Router();
+        this.router.use(RENDER_ROUTE_PATH, renderRouter);
+        new RenderRouter(renderRouter, debug);
     }
 }

--- a/calm-server/src/server/routes/validation-route.ts
+++ b/calm-server/src/server/routes/validation-route.ts
@@ -2,6 +2,7 @@ import { SchemaDirectory, validate, ValidationOutcome, initLogger } from '@finos
 import type { Logger } from '@finos/calm-shared';
 import { Router, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
+import { ErrorResponse } from './error-response';
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -201,13 +202,6 @@ export class ValidationRouter {
             return res.status(500).type('json').send(new ErrorResponse('Failed to validate architecture against pattern'));
         }
     };
-}
-
-class ErrorResponse {
-    error: string;
-    constructor(error: string) {
-        this.error = error;
-    }
 }
 
 interface ValidationRequest {

--- a/calm-server/src/server/server.ts
+++ b/calm-server/src/server/server.ts
@@ -20,7 +20,16 @@ export function startServer(
     );
     const allRoutes = serverRoutesInstance.router;
 
-    app.use(express.json());
+    // The render endpoint accepts whole CALM documents, which routinely exceed
+    // express.json's 100kb default. RenderRouter mounts its own higher-limit parser,
+    // so the app-level parser must skip that route or it would 413 large bodies first.
+    const jsonParser = express.json();
+    app.use((req, res, next) => {
+        if (req.path.startsWith('/calm/render')) {
+            return next();
+        }
+        return jsonParser(req, res, next);
+    });
     app.use('/', allRoutes);
 
     return app.listen(parseInt(port), host, () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,18 +207,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "calm-guard/node_modules/@mermaid-js/layout-elk": {
-            "version": "0.1.9",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "d3": "^7.9.0",
-                "elkjs": "^0.9.3"
-            },
-            "peerDependencies": {
-                "mermaid": "^11.0.2"
-            }
-        },
         "calm-guard/node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -258,11 +246,6 @@
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
-        },
-        "calm-guard/node_modules/elkjs": {
-            "version": "0.9.3",
-            "extraneous": true,
-            "license": "EPL-2.0"
         },
         "calm-guard/node_modules/html-encoding-sniffer": {
             "version": "6.0.0",
@@ -621,14 +604,15 @@
         },
         "calm-server": {
             "name": "@finos/calm-server",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@finos/calm-shared": "file:../shared",
                 "commander": "^14.0.0",
                 "copyfiles": "^2.4.1",
                 "express": "^4.18.2",
-                "express-rate-limit": "^8.5.0"
+                "express-rate-limit": "^8.5.0",
+                "playwright-core": "^1.56.0"
             },
             "bin": {
                 "calm-server": "dist/index.js"
@@ -933,7 +917,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.47.1",
+            "version": "1.48.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -19049,16 +19033,6 @@
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
             "license": "Apache-2.0"
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.23",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-            "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
         },
         "node_modules/@swc/html": {
             "version": "1.15.43",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -48,6 +48,12 @@ export {
     type FrontMatterInjectionParams
 } from './template/front-matter.js';
 export { Docifier, DocifyMode, DiagramExportFormat } from './docify/docifier.js';
+export {
+    launchBrowser,
+    type BrowserLaunchOptions,
+    type LaunchedBrowser,
+} from './docify/diagram-rendering/browser-launch.js';
+export { BrowserLaunchError, BrowserOverrideError } from './docify/diagram-rendering/errors.js';
 export { C4Model } from './docify/graphing/c4.js';
 export { CalmRelationshipGraph } from './docify/graphing/relationship-graph.js';
 export { ValidationOutcome } from './commands/validate/validation.output';


### PR DESCRIPTION
## Description

Implements the first two phases of #2806: real diagram thumbnails on architecture/pattern browse cards, and type icons for the non-visual resource types.

**Commit 1 — resource type icons (`calm-hub-ui` only).** A central registry (`src/theme/resource-type-meta.ts`) now maps each resource type to its icon alongside the existing label/colour metadata: Flows, Standards, ADRs and Interfaces get a type glyph on their browse cards (the pattern Controls already used — its hardcoded shield migrated into the registry), and every search surface (navbar dropdown, explorer, intro search, full results page) shows the icon on its type-group headers.

**Commit 2 — diagram thumbnails rendered via calm-server.**
- **calm-server** gains an internal `POST /calm/render/thumbnail`: it drives a local headless Chrome (via `@finos/calm-shared`'s existing `launchBrowser`) against the Hub UI's new chrome-free `/#/render` route, injects the document with `addInitScript`, waits for the diagram's `data-render-ready` signal, and returns a PNG clipped to the graph's content bounds. The clip is expanded toward the browse card's aspect ratio so the card's `object-cover` never crops away nodes — a two-node architecture shows both nodes, not just the edge between them.
- **calm-hub** stores thumbnails base64-per-version in both Nitrite and Mongo stores and serves them via `GET .../versions/{version}/thumbnail` and a latest-version `GET .../{id}/thumbnail` (`image/png`, private cache). Rendering is triggered asynchronously on every architecture/pattern write — a render failure never affects the write — and a GET for a missing thumbnail attempts a synchronous single-flight render (with a short failure cache) before 404ing, so failed renders self-heal on next browse. The whole pipeline is **disabled unless `calm.render.service-url` is configured**, and requires a deployment where the UI and thumbnail GETs are reachable without interactive auth (standalone / no-auth / proxy-auth / public-read) — documented in `application.properties` and `calm-hub/AGENTS.md`.
- **calm-hub-ui** adds the chromeless `/#/render` route, `ItemCard` thumbnail support with graceful fallback to the existing striped placeholder, capped-width auto-fill card grids (namespace, domain), and the search results page now renders the same browse cards.
- **Bundled fix:** the SPA shell (`/`, `/index.html`) was served `public, immutable, max-age=86400`, pinning browsers to a stale bundle for up to a day after every upgrade; it is now `no-cache` while hashed `/assets/*` keep immutable caching.

Open follow-ups from #2806 deliberately not in this PR: ADR descriptions (needs a backend schema change), auth-aware thumbnail loading for secure OIDC deployments, and thumbnail backfill for existing versions (they render on first browse via the self-healing GET).

Note on `package-lock.json`: beyond the `playwright-core` addition for calm-server, the diff includes lockfile sync of pre-existing drift (cli/calm-server version fields already bumped by release commits) and removal of stale extraneous entries.

### Screenshots

**Architecture cards with rendered thumbnails (namespace browse):**
<img width="800" alt="architecture cards with diagram thumbnails" src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/card-thumbnails/pr-traderx-thumbnails.png" />

**Type icons on non-visual resource cards (flows):**
<img width="800" alt="flow cards with type icons" src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/card-thumbnails/pr-flow-icons.png" />

**Search results using the shared browse cards:**
<img width="800" alt="search results rendered as browse cards" src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/card-thumbnails/pr-search-cards.png" />

**Small architectures render minimap-style (aspect-bounded clip):**
<img width="800" alt="two-node architectures showing both nodes in thumbnails" src="https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/card-thumbnails/pr-timeline-minimaps.png" />

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)
- [x] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified end-to-end against a local standalone deployment (calm-hub + calm-server + system Chrome): eager render on write, self-healing render on GET-miss with single-flight dedup and failure caching, graceful degradation with calm-server down (writes succeed, cards fall back to the striped placeholder), and thumbnail regeneration via PUT updates. Suites: calm-hub-ui 1248 tests, calm-server 73 tests (coverage gate passing), shared 963 tests, calm-hub 2199 tests.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
