### PR TITLE
fix(ci): make calm-models release PR-based instead of pushing to main

### DIFF
--- a/.github/workflows/release-calm-models-maven-publish.yml
+++ b/.github/workflows/release-calm-models-maven-publish.yml
@@ -1,0 +1,82 @@
+name: "CALM models - publish to Maven Central"
+
+on:
+    pull_request:
+        types: [closed]
+        branches: [main]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    publish-central:
+        name: Publish CALM models to Maven Central
+        if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-prep/calm-models-v')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Extract release version
+              id: version
+              run: |
+                REF="${{ github.event.pull_request.head.ref }}"
+                echo "release_version=${REF#release-prep/calm-models-v}" >> "$GITHUB_OUTPUT"
+
+            - name: Checkout main at merge commit
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.pull_request.merge_commit_sha }}
+                token: ${{ secrets.GITHUB_TOKEN }}
+                persist-credentials: true
+                fetch-depth: 0
+
+            - name: Setup JDK 21 and auto-generate Sonatype settings
+              uses: actions/setup-java@v4
+              with:
+                distribution: 'temurin'
+                java-version: '21'
+                server-id: central
+                server-username: CI_DEPLOY_USERNAME
+                server-password: CI_DEPLOY_PASSWORD
+                gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
+                gpg-passphrase: CI_GPG_PASSPHRASE
+
+            - name: Establish Git Deployment Author Info
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+            - name: Tag release
+              run: |
+                RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+                git tag -a "calm-models-v${RELEASE_VERSION}" -m "calm-models v${RELEASE_VERSION}"
+                git push origin "calm-models-v${RELEASE_VERSION}"
+
+            - name: Build and deploy to Maven Central
+              run: |
+                ./mvnw -B -Prelease -DskipTests -pl :calm-models deploy
+              env:
+                CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+                CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+                CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
+
+            # Bumps to the next SNAPSHOT and opens a PR (rather than pushing to main
+            # directly), for the same reason release-calm-models-maven.yml does: main
+            # requires PRs.
+            - name: Prepare next development iteration PR
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+                IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
+                NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+                BRANCH="release-prep/calm-models-next-dev-v${NEXT_VERSION}"
+                git checkout -b "$BRANCH"
+                ./mvnw -q versions:set -pl calm-models -DnewVersion="${NEXT_VERSION}" -DgenerateBackupPoms=false
+                git commit -am "ci(calm-models): prepare next development iteration v${NEXT_VERSION}"
+                git push origin "$BRANCH"
+                gh pr create --repo ${{ github.repository }} \
+                  --base main \
+                  --head "$BRANCH" \
+                  --title "ci(calm-models): prepare next development iteration v${NEXT_VERSION}" \
+                  --body "Bumps \`calm-models\` to \`${NEXT_VERSION}\` following the release of v${RELEASE_VERSION}."

--- a/.github/workflows/release-calm-models-maven.yml
+++ b/.github/workflows/release-calm-models-maven.yml
@@ -1,17 +1,18 @@
-name: "Release and publish CALM models to Maven Central"
+name: "CALM models - prepare release PR"
 
 on:
     workflow_dispatch:
     push:
         branches:
             - 'release/calm-models-*'
-            
+
 permissions:
     contents: write
+    pull-requests: write
 
 jobs:
-    publish-central:
-        name: Publish CALM models to Maven Central
+    prepare-release:
+        name: Prepare CALM models release PR
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -20,33 +21,57 @@ jobs:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 persist-credentials: true
                 fetch-depth: 0
-            - name: Setup JDK 21 and auto-generate Sonatype settings
+
+            - name: Setup JDK 21
               uses: actions/setup-java@v4
               with:
                 distribution: 'temurin'
                 java-version: '21'
-                server-id: central
-                server-username: CI_DEPLOY_USERNAME
-                server-password: CI_DEPLOY_PASSWORD
-                gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
-                gpg-passphrase: CI_GPG_PASSPHRASE
 
             - name: Establish Git Deployment Author Info
               run: |
                 git config --global user.name "github-actions[bot]"
                 git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-            - name: Execute release lifecycle (Isolating calm-models module)
+            - name: Compute release version
+              id: version
               run: |
-                ./mvnw -B release:prepare release:perform \
-                  -pl :calm-models -am \
-                  -DpreparationGoals=clean \
-                  -DreleaseProfiles=release \
-                  -Darguments="-Prelease -DskipTests -pl :calm-models" \
-                  -DignoreSnapshots=true \
-                  -DinteractiveMode=false
+                CURRENT_VERSION=$(./mvnw -q -pl calm-models help:evaluate -Dexpression=project.version -DforceStdout)
+                if [[ "$CURRENT_VERSION" != *-SNAPSHOT ]]; then
+                  echo "calm-models is not on a SNAPSHOT version ($CURRENT_VERSION) - nothing to release." >&2
+                  exit 1
+                fi
+                RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
+                echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Check for an existing release PR
               env:
-                CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
-                CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-                CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                BRANCH="release-prep/calm-models-v${{ steps.version.outputs.release_version }}"
+                EXISTING=$(gh pr list --repo ${{ github.repository }} --state open \
+                  --json headRefName --jq "[.[] | select(.headRefName == \"$BRANCH\")] | length")
+                if [ "$EXISTING" -gt 0 ]; then
+                  echo "A release PR for v${{ steps.version.outputs.release_version }} ($BRANCH) is already open. Merge or close it before preparing another release." >&2
+                  exit 1
+                fi
+
+            # main is a protected branch (requires PRs), so the version-bump commit for the
+            # release is pushed to a branch and opened as a PR rather than pushed directly.
+            # Merging the PR triggers release-calm-models-maven-publish.yml, which tags,
+            # builds, and deploys to Maven Central.
+            - name: Bump calm-models to release version and open PR
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+                BRANCH="release-prep/calm-models-v${RELEASE_VERSION}"
+                git checkout -b "$BRANCH"
+                ./mvnw -q versions:set -pl calm-models -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false
+                git commit -am "ci(calm-models): release v${RELEASE_VERSION}"
+                git push origin "$BRANCH"
+                gh pr create --repo ${{ github.repository }} \
+                  --base main \
+                  --head "$BRANCH" \
+                  --title "ci(calm-models): release v${RELEASE_VERSION}" \
+                  --body "Bumps \`calm-models\` to release version \`${RELEASE_VERSION}\`. Merging this PR publishes it to Maven Central and opens a follow-up PR for the next development iteration."


### PR DESCRIPTION
## Description
Follow-up to #2832. Even with SCM auth fixed, the release workflow still fails because `main` is a protected branch requiring PRs, and `maven-release-plugin`'s `release:prepare`/`release:perform` push version-bump commits and tags directly to `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

See failing run: https://github.com/finos/architecture-as-code/actions/runs/29492134447/job/87600539438

I don't have admin rights on this repo to grant the release automation a branch-protection bypass, so instead this switches the release to a PR-based flow, mirroring how `automated-release.yml` already handles the CLI's version bump:

- **`release-calm-models-maven.yml`** now only computes the release version (strips `-SNAPSHOT`), bumps `calm-models/pom.xml` on a `release-prep/calm-models-v*` branch, and opens a PR into `main`.
- **`release-calm-models-maven-publish.yml`** (new) triggers when that PR merges: it tags the release commit, runs `mvn deploy -Prelease -pl :calm-models` directly (no longer via `release:perform`) to publish to Maven Central, then opens a follow-up PR bumping `calm-models` to the next `-SNAPSHOT` version.

Both PR-opening steps push to non-protected feature branches (not `main`), so no branch-protection bypass is required anywhere in the flow. Tag pushes also aren't affected by the branch protection rule, since it only covers `refs/heads/main`.

I verified locally that `mvn versions:set -pl calm-models -DnewVersion=...` only touches `calm-models/pom.xml` and leaves the root parent `pom.xml` untouched — important since `calm-hub`, `cli`, `calm`, `docs`, and `shared` all inherit from that same parent POM and pin its version.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Testing
- [x] I have tested my changes locally (validated both workflow YAML files parse correctly, syntax-checked the embedded shell scripts with `bash -n`, and confirmed the `versions:set` scoping behavior against the real poms)
- [ ] I have added/updated unit tests (not applicable — GitHub Actions workflow files)
- [ ] All existing tests pass (not applicable — GitHub Actions workflow files)

This can't be fully end-to-end tested without merging (the publish workflow only triggers on a PR merge to `main`), so I'd suggest keeping an eye on the first real run after merge.

## Checklist
- [x] My commits follow the conventional commit format
- [ ] I have updated documentation if necessary (not applicable)
- [ ] I have added tests for my changes (not applicable)
- [x] My changes follow the project's coding standards