### PR TITLE
ci: scope publish-on-merge triggers to their own release branches

### DIFF
--- a/.github/workflows/automated-release-calm-server.yml
+++ b/.github/workflows/automated-release-calm-server.yml
@@ -429,7 +429,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'automated-release')
+      contains(github.event.pull_request.labels.*.name, 'automated-release') &&
+      startsWith(github.event.pull_request.head.ref, 'release/calm-server-v')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -433,7 +433,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'automated-release')
+      contains(github.event.pull_request.labels.*.name, 'automated-release') &&
+      startsWith(github.event.pull_request.head.ref, 'release/cli-v')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2


### PR DESCRIPTION
## Description
Both `automated-release.yml` (CLI) and `automated-release-calm-server.yml` (CALM Server) listen to `pull_request: types: [closed]` on any PR in the repo, and both `publish-on-merge` jobs fire whenever a PR with the `automated-release` label is merged. Because both workflows apply that same label, merging either release PR causes both publish jobs to run — the wrong workflow would create a git tag and publish to npm for a package it doesn't own.

Fix: add a `startsWith` branch-name guard to each `publish-on-merge` `if:` condition so each workflow only acts on its own PRs:
- CLI workflow: `startsWith(github.event.pull_request.head.ref, 'release/cli-v')`
- CALM Server workflow: `startsWith(github.event.pull_request.head.ref, 'release/calm-server-v')`

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Commit Message Format ✅

`ci: scope publish-on-merge triggers to their own release branches`

## Testing
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

The fix cannot be exercised by local tests — it only manifests when a real release PR is merged on GitHub Actions. The logic change is a two-line addition of a `startsWith` guard that is straightforward to reason about.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards