### PR TITLE
fix(calm-server): declare ts-node runtime dependency and drop file:../shared dependency

### DIFF
--- a/calm-server/package.json
+++ b/calm-server/package.json
@@ -29,11 +29,11 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
-        "@finos/calm-shared": "file:../shared",
         "commander": "^14.0.0",
         "copyfiles": "^2.4.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.5.0"
+        "express-rate-limit": "^8.5.0",
+        "ts-node": "10.9.2"
     },
     "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,18 +207,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "calm-guard/node_modules/@mermaid-js/layout-elk": {
-            "version": "0.1.9",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "d3": "^7.9.0",
-                "elkjs": "^0.9.3"
-            },
-            "peerDependencies": {
-                "mermaid": "^11.0.2"
-            }
-        },
         "calm-guard/node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -258,11 +246,6 @@
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
-        },
-        "calm-guard/node_modules/elkjs": {
-            "version": "0.9.3",
-            "extraneous": true,
-            "license": "EPL-2.0"
         },
         "calm-guard/node_modules/html-encoding-sniffer": {
             "version": "6.0.0",
@@ -621,14 +604,14 @@
         },
         "calm-server": {
             "name": "@finos/calm-server",
-            "version": "0.2.1",
+            "version": "0.3.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@finos/calm-shared": "file:../shared",
                 "commander": "^14.0.0",
                 "copyfiles": "^2.4.1",
                 "express": "^4.18.2",
-                "express-rate-limit": "^8.5.0"
+                "express-rate-limit": "^8.5.0",
+                "ts-node": "10.9.2"
             },
             "bin": {
                 "calm-server": "dist/index.js"
@@ -933,7 +916,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.47.1",
+            "version": "1.48.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",
@@ -19049,16 +19032,6 @@
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
             "license": "Apache-2.0"
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.23",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-            "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
         },
         "node_modules/@swc/html": {
             "version": "1.15.43",


### PR DESCRIPTION
## Description

Fixes #2817

`@finos/calm-server` installed from npm is unrunnable, for two compounding reasons:

1. **Startup crash `Cannot find module 'ts-node'`** — `shared/src/template/template-processor.ts` statically imports `ts-node`; `calm-server/tsup.config.ts` bundles `@finos/calm-shared` (`noExternal`) but marks `ts-node` as `external`, leaving a live `require('ts-node')` in `dist/index.js` that `calm-server/package.json` never satisfied.
2. **Unresolvable `"@finos/calm-shared": "file:../shared"` dependency** — shipped verbatim in the published package; `@finos/calm-shared` is private (404 on npm), so npm creates a dangling symlink that corrupts the consumer's dependency tree (any subsequent `npm install` fails with `Cannot destructure property 'package' of 'node.target' as it is null`).

This PR mirrors the established pattern in `cli/package.json` (identical tsup config, works on npm): declare `"ts-node": "10.9.2"` in `dependencies` and remove the redundant `file:../shared` entry (the shared code is already bundled by tsup).

**Lockfile note:** `package-lock.json` was updated by deleting `node_modules` and running `npm install` against the committed lockfile (avoiding npm/cli#4828 platform pruning; `scripts/validate-lockfile-platforms.js` passes). Besides the calm-server entry, the diff only contains corrections npm makes for any install on `main`: stale workspace version syncs (`calm-server` 0.2.1→0.3.1, `cli` 1.47.1→1.48.0) and removal of three `"extraneous": true` records.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [x] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [x] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

`fix(calm-server): declare ts-node runtime dependency and drop file:../shared dependency`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Local verification on the exact repro from #2817:
- `npm run build:calm-server`, `npm test --workspace calm-server` (100% statement coverage), `npm run lint --workspace calm-server` — all pass
- Packed the workspace (`npm pack --workspace calm-server`) and installed the tarball in a clean directory: `ts-node` resolves from the registry, no `@finos/calm-shared` symlink is created, `npx calm-server` starts, and `GET /health` returns `{"status":"OK"}`
- A subsequent `npm install <pkg>` in that consumer project now succeeds (previously failed with the reify/destructure error)

No unit tests added: the change is package metadata only; behaviour is covered by the end-to-end install verification above.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6KgcyF7Bxo2fL8e8FUQ6c