### PR TITLE
fix(shared): deep copy pattern in selectChoices to avoid mutating caller input

### DIFF
--- a/shared/src/commands/generate/components/options.spec.ts
+++ b/shared/src/commands/generate/components/options.spec.ts
@@ -272,6 +272,34 @@ describe('Pattern Options', () => {
             expect(selectChoices(pattern, choices)).toEqual(expectedPattern);
         });
 
+        it('should not mutate the input pattern', () => {
+            const applicationA = buildNode('application-a');
+            const applicationB = buildNode('application-b');
+            const connectsRelationshipA = buildConnectsRelationship('application-a-to-c', 'app a to app c', 'application-a', 'application-c');
+            const connectsRelationshipB = buildConnectsRelationship('application-b-to-c', 'app b to app c', 'application-b', 'application-c');
+
+            const pattern = buildPattern(
+                [
+                    { 'anyOf': [ applicationA, applicationB ] }
+                ],
+                [
+                    buildPatternOptionRelationship(
+                        'option-id',
+                        'The choice of nodes and relationships in the pattern',
+                        buildPatternOption('anyOf', buildPatternChoice(applicationAtoC), buildPatternChoice(applicationBtoC))
+                    ),
+                    {
+                        'anyOf': [ connectsRelationshipA, connectsRelationshipB ]
+                    }
+                ]
+            );
+            const patternBeforeSelection = structuredClone(pattern);
+
+            selectChoices(pattern, [applicationAtoC]);
+
+            expect(pattern).toEqual(patternBeforeSelection);
+        });
+
         it('should not affect a normal pattern', () => {
             const applicationA = buildNode('application-a');
             const applicationB = buildNode('application-b');

--- a/shared/src/commands/generate/components/options.ts
+++ b/shared/src/commands/generate/components/options.ts
@@ -156,7 +156,7 @@ export function selectChoices(inputPattern: object, choices: CalmChoice[], debug
     const logger = initLogger(debug, 'calm-generate-options');
     logger.debug(`Selecting these choices from the pattern [${JSON.stringify(choices)}]`);
 
-    const pattern = {...inputPattern} as SchemaNode; // make a copy so we don't mutate the input pattern
+    const pattern = structuredClone(inputPattern) as SchemaNode; // deep copy so we don't mutate the input pattern, which may be cached and reused by callers
     const nodeIds: string[] = choices.flatMap(choice => choice.nodes);
     const relationshipIds: string[] = choices.flatMap(choice => choice.relationships);
 

--- a/shared/src/commands/validate/validate.e2e.spec.ts
+++ b/shared/src/commands/validate/validate.e2e.spec.ts
@@ -82,6 +82,20 @@ describe('validate E2E', () => {
         expect(response.spectralSchemaValidationOutputs[1].path).toBe('/nodes/1/description');
     });
 
+    it('produces the same outcome when the same pattern object is validated repeatedly', async () => {
+        // Long-lived processes (e.g. calm-server) cache pattern objects and reuse
+        // them across validations, so validating must not mutate the pattern.
+        const inputPattern = JSON.parse(readFileSync(inputPatternPath, 'utf-8'));
+        const inputArch = JSON.parse(readFileSync(inputArchPath, 'utf-8'));
+        const patternBeforeValidation = structuredClone(inputPattern);
+
+        const firstResponse = await validate(inputArch, inputPattern, undefined, schemaDirectory, false);
+        const secondResponse = await validate(inputArch, inputPattern, undefined, schemaDirectory, false);
+
+        expect(inputPattern).toEqual(patternBeforeValidation);
+        expect(secondResponse).toEqual(firstResponse);
+    });
+
     it('reports json schema compilation errors for bad-json-schema fixture', async () => {
         const badPattern = JSON.parse(readFileSync(badPatternPath, 'utf-8'));
         const inputArch = JSON.parse(readFileSync(inputArchPath, 'utf-8'));


### PR DESCRIPTION
## Description

Fixes #2823.

`selectChoices` in `shared` claimed to copy the input pattern before flattening selected `oneOf`/`anyOf` choices, but only made a shallow copy (`{...inputPattern}`). The flattening therefore wrote through into the caller's nested objects.

calm-server hands the same cached pattern object from `SchemaDirectory` to every validation of the same `$schema`. The first request lints the pristine pattern (passes), then permanently replaces the cached pattern's options `anyOf`/`oneOf` blocks with the selected decision. Every subsequent identical request then fails the pattern lint (`pattern-option-relationship-must-only-have-oneof-or-anyof-items`, `nodes-referenced-in-pattern-decision-must-be-in-oneof-or-anyof-block`) until the server is restarted.

This PR replaces the shallow copy with `structuredClone`, making the existing "make a copy so we don't mutate" intent true and protecting any consumer that holds onto a pattern object.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [x] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

`fix(shared): deep copy pattern in selectChoices to avoid mutating caller input`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

**New tests (both fail on the unfixed code, pass with the fix):**
- `options.spec.ts` — `selectChoices` leaves its input pattern deep-equal to its pre-call state.
- `validate.e2e.spec.ts` — validating the same in-memory pattern object twice yields identical outcomes (the calm-server scenario, using the repo's real options fixtures and Spectral rules).

**Local verification:**
- Because this touches `shared`, consumer suites were run: `shared` (965 tests), `cli` (595), `calm-server` (51), `calm-plugins/vscode` (491) — all pass; `npm run lint` reports 0 errors.
- End-to-end: rebuilt calm-server with the fixed `shared` bundled in and re-ran the exact repro from #2823 (architecture-only `POST /calm/validate` against a served anyOf options pattern) — five consecutive identical requests all pass, where previously the second request onwards failed until restart.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
