### PR TITLE
fix(calm-hub): harden Nitrite stores against read/write concurrency race

### DIFF
--- a/calm-hub/src/integration-test/java/integration/performance/NitriteConcurrencyIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/NitriteConcurrencyIntegration.java
@@ -374,6 +374,64 @@ public class NitriteConcurrencyIntegration {
         assertNoDataLoss(THREADS + 1, versionCount, "PatternVersion");
     }
 
+    /**
+     * Regression test for a race where an unsynchronized read (iterating a version Document's
+     * fields) could observe a Nitrite document mid-mutation while a writer held the store's lock,
+     * throwing ConcurrentModificationException and surfacing as a 500. Reads now share a
+     * ReentrantReadWriteLock read lock that excludes concurrent writers, so this must stay clean
+     * across every Nitrite store that mutates a versions/requirement Document in place.
+     */
+    @Test
+    void concurrent_reads_during_pattern_version_writes_produce_no_server_errors() {
+        Response createResponse = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "name": "read-write-race-pattern",
+                            "description": "for read/write race concurrency test",
+                            "patternJson": "{\\"v\\": \\"1.0.0\\"}"
+                        }
+                        """)
+                .when().post("/api/calm/namespaces/finos/patterns")
+                .thenReturn();
+        assertEquals(201, createResponse.getStatusCode());
+
+        List<Integer> patternIds = extractIdsFromLocations(List.of(createResponse), "patterns/(\\d+)");
+        int patternId = patternIds.get(0);
+
+        int writerCount = THREADS / 2;
+
+        // Half the threads each create a new version; the other half repeatedly hit the versions
+        // list endpoint (which iterates the same in-memory Document the writers mutate). Every
+        // response - reader or writer - must stay below 500.
+        ConcurrencyResult<Integer> result = runConcurrently(THREADS, new java.util.concurrent.atomic.AtomicInteger(0), (index) -> {
+            if (index < writerCount) {
+                return given()
+                        .contentType(ContentType.JSON)
+                        .body("{\"name\":\"read-write-race-pattern\",\"description\":\"for read/write race concurrency test\",\"patternJson\":\"{\\\"v\\\": \\\"" + (index + 2) + ".0.0\\\"}\"}")
+                        .when().post("/api/calm/namespaces/finos/patterns/" + patternId + "/versions/" + (index + 2) + ".0.0")
+                        .thenReturn().getStatusCode();
+            }
+
+            int worstStatus = 200;
+            for (int i = 0; i < 10; i++) {
+                int status = given()
+                        .when().get("/api/calm/namespaces/finos/patterns/" + patternId + "/versions")
+                        .thenReturn().getStatusCode();
+                if (status > worstStatus) {
+                    worstStatus = status;
+                }
+            }
+            return worstStatus;
+        });
+
+        assertTrue(result.allSucceeded(), "Some requests failed: " + result.errors());
+        List<Integer> statusCodes = result.successfulResults();
+        for (int i = 0; i < statusCodes.size(); i++) {
+            assertTrue(statusCodes.get(i) < 500, "Request " + i + " returned server error status " + statusCodes.get(i));
+        }
+    }
+
     @Test
     void concurrent_control_requirement_version_creation_no_data_loss() {
         // Pre-create a named control at version 1.0.0 via the requirement endpoint.

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -50,7 +50,7 @@ public class NitriteAdrStore implements AdrStore {
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
     private final ObjectMapper objectMapper;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteAdrStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -69,45 +69,50 @@ public class NitriteAdrStore implements AdrStore {
             throw new NamespaceNotFoundException();
         }
 
-        TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(adrCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
-        List<Document> adrs = namespaceDocument.getList(ADRS_FIELD);
-        if (adrs == null || adrs.isEmpty()) {
-            return List.of();
-        }
+        lock.readLock().lock();
+        try {
+            TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(adrCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
+            List<Document> adrs = namespaceDocument.getList(ADRS_FIELD);
+            if (adrs == null || adrs.isEmpty()) {
+                return List.of();
+            }
 
-        List<NamespaceAdrSummary> summaries = new ArrayList<>();
-        for (Document adr : adrs) {
-            int adrId = adr.get(ADR_ID_FIELD, Integer.class);
-            String title = "ADR " + adrId;
-            String status = "unknown";
+            List<NamespaceAdrSummary> summaries = new ArrayList<>();
+            for (Document adr : adrs) {
+                int adrId = adr.get(ADR_ID_FIELD, Integer.class);
+                String title = "ADR " + adrId;
+                String status = "unknown";
 
-            Document revisions = adr.get(REVISIONS_FIELD, Document.class);
-            if (revisions != null) {
-                Set<String> fieldNames = revisions.getFields();
-                if (!fieldNames.isEmpty()) {
-                    int latestRevision = fieldNames.stream()
-                            .map(Integer::parseInt)
-                            .mapToInt(i -> i)
-                            .max()
-                            .getAsInt();
-                    String adrStr = revisions.get(String.valueOf(latestRevision), String.class);
-                    if (adrStr != null) {
-                        try {
-                            Adr adrObj = objectMapper.readValue(adrStr, Adr.class);
-                            if (adrObj.getTitle() != null) title = adrObj.getTitle();
-                            if (adrObj.getStatus() != null) status = adrObj.getStatus().name();
-                        } catch (JsonProcessingException e) {
-                            LOG.warn("Could not parse ADR {} for summary, using fallback", adrId, e);
+                Document revisions = adr.get(REVISIONS_FIELD, Document.class);
+                if (revisions != null) {
+                    Set<String> fieldNames = revisions.getFields();
+                    if (!fieldNames.isEmpty()) {
+                        int latestRevision = fieldNames.stream()
+                                .map(Integer::parseInt)
+                                .mapToInt(i -> i)
+                                .max()
+                                .getAsInt();
+                        String adrStr = revisions.get(String.valueOf(latestRevision), String.class);
+                        if (adrStr != null) {
+                            try {
+                                Adr adrObj = objectMapper.readValue(adrStr, Adr.class);
+                                if (adrObj.getTitle() != null) title = adrObj.getTitle();
+                                if (adrObj.getStatus() != null) status = adrObj.getStatus().name();
+                            } catch (JsonProcessingException e) {
+                                LOG.warn("Could not parse ADR {} for summary, using fallback", adrId, e);
+                            }
                         }
                     }
                 }
+
+                summaries.add(new NamespaceAdrSummary(title, status, adrId));
             }
 
-            summaries.add(new NamespaceAdrSummary(title, status, adrId));
+            LOG.debug("Retrieved {} ADRs for namespace '{}'", summaries.size(), namespace);
+            return summaries;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        LOG.debug("Retrieved {} ADRs for namespace '{}'", summaries.size(), namespace);
-        return summaries;
     }
 
     @Override
@@ -130,7 +135,7 @@ public class NitriteAdrStore implements AdrStore {
             throw new AdrParseException();
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextAdrSequenceValue();
             Document adrDocument = Document.createDocument()
@@ -164,91 +169,116 @@ public class NitriteAdrStore implements AdrStore {
             LOG.info("Created ADR with ID {} for namespace '{}'", id, adrMeta.getNamespace());
             return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public AdrMeta getAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        return retrieveLatestRevision(adrMeta, adrDoc);
+        lock.readLock().lock();
+        try {
+            Document adrDoc = retrieveAdrDoc(adrMeta);
+            return retrieveLatestRevision(adrMeta, adrDoc);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public List<Integer> getAdrRevisions(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        Document revisions = retrieveRevisionsDoc(adrDoc, adrMeta);
+        lock.readLock().lock();
+        try {
+            Document adrDoc = retrieveAdrDoc(adrMeta);
+            Document revisions = retrieveRevisionsDoc(adrDoc, adrMeta);
 
-        List<Integer> revisionList = new ArrayList<>();
-        // In NitriteDB, we need to get the field names directly
-        Set<String> fieldNames = revisions.getFields();
-        for (String revision : fieldNames) {
-            revisionList.add(Integer.parseInt(revision));
+            List<Integer> revisionList = new ArrayList<>();
+            // In NitriteDB, we need to get the field names directly
+            Set<String> fieldNames = revisions.getFields();
+            for (String revision : fieldNames) {
+                revisionList.add(Integer.parseInt(revision));
+            }
+
+            LOG.debug("Retrieved {} revisions for ADR {} in namespace '{}'",
+                    revisionList.size(), adrMeta.getId(), adrMeta.getNamespace());
+            return revisionList;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        LOG.debug("Retrieved {} revisions for ADR {} in namespace '{}'", 
-                revisionList.size(), adrMeta.getId(), adrMeta.getNamespace());
-        return revisionList;
     }
 
     @Override
     public AdrMeta getAdrRevision(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
-
-        // Return the ADR JSON blob for the specified revision
-        String adrStr = revisionsDoc.get(String.valueOf(adrMeta.getRevision()), String.class);
-        LOG.info("RevisionDoc: [{}], Revision: [{}]", revisionsDoc, adrMeta.getRevision());
-
-        if (adrStr == null) {
-            LOG.warn("Revision {} not found for ADR {} in namespace '{}'", 
-                    adrMeta.getRevision(), adrMeta.getId(), adrMeta.getNamespace());
-            throw new AdrRevisionNotFoundException();
-        }
-
+        lock.readLock().lock();
         try {
-            return new AdrMeta.AdrMetaBuilder(adrMeta)
-                    .setAdr(objectMapper.readValue(adrStr, Adr.class))
-                    .build();
-        } catch (JsonProcessingException e) {
-            LOG.error("Could not parse stored ADR to ADR Content.", e);
-            throw new AdrParseException();
+            Document adrDoc = retrieveAdrDoc(adrMeta);
+            Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
+
+            // Return the ADR JSON blob for the specified revision
+            String adrStr = revisionsDoc.get(String.valueOf(adrMeta.getRevision()), String.class);
+            LOG.info("RevisionDoc: [{}], Revision: [{}]", revisionsDoc, adrMeta.getRevision());
+
+            if (adrStr == null) {
+                LOG.warn("Revision {} not found for ADR {} in namespace '{}'",
+                        adrMeta.getRevision(), adrMeta.getId(), adrMeta.getNamespace());
+                throw new AdrRevisionNotFoundException();
+            }
+
+            try {
+                return new AdrMeta.AdrMetaBuilder(adrMeta)
+                        .setAdr(objectMapper.readValue(adrStr, Adr.class))
+                        .build();
+            } catch (JsonProcessingException e) {
+                LOG.error("Could not parse stored ADR to ADR Content.", e);
+                throw new AdrParseException();
+            }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
+        lock.writeLock().lock();
+        try {
+            Document adrDoc = retrieveAdrDoc(adrMeta);
+            AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
 
-        int newRevision = latestRevision.getRevision() + 1;
-        AdrMeta newAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
-                .setAdr(new Adr.AdrBuilder(adrMeta.getAdr())
-                        .setStatus(latestRevision.getAdr().getStatus())
-                        .setCreationDateTime(latestRevision.getAdr().getCreationDateTime())
-                        .build())
-                .setRevision(newRevision)
-                .build();
+            int newRevision = latestRevision.getRevision() + 1;
+            AdrMeta newAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
+                    .setAdr(new Adr.AdrBuilder(adrMeta.getAdr())
+                            .setStatus(latestRevision.getAdr().getStatus())
+                            .setCreationDateTime(latestRevision.getAdr().getCreationDateTime())
+                            .build())
+                    .setRevision(newRevision)
+                    .build();
 
-        writeAdrToNitrite(newAdrMeta);
-        return newAdrMeta;
+            writeAdrToNitrite(newAdrMeta);
+            return newAdrMeta;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
+        lock.writeLock().lock();
+        try {
+            Document adrDoc = retrieveAdrDoc(adrMeta);
+            AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
 
-        int newRevisionNum = latestRevision.getRevision() + 1;
-        AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latestRevision)
-                .setRevision(newRevisionNum)
-                .setAdr(new Adr.AdrBuilder(latestRevision.getAdr())
-                        .setStatus(status)
-                        .build())
-                .build();
+            int newRevisionNum = latestRevision.getRevision() + 1;
+            AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latestRevision)
+                    .setRevision(newRevisionNum)
+                    .setAdr(new Adr.AdrBuilder(latestRevision.getAdr())
+                            .setStatus(status)
+                            .build())
+                    .build();
 
-        writeAdrToNitrite(newRevision);
-        return newRevision;
+            writeAdrToNitrite(newRevision);
+            return newRevision;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     private List<Document> retrieveAdrsDocs(String namespace) throws NamespaceNotFoundException, AdrNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -52,7 +52,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
     private final NitriteCollection architectureCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteArchitectureStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -69,32 +69,37 @@ public class NitriteArchitectureStore implements ArchitectureStore {
             throw new NamespaceNotFoundException();
         }
 
-        TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(architectureCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
-        List<Document> architectures = namespaceDocument.getList(ARCHITECTURES_FIELD);
-        if (architectures == null || architectures.isEmpty()) {
-            return List.of();
-        }
+        lock.readLock().lock();
+        try {
+            TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(architectureCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
+            List<Document> architectures = namespaceDocument.getList(ARCHITECTURES_FIELD);
+            if (architectures == null || architectures.isEmpty()) {
+                return List.of();
+            }
 
-        List<NamespaceResourceSummary> architectureSummaries = new ArrayList<>();
-        for (Document architecture : architectures) {
-            Integer archId = architecture.get(ARCHITECTURE_ID_FIELD, Integer.class);
-            String name = architecture.get(NAME_FIELD, String.class);
-            String description = architecture.get(DESCRIPTION_FIELD, String.class);
-            if (name == null) name = "Architecture " + archId;
-            if (description == null) description = "";
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = architecture.get(VERSIONS_FIELD);
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-            NamespaceResourceSummary summary = new NamespaceResourceSummary(
-                    name, description, archId, versionCount
-            );
-            architectureSummaries.add(summary);
-        }
+            List<NamespaceResourceSummary> architectureSummaries = new ArrayList<>();
+            for (Document architecture : architectures) {
+                Integer archId = architecture.get(ARCHITECTURE_ID_FIELD, Integer.class);
+                String name = architecture.get(NAME_FIELD, String.class);
+                String description = architecture.get(DESCRIPTION_FIELD, String.class);
+                if (name == null) name = "Architecture " + archId;
+                if (description == null) description = "";
+                // Count versions from the already-in-memory sub-document (O(1), no extra query).
+                Object rawVersions = architecture.get(VERSIONS_FIELD);
+                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
+                NamespaceResourceSummary summary = new NamespaceResourceSummary(
+                        name, description, archId, versionCount
+                );
+                architectureSummaries.add(summary);
+            }
 
-        // Nitrite has no array-slice projection, so apply the limit/offset window in memory.
-        List<NamespaceResourceSummary> pageResults = page.apply(architectureSummaries);
-        LOG.debug("Retrieved {} of {} architectures for namespace '{}'", pageResults.size(), architectureSummaries.size(), namespace);
-        return pageResults;
+            // Nitrite has no array-slice projection, so apply the limit/offset window in memory.
+            List<NamespaceResourceSummary> pageResults = page.apply(architectureSummaries);
+            LOG.debug("Retrieved {} of {} architectures for namespace '{}'", pageResults.size(), architectureSummaries.size(), namespace);
+            return pageResults;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -106,7 +111,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         validateArchitectureJson(architecture.getArchitectureJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextArchitectureSequenceValue();
             // Store the architecture JSON as a string
@@ -149,37 +154,42 @@ public class NitriteArchitectureStore implements ArchitectureStore {
                     .setArchitecture(architecture.getArchitectureJson())
                     .build();
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public List<String> getArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        Document result = retrieveArchitectureVersions(architecture);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveArchitectureVersions(architecture);
 
-        List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
-        for (Document architectureDoc : architectures) {
-            if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
-                // Extract the versions map from the matching architecture
-                Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                if (versions == null) {
-                    throw new ArchitectureNotFoundException();
-                }
-                Set<String> versionKeys = versions.getFields();
+            List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
+            for (Document architectureDoc : architectures) {
+                if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
+                    // Extract the versions map from the matching architecture
+                    Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                    if (versions == null) {
+                        throw new ArchitectureNotFoundException();
+                    }
+                    Set<String> versionKeys = versions.getFields();
 
-                // Convert from Nitrite representation
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
+                    // Convert from Nitrite representation
+                    List<String> resourceVersions = new ArrayList<>();
+                    for (String versionKey : versionKeys) {
+                        resourceVersions.add(versionKey.replace('-', '.'));
+                    }
+                    LOG.debug("Retrieved {} versions for architecture {} in namespace '{}'",
+                            resourceVersions.size(), architecture.getId(), architecture.getNamespace());
+                    return resourceVersions;
                 }
-                LOG.debug("Retrieved {} versions for architecture {} in namespace '{}'",
-                        resourceVersions.size(), architecture.getId(), architecture.getNamespace());
-                return resourceVersions;
             }
-        }
 
-        LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
-        throw new ArchitectureNotFoundException();
+            LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
+            throw new ArchitectureNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     private Document retrieveArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
@@ -201,35 +211,40 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
     @Override
     public String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
-        Document result = retrieveArchitectureVersions(architecture);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveArchitectureVersions(architecture);
 
-        List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
-        for (Document architectureDoc : architectures) {
-            if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
-                // Retrieve the versions map from the matching architecture
-                Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                if (versions == null) {
-                    throw new ArchitectureVersionNotFoundException();
+            List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
+            for (Document architectureDoc : architectures) {
+                if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
+                    // Retrieve the versions map from the matching architecture
+                    Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
+                    if (versions == null) {
+                        throw new ArchitectureVersionNotFoundException();
+                    }
+
+                    // Return the architecture JSON blob for the specified version
+                    String mongoVersion = architecture.getMongoVersion();
+                    Object versionObj = versions.get(mongoVersion);
+                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+
+                    if (!(versionObj instanceof String)) {
+                        LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",
+                                architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
+                        throw new ArchitectureVersionNotFoundException();
+                    }
+
+                    return (String) versionObj;
                 }
-
-                // Return the architecture JSON blob for the specified version
-                String mongoVersion = architecture.getMongoVersion();
-                Object versionObj = versions.get(mongoVersion);
-                LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
-
-                if (!(versionObj instanceof String)) {
-                    LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",
-                            architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                    throw new ArchitectureVersionNotFoundException();
-                }
-
-                return (String) versionObj;
             }
-        }
 
-        // Architectures is empty, no version to find
-        LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
-        throw new ArchitectureVersionNotFoundException();
+            // Architectures is empty, no version to find
+            LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
+            throw new ArchitectureVersionNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -241,7 +256,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         validateArchitectureJson(architecture.getArchitectureJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             if (versionExists(architecture)) {
                 LOG.warn("Version '{}' already exists for architecture {} in namespace '{}'",
@@ -251,7 +266,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
             writeArchitectureToNitrite(architecture);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
         return architecture;
     }
@@ -265,7 +280,12 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         validateArchitectureJson(architecture.getArchitectureJson());
 
-        writeArchitectureToNitrite(architecture);
+        lock.writeLock().lock();
+        try {
+            writeArchitectureToNitrite(architecture);
+        } finally {
+            lock.writeLock().unlock();
+        }
         return architecture;
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.finos.calm.store.util.VersionKeySelector;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
@@ -58,7 +58,7 @@ public class NitriteControlStore implements ControlStore {
     private final NitriteCollection controlCollection;
     private final NitriteDomainStore domainStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteControlStore(@StandaloneQualifier Nitrite db, NitriteDomainStore domainStore, NitriteCounterStore counterStore) {
@@ -72,31 +72,36 @@ public class NitriteControlStore implements ControlStore {
     public List<ControlDetail> getControlsForDomain(String domain) throws DomainNotFoundException {
         validateDomain(domain);
 
-        List<ControlDetail> result = new ArrayList<>();
-        for (Document domainDoc : controlCollection.find(where(DOMAIN_FIELD).eq(domain))) {
-            @SuppressWarnings("unchecked")
-            List<Document> controls = (List<Document>) domainDoc.get(CONTROLS_FIELD);
-            if (controls == null) {
-                continue;
+        lock.readLock().lock();
+        try {
+            List<ControlDetail> result = new ArrayList<>();
+            for (Document domainDoc : controlCollection.find(where(DOMAIN_FIELD).eq(domain))) {
+                @SuppressWarnings("unchecked")
+                List<Document> controls = (List<Document>) domainDoc.get(CONTROLS_FIELD);
+                if (controls == null) {
+                    continue;
+                }
+                for (Document control : controls) {
+                    Document requirement = control.get(REQUIREMENT_FIELD, Document.class);
+                    String title = titleFromRequirementNitriteDoc(requirement);
+                    result.add(new ControlDetail(
+                            control.get(CONTROL_ID_FIELD, Integer.class),
+                            control.get("name", String.class),
+                            control.get("description", String.class),
+                            title
+                    ));
+                }
             }
-            for (Document control : controls) {
-                Document requirement = control.get(REQUIREMENT_FIELD, Document.class);
-                String title = titleFromRequirementNitriteDoc(requirement);
-                result.add(new ControlDetail(
-                        control.get(CONTROL_ID_FIELD, Integer.class),
-                        control.get("name", String.class),
-                        control.get("description", String.class),
-                        title
-                ));
-            }
+            return result;
+        } finally {
+            lock.readLock().unlock();
         }
-        return result;
     }
 
     @Override
     public ControlDetail createControlRequirement(CreateControlRequirement request, String domain) throws DomainNotFoundException {
         validateDomain(domain);
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int controlId = counterStore.getNextControlSequenceValue();
 
@@ -137,119 +142,149 @@ public class NitriteControlStore implements ControlStore {
 
             return new ControlDetail(controlId, name, description);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public List<String> getRequirementVersions(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException {
-        Document controlDoc = findControl(domain, controlId);
-        Document requirement = controlDoc.get(REQUIREMENT_FIELD, Document.class);
-        if (requirement == null) {
-            return List.of();
-        }
+        lock.readLock().lock();
+        try {
+            Document controlDoc = findControl(domain, controlId);
+            Document requirement = controlDoc.get(REQUIREMENT_FIELD, Document.class);
+            if (requirement == null) {
+                return List.of();
+            }
 
-        Set<String> fieldNames = requirement.getFields();
-        List<String> versions = new ArrayList<>();
-        for (String key : fieldNames) {
-            versions.add(key.replace('-', '.'));
+            Set<String> fieldNames = requirement.getFields();
+            List<String> versions = new ArrayList<>();
+            for (String key : fieldNames) {
+                versions.add(key.replace('-', '.'));
+            }
+            return versions;
+        } finally {
+            lock.readLock().unlock();
         }
-        return versions;
     }
 
     @Override
     public String getRequirementForVersion(String domain, int controlId, String version) throws DomainNotFoundException, ControlNotFoundException, ControlRequirementVersionNotFoundException {
-        Document controlDoc = findControl(domain, controlId);
-        Document requirement = controlDoc.get(REQUIREMENT_FIELD, Document.class);
+        lock.readLock().lock();
+        try {
+            Document controlDoc = findControl(domain, controlId);
+            Document requirement = controlDoc.get(REQUIREMENT_FIELD, Document.class);
 
-        if (requirement == null) {
-            throw new ControlRequirementVersionNotFoundException();
+            if (requirement == null) {
+                throw new ControlRequirementVersionNotFoundException();
+            }
+
+            String mongoVersion = version.replace('.', '-');
+            String versionJson = requirement.get(mongoVersion, String.class);
+            if (versionJson == null) {
+                throw new ControlRequirementVersionNotFoundException();
+            }
+
+            return versionJson;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        String mongoVersion = version.replace('.', '-');
-        String versionJson = requirement.get(mongoVersion, String.class);
-        if (versionJson == null) {
-            throw new ControlRequirementVersionNotFoundException();
-        }
-
-        return versionJson;
     }
 
     @Override
     public List<Integer> getConfigurationsForControl(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException {
-        Document controlDoc = findControl(domain, controlId);
+        lock.readLock().lock();
+        try {
+            Document controlDoc = findControl(domain, controlId);
 
-        @SuppressWarnings("unchecked")
-        List<Document> configurations = (List<Document>) controlDoc.get(CONFIGURATIONS_FIELD);
-        if (configurations == null) {
-            return List.of();
-        }
+            @SuppressWarnings("unchecked")
+            List<Document> configurations = (List<Document>) controlDoc.get(CONFIGURATIONS_FIELD);
+            if (configurations == null) {
+                return List.of();
+            }
 
-        List<Integer> configIds = new ArrayList<>();
-        for (Document config : configurations) {
-            configIds.add(config.get(CONFIGURATION_ID_FIELD, Integer.class));
+            List<Integer> configIds = new ArrayList<>();
+            for (Document config : configurations) {
+                configIds.add(config.get(CONFIGURATION_ID_FIELD, Integer.class));
+            }
+            return configIds;
+        } finally {
+            lock.readLock().unlock();
         }
-        return configIds;
     }
 
     @Override
     public List<ControlConfigDetail> getConfigurationDetailsForControl(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException {
-        Document controlDoc = findControl(domain, controlId);
+        lock.readLock().lock();
+        try {
+            Document controlDoc = findControl(domain, controlId);
 
-        @SuppressWarnings("unchecked")
-        List<Document> configurations = (List<Document>) controlDoc.get(CONFIGURATIONS_FIELD);
-        if (configurations == null) {
-            return List.of();
-        }
+            @SuppressWarnings("unchecked")
+            List<Document> configurations = (List<Document>) controlDoc.get(CONFIGURATIONS_FIELD);
+            if (configurations == null) {
+                return List.of();
+            }
 
-        List<ControlConfigDetail> details = new ArrayList<>();
-        for (Document config : configurations) {
-            Document versions = config.get(VERSIONS_FIELD, Document.class);
-            String title = titleFromVersionsNitriteDoc(versions);
-            details.add(new ControlConfigDetail(
-                    config.get(CONFIGURATION_ID_FIELD, Integer.class),
-                    config.get("name", String.class),
-                    title));
+            List<ControlConfigDetail> details = new ArrayList<>();
+            for (Document config : configurations) {
+                Document versions = config.get(VERSIONS_FIELD, Document.class);
+                String title = titleFromVersionsNitriteDoc(versions);
+                details.add(new ControlConfigDetail(
+                        config.get(CONFIGURATION_ID_FIELD, Integer.class),
+                        config.get("name", String.class),
+                        title));
+            }
+            return details;
+        } finally {
+            lock.readLock().unlock();
         }
-        return details;
     }
 
     @Override
     public List<String> getConfigurationVersions(String domain, int controlId, int configurationId) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException {
-        Document configDoc = findConfiguration(domain, controlId, configurationId);
-        Document versions = configDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            return List.of();
-        }
+        lock.readLock().lock();
+        try {
+            Document configDoc = findConfiguration(domain, controlId, configurationId);
+            Document versions = configDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                return List.of();
+            }
 
-        List<String> versionList = new ArrayList<>();
-        for (String key : versions.getFields()) {
-            versionList.add(key.replace('-', '.'));
+            List<String> versionList = new ArrayList<>();
+            for (String key : versions.getFields()) {
+                versionList.add(key.replace('-', '.'));
+            }
+            return versionList;
+        } finally {
+            lock.readLock().unlock();
         }
-        return versionList;
     }
 
     @Override
     public String getConfigurationForVersion(String domain, int controlId, int configurationId, String version) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException, ControlConfigurationVersionNotFoundException {
-        Document configDoc = findConfiguration(domain, controlId, configurationId);
-        Document versions = configDoc.get(VERSIONS_FIELD, Document.class);
+        lock.readLock().lock();
+        try {
+            Document configDoc = findConfiguration(domain, controlId, configurationId);
+            Document versions = configDoc.get(VERSIONS_FIELD, Document.class);
 
-        if (versions == null) {
-            throw new ControlConfigurationVersionNotFoundException();
+            if (versions == null) {
+                throw new ControlConfigurationVersionNotFoundException();
+            }
+
+            String mongoVersion = version.replace('.', '-');
+            String versionJson = versions.get(mongoVersion, String.class);
+            if (versionJson == null) {
+                throw new ControlConfigurationVersionNotFoundException();
+            }
+
+            return versionJson;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        String mongoVersion = version.replace('.', '-');
-        String versionJson = versions.get(mongoVersion, String.class);
-        if (versionJson == null) {
-            throw new ControlConfigurationVersionNotFoundException();
-        }
-
-        return versionJson;
     }
 
     @Override
     public void createRequirementForVersion(String domain, int controlId, String version, CreateControlRequirement request) throws DomainNotFoundException, ControlNotFoundException, ControlRequirementVersionExistsException {
-        lock.lock();
+        lock.writeLock().lock();
         try {
             validateDomain(domain);
             Document domainDoc = controlCollection.find(where(DOMAIN_FIELD).eq(domain)).firstOrNull();
@@ -279,13 +314,13 @@ public class NitriteControlStore implements ControlStore {
 
             controlCollection.update(where(DOMAIN_FIELD).eq(domain), domainDoc);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public int createControlConfiguration(CreateControlConfiguration request, String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException {
-        lock.lock();
+        lock.writeLock().lock();
         try {
             validateDomain(domain);
             Document domainDoc = controlCollection.find(where(DOMAIN_FIELD).eq(domain)).firstOrNull();
@@ -315,13 +350,13 @@ public class NitriteControlStore implements ControlStore {
 
             return configurationId;
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public void createConfigurationForVersion(String domain, int controlId, int configurationId, String version, CreateControlConfiguration request) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException, ControlConfigurationVersionExistsException {
-        lock.lock();
+        lock.writeLock().lock();
         try {
             validateDomain(domain);
             Document domainDoc = controlCollection.find(where(DOMAIN_FIELD).eq(domain)).firstOrNull();
@@ -343,7 +378,7 @@ public class NitriteControlStore implements ControlStore {
 
             controlCollection.update(where(DOMAIN_FIELD).eq(domain), domainDoc);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -52,7 +52,7 @@ public class NitriteFlowStore implements FlowStore {
     private final NitriteCollection flowCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteFlowStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -69,33 +69,38 @@ public class NitriteFlowStore implements FlowStore {
             throw new NamespaceNotFoundException();
         }
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDoc = flowCollection.find(filter).firstOrNull();
+        lock.readLock().lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            Document namespaceDoc = flowCollection.find(filter).firstOrNull();
 
-        if (namespaceDoc == null) {
-            LOG.warn("No flows found for namespace '{}'", namespace);
-            return List.of();
+            if (namespaceDoc == null) {
+                LOG.warn("No flows found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<Document> flows = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(FLOWS_FIELD);
+            if (flows == null || flows.isEmpty()) {
+                return List.of();
+            }
+
+            List<NamespaceResourceSummary> flowSummaries = new ArrayList<>();
+            for (Document flow : flows) {
+                Integer flowId = flow.get(FLOW_ID_FIELD, Integer.class);
+                String name = flow.get(NAME_FIELD, String.class);
+                String description = flow.get(DESCRIPTION_FIELD, String.class);
+                if (name == null) name = "Flow " + flowId;
+                if (description == null) description = "";
+                // Count versions from the already-in-memory sub-document (O(1), no extra query).
+                Object rawVersions = flow.get(VERSIONS_FIELD);
+                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
+                flowSummaries.add(new NamespaceResourceSummary(name, description, flowId, versionCount));
+            }
+
+            return flowSummaries;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        List<Document> flows = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(FLOWS_FIELD);
-        if (flows == null || flows.isEmpty()) {
-            return List.of();
-        }
-
-        List<NamespaceResourceSummary> flowSummaries = new ArrayList<>();
-        for (Document flow : flows) {
-            Integer flowId = flow.get(FLOW_ID_FIELD, Integer.class);
-            String name = flow.get(NAME_FIELD, String.class);
-            String description = flow.get(DESCRIPTION_FIELD, String.class);
-            if (name == null) name = "Flow " + flowId;
-            if (description == null) description = "";
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = flow.get(VERSIONS_FIELD);
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-            flowSummaries.add(new NamespaceResourceSummary(name, description, flowId, versionCount));
-        }
-
-        return flowSummaries;
     }
 
     @Override
@@ -114,7 +119,7 @@ public class NitriteFlowStore implements FlowStore {
             throw new JsonParseException(e.getMessage());
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextFlowSequenceValue();
             Document flowDocument = Document.createDocument()
@@ -155,33 +160,38 @@ public class NitriteFlowStore implements FlowStore {
                     .setFlow(flowRequest.getFlowJson())
                     .build();
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public List<String> getFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        Document result = retrieveFlowVersions(flow);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveFlowVersions(flow);
 
-        List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
-        for (Document flowDoc : flows) {
-            if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
-                // Extract the versions map from the matching flow
-                Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
+            List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
+            for (Document flowDoc : flows) {
+                if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
+                    // Extract the versions map from the matching flow
+                    Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
 
-                // Convert from Nitrite representation
-                List<String> resourceVersions = new ArrayList<>();
-                if (versions != null) {
-                    Set<String> versionKeys = versions.getFields();
-                    for (String versionKey : versionKeys) {
-                        resourceVersions.add(versionKey.replace('-', '.'));
+                    // Convert from Nitrite representation
+                    List<String> resourceVersions = new ArrayList<>();
+                    if (versions != null) {
+                        Set<String> versionKeys = versions.getFields();
+                        for (String versionKey : versionKeys) {
+                            resourceVersions.add(versionKey.replace('-', '.'));
+                        }
                     }
+                    return resourceVersions;  // Return the list of version keys
                 }
-                return resourceVersions;  // Return the list of version keys
             }
-        }
 
-        throw new FlowNotFoundException();
+            throw new FlowNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     private Document retrieveFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
@@ -203,34 +213,39 @@ public class NitriteFlowStore implements FlowStore {
 
     @Override
     public String getFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException {
-        Document result = retrieveFlowVersions(flow);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveFlowVersions(flow);
 
-        List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
-        for (Document flowDoc : flows) {
-            if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
-                // Retrieve the versions map from the matching flow
-                Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
+            List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
+            for (Document flowDoc : flows) {
+                if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
+                    // Retrieve the versions map from the matching flow
+                    Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
 
-                // Return the flow JSON blob for the specified version
-                String mongoVersion = flow.getMongoVersion();
-                Object versionObj = versions.get(mongoVersion);
-                LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+                    // Return the flow JSON blob for the specified version
+                    String mongoVersion = flow.getMongoVersion();
+                    Object versionObj = versions.get(mongoVersion);
+                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
 
-                if (versionObj == null) {
-                    LOG.warn("Version '{}' not found for flow {} in namespace '{}'", 
-                            flow.getDotVersion(), flow.getId(), flow.getNamespace());
-                    throw new FlowVersionNotFoundException();
+                    if (versionObj == null) {
+                        LOG.warn("Version '{}' not found for flow {} in namespace '{}'",
+                                flow.getDotVersion(), flow.getId(), flow.getNamespace());
+                        throw new FlowVersionNotFoundException();
+                    }
+
+                    // In NitriteDB, we're storing the JSON as a string directly
+                    // No need to convert to JSON string
+                    return (String) versionObj;
                 }
-
-                // In NitriteDB, we're storing the JSON as a string directly
-                // No need to convert to JSON string
-                return (String) versionObj;
             }
-        }
 
-        // Flows is empty, no version to find
-        LOG.warn("Flow with ID {} not found in namespace '{}'", flow.getId(), flow.getNamespace());
-        throw new FlowVersionNotFoundException();
+            // Flows is empty, no version to find
+            LOG.warn("Flow with ID {} not found in namespace '{}'", flow.getId(), flow.getNamespace());
+            throw new FlowVersionNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -240,7 +255,7 @@ public class NitriteFlowStore implements FlowStore {
             throw new NamespaceNotFoundException();
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             if (versionExists(flow)) {
                 LOG.warn("Version '{}' already exists for flow {} in namespace '{}'",
@@ -250,7 +265,7 @@ public class NitriteFlowStore implements FlowStore {
 
             writeFlowToNitrite(flow);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
         return flow;
     }
@@ -262,8 +277,13 @@ public class NitriteFlowStore implements FlowStore {
             throw new NamespaceNotFoundException();
         }
 
-        writeFlowToNitrite(flow);
-        LOG.info("Updated version '{}' for flow {} in namespace '{}'", 
+        lock.writeLock().lock();
+        try {
+            writeFlowToNitrite(flow);
+        } finally {
+            lock.writeLock().unlock();
+        }
+        LOG.info("Updated version '{}' for flow {} in namespace '{}'",
                 flow.getDotVersion(), flow.getId(), flow.getNamespace());
         return flow;
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -51,7 +51,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
     private final NitriteCollection interfaceCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteInterfaceStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -68,33 +68,38 @@ public class NitriteInterfaceStore implements InterfaceStore {
             throw new NamespaceNotFoundException();
         }
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = interfaceCollection.find(filter).firstOrNull();
+        lock.readLock().lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            Document namespaceDocument = interfaceCollection.find(filter).firstOrNull();
 
-        if (namespaceDocument == null) {
-            LOG.debug("No interfaces found for namespace '{}'", namespace);
-            return List.of();
+            if (namespaceDocument == null) {
+                LOG.debug("No interfaces found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
+            if (interfaces == null || interfaces.isEmpty()) {
+                LOG.debug("No interfaces found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<NamespaceInterfaceSummary> namespaceInterfaceSummary = new ArrayList<>();
+
+            for (Document interfaceDoc : interfaces) {
+                NamespaceInterfaceSummary summary = new NamespaceInterfaceSummary(
+                        interfaceDoc.get(NAME_FIELD, String.class),
+                        interfaceDoc.get(DESCRIPTION_FIELD, String.class),
+                        interfaceDoc.get(INTERFACE_ID_FIELD, Integer.class)
+                );
+                namespaceInterfaceSummary.add(summary);
+            }
+
+            LOG.debug("Retrieved {} interfaces for namespace '{}'", namespaceInterfaceSummary.size(), namespace);
+            return namespaceInterfaceSummary;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
-        if (interfaces == null || interfaces.isEmpty()) {
-            LOG.debug("No interfaces found for namespace '{}'", namespace);
-            return List.of();
-        }
-
-        List<NamespaceInterfaceSummary> namespaceInterfaceSummary = new ArrayList<>();
-
-        for (Document interfaceDoc : interfaces) {
-            NamespaceInterfaceSummary summary = new NamespaceInterfaceSummary(
-                    interfaceDoc.get(NAME_FIELD, String.class),
-                    interfaceDoc.get(DESCRIPTION_FIELD, String.class),
-                    interfaceDoc.get(INTERFACE_ID_FIELD, Integer.class)
-            );
-            namespaceInterfaceSummary.add(summary);
-        }
-
-        LOG.debug("Retrieved {} interfaces for namespace '{}'", namespaceInterfaceSummary.size(), namespace);
-        return namespaceInterfaceSummary;
     }
 
     @Override
@@ -112,7 +117,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
             throw new JsonParseException(e.getMessage());
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextInterfaceSequenceValue();
 
@@ -151,7 +156,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
             createdInterface.setNamespace(namespace);
             return createdInterface;
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
@@ -162,25 +167,30 @@ public class NitriteInterfaceStore implements InterfaceStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document interfaceDoc = findInterfaceDocument(namespace, interfaceId);
-        if (interfaceDoc == null) {
-            LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
-            throw new InterfaceNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document interfaceDoc = findInterfaceDocument(namespace, interfaceId);
+            if (interfaceDoc == null) {
+                LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
+                throw new InterfaceNotFoundException();
+            }
 
-        Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new InterfaceNotFoundException();
-        }
-        Set<String> fieldNames = versions.getFields();
-        List<String> versionList = new ArrayList<>();
-        for (String fieldName : fieldNames) {
-            versionList.add(fieldName.replace('-', '.'));
-        }
+            Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new InterfaceNotFoundException();
+            }
+            Set<String> fieldNames = versions.getFields();
+            List<String> versionList = new ArrayList<>();
+            for (String fieldName : fieldNames) {
+                versionList.add(fieldName.replace('-', '.'));
+            }
 
-        LOG.debug("Retrieved {} versions for interface {} in namespace '{}'",
-                versionList.size(), interfaceId, namespace);
-        return versionList;
+            LOG.debug("Retrieved {} versions for interface {} in namespace '{}'",
+                    versionList.size(), interfaceId, namespace);
+            return versionList;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -189,30 +199,35 @@ public class NitriteInterfaceStore implements InterfaceStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document interfaceDocument = findInterfaceDocument(namespace, interfaceId);
-        if (interfaceDocument == null) {
-            LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
-            throw new InterfaceNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document interfaceDocument = findInterfaceDocument(namespace, interfaceId);
+            if (interfaceDocument == null) {
+                LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
+                throw new InterfaceNotFoundException();
+            }
 
-        Document versions = interfaceDocument.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new InterfaceVersionNotFoundException();
-        }
+            Document versions = interfaceDocument.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new InterfaceVersionNotFoundException();
+            }
 
-        String storedVersion = version.replace('.', '-');
-        Object versionObj = versions.get(storedVersion);
+            String storedVersion = version.replace('.', '-');
+            Object versionObj = versions.get(storedVersion);
 
-        if (!(versionObj instanceof String)) {
-            LOG.warn("Version '{}' not found for interface {} in namespace '{}'",
+            if (!(versionObj instanceof String)) {
+                LOG.warn("Version '{}' not found for interface {} in namespace '{}'",
+                        storedVersion, interfaceId, namespace);
+                throw new InterfaceVersionNotFoundException();
+            }
+
+            LOG.debug("Retrieved version '{}' for interface {} in namespace '{}'",
                     storedVersion, interfaceId, namespace);
-            throw new InterfaceVersionNotFoundException();
+
+            return (String) versionObj;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        LOG.debug("Retrieved version '{}' for interface {} in namespace '{}'",
-                storedVersion, interfaceId, namespace);
-
-        return (String) versionObj;
     }
 
     @Override
@@ -221,7 +236,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
             throw new NamespaceNotFoundException();
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             Filter namespaceFilter = where(NAMESPACE_FIELD).eq(namespace);
             Document namespaceDocument = interfaceCollection.find(namespaceFilter).firstOrNull();
@@ -269,7 +284,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
             namespaceDocument.put(INTERFACES_FIELD, interfaces);
             interfaceCollection.update(namespaceFilter, namespaceDocument);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
 
         LOG.info("Created version '{}' for interface {} in namespace '{}'",

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -26,8 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -53,7 +53,7 @@ public class NitritePatternStore implements PatternStore {
     private final NitriteCollection patternCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitritePatternStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -70,41 +70,46 @@ public class NitritePatternStore implements PatternStore {
             throw new NamespaceNotFoundException();
         }
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = patternCollection.find(filter).firstOrNull();
+        lock.readLock().lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            Document namespaceDocument = patternCollection.find(filter).firstOrNull();
 
-        // If no patterns exist for this namespace yet
-        if (namespaceDocument == null) {
-            LOG.debug("No patterns found for namespace '{}'", namespace);
-            return List.of();
-        }
+            // If no patterns exist for this namespace yet
+            if (namespaceDocument == null) {
+                LOG.debug("No patterns found for namespace '{}'", namespace);
+                return List.of();
+            }
 
-        List<NamespaceResourceSummary> patternSummaries = new ArrayList<>();
-        // Get patterns list with proper type handling
-        List<Object> rawPatterns = new TypeSafeNitriteDocument<>(namespaceDocument, Object.class).getList(PATTERNS_FIELD);
+            List<NamespaceResourceSummary> patternSummaries = new ArrayList<>();
+            // Get patterns list with proper type handling
+            List<Object> rawPatterns = new TypeSafeNitriteDocument<>(namespaceDocument, Object.class).getList(PATTERNS_FIELD);
 
-        if (rawPatterns != null) {
-            for (Object patternObj : rawPatterns) {
-                if (patternObj instanceof Document patternDoc) {
-                    Integer patternId = patternDoc.get(PATTERN_ID_FIELD, Integer.class);
-                    String name = patternDoc.get(NAME_FIELD, String.class);
-                    String description = patternDoc.get(DESCRIPTION_FIELD, String.class);
-                    if (patternId != null) {
-                        if (name == null) name = "Pattern " + patternId;
-                        if (description == null) description = "";
-                        // Count versions from the already-in-memory sub-document (O(1), no extra query).
-                        Object rawVersions = patternDoc.get(VERSIONS_FIELD);
-                        int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-                        patternSummaries.add(new NamespaceResourceSummary(name, description, patternId, versionCount));
+            if (rawPatterns != null) {
+                for (Object patternObj : rawPatterns) {
+                    if (patternObj instanceof Document patternDoc) {
+                        Integer patternId = patternDoc.get(PATTERN_ID_FIELD, Integer.class);
+                        String name = patternDoc.get(NAME_FIELD, String.class);
+                        String description = patternDoc.get(DESCRIPTION_FIELD, String.class);
+                        if (patternId != null) {
+                            if (name == null) name = "Pattern " + patternId;
+                            if (description == null) description = "";
+                            // Count versions from the already-in-memory sub-document (O(1), no extra query).
+                            Object rawVersions = patternDoc.get(VERSIONS_FIELD);
+                            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
+                            patternSummaries.add(new NamespaceResourceSummary(name, description, patternId, versionCount));
+                        }
                     }
                 }
             }
-        }
 
-        // Nitrite has no array-slice projection, so apply the limit/offset window in memory.
-        List<NamespaceResourceSummary> pageResults = page.apply(patternSummaries);
-        LOG.debug("Retrieved {} of {} patterns for namespace '{}'", pageResults.size(), patternSummaries.size(), namespace);
-        return pageResults;
+            // Nitrite has no array-slice projection, so apply the limit/offset window in memory.
+            List<NamespaceResourceSummary> pageResults = page.apply(patternSummaries);
+            LOG.debug("Retrieved {} of {} patterns for namespace '{}'", pageResults.size(), patternSummaries.size(), namespace);
+            return pageResults;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -116,7 +121,7 @@ public class NitritePatternStore implements PatternStore {
 
         validatePatternJson(patternRequest.getPatternJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextPatternSequenceValue();
 
@@ -164,7 +169,7 @@ public class NitritePatternStore implements PatternStore {
             LOG.info("Created pattern with ID {} for namespace '{}'", id, namespace);
             return persistedPattern;
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
@@ -175,25 +180,30 @@ public class NitritePatternStore implements PatternStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-        if (patternDoc == null) {
-            LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+            if (patternDoc == null) {
+                LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+                throw new PatternNotFoundException();
+            }
 
-        Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new PatternNotFoundException();
-        }
-        Set<String> fieldNames = versions.getFields();
-        List<String> versionList = new ArrayList<>();
-        for (String fieldName : fieldNames) {
-            versionList.add(fieldName.replace('-', '.'));
-        }
+            Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new PatternNotFoundException();
+            }
+            Set<String> fieldNames = versions.getFields();
+            List<String> versionList = new ArrayList<>();
+            for (String fieldName : fieldNames) {
+                versionList.add(fieldName.replace('-', '.'));
+            }
 
-        LOG.debug("Retrieved {} versions for pattern {} in namespace '{}'",
-                versionList.size(), pattern.getId(), pattern.getNamespace());
-        return versionList;
+            LOG.debug("Retrieved {} versions for pattern {} in namespace '{}'",
+                    versionList.size(), pattern.getId(), pattern.getNamespace());
+            return versionList;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -203,27 +213,32 @@ public class NitritePatternStore implements PatternStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-        if (patternDoc == null) {
-            LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+            if (patternDoc == null) {
+                LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+                throw new PatternNotFoundException();
+            }
 
-        Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new PatternVersionNotFoundException();
-        }
-        Object versionObj = versions.get(pattern.getMongoVersion());
+            Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new PatternVersionNotFoundException();
+            }
+            Object versionObj = versions.get(pattern.getMongoVersion());
 
-        if (!(versionObj instanceof String)) {
-            LOG.warn("Version '{}' not found for pattern {} in namespace '{}'",
+            if (!(versionObj instanceof String)) {
+                LOG.warn("Version '{}' not found for pattern {} in namespace '{}'",
+                        pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
+                throw new PatternVersionNotFoundException();
+            }
+
+            LOG.debug("Retrieved version '{}' for pattern {} in namespace '{}'",
                     pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
-            throw new PatternVersionNotFoundException();
+            return (String) versionObj;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        LOG.debug("Retrieved version '{}' for pattern {} in namespace '{}'",
-                pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());
-        return (String) versionObj;
     }
 
     @Override
@@ -235,7 +250,7 @@ public class NitritePatternStore implements PatternStore {
 
         validatePatternJson(pattern.getPatternJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
             Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
@@ -289,7 +304,7 @@ public class NitritePatternStore implements PatternStore {
             namespaceDocument.put(PATTERNS_FIELD, patterns);
             patternCollection.update(namespaceFilter, namespaceDocument);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
 
         LOG.info("Created version '{}' for pattern {} in namespace '{}'",
@@ -306,50 +321,55 @@ public class NitritePatternStore implements PatternStore {
 
         validatePatternJson(pattern.getPatternJson());
 
-        Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
-        Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
+        lock.writeLock().lock();
+        try {
+            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(pattern.getNamespace());
+            Document namespaceDocument = patternCollection.find(namespaceFilter).firstOrNull();
 
-        if (namespaceDocument == null) {
-            LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
-
-        Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
-        if (patternDoc == null) {
-            LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
-            throw new PatternNotFoundException();
-        }
-
-        Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new PatternNotFoundException();
-        }
-        versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
-        patternDoc.put(VERSIONS_FIELD, versions);
-
-        // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
-        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-        if (pattern.getName() != null && !pattern.getName().isBlank()) {
-            patternDoc.put(NAME_FIELD, pattern.getName());
-        }
-        if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
-            patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
-        }
-
-        // Update the pattern in the namespace document
-        List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
-        // Create a mutable copy of the list
-        patterns = new ArrayList<>(patterns);
-        for (int i = 0; i < patterns.size(); i++) {
-            Document doc = patterns.get(i);
-            if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
-                patterns.set(i, patternDoc);
-                break;
+            if (namespaceDocument == null) {
+                LOG.warn("Namespace document for '{}' not found when updating pattern version", pattern.getNamespace());
+                throw new PatternNotFoundException();
             }
-        }
 
-        namespaceDocument.put(PATTERNS_FIELD, patterns);
-        patternCollection.update(namespaceFilter, namespaceDocument);
+            Document patternDoc = findPatternDocument(pattern.getNamespace(), pattern.getId());
+            if (patternDoc == null) {
+                LOG.warn("Pattern with ID {} not found in namespace '{}'", pattern.getId(), pattern.getNamespace());
+                throw new PatternNotFoundException();
+            }
+
+            Document versions = patternDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new PatternNotFoundException();
+            }
+            versions.put(pattern.getMongoVersion(), pattern.getPatternJson());
+            patternDoc.put(VERSIONS_FIELD, versions);
+
+            // Defensive: the REST layer enforces @NotBlank on name/description via CreatePatternRequest,
+            // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
+            if (pattern.getName() != null && !pattern.getName().isBlank()) {
+                patternDoc.put(NAME_FIELD, pattern.getName());
+            }
+            if (pattern.getDescription() != null && !pattern.getDescription().isBlank()) {
+                patternDoc.put(DESCRIPTION_FIELD, pattern.getDescription());
+            }
+
+            // Update the pattern in the namespace document
+            List<Document> patterns = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(PATTERNS_FIELD);
+            // Create a mutable copy of the list
+            patterns = new ArrayList<>(patterns);
+            for (int i = 0; i < patterns.size(); i++) {
+                Document doc = patterns.get(i);
+                if (doc.get(PATTERN_ID_FIELD, Integer.class) == pattern.getId()) {
+                    patterns.set(i, patternDoc);
+                    break;
+                }
+            }
+
+            namespaceDocument.put(PATTERNS_FIELD, patterns);
+            patternCollection.update(namespaceFilter, namespaceDocument);
+        } finally {
+            lock.writeLock().unlock();
+        }
 
         LOG.info("Updated version '{}' for pattern {} in namespace '{}'",
                 pattern.getMongoVersion(), pattern.getId(), pattern.getNamespace());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
@@ -52,7 +52,7 @@ public class NitriteStandardStore implements StandardStore {
     private final NitriteCollection standardCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteStandardStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -70,38 +70,43 @@ public class NitriteStandardStore implements StandardStore {
             throw new NamespaceNotFoundException();
         }
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = standardCollection.find(filter).firstOrNull();
+        lock.readLock().lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            Document namespaceDocument = standardCollection.find(filter).firstOrNull();
 
-        // If no standards exist for this namespace yet
-        if (namespaceDocument == null) {
-            LOG.debug("No standards found for namespace '{}'", namespace);
-            return List.of();
+            // If no standards exist for this namespace yet
+            if (namespaceDocument == null) {
+                LOG.debug("No standards found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
+            if (standards == null || standards.isEmpty()) {
+                LOG.debug("No standards found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<NamespaceResourceSummary> namespaceStandardSummary = new ArrayList<>();
+
+            for (Document standard : standards) {
+                // Count versions from the already-in-memory sub-document (O(1), no extra query).
+                Object rawVersions = standard.get(VERSIONS_FIELD);
+                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
+                NamespaceResourceSummary summary = new NamespaceResourceSummary(
+                        standard.get(NAME_FIELD, String.class),
+                        standard.get(DESCRIPTION_FIELD, String.class),
+                        standard.get(STANDARD_ID_FIELD, Integer.class),
+                        versionCount
+                );
+                namespaceStandardSummary.add(summary);
+            }
+
+            LOG.debug("Retrieved {} standards for namespace '{}'", namespaceStandardSummary.size(), namespace);
+            return namespaceStandardSummary;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
-        if (standards == null || standards.isEmpty()) {
-            LOG.debug("No standards found for namespace '{}'", namespace);
-            return List.of();
-        }
-
-        List<NamespaceResourceSummary> namespaceStandardSummary = new ArrayList<>();
-
-        for (Document standard : standards) {
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = standard.get(VERSIONS_FIELD);
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-            NamespaceResourceSummary summary = new NamespaceResourceSummary(
-                    standard.get(NAME_FIELD, String.class),
-                    standard.get(DESCRIPTION_FIELD, String.class),
-                    standard.get(STANDARD_ID_FIELD, Integer.class),
-                    versionCount
-            );
-            namespaceStandardSummary.add(summary);
-        }
-
-        LOG.debug("Retrieved {} standards for namespace '{}'", namespaceStandardSummary.size(), namespace);
-        return namespaceStandardSummary;
     }
 
     @Override
@@ -120,7 +125,7 @@ public class NitriteStandardStore implements StandardStore {
             throw new JsonParseException(e.getMessage());
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextStandardSequenceValue();
 
@@ -159,7 +164,7 @@ public class NitriteStandardStore implements StandardStore {
             createdStandard.setNamespace(namespace);
             return createdStandard;
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
@@ -170,25 +175,30 @@ public class NitriteStandardStore implements StandardStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document standardDoc = findStandardDocument(namespace, standardId);
-        if (standardDoc == null) {
-            LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
-            throw new StandardNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document standardDoc = findStandardDocument(namespace, standardId);
+            if (standardDoc == null) {
+                LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
+                throw new StandardNotFoundException();
+            }
 
-        Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new StandardNotFoundException();
-        }
-        Set<String> fieldNames = versions.getFields();
-        List<String> versionList = new ArrayList<>();
-        for (String fieldName : fieldNames) {
-            versionList.add(fieldName.replace('-', '.'));
-        }
+            Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new StandardNotFoundException();
+            }
+            Set<String> fieldNames = versions.getFields();
+            List<String> versionList = new ArrayList<>();
+            for (String fieldName : fieldNames) {
+                versionList.add(fieldName.replace('-', '.'));
+            }
 
-        LOG.debug("Retrieved {} versions for standard {} in namespace '{}'",
-                versionList.size(), standardId, namespace);
-        return versionList;
+            LOG.debug("Retrieved {} versions for standard {} in namespace '{}'",
+                    versionList.size(), standardId, namespace);
+            return versionList;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -197,30 +207,35 @@ public class NitriteStandardStore implements StandardStore {
             throw new NamespaceNotFoundException();
         }
 
-        Document standardDocument = findStandardDocument(namespace, standardId);
-        if (standardDocument == null) {
-            LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
-            throw new StandardNotFoundException();
-        }
+        lock.readLock().lock();
+        try {
+            Document standardDocument = findStandardDocument(namespace, standardId);
+            if (standardDocument == null) {
+                LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
+                throw new StandardNotFoundException();
+            }
 
-        Document versions = standardDocument.get(VERSIONS_FIELD, Document.class);
-        if (versions == null) {
-            throw new StandardVersionNotFoundException();
-        }
+            Document versions = standardDocument.get(VERSIONS_FIELD, Document.class);
+            if (versions == null) {
+                throw new StandardVersionNotFoundException();
+            }
 
-        String mongoVersion = version.replace('.', '-');
-        Object versionObj = versions.get(mongoVersion);
+            String mongoVersion = version.replace('.', '-');
+            Object versionObj = versions.get(mongoVersion);
 
-        if (!(versionObj instanceof String)) {
-            LOG.warn("Version '{}' not found for standard {} in namespace '{}'",
+            if (!(versionObj instanceof String)) {
+                LOG.warn("Version '{}' not found for standard {} in namespace '{}'",
+                        mongoVersion, standardId, namespace);
+                throw new StandardVersionNotFoundException();
+            }
+
+            LOG.debug("Retrieved version '{}' for standard {} in namespace '{}'",
                     mongoVersion, standardId, namespace);
-            throw new StandardVersionNotFoundException();
+
+            return (String) versionObj;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        LOG.debug("Retrieved version '{}' for standard {} in namespace '{}'",
-                mongoVersion, standardId, namespace);
-
-        return (String) versionObj;
     }
 
     @Override
@@ -229,7 +244,7 @@ public class NitriteStandardStore implements StandardStore {
             throw new NamespaceNotFoundException();
         }
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             Filter namespaceFilter = where(NAMESPACE_FIELD).eq(namespace);
             Document namespaceDocument = standardCollection.find(namespaceFilter).firstOrNull();
@@ -278,7 +293,7 @@ public class NitriteStandardStore implements StandardStore {
             namespaceDocument.put(STANDARDS_FIELD, standards);
             standardCollection.update(namespaceFilter, namespaceDocument);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
 
         LOG.info("Created version '{}' for standard {} in namespace '{}'",

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 
@@ -49,7 +49,7 @@ public class NitriteTimelineStore implements TimelineStore {
     private final NitriteCollection timelineCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final Lock lock = new ReentrantLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteTimelineStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
@@ -66,30 +66,35 @@ public class NitriteTimelineStore implements TimelineStore {
             throw new NamespaceNotFoundException();
         }
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDoc = timelineCollection.find(filter).firstOrNull();
+        lock.readLock().lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            Document namespaceDoc = timelineCollection.find(filter).firstOrNull();
 
-        if (namespaceDoc == null) {
-            LOG.warn("No timelines found for namespace '{}'", namespace);
-            return List.of();
+            if (namespaceDoc == null) {
+                LOG.warn("No timelines found for namespace '{}'", namespace);
+                return List.of();
+            }
+
+            List<Document> timelines = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(TIMELINES_FIELD);
+            if (timelines == null || timelines.isEmpty()) {
+                return List.of();
+            }
+
+            List<NamespaceTimelineSummary> timelineSummaries = new ArrayList<>();
+            for (Document timeline : timelines) {
+                Integer timelineId = timeline.get(TIMELINE_ID_FIELD, Integer.class);
+                String name = timeline.get(NAME_FIELD, String.class);
+                String description = timeline.get(DESCRIPTION_FIELD, String.class);
+                if (name == null) name = "Timeline " + timelineId;
+                if (description == null) description = "";
+                timelineSummaries.add(new NamespaceTimelineSummary(name, description, timelineId));
+            }
+
+            return timelineSummaries;
+        } finally {
+            lock.readLock().unlock();
         }
-
-        List<Document> timelines = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(TIMELINES_FIELD);
-        if (timelines == null || timelines.isEmpty()) {
-            return List.of();
-        }
-
-        List<NamespaceTimelineSummary> timelineSummaries = new ArrayList<>();
-        for (Document timeline : timelines) {
-            Integer timelineId = timeline.get(TIMELINE_ID_FIELD, Integer.class);
-            String name = timeline.get(NAME_FIELD, String.class);
-            String description = timeline.get(DESCRIPTION_FIELD, String.class);
-            if (name == null) name = "Timeline " + timelineId;
-            if (description == null) description = "";
-            timelineSummaries.add(new NamespaceTimelineSummary(name, description, timelineId));
-        }
-
-        return timelineSummaries;
     }
 
     @Override
@@ -101,7 +106,7 @@ public class NitriteTimelineStore implements TimelineStore {
 
         validateTimelineJson(timelineRequest.getTimelineJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             int id = counterStore.getNextTimelineSequenceValue();
             Document timelineDocument = Document.createDocument()
@@ -142,34 +147,39 @@ public class NitriteTimelineStore implements TimelineStore {
                     .setTimeline(timelineRequest.getTimelineJson())
                     .build();
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public List<String> getTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        Document result = retrieveTimelineVersions(timeline);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveTimelineVersions(timeline);
 
-        List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
-        for (Document timelineDoc : timelines) {
-            if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
-                // Extract the versions map from the matching timeline
-                Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                if (versions == null) {
-                    throw new TimelineNotFoundException();
-                }
+            List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
+            for (Document timelineDoc : timelines) {
+                if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
+                    // Extract the versions map from the matching timeline
+                    Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
+                    if (versions == null) {
+                        throw new TimelineNotFoundException();
+                    }
 
-                // Convert from Nitrite representation
-                List<String> resourceVersions = new ArrayList<>();
-                Set<String> versionKeys = versions.getFields();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
+                    // Convert from Nitrite representation
+                    List<String> resourceVersions = new ArrayList<>();
+                    Set<String> versionKeys = versions.getFields();
+                    for (String versionKey : versionKeys) {
+                        resourceVersions.add(versionKey.replace('-', '.'));
+                    }
+                    return resourceVersions;
                 }
-                return resourceVersions;
             }
-        }
 
-        throw new TimelineNotFoundException();
+            throw new TimelineNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     private Document retrieveTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
@@ -191,35 +201,40 @@ public class NitriteTimelineStore implements TimelineStore {
 
     @Override
     public String getTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
-        Document result = retrieveTimelineVersions(timeline);
+        lock.readLock().lock();
+        try {
+            Document result = retrieveTimelineVersions(timeline);
 
-        List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
-        for (Document timelineDoc : timelines) {
-            if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
-                // Retrieve the versions map from the matching timeline
-                Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                if (versions == null) {
-                    throw new TimelineVersionNotFoundException();
+            List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
+            for (Document timelineDoc : timelines) {
+                if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
+                    // Retrieve the versions map from the matching timeline
+                    Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
+                    if (versions == null) {
+                        throw new TimelineVersionNotFoundException();
+                    }
+
+                    // Return the timeline JSON blob for the specified version
+                    String mongoVersion = timeline.getMongoVersion();
+                    Object versionObj = versions.get(mongoVersion);
+                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+
+                    if (!(versionObj instanceof String)) {
+                        LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",
+                                timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
+                        throw new TimelineVersionNotFoundException();
+                    }
+
+                    return (String) versionObj;
                 }
-
-                // Return the timeline JSON blob for the specified version
-                String mongoVersion = timeline.getMongoVersion();
-                Object versionObj = versions.get(mongoVersion);
-                LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
-
-                if (!(versionObj instanceof String)) {
-                    LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",
-                            timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
-                    throw new TimelineVersionNotFoundException();
-                }
-
-                return (String) versionObj;
             }
-        }
 
-        // Timelines is empty, no version to find
-        LOG.warn("Timeline with ID {} not found in namespace '{}'", timeline.getId(), timeline.getNamespace());
-        throw new TimelineVersionNotFoundException();
+            // Timelines is empty, no version to find
+            LOG.warn("Timeline with ID {} not found in namespace '{}'", timeline.getId(), timeline.getNamespace());
+            throw new TimelineVersionNotFoundException();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -231,7 +246,7 @@ public class NitriteTimelineStore implements TimelineStore {
 
         validateTimelineJson(timeline.getTimelineJson());
 
-        lock.lock();
+        lock.writeLock().lock();
         try {
             if (versionExists(timeline)) {
                 LOG.warn("Version '{}' already exists for timeline {} in namespace '{}'",
@@ -241,7 +256,7 @@ public class NitriteTimelineStore implements TimelineStore {
 
             writeTimelineToNitrite(timeline);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
         return timeline;
     }
@@ -255,7 +270,12 @@ public class NitriteTimelineStore implements TimelineStore {
 
         validateTimelineJson(timeline.getTimelineJson());
 
-        writeTimelineToNitrite(timeline);
+        lock.writeLock().lock();
+        try {
+            writeTimelineToNitrite(timeline);
+        } finally {
+            lock.writeLock().unlock();
+        }
         LOG.info("Updated version '{}' for timeline {} in namespace '{}'",
                 timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
         return timeline;


### PR DESCRIPTION
## Description
`NitriteConcurrencyIntegration.concurrent_control_requirement_version_creation_no_data_loss` was failing intermittently on `main` (https://github.com/finos/architecture-as-code/actions/runs/29605567357/job/87967825735) with a 500 instead of 201. The server-side stack trace showed a `java.util.ConcurrentModificationException` thrown from `NitriteDocument.getFields()`.

Root cause: `NitriteControlStore` (and 7 other Nitrite stores with the same shape — Pattern, Architecture, Flow, Standard, Interface, Adr, Timeline) guard writes with a plain `ReentrantLock`, but their **read** methods are unsynchronized. Nitrite documents are mutated in place, not copy-on-write, so an unguarded read iterating a version/requirement `Document`'s fields can race a concurrent locked writer mutating that same `Document`, throwing `ConcurrentModificationException`. Controls hit this reliably because the name-based control endpoints resolve name→ID via `getControlsForDomain` (a full-domain read) on every single write.

Fix: switch all 8 affected stores from `ReentrantLock` to `ReentrantReadWriteLock` — reads take the shared read lock (so concurrent GETs no longer serialize behind each other either), writes take the exclusive write lock, same mutual-exclusion guarantee against other writers as before.

While auditing every read/write method in these 8 stores, also found and fixed 5 write methods that held **no lock at all**: `NitritePatternStore.updatePatternForVersion`, `NitriteArchitectureStore.updateArchitectureForVersion`, `NitriteFlowStore.updateFlowForVersion`, `NitriteAdrStore.updateAdrForNamespace`/`updateAdrStatus`, `NitriteTimelineStore.updateTimelineForVersion`.

Added a regression test (`concurrent_reads_during_pattern_version_writes_produce_no_server_errors`) that mixes concurrent readers and writers against the same pattern's version document.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- Commit follows `fix(calm-hub): ...` conventional commit format.

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Ran locally:
- `../mvnw -P integration verify` → 11/11 integration tests pass, including the previously-failing `concurrent_control_requirement_version_creation_no_data_loss` and the new regression test.
- `../mvnw test` → 2177/2177 unit tests pass.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards