### PR TITLE
fix(calm-hub-ui): sort namespace and domain lists alphabetically

### DIFF
--- a/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/EntitlementsPanel.tsx
@@ -39,13 +39,13 @@ export function EntitlementsPanel({ calmService, userAccessService }: Entitlemen
 
     useEffect(() => {
         calmSvc.fetchDomains()
-            .then((d) => setDomains([...d].sort()))
+            .then(setDomains)
             .catch(() => setDomainsError('Failed to load domains.'))
             .finally(() => setDomainsLoading(false));
     }, [calmSvc]);
 
     const loading = namespacesLoading || domainsLoading || accessLoading;
-    const adminNamespaces = namespaces.filter(canAdminNamespace).sort();
+    const adminNamespaces = namespaces.filter(canAdminNamespace);
     const error = namespacesError ?? domainsError ?? accessError;
 
     return (

--- a/calm-hub-ui/src/service/calm-service.test.tsx
+++ b/calm-hub-ui/src/service/calm-service.test.tsx
@@ -42,6 +42,31 @@ describe('CalmService', () => {
             mock.onGet('/api/calm/namespaces').reply(500, { message: 'Error' });
             await expect(calmService.fetchNamespaces()).rejects.toThrowError();
         });
+
+        it('should return namespaces in alphabetical order regardless of API response order', async () => {
+            mock.onGet('/api/calm/namespaces').reply(200, {
+                values: [
+                    { name: 'zebra', description: '' },
+                    { name: 'apple', description: '' },
+                    { name: 'mango', description: '' },
+                ],
+            });
+            const actual = await calmService.fetchNamespaces();
+            expect(actual).toEqual(['apple', 'mango', 'zebra']);
+        });
+    });
+
+    describe('fetchDomains', () => {
+        it('should return domains in alphabetical order regardless of API response order', async () => {
+            mock.onGet('/api/calm/domains').reply(200, { values: ['wholesale', 'retail'] });
+            const actual = await calmService.fetchDomains();
+            expect(actual).toEqual(['retail', 'wholesale']);
+        });
+
+        it('should throw an error when backend returns error status', async () => {
+            mock.onGet('/api/calm/domains').reply(500, { message: 'Error' });
+            await expect(calmService.fetchDomains()).rejects.toThrowError();
+        });
     });
 
     describe('fetchPatternSummaries', () => {

--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -55,7 +55,7 @@ export class CalmService {
                 const namespaces = (res.data?.values ?? [])
                     .map((v: { name?: string }) => v?.name)
                     .filter((name: string | undefined): name is string => !!name);
-                return namespaces;
+                return namespaces.sort((a: string, b: string) => a.localeCompare(b));
             })
             .catch((error) => {
                 const errorMessage = 'Error fetching namespaces:';
@@ -69,7 +69,8 @@ export class CalmService {
         return this.ax
             .get('/api/calm/domains', { headers })
             .then((res) => {
-                return Array.isArray(res.data?.values) ? res.data.values : [];
+                const domains: string[] = Array.isArray(res.data?.values) ? res.data.values : [];
+                return domains.sort((a, b) => a.localeCompare(b));
             })
             .catch((error) => {
                 const errorMessage = 'Error fetching domains:';

--- a/calm-hub-ui/src/service/counts-service.test.ts
+++ b/calm-hub-ui/src/service/counts-service.test.ts
@@ -34,6 +34,15 @@ describe('CountsService', () => {
             expect(result).toEqual(expected);
         });
 
+        it('returns namespace counts sorted alphabetically by namespace regardless of API response order', async () => {
+            const zebra = { ...expected[0], namespace: 'zebra' };
+            const apple = { ...expected[0], namespace: 'apple' };
+            mock.onGet('/api/calm/namespaces/counts').reply(200, { values: [zebra, apple] });
+
+            const result = await service.fetchNamespaceCounts();
+            expect(result.map((r) => r.namespace)).toEqual(['apple', 'zebra']);
+        });
+
         it('returns an empty array when values is missing', async () => {
             mock.onGet('/api/calm/namespaces/counts').reply(200, {});
 

--- a/calm-hub-ui/src/service/counts-service.ts
+++ b/calm-hub-ui/src/service/counts-service.ts
@@ -23,7 +23,10 @@ export class CountsService {
         const headers = await getAuthHeaders();
         return this.ax
             .get('/api/calm/namespaces/counts', { headers })
-            .then((res) => (Array.isArray(res.data?.values) ? res.data.values : []))
+            .then((res) => {
+                const values: NamespaceCounts[] = Array.isArray(res.data?.values) ? res.data.values : [];
+                return values.sort((a, b) => a.namespace.localeCompare(b.namespace));
+            })
             .catch((error) => {
                 const errorMessage = 'Error fetching namespace counts:';
                 console.error('%s', errorMessage, error);


### PR DESCRIPTION
## Description
Namespace lists across the UI (explore rail sidebar, intro-screen browse tiles, mobile nav drill-down, admin "Existing Namespaces" panel, and the entitlements dropdowns) inherited whatever order the backend returned — effectively raw API/MongoDB order rather than anything deterministic or alphabetical.

Sorting is now done once in the service layer:
- `CalmService.fetchNamespaces()` and `fetchDomains()` sort with `localeCompare` before returning
- `CountsService.fetchNamespaceCounts()` sorts by the `namespace` field with `localeCompare`

Every UI location that renders these lists consumes one of these two service methods (directly or via `Hub.tsx`), so they all get consistent alphabetical order for free — no per-component changes needed. Also removed the now-redundant plain `.sort()` calls in `EntitlementsPanel.tsx`, which previously did a case-sensitive code-unit sort locally.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅
- Commit follows `fix(calm-hub-ui): ...` conventional commit format.

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards