### PR TITLE
fix(calm-hub): harden Mongo stores for multi-instance concurrency

### DIFF
--- a/calm-hub/src/integration-test/java/integration/PermittedScopesIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/PermittedScopesIntegration.java
@@ -3,6 +3,7 @@ package integration;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.bson.Document;
@@ -53,8 +54,15 @@ public class PermittedScopesIntegration {
                 );
             }
 
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("userAccess")) {
-                database.createCollection("userAccess");
+            // Guard on the specific grant, not collection existence: MongoIndexInitializer's
+            // startup index creation on userAccess implicitly creates the (empty) collection
+            // before this ever runs, so "does the collection exist" is never a useful check here.
+            boolean grantExists = database.getCollection("userAccess").find(Filters.and(
+                    Filters.eq("username", "test-user"),
+                    Filters.eq("namespace", "finos"),
+                    Filters.eq("permission", UserAccess.Permission.read.name())
+            )).first() != null;
+            if (!grantExists) {
                 database.getCollection("userAccess").insertOne(
                         new Document("username", "test-user")
                                 .append("namespace", "finos")

--- a/calm-hub/src/integration-test/java/integration/ProxyAuthIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/ProxyAuthIntegration.java
@@ -3,6 +3,7 @@ package integration;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.bson.Document;
@@ -93,8 +94,15 @@ public class ProxyAuthIntegration {
                 );
             }
 
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("userAccess")) {
-                database.createCollection("userAccess");
+            // Guard on a specific grant, not collection existence: MongoIndexInitializer's
+            // startup index creation on userAccess implicitly creates the (empty) collection
+            // before this ever runs, so "does the collection exist" is never a useful check here.
+            boolean grantsExist = database.getCollection("userAccess").find(Filters.and(
+                    Filters.eq("username", USER_ALICE),
+                    Filters.eq("namespace", "finos"),
+                    Filters.eq("permission", UserAccess.Permission.read.name())
+            )).first() != null;
+            if (!grantsExist) {
                 database.getCollection("userAccess").insertMany(List.of(
                         new Document("username", USER_ALICE)
                                 .append("namespace", "finos")

--- a/calm-hub/src/integration-test/java/integration/UserAccessGrantsIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/UserAccessGrantsIntegration.java
@@ -3,6 +3,7 @@ package integration;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.bson.Document;
@@ -69,13 +70,25 @@ public class UserAccessGrantsIntegration {
                 database.createCollection("userAccess");
             }
 
-            // test-user has admin access on finos, so they can manage grants there
-            database.getCollection("userAccess").insertOne(
-                    new Document("username", "test-user")
-                            .append("namespace", "finos")
-                            .append("permission", UserAccess.Permission.admin.name())
-                            .append("userAccessId", 101)
-            );
+            // test-user has admin access on finos, so they can manage grants there.
+            // Guarded on the specific grant (not collection existence, since
+            // MongoIndexInitializer's startup index creation on userAccess implicitly
+            // creates the collection before this ever runs) — this @BeforeEach runs before
+            // every test in this class, so without the guard the second test's insert
+            // collides with the first test's leftover document.
+            boolean grantExists = database.getCollection("userAccess").find(Filters.and(
+                    Filters.eq("username", "test-user"),
+                    Filters.eq("namespace", "finos"),
+                    Filters.eq("permission", UserAccess.Permission.admin.name())
+            )).first() != null;
+            if (!grantExists) {
+                database.getCollection("userAccess").insertOne(
+                        new Document("username", "test-user")
+                                .append("namespace", "finos")
+                                .append("permission", UserAccess.Permission.admin.name())
+                                .append("userAccessId", 101)
+                );
+            }
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/AdrRevisionExistsException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/AdrRevisionExistsException.java
@@ -1,0 +1,7 @@
+package org.finos.calm.domain.exception;
+
+/**
+ * Exception thrown when an ADR revision already exists.
+ */
+public class AdrRevisionExistsException extends Exception {
+}

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
@@ -260,6 +260,9 @@ public class AdrTools {
         } catch (AdrParseException e) {
             logger.warn("ADR parse error for ADR [{}] in namespace [{}]", adrId, namespace, e);
             return ToolResponse.error("Error: Failed to parse ADR content. Check the JSON structure.");
+        } catch (AdrRevisionExistsException e) {
+            logger.warn("Concurrent update created a conflicting revision for ADR [{}] in namespace [{}]", adrId, namespace, e);
+            return ToolResponse.error("Error: ADR " + adrId + " was concurrently updated, please retry.");
         } catch (Exception e) {
             logger.error("Unexpected error updating ADR [{}] in namespace [{}]", adrId, namespace, e);
             return ToolResponse.error("Error: Unexpected error updating ADR " + adrId + ".");
@@ -307,6 +310,9 @@ public class AdrTools {
         } catch (AdrParseException e) {
             logger.warn("Parse error updating status for ADR [{}] in namespace [{}]", adrId, namespace, e);
             return ToolResponse.error("Error: Failed to parse ADR " + adrId + " when updating status.");
+        } catch (AdrRevisionExistsException e) {
+            logger.warn("Concurrent update created a conflicting revision for ADR [{}] in namespace [{}]", adrId, namespace, e);
+            return ToolResponse.error("Error: ADR " + adrId + " was concurrently updated, please retry.");
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
@@ -309,7 +309,8 @@ public class AdrResource {
                 AdrNotFoundException.class, ex -> handleAdrNotFoundException(adrId, ex),
                 AdrRevisionNotFoundException.class, ex -> handleAdrRevisionNotFoundException(adrId, revision, ex),
                 AdrParseException.class, this::handleAdrParseException,
-                AdrPersistenceException.class, ex -> handleAdrPersistenceException(adrId, ex)
+                AdrPersistenceException.class, ex -> handleAdrPersistenceException(adrId, ex),
+                AdrRevisionExistsException.class, ex -> handleAdrRevisionExistsException(adrId, ex)
         );
 
         return handlers.getOrDefault(e.getClass(), ex -> {
@@ -346,5 +347,10 @@ public class AdrResource {
     private Response handleAdrPersistenceException(int adrId, Exception ex) {
         logger.error("Could not persist update of ADR [{}]", adrId, ex);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not persist update of ADR: [{}]:" + adrId).build();
+    }
+
+    private Response handleAdrRevisionExistsException(int adrId, Exception ex) {
+        logger.error("Concurrent update created a conflicting revision for ADR [{}]", adrId, ex);
+        return Response.status(Response.Status.CONFLICT).entity("ADR " + adrId + " was concurrently updated, please retry").build();
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
@@ -6,6 +6,7 @@ import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.AdrNotFoundException;
 import org.finos.calm.domain.exception.AdrParseException;
 import org.finos.calm.domain.exception.AdrPersistenceException;
+import org.finos.calm.domain.exception.AdrRevisionExistsException;
 import org.finos.calm.domain.exception.AdrRevisionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 
@@ -18,6 +19,6 @@ public interface AdrStore {
     AdrMeta getAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException;
     List<Integer> getAdrRevisions(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException;
     AdrMeta getAdrRevision(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException;
-    AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException;
-    AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException;
+    AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException;
+    AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -8,8 +8,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
@@ -20,6 +18,7 @@ import org.finos.calm.domain.adr.NamespaceAdrSummary;
 import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.*;
 import org.finos.calm.store.AdrStore;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +28,22 @@ import java.util.Optional;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
+/**
+ * MongoDB-backed implementation of {@link AdrStore}.
+ *
+ * <h2>Document model &amp; concurrency</h2>
+ * Follows the same namespace-scoped document pattern as {@link MongoArchitectureStore}:
+ * one document per namespace (enforced by a unique index on {@code adrs.namespace}), with
+ * an array of ADR sub-documents each holding a {@code revisions} map (revision number → JSON).
+ * New ADRs are added via upsert + {@code $push}. New revisions use an atomic conditional
+ * update with {@code $elemMatch} / {@code $exists: false} on the target revision key: if a
+ * concurrent writer already wrote that revision, {@code matchedCount == 0} signals the
+ * conflict and {@link org.finos.calm.domain.exception.AdrRevisionExistsException} is thrown
+ * instead of silently overwriting the other writer's revision.
+ *
+ * @see MongoIndexInitializer
+ * @see MongoCounterStore
+ */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoAdrStore.class)
@@ -109,10 +124,9 @@ public class MongoAdrStore implements AdrStore {
         Document adrDocument = new Document("adrId", id).append("revisions",
                 new Document(String.valueOf(adrMeta.getRevision()), Document.parse(adrStr)));
 
-        adrCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(adrCollection,
                 Filters.eq("namespace", adrMeta.getNamespace()),
-                Updates.push("adrs", adrDocument),
-                new UpdateOptions().upsert(true));
+                "adrs", adrDocument);
 
         return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
     }
@@ -155,7 +169,7 @@ public class MongoAdrStore implements AdrStore {
     }
 
     @Override
-    public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
+    public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
         Document adrDoc = retrieveAdrDoc(adrMeta);
         AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
 
@@ -173,7 +187,7 @@ public class MongoAdrStore implements AdrStore {
     }
 
     @Override
-    public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
+    public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
         Document adrDoc = retrieveAdrDoc(adrMeta);
         AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
 
@@ -248,17 +262,25 @@ public class MongoAdrStore implements AdrStore {
         }
     }
 
-    private void writeAdrToMongo(AdrMeta adrMeta) throws AdrPersistenceException, AdrParseException {
+    private void writeAdrToMongo(AdrMeta adrMeta) throws AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
 
         try {
             Document adrDocument = Document.parse(objectMapper.writeValueAsString(adrMeta.getAdr()));
+
+            // Atomic conditional update: only succeeds if this revision doesn't already exist.
+            // Two concurrent writers both computing the same "latest + 1" revision will race here;
+            // the loser gets matchedCount == 0 instead of silently overwriting the winner's write.
             Document filter = new Document("namespace", adrMeta.getNamespace())
-                    .append("adrs.adrId", adrMeta.getId());
+                    .append("adrs", new Document("$elemMatch",
+                            new Document("adrId", adrMeta.getId())
+                                    .append("revisions." + adrMeta.getRevision(), new Document("$exists", false))));
+
             Document update = new Document("$set",
                     new Document("adrs.$.revisions." + adrMeta.getRevision(), adrDocument));
 
-            adrCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-
+            if (adrCollection.updateOne(filter, update).getMatchedCount() == 0) {
+                throw new AdrRevisionExistsException();
+            }
         } catch(MongoWriteException ex) {
             log.error("Failed to write ADR to mongo [{}]", adrMeta, ex);
             throw new AdrPersistenceException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -6,10 +6,10 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Architecture;
@@ -121,10 +121,9 @@ public class MongoArchitectureStore implements ArchitectureStore {
                 .append("description", architecture.getDescription())
                 .append("versions", new Document("1-0-0", Document.parse(architecture.getArchitectureJson())));
 
-        architectureCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(architectureCollection,
                 Filters.eq("namespace", architecture.getNamespace()),
-                Updates.push("architectures", architectureDocument),
-                new UpdateOptions().upsert(true));
+                "architectures", architectureDocument);
 
         Architecture persistedArchitecture = new Architecture.ArchitectureBuilder()
                 .setId(id)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -22,6 +22,7 @@ import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
 import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.store.ControlStore;
+import org.finos.calm.store.util.MongoUpsertPush;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,11 +122,9 @@ public class MongoControlStore implements ControlStore {
                 .append("requirement", requirementVersions)
                 .append("configurations", new ArrayList<>());
 
-        controlCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(controlCollection,
                 Filters.eq("domain", domain),
-                Updates.push("controls", controlDoc),
-                new UpdateOptions().upsert(true)
-        );
+                "controls", controlDoc);
 
         return new ControlDetail(controlId, name, description);
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDecoratorStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDecoratorStore.java
@@ -3,7 +3,6 @@ package org.finos.calm.store.mongo;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
@@ -13,6 +12,7 @@ import org.finos.calm.domain.Decorator;
 import org.finos.calm.domain.exception.DecoratorNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.DecoratorStore;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,10 +119,9 @@ public class MongoDecoratorStore implements DecoratorStore {
         Document decoratorDocument = new Document("decoratorId", id)
                 .append("decorator", parsedDecorator);
 
-        decoratorCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(decoratorCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("decorators", decoratorDocument),
-                new UpdateOptions().upsert(true));
+                "decorators", decoratorDocument);
 
         LOG.debug("Created decorator with ID {} in namespace '{}'", id, namespace);
         return id;

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -6,11 +6,11 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.Flow;
 import org.finos.calm.domain.exception.FlowNotFoundException;
@@ -101,10 +101,9 @@ public class MongoFlowStore implements FlowStore {
                 .append("versions",
                 new Document("1-0-0", Document.parse(flowRequest.getFlowJson())));
 
-        flowCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(flowCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("flows", flowDocument),
-                new UpdateOptions().upsert(true));
+                "flows", flowDocument);
 
         Flow persistedFlow = new Flow.FlowBuilder()
                 .setId(id)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoIndexInitializer.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoIndexInitializer.java
@@ -39,10 +39,15 @@ import org.slf4j.LoggerFactory;
  *   <li>{@code domains.name} (unique) — one document per domain name</li>
  *   <li>{@code schemas.version} (unique) — one document per schema version string</li>
  *   <li>{@code architectures.namespace}, {@code patterns.namespace}, {@code flows.namespace},
- *       {@code standards.namespace}, {@code interfaces.namespace} (unique) — one document
+ *       {@code timelines.namespace}, {@code standards.namespace}, {@code interfaces.namespace},
+ *       {@code adrs.namespace}, {@code decorators.namespace} (unique) — one document
  *       per namespace in each entity collection, containing an array of that entity type</li>
  *   <li>{@code controls.domain} (unique) — one document per domain, containing an array
  *       of controls</li>
+ *   <li>{@code userAccess.(username, namespace, permission)} and
+ *       {@code userAccess.(username, domain, permission)} (unique, partial) — prevent
+ *       duplicate grants; partial on the presence of {@code namespace}/{@code domain}
+ *       respectively since a grant document has exactly one of the two</li>
  * </ul>
  *
  * <h2>Failure behaviour</h2>
@@ -115,7 +120,7 @@ public class MongoIndexInitializer {
             LOG.info("Ensured unique index on schemas.version");
 
             // Namespace-scoped collections — one document per namespace
-            for (String collection : new String[]{"architectures", "patterns", "flows", "timelines", "standards", "interfaces"}) {
+            for (String collection : new String[]{"architectures", "patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"}) {
                 database.getCollection(collection)
                         .createIndex(new Document("namespace", 1), uniqueIndex);
                 LOG.info("Ensured unique index on {}.namespace", collection);
@@ -134,6 +139,21 @@ public class MongoIndexInitializer {
             database.getCollection("resource_mappings")
                     .createIndex(new Document("namespace", 1).append("resourceType", 1).append("numericId", 1));
             LOG.info("Ensured index on resource_mappings.(namespace, resourceType, numericId)");
+
+            // userAccess grants — partial unique indexes so identical concurrent grants dedupe.
+            // Two partials (not one compound index) because namespace-scoped and domain-scoped
+            // grant documents don't share a discriminating field.
+            database.getCollection("userAccess").createIndex(
+                    new Document("username", 1).append("namespace", 1).append("permission", 1),
+                    new IndexOptions().unique(true)
+                            .partialFilterExpression(new Document("namespace", new Document("$exists", true))));
+            LOG.info("Ensured unique partial index on userAccess.(username, namespace, permission)");
+
+            database.getCollection("userAccess").createIndex(
+                    new Document("username", 1).append("domain", 1).append("permission", 1),
+                    new IndexOptions().unique(true)
+                            .partialFilterExpression(new Document("domain", new Document("$exists", true))));
+            LOG.info("Ensured unique partial index on userAccess.(username, domain, permission)");
         } catch (Exception e) {
             LOG.warn("Failed to create MongoDB indexes — indexes may already exist or MongoDB is unavailable", e);
         }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -5,14 +5,13 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.CalmInterface;
 import org.finos.calm.domain.exception.*;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.store.InterfaceStore;
@@ -96,10 +95,9 @@ public class MongoInterfaceStore implements InterfaceStore {
                 .append("versions",
                         new Document("1-0-0", Document.parse(interfaceRequest.getInterfaceJson())));
 
-        interfaceCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(interfaceCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("interfaces", interfaceDocument),
-                new UpdateOptions().upsert(true));
+                "interfaces", interfaceDocument);
 
         createdInterface.setId(id);
         createdInterface.setVersion("1.0.0");

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -6,12 +6,12 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Pattern;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
@@ -110,10 +110,9 @@ public class MongoPatternStore implements PatternStore {
                 .append("versions",
                 new Document("1-0-0", parsedPattern));
 
-        patternCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(patternCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("patterns", patternDocument),
-                new UpdateOptions().upsert(true));
+                "patterns", patternDocument);
 
         Pattern persistedPattern = new Pattern.PatternBuilder()
                 .setId(id)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -5,13 +5,12 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Standard;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.exception.*;
 import org.finos.calm.domain.standards.CreateStandardRequest;
@@ -98,10 +97,9 @@ public class MongoStandardStore implements StandardStore {
                 .append("versions",
                 new Document("1-0-0", Document.parse(standardRequest.getStandardJson())));
 
-        standardCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(standardCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("standards", standardDocument),
-                new UpdateOptions().upsert(true));
+                "standards", standardDocument);
 
         createdStandard.setId(id);
         createdStandard.setVersion("1.0.0");

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -6,7 +6,6 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
@@ -19,6 +18,7 @@ import org.finos.calm.domain.timeline.CreateTimelineRequest;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
 import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.store.TimelineStore;
+import org.finos.calm.store.util.MongoUpsertPush;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,10 +95,9 @@ public class MongoTimelineStore implements TimelineStore {
                 .append("versions",
                         new Document("1-0-0", Document.parse(timelineRequest.getTimelineJson())));
 
-        timelineCollection.updateOne(
+        MongoUpsertPush.pushWithDuplicateRetry(timelineCollection,
                 Filters.eq("namespace", namespace),
-                Updates.push("timelines", timelineDocument),
-                new UpdateOptions().upsert(true));
+                "timelines", timelineDocument);
 
         return new Timeline.TimelineBuilder()
                 .setId(id)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -1,5 +1,7 @@
 package org.finos.calm.store.mongo;
 
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -7,6 +9,7 @@ import com.mongodb.client.result.DeleteResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.UserAccessNotFoundException;
@@ -53,7 +56,19 @@ public class MongoUserAccessStore implements UserAccessStore {
                 .append("lastUpdated", userAccess.getUpdateDateTime())
                 .append("userAccessId", userAccessId);
 
-        userAccessCollection.insertOne(userAccessDoc);
+        try {
+            userAccessCollection.insertOne(userAccessDoc);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            // A concurrent request already granted this exact (username, namespace, permission)
+            // triple; the grant is additive/idempotent, so return the existing record.
+            log.info("Grant already exists for namespace: {}, permission: {}, username: {}",
+                    userAccess.getNamespace(), userAccess.getPermission(), userAccess.getUsername());
+            return buildFromDocument(findExistingGrant(
+                    Filters.eq("namespace", userAccess.getNamespace()), userAccess));
+        }
         log.info("UserAccess has been created for namespace: {}, permission: {}, username: {}",
                 userAccess.getNamespace(), userAccess.getPermission(), userAccess.getUsername());
 
@@ -76,7 +91,19 @@ public class MongoUserAccessStore implements UserAccessStore {
                 .append("lastUpdated", userAccess.getUpdateDateTime())
                 .append("userAccessId", userAccessId);
 
-        userAccessCollection.insertOne(userAccessDoc);
+        try {
+            userAccessCollection.insertOne(userAccessDoc);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            // A concurrent request already granted this exact (username, domain, permission)
+            // triple; the grant is additive/idempotent, so return the existing record.
+            log.info("Grant already exists for domain: {}, permission: {}, username: {}",
+                    userAccess.getDomain(), userAccess.getPermission(), userAccess.getUsername());
+            return buildFromDocument(findExistingGrant(
+                    Filters.eq("domain", userAccess.getDomain()), userAccess));
+        }
         log.info("UserAccess has been created for domain: {}, permission: {}, username: {}",
                 userAccess.getDomain(), userAccess.getPermission(), userAccess.getUsername());
 
@@ -192,6 +219,14 @@ public class MongoUserAccessStore implements UserAccessStore {
         if (result.getDeletedCount() == 0) {
             throw new UserAccessNotFoundException();
         }
+    }
+
+    private Document findExistingGrant(Bson scopeFilter, UserAccess userAccess) {
+        return userAccessCollection.find(Filters.and(
+                Filters.eq("username", userAccess.getUsername()),
+                scopeFilter,
+                Filters.eq("permission", userAccess.getPermission().name())
+        )).first();
     }
 
     private UserAccess buildFromDocument(Document doc) {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -48,45 +48,26 @@ public class MongoUserAccessStore implements UserAccessStore {
             throw new NamespaceNotFoundException();
         }
 
-        int userAccessId = counterStore.getNextUserAccessSequenceValue();
-        Document userAccessDoc = new Document("username", userAccess.getUsername())
-                .append("permission", userAccess.getPermission().name())
-                .append("namespace", userAccess.getNamespace())
-                .append("createdAt", userAccess.getCreationDateTime())
-                .append("lastUpdated", userAccess.getUpdateDateTime())
-                .append("userAccessId", userAccessId);
-
-        try {
-            userAccessCollection.insertOne(userAccessDoc);
-        } catch (MongoWriteException e) {
-            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
-                throw e;
-            }
-            // A concurrent request already granted this exact (username, namespace, permission)
-            // triple; the grant is additive/idempotent, so return the existing record.
-            log.info("Grant already exists for namespace: {}, permission: {}, username: {}",
-                    userAccess.getNamespace(), userAccess.getPermission(), userAccess.getUsername());
-            return buildFromDocument(findExistingGrant(
-                    Filters.eq("namespace", userAccess.getNamespace()), userAccess));
-        }
-        log.info("UserAccess has been created for namespace: {}, permission: {}, username: {}",
-                userAccess.getNamespace(), userAccess.getPermission(), userAccess.getUsername());
-
-        return new UserAccess.UserAccessBuilder()
-                .setUserAccessId(userAccessId)
-                .setNamespace(userAccess.getNamespace())
-                .setPermission(userAccess.getPermission())
-                .setUsername(userAccess.getUsername())
-                .build();
+        return createUserAccess(userAccess, "namespace", userAccess.getNamespace());
     }
 
     @Override
     public UserAccess createUserAccessForDomain(UserAccess userAccess) {
         log.info("User-access details: {}", userAccess);
+        return createUserAccess(userAccess, "domain", userAccess.getDomain());
+    }
+
+    /**
+     * Creates a grant scoped by either {@code namespace} or {@code domain} (whichever
+     * {@code scopeField} names). On a concurrent duplicate-key race, returns the winner's
+     * grant instead of throwing — the grant is additive/idempotent, so this keeps create
+     * idempotent under multi-instance concurrency.
+     */
+    private UserAccess createUserAccess(UserAccess userAccess, String scopeField, String scopeValue) {
         int userAccessId = counterStore.getNextUserAccessSequenceValue();
         Document userAccessDoc = new Document("username", userAccess.getUsername())
                 .append("permission", userAccess.getPermission().name())
-                .append("domain", userAccess.getDomain())
+                .append(scopeField, scopeValue)
                 .append("createdAt", userAccess.getCreationDateTime())
                 .append("lastUpdated", userAccess.getUpdateDateTime())
                 .append("userAccessId", userAccessId);
@@ -97,22 +78,20 @@ public class MongoUserAccessStore implements UserAccessStore {
             if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
                 throw e;
             }
-            // A concurrent request already granted this exact (username, domain, permission)
-            // triple; the grant is additive/idempotent, so return the existing record.
-            log.info("Grant already exists for domain: {}, permission: {}, username: {}",
-                    userAccess.getDomain(), userAccess.getPermission(), userAccess.getUsername());
-            return buildFromDocument(findExistingGrant(
-                    Filters.eq("domain", userAccess.getDomain()), userAccess));
+            log.info("Grant already exists for {}: {}, permission: {}, username: {}",
+                    scopeField, scopeValue, userAccess.getPermission(), userAccess.getUsername());
+            Document existingGrant = findExistingGrant(Filters.eq(scopeField, scopeValue), userAccess);
+            if (existingGrant == null) {
+                // The racing writer's document is gone by the time we looked it up (e.g. revoked
+                // concurrently) — nothing to return, so surface the original write failure.
+                throw e;
+            }
+            return buildFromDocument(existingGrant);
         }
-        log.info("UserAccess has been created for domain: {}, permission: {}, username: {}",
-                userAccess.getDomain(), userAccess.getPermission(), userAccess.getUsername());
+        log.info("UserAccess has been created for {}: {}, permission: {}, username: {}",
+                scopeField, scopeValue, userAccess.getPermission(), userAccess.getUsername());
 
-        return new UserAccess.UserAccessBuilder()
-                .setUserAccessId(userAccessId)
-                .setDomain(userAccess.getDomain())
-                .setPermission(userAccess.getPermission())
-                .setUsername(userAccess.getUsername())
-                .build();
+        return buildFromDocument(userAccessDoc);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertPush.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertPush.java
@@ -1,0 +1,43 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+/**
+ * Shared helper for the "one document per namespace/domain, entities appended via
+ * {@code $push} with {@code upsert: true}" pattern used across the namespace/domain-scoped
+ * Mongo stores.
+ *
+ * <h2>Why this exists</h2>
+ * The upsert-insert that creates the very first entity in a brand-new namespace/domain can
+ * race with a concurrent request doing the same thing: the unique index on the namespace/domain
+ * field (see {@code MongoIndexInitializer}) lets exactly one of them insert, and the loser gets
+ * a {@link MongoWriteException} with {@link ErrorCategory#DUPLICATE_KEY} instead of a matched
+ * document to push into. Retrying the same push once the document exists resolves this safely
+ * with no data loss, instead of surfacing a spurious 500.
+ */
+public final class MongoUpsertPush {
+
+    private MongoUpsertPush() {
+    }
+
+    public static void pushWithDuplicateRetry(MongoCollection<Document> collection, Bson filter,
+                                               String arrayField, Document entry) {
+        Bson update = Updates.push(arrayField, entry);
+        UpdateOptions options = new UpdateOptions().upsert(true);
+        try {
+            collection.updateOne(filter, update, options);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            // Lost the race to create the namespace/domain document — it exists now, retry the push.
+            collection.updateOne(filter, update, options);
+        }
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestAdrToolsShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestAdrToolsShould.java
@@ -8,6 +8,7 @@ import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.AdrNotFoundException;
 import org.finos.calm.domain.exception.AdrParseException;
 import org.finos.calm.domain.exception.AdrPersistenceException;
+import org.finos.calm.domain.exception.AdrRevisionExistsException;
 import org.finos.calm.domain.exception.AdrRevisionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.AdrStore;
@@ -541,6 +542,17 @@ class TestAdrToolsShould {
         assertThat(text(result), not(containsString("sensitive internal detail")));
     }
 
+    @Test
+    void return_error_when_concurrent_update_conflicts_on_revision() throws Exception {
+        when(adrStore.updateAdrForNamespace(any(AdrMeta.class)))
+                .thenThrow(new AdrRevisionExistsException());
+
+        ToolResponse result = adrTools.updateAdr("finos", 1, VALID_ADR_JSON);
+
+        assertThat(result.isError(), is(true));
+        assertThat(text(result), containsString("concurrently updated"));
+    }
+
     // --- updateAdrStatus ---
 
     @Test
@@ -611,6 +623,17 @@ class TestAdrToolsShould {
 
         assertThat(result.isError(), is(true));
         assertThat(text(result), containsString("not found"));
+    }
+
+    @Test
+    void return_error_when_concurrent_status_update_conflicts_on_revision() throws Exception {
+        when(adrStore.updateAdrStatus(any(AdrMeta.class), any(Status.class)))
+                .thenThrow(new AdrRevisionExistsException());
+
+        ToolResponse result = adrTools.updateAdrStatus("finos", 1, "accepted");
+
+        assertThat(result.isError(), is(true));
+        assertThat(text(result), containsString("concurrently updated"));
     }
 
     @ParameterizedTest

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
@@ -136,13 +136,14 @@ public class TestAdrResourceShould {
                 Arguments.of("valid", new AdrRevisionNotFoundException(), 404),
                 Arguments.of("valid", new AdrParseException(), 500),
                 Arguments.of("valid", new AdrPersistenceException(), 500),
+                Arguments.of("valid", new AdrRevisionExistsException(), 409),
                 Arguments.of("valid", null, 201)
         );
     }
 
     @ParameterizedTest
     @MethodSource("provideParametersForUpdateAdrTests")
-    void respond_correctly_to_update_adr(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
+    void respond_correctly_to_update_adr(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
         String adrJson = "{ \"title\": \"My ADR\" }";
         if (exceptionToThrow != null) {
             when(mockAdrStore.updateAdrForNamespace(any(AdrMeta.class))).thenThrow(exceptionToThrow);
@@ -325,13 +326,14 @@ public class TestAdrResourceShould {
                 Arguments.of("valid", new AdrRevisionNotFoundException(), 404),
                 Arguments.of("valid", new AdrParseException(), 500),
                 Arguments.of("valid", new AdrPersistenceException(), 500),
+                Arguments.of("valid", new AdrRevisionExistsException(), 409),
                 Arguments.of("valid", null, 201)
         );
     }
 
     @ParameterizedTest
     @MethodSource("provideParametersForUpdateAdrStatusTests")
-    void respond_correctly_on_update_adr_status(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
+    void respond_correctly_on_update_adr_status(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
         String adrJson = "{ \"title\": \"My ADR\" }";
         if (exceptionToThrow != null) {
             when(mockAdrStore.updateAdrStatus(any(AdrMeta.class), any(Status.class))).thenThrow(exceptionToThrow);

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -13,6 +13,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.bson.BsonDocument;
@@ -208,6 +209,40 @@ public class TestMongoAdrStoreShould {
                 eq(Filters.eq("namespace", validNamespace)),
                 eq(Updates.push("adrs", expectedDoc)),
                 any(UpdateOptions.class));
+    }
+
+    @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException, AdrParseException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(42);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        AdrMeta adrMetaToCreate = new AdrMeta.AdrMetaBuilder()
+                .setAdr(new Adr.AdrBuilder().build())
+                .setNamespace(NAMESPACE)
+                .setRevision(1)
+                .build();
+
+        mongoAdrStore.createAdrForNamespace(adrMetaToCreate);
+
+        verify(adrCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_an_adr() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(42);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        AdrMeta adrMetaToCreate = new AdrMeta.AdrMetaBuilder()
+                .setAdr(new Adr.AdrBuilder().build())
+                .setNamespace(NAMESPACE)
+                .setRevision(1)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoAdrStore.createAdrForNamespace(adrMetaToCreate));
     }
 
     @Test
@@ -415,7 +450,7 @@ public class TestMongoAdrStoreShould {
     @Test
     void throw_an_exception_when_updating_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
 
         AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
@@ -429,8 +464,29 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
-    void return_successfully_when_correctly_updating_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException {
+    void throw_an_exception_when_a_concurrent_writer_already_created_the_same_adr_revision() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
+        UpdateResult conflictingResult = mock(UpdateResult.class);
+        when(conflictingResult.getMatchedCount()).thenReturn(0L);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(conflictingResult);
+
+        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(42)
+                .setAdr(new Adr.AdrBuilder().build())
+                .build();
+
+        assertThrows(AdrRevisionExistsException.class,
+                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+    }
+
+    @Test
+    void return_successfully_when_correctly_updating_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
+        mockSetupAdrDocumentWithRevisions();
+        UpdateResult successfulResult = mock(UpdateResult.class);
+        when(successfulResult.getMatchedCount()).thenReturn(1L);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(successfulResult);
+
         AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
                 .setNamespace(NAMESPACE)
                 .setId(42)
@@ -440,7 +496,7 @@ public class TestMongoAdrStoreShould {
 
         mongoAdrStore.updateAdrForNamespace(adrMeta);
 
-        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test
@@ -487,7 +543,7 @@ public class TestMongoAdrStoreShould {
     @Test
     void throw_an_exception_when_updating_the_status_of_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
 
         AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
@@ -500,8 +556,28 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
-    void return_successfully_when_correctly_updating_the_status_of_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException {
+    void throw_an_exception_when_a_concurrent_writer_already_created_the_same_status_revision() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
+        UpdateResult conflictingResult = mock(UpdateResult.class);
+        when(conflictingResult.getMatchedCount()).thenReturn(0L);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(conflictingResult);
+
+        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(42)
+                .build();
+
+        assertThrows(AdrRevisionExistsException.class,
+                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted));
+    }
+
+    @Test
+    void return_successfully_when_correctly_updating_the_status_of_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
+        mockSetupAdrDocumentWithRevisions();
+        UpdateResult successfulResult = mock(UpdateResult.class);
+        when(successfulResult.getMatchedCount()).thenReturn(1L);
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(successfulResult);
+
         AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
                 .setNamespace(NAMESPACE)
                 .setId(42)
@@ -509,6 +585,6 @@ public class TestMongoAdrStoreShould {
 
         mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted);
 
-        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -317,6 +317,38 @@ public class TestMongoArchitectureStoreShould {
     }
 
     @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(42);
+        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+
+        Architecture architectureToCreate = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
+                .setNamespace(NAMESPACE)
+                .build();
+
+        mongoArchitectureStore.createArchitectureForNamespace(architectureToCreate);
+
+        verify(architectureCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_an_architecture() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(42);
+        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+
+        Architecture architectureToCreate = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
+                .setNamespace(NAMESPACE)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoArchitectureStore.createArchitectureForNamespace(architectureToCreate));
+    }
+
+    @Test
     void get_architecture_version_for_invalid_namespace_throws_exception() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
         Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace("does-not-exist").build();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
@@ -1,5 +1,8 @@
 package org.finos.calm.store.mongo;
 
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -7,6 +10,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.controls.ControlConfigDetail;
@@ -33,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -162,6 +167,32 @@ public class TestMongoControlStoreShould {
 
         verify(controlCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
         verify(counterStore).getNextControlSequenceValue();
+    }
+
+    @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws DomainNotFoundException {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+        when(counterStore.getNextControlSequenceValue()).thenReturn(5);
+        when(controlCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreateControlRequirement createRequest = new CreateControlRequirement("Test Control", "Test Description", "{}");
+
+        mongoControlStore.createControlRequirement(createRequest, "security");
+
+        verify(controlCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_control_requirement() {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+        when(counterStore.getNextControlSequenceValue()).thenReturn(5);
+        when(controlCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreateControlRequirement createRequest = new CreateControlRequirement("Test Control", "Test Description", "{}");
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoControlStore.createControlRequirement(createRequest, "security"));
     }
 
     // --- getRequirementVersions ---

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDecoratorStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDecoratorStoreShould.java
@@ -1,9 +1,14 @@
 package org.finos.calm.store.mongo;
 
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.exception.DecoratorNotFoundException;
@@ -28,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -579,6 +585,32 @@ class TestMongoDecoratorStoreShould {
         verify(namespaceStore).namespaceExists(namespace);
         verify(counterStore, never()).getNextDecoratorSequenceValue();
         verify(decoratorCollection, never()).updateOne(any(Bson.class), any(Bson.class), any());
+    }
+
+    @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(counterStore.getNextDecoratorSequenceValue()).thenReturn(42);
+        when(decoratorCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+
+        decoratorStore.createDecorator(namespace, "{\"unique-id\": \"test-decorator\", \"type\": \"deployment\"}");
+
+        verify(decoratorCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_decorator() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(counterStore.getNextDecoratorSequenceValue()).thenReturn(42);
+        when(decoratorCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+
+        assertThrows(MongoWriteException.class,
+                () -> decoratorStore.createDecorator(namespace, "{\"unique-id\": \"test-decorator\", \"type\": \"deployment\"}"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
@@ -232,6 +232,32 @@ public class TestMongoFlowStoreShould {
     }
 
     @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextFlowSequenceValue()).thenReturn(42);
+        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", validJson);
+
+        mongoFlowStore.createFlowForNamespace(request, NAMESPACE);
+
+        verify(flowCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_flow() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextFlowSequenceValue()).thenReturn(42);
+        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", validJson);
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoFlowStore.createFlowForNamespace(request, NAMESPACE));
+    }
+
+    @Test
     void get_flow_version_for_invalid_namespace_throws_exception() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
         Flow flow = new Flow.FlowBuilder().setNamespace("does-not-exist").build();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoIndexInitializerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoIndexInitializerShould.java
@@ -48,15 +48,20 @@ class TestMongoIndexInitializerShould {
         verify(mockDatabase).getCollection("namespaces");
         verify(mockDatabase).getCollection("domains");
         verify(mockDatabase).getCollection("schemas");
-        // Namespace-scoped: architectures, patterns, flows, standards, interfaces
+        // Namespace-scoped: architectures, patterns, flows, timelines, standards, interfaces, adrs, decorators
         verify(mockDatabase).getCollection("architectures");
         verify(mockDatabase).getCollection("patterns");
         verify(mockDatabase).getCollection("flows");
+        verify(mockDatabase).getCollection("timelines");
         verify(mockDatabase).getCollection("standards");
         verify(mockDatabase).getCollection("interfaces");
+        verify(mockDatabase).getCollection("adrs");
+        verify(mockDatabase).getCollection("decorators");
         // Domain-scoped + resource mappings
         verify(mockDatabase).getCollection("controls");
         verify(mockDatabase, times(2)).getCollection("resource_mappings");
+        // userAccess partial unique indexes
+        verify(mockDatabase, times(2)).getCollection("userAccess");
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -208,6 +209,32 @@ public class TestMongoInterfaceStoreShould {
                 eq(Filters.eq("namespace", validNamespace)),
                 eq(Updates.push("interfaces", expectedDoc)),
                 any(UpdateOptions.class));
+    }
+
+    @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(42);
+        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreateInterfaceRequest interfaceToCreate = new CreateInterfaceRequest("test", "Test Interface", "{}");
+
+        mongoInterfaceStore.createInterfaceForNamespace(interfaceToCreate, "finos");
+
+        verify(interfaceCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_an_interface() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(42);
+        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreateInterfaceRequest interfaceToCreate = new CreateInterfaceRequest("test", "Test Interface", "{}");
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoInterfaceStore.createInterfaceForNamespace(interfaceToCreate, "finos"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -283,6 +283,32 @@ public class TestMongoPatternStoreShould {
     }
 
     @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextPatternSequenceValue()).thenReturn(42);
+        when(patternCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreatePatternRequest request = new CreatePatternRequest("Test Pattern", "A test", validJson);
+
+        mongoPatternStore.createPatternForNamespace(request, "finos");
+
+        verify(patternCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_pattern() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextPatternSequenceValue()).thenReturn(42);
+        when(patternCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreatePatternRequest request = new CreatePatternRequest("Test Pattern", "A test", validJson);
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoPatternStore.createPatternForNamespace(request, "finos"));
+    }
+
+    @Test
     void get_pattern_version_for_invalid_namespace_throws_exception() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
         Pattern pattern = new Pattern.PatternBuilder().setNamespace("does-not-exist").build();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -229,6 +230,32 @@ public class TestMongoStandardStoreShould {
                 eq(Filters.eq("namespace", validNamespace)),
                 eq(Updates.push("standards", expectedDoc)),
                 any(UpdateOptions.class));
+    }
+
+    @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextStandardSequenceValue()).thenReturn(42);
+        when(standardCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreateStandardRequest standardToCreate = new CreateStandardRequest("test", "Test Standard", "{}");
+
+        mongoStandardStore.createStandardForNamespace(standardToCreate, "finos");
+
+        verify(standardCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_standard() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextStandardSequenceValue()).thenReturn(42);
+        when(standardCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreateStandardRequest standardToCreate = new CreateStandardRequest("test", "Test Standard", "{}");
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoStandardStore.createStandardForNamespace(standardToCreate, "finos"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -224,6 +224,32 @@ public class TestMongoTimelineStoreShould {
     }
 
     @Test
+    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextTimelineSequenceValue()).thenReturn(42);
+        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", validJson);
+
+        mongoTimelineStore.createTimelineForNamespace(request, NAMESPACE);
+
+        verify(timelineCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_a_timeline() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextTimelineSequenceValue()).thenReturn(42);
+        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", validJson);
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoTimelineStore.createTimelineForNamespace(request, NAMESPACE));
+    }
+
+    @Test
     void get_timeline_version_for_invalid_namespace_throws_exception() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
         Timeline timeline = new Timeline.TimelineBuilder().setNamespace("does-not-exist").build();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -1,5 +1,8 @@
 package org.finos.calm.store.mongo;
 
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -7,6 +10,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.UserAccess.Permission;
@@ -167,6 +171,49 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
+    void return_existing_grant_when_a_concurrent_request_already_created_the_same_namespace_grant() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(101);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()));
+
+        Document existingDoc = new Document("username", "test")
+                .append("namespace", "finos")
+                .append("permission", Permission.write.name())
+                .append("userAccessId", 55);
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(userAccessCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(existingDoc);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace("finos")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        UserAccess actual = mongoUserAccessStore.createUserAccessForNamespace(userAccess);
+
+        assertThat(actual.getUserAccessId(), is(55));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_namespace_user_access() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(101);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace("finos")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoUserAccessStore.createUserAccessForNamespace(userAccess));
+    }
+
+    @Test
     void return_user_access_list_for_namespace() throws Exception {
         String namespace = "finos";
         Document doc = new Document("username", "test")
@@ -251,6 +298,47 @@ public class TestMongoUserAccessStoreShould {
         assertThat(actual.getUserAccessId(), is(201));
         assertThat(actual.getDomain(), is("payments"));
         verify(userAccessCollection).insertOne(ArgumentMatchers.any(Document.class));
+    }
+
+    @Test
+    void return_existing_grant_when_a_concurrent_request_already_created_the_same_domain_grant() {
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(201);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()));
+
+        Document existingDoc = new Document("username", "test")
+                .append("domain", "payments")
+                .append("permission", Permission.write.name())
+                .append("userAccessId", 77);
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(userAccessCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(existingDoc);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setDomain("payments")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        UserAccess actual = mongoUserAccessStore.createUserAccessForDomain(userAccess);
+
+        assertThat(actual.getUserAccessId(), is(77));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_errors_when_creating_domain_user_access() {
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(201);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setDomain("payments")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoUserAccessStore.createUserAccessForDomain(userAccess));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -197,6 +197,27 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
+    void rethrow_original_error_when_existing_namespace_grant_lookup_finds_nothing() {
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(101);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()));
+
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(userAccessCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(null);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setNamespace("finos")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoUserAccessStore.createUserAccessForNamespace(userAccess));
+    }
+
+    @Test
     void propagate_non_duplicate_key_errors_when_creating_namespace_user_access() {
         when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
         when(counterStore.getNextUserAccessSequenceValue()).thenReturn(101);
@@ -323,6 +344,26 @@ public class TestMongoUserAccessStoreShould {
         UserAccess actual = mongoUserAccessStore.createUserAccessForDomain(userAccess);
 
         assertThat(actual.getUserAccessId(), is(77));
+    }
+
+    @Test
+    void rethrow_original_error_when_existing_domain_grant_lookup_finds_nothing() {
+        when(counterStore.getNextUserAccessSequenceValue()).thenReturn(201);
+        when(userAccessCollection.insertOne(ArgumentMatchers.any(Document.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()));
+
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(userAccessCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(null);
+
+        UserAccess userAccess = new UserAccess.UserAccessBuilder()
+                .setDomain("payments")
+                .setUsername("test")
+                .setPermission(Permission.write)
+                .build();
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoUserAccessStore.createUserAccessForDomain(userAccess));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoUpsertPushShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoUpsertPushShould.java
@@ -1,0 +1,74 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestMongoUpsertPushShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    @Test
+    void push_once_when_there_is_no_race() {
+        MongoCollection<Document> collection = mock(DocumentMongoCollection.class);
+        Bson filter = Filters.eq("namespace", "finos");
+        Document entry = new Document("id", 1);
+
+        MongoUpsertPush.pushWithDuplicateRetry(collection, filter, "architectures", entry);
+
+        verify(collection, times(1)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void retry_once_when_the_first_push_loses_a_create_race() {
+        MongoCollection<Document> collection = mock(DocumentMongoCollection.class);
+        Bson filter = Filters.eq("namespace", "finos");
+        Document entry = new Document("id", 1);
+
+        when(collection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(new MongoWriteException(
+                        new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+
+        MongoUpsertPush.pushWithDuplicateRetry(collection, filter, "architectures", entry);
+
+        verify(collection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_write_errors() {
+        MongoCollection<Document> collection = mock(DocumentMongoCollection.class);
+        Bson filter = Filters.eq("namespace", "finos");
+        Document entry = new Document("id", 1);
+
+        MongoWriteException notADuplicateKeyError = new MongoWriteException(
+                new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of());
+        when(collection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(notADuplicateKeyError);
+
+        assertThrows(MongoWriteException.class,
+                () -> MongoUpsertPush.pushWithDuplicateRetry(collection, filter, "architectures", entry));
+
+        verify(collection, times(1)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+}


### PR DESCRIPTION
## Description
Fixes four concurrency defects in calm-hub's MongoDB storage layer identified in a self-audit (#2831), so CalmHub can safely run multiple replicas against one shared database:

- **ADR revision lost-update**: `MongoAdrStore` computed the next revision in application code and blind-`$set` it, letting two concurrent writers silently overwrite each other's revision. Now uses the same atomic `$elemMatch`/`$exists:false` conditional-update pattern the other entity stores already use, throwing a new `AdrRevisionExistsException` (mapped to 409) on a lost race.
- **Missing unique indexes on `adrs`/`decorators`**: every other namespace-scoped collection had a unique index on `namespace`; these two didn't, so concurrent first-creates could produce duplicate, partially-unreachable documents. Added to `MongoIndexInitializer`.
- **Uncaught duplicate-key on first-entity-create**: the upsert-insert for the first entity in a namespace/domain had no handling for a concurrent duplicate-key race in 7 stores, causing a spurious 500. Added a shared `MongoUpsertPush` helper that retries the push once the racing document exists. Adding the new `adrs`/`decorators` indexes above newly exposes those two stores to the same race, so they're covered as well (9 stores total).
- **`userAccess` duplicate grants**: no uniqueness constraint on `(username, namespace/domain, permission)`, so concurrent identical grants inserted as duplicate rows. Added partial unique indexes plus duplicate-key handling that returns the existing grant instead of erroring — including a fix for a null-lookup edge case (grant revoked between the duplicate-key error and the follow-up lookup) that would otherwise NPE, and a consolidation of the two near-identical namespace/domain create methods into one.

`CountsService`/`NamespaceMigrationService` were intentionally left untouched — the issue explicitly calls these self-healing/UI-advisory, not defects.

Note: on deployments that already have pre-existing duplicate data (e.g. duplicate `userAccess` grants, or duplicate `adrs`/`decorators` namespace docs from before this fix), the corresponding unique index will fail to build until that data is deduplicated — this needs to be handled operationally, it isn't automated by this PR.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
Commits use `fix(calm-hub): ...` conventional commit format.

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

`../mvnw clean verify -Ddependency-check.skip=true` passes: 2177/2177 tests, JaCoCo coverage checks met.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

Closes #2831