### PR TITLE
docs(calm-ai): document calm docify --export-diagrams in CLI instructions

### DIFF
--- a/calm-ai/tools/calm-cli-instructions.md
+++ b/calm-ai/tools/calm-cli-instructions.md
@@ -149,10 +149,23 @@ Useful for producing documentation, reports, or configs. Template bundles requir
 Generate a documentation website from a CALM model:
 
 ```shell
-calm docify -a <architecture> -o <output> [--template <file>] [--template-dir <dir>] [--url-to-local-file-mapping <json>] [--clear-output-directory] [--verbose]
+calm docify -a <architecture> -o <output> [--template <file>] [--template-dir <dir>] [--url-to-local-file-mapping <json>] [--clear-output-directory] [--export-diagrams <svg|png>] [--browser-path <path>] [--diagram-render-timeout <ms>] [--verbose]
 ```
 
 Creates a browsable site that visualizes nodes, relationships, interfaces, and metadata.
+
+### Exporting Diagrams as Images
+
+By default, generated documentation contains Mermaid diagrams as ` ```mermaid ` code blocks. Pass `--export-diagrams <svg|png>` to render these into image files using a local Chromium-based browser, replacing each code block with an image reference (e.g. `_diagrams/my-page-1.svg`).
+
+```shell
+calm docify -a architecture.json -o docs/output --export-diagrams svg
+```
+
+- Requires Google Chrome or Microsoft Edge installed locally (auto-detected). Use `--browser-path <path>` to point at another Chromium-based browser (Brave, Vivaldi, Chromium, etc.) if auto-detection fails.
+- `--diagram-render-timeout <ms>`: per-diagram render timeout (default `30000`).
+- Adds roughly 10-40 seconds to the command depending on the number of diagrams.
+- If no browser is found, or a diagram fails to render (timeout/invalid syntax), that diagram is left as a Mermaid code block with a warning logged; the rest of the documentation is unaffected. An invalid `--browser-path` is a fatal error.
 
 ### Using `--url-to-local-file-mapping`
 

--- a/calm-ai/tools/documentation-creation.md
+++ b/calm-ai/tools/documentation-creation.md
@@ -27,6 +27,8 @@ calm docify \
   --template-dir ./templates
 ```
 
+Add `--export-diagrams <svg|png>` to render the generated Mermaid diagrams to image files (via a local Chromium-based browser) instead of leaving them as Mermaid code blocks. See **calm-cli-instructions.md** for the full set of docify options.
+
 ### 2. Custom Templates
 
 Create Handlebars templates for custom documentation:


### PR DESCRIPTION
## Description
PR #2634 added a `--export-diagrams <svg|png>` flag (plus `--browser-path` and `--diagram-render-timeout`) to `calm docify`, which renders Mermaid diagrams to image files via a local Chromium-based browser. The `calm-ai` tool prompts that AI assistants use (via `calm init-ai`) hadn't been updated to reflect this, so agents configured with CALM AI tooling had no knowledge of the feature.

This updates the CLI knowledge that `calm-ai` distributes to AI assistant integrations (Copilot, Kiro, Claude Code, Codex) so they can correctly invoke `--export-diagrams` and understand its prerequisites and failure behavior.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [x] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format
`docs(calm-ai): document calm docify --export-diagrams in CLI instructions`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Documentation-only change (markdown files consumed as-is by `calm init-ai`); no code paths affected. Reviewed the rendered markdown for accuracy against the flags and behavior introduced in #2634.

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
