### PR TITLE
feat(calm-hub,calm-hub-ui): namespace description editing and namespace/domain deletion

### DIFF
--- a/calm-hub-ui/src/admin/components/ConfirmDeleteDialog.test.tsx
+++ b/calm-hub-ui/src/admin/components/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmDeleteDialog } from './ConfirmDeleteDialog.js';
+
+describe('ConfirmDeleteDialog', () => {
+    it('renders nothing when closed', () => {
+        render(
+            <ConfirmDeleteDialog
+                open={false}
+                message="Delete finos?"
+                error={null}
+                deleting={false}
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders the message when open', () => {
+        render(
+            <ConfirmDeleteDialog
+                open
+                message="Delete namespace finos?"
+                error={null}
+                deleting={false}
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(screen.getByText('Delete namespace finos?')).toBeInTheDocument();
+    });
+
+    it('renders the error message when present', () => {
+        render(
+            <ConfirmDeleteDialog
+                open
+                message="Delete finos?"
+                error="Namespace finos contains resources and cannot be deleted"
+                deleting={false}
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(screen.getByRole('alert')).toHaveTextContent('contains resources');
+    });
+
+    it('calls onConfirm when Delete is clicked', () => {
+        const onConfirm = vi.fn();
+        render(
+            <ConfirmDeleteDialog
+                open
+                message="Delete finos?"
+                error={null}
+                deleting={false}
+                onConfirm={onConfirm}
+                onCancel={() => {}}
+            />
+        );
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+        expect(onConfirm).toHaveBeenCalled();
+    });
+
+    it('calls onCancel when Cancel is clicked', () => {
+        const onCancel = vi.fn();
+        render(
+            <ConfirmDeleteDialog
+                open
+                message="Delete finos?"
+                error={null}
+                deleting={false}
+                onConfirm={() => {}}
+                onCancel={onCancel}
+            />
+        );
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+        expect(onCancel).toHaveBeenCalled();
+    });
+
+    it('disables both buttons and relabels Delete while deleting', () => {
+        render(
+            <ConfirmDeleteDialog
+                open
+                message="Delete finos?"
+                error={null}
+                deleting
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(screen.getByRole('button', { name: /deleting…/i })).toBeDisabled();
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+    });
+});

--- a/calm-hub-ui/src/admin/components/ConfirmDeleteDialog.tsx
+++ b/calm-hub-ui/src/admin/components/ConfirmDeleteDialog.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+
+interface ConfirmDeleteDialogProps {
+    open: boolean;
+    message: ReactNode;
+    error: string | null;
+    deleting: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export function ConfirmDeleteDialog({ open, message, error, deleting, onConfirm, onCancel }: ConfirmDeleteDialogProps) {
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <dialog open className="modal modal-open">
+            <div className="modal-box">
+                <h3 className="font-bold text-lg">Confirm delete</h3>
+                <p className="py-4">{message}</p>
+                {error && <p className="text-error text-sm mb-2" role="alert">{error}</p>}
+                <div className="modal-action">
+                    <button
+                        className="btn btn-error"
+                        onClick={onConfirm}
+                        disabled={deleting}
+                    >
+                        {deleting ? 'Deleting…' : 'Delete'}
+                    </button>
+                    <button
+                        className="btn btn-ghost"
+                        onClick={onCancel}
+                        disabled={deleting}
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+                <button onClick={onCancel}>close</button>
+            </form>
+        </dialog>
+    );
+}

--- a/calm-hub-ui/src/admin/components/domains/DomainRow.test.tsx
+++ b/calm-hub-ui/src/admin/components/domains/DomainRow.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DomainRow } from './DomainRow.js';
+
+function renderRow(onRequestDelete = vi.fn()) {
+    render(
+        <table>
+            <tbody>
+                <DomainRow name="retail" onRequestDelete={onRequestDelete} />
+            </tbody>
+        </table>
+    );
+    return { onRequestDelete };
+}
+
+describe('DomainRow', () => {
+    it('renders the name', () => {
+        renderRow();
+        expect(screen.getByText('retail')).toBeInTheDocument();
+    });
+
+    it('calls onRequestDelete with the domain name when Delete is clicked', () => {
+        const { onRequestDelete } = renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /delete domain retail/i }));
+        expect(onRequestDelete).toHaveBeenCalledWith('retail');
+    });
+});

--- a/calm-hub-ui/src/admin/components/domains/DomainRow.tsx
+++ b/calm-hub-ui/src/admin/components/domains/DomainRow.tsx
@@ -1,0 +1,23 @@
+interface DomainRowProps {
+    name: string;
+    onRequestDelete: (name: string) => void;
+}
+
+export function DomainRow({ name, onRequestDelete }: DomainRowProps) {
+    return (
+        <tr>
+            <td className="font-mono text-sm">{name}</td>
+            <td className="text-right">
+                <div className="flex gap-1 justify-end">
+                    <button
+                        className="btn btn-xs btn-error btn-outline"
+                        onClick={() => onRequestDelete(name)}
+                        aria-label={`Delete domain ${name}`}
+                    >
+                        Delete
+                    </button>
+                </div>
+            </td>
+        </tr>
+    );
+}

--- a/calm-hub-ui/src/admin/components/namespaces/NamespaceRow.test.tsx
+++ b/calm-hub-ui/src/admin/components/namespaces/NamespaceRow.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NamespaceRow } from './NamespaceRow.js';
+
+function renderRow(onSave = vi.fn().mockResolvedValue(undefined), onRequestDelete = vi.fn()) {
+    render(
+        <table>
+            <tbody>
+                <NamespaceRow name="finos" description="FINOS namespace" onSave={onSave} onRequestDelete={onRequestDelete} />
+            </tbody>
+        </table>
+    );
+    return { onSave, onRequestDelete };
+}
+
+describe('NamespaceRow', () => {
+    it('renders the name and description', () => {
+        renderRow();
+        expect(screen.getByText('finos')).toBeInTheDocument();
+        expect(screen.getByText('FINOS namespace')).toBeInTheDocument();
+    });
+
+    it('calls onRequestDelete with the namespace name when Delete is clicked', () => {
+        const { onRequestDelete } = renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /delete namespace finos/i }));
+        expect(onRequestDelete).toHaveBeenCalledWith('finos');
+    });
+
+    it('switches to an editable description field when Edit is clicked', () => {
+        renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        expect(screen.getByLabelText('Description for finos')).toHaveValue('FINOS namespace');
+    });
+
+    it('disables Save while the description is blank', () => {
+        renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        fireEvent.change(screen.getByLabelText('Description for finos'), { target: { value: '  ' } });
+        expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
+    });
+
+    it('calls onSave with the trimmed name and description on Save', async () => {
+        const { onSave } = renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        fireEvent.change(screen.getByLabelText('Description for finos'), {
+            target: { value: '  updated desc  ' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalledWith('finos', 'updated desc'));
+    });
+
+    it('returns to display mode after a successful save', async () => {
+        renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        fireEvent.change(screen.getByLabelText('Description for finos'), {
+            target: { value: 'updated desc' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+        await waitFor(() =>
+            expect(screen.queryByLabelText('Description for finos')).not.toBeInTheDocument()
+        );
+    });
+
+    it('discards changes and returns to display mode on Cancel', () => {
+        renderRow();
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        fireEvent.change(screen.getByLabelText('Description for finos'), {
+            target: { value: 'discarded' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+        expect(screen.queryByLabelText('Description for finos')).not.toBeInTheDocument();
+        expect(screen.getByText('FINOS namespace')).toBeInTheDocument();
+    });
+
+    it('shows an inline error and stays in edit mode when save fails', async () => {
+        const onSave = vi.fn().mockRejectedValue(new Error('Namespace not found'));
+        renderRow(onSave);
+        fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+        await waitFor(() =>
+            expect(screen.getByRole('alert')).toHaveTextContent('Namespace not found')
+        );
+        expect(screen.getByLabelText('Description for finos')).toBeInTheDocument();
+    });
+});

--- a/calm-hub-ui/src/admin/components/namespaces/NamespaceRow.tsx
+++ b/calm-hub-ui/src/admin/components/namespaces/NamespaceRow.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+
+interface NamespaceRowProps {
+    name: string;
+    description: string;
+    onSave: (name: string, description: string) => Promise<void>;
+    onRequestDelete: (name: string) => void;
+}
+
+export function NamespaceRow({ name, description, onSave, onRequestDelete }: NamespaceRowProps) {
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState(description);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    function startEditing() {
+        setDraft(description);
+        setError(null);
+        setEditing(true);
+    }
+
+    function cancelEditing() {
+        setEditing(false);
+        setError(null);
+    }
+
+    async function handleSave() {
+        const trimmed = draft.trim();
+        if (!trimmed) return;
+
+        setSubmitting(true);
+        setError(null);
+        try {
+            await onSave(name, trimmed);
+            setEditing(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to update namespace.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (editing) {
+        return (
+            <tr>
+                <td className="font-mono text-sm">{name}</td>
+                <td>
+                    <input
+                        className="input input-sm input-bordered w-full"
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        disabled={submitting}
+                        aria-label={`Description for ${name}`}
+                    />
+                    {error && <p className="text-error text-xs mt-1" role="alert">{error}</p>}
+                </td>
+                <td className="text-right">
+                    <div className="flex gap-1 justify-end">
+                        <button
+                            className="btn btn-xs btn-primary"
+                            onClick={handleSave}
+                            disabled={submitting || !draft.trim()}
+                        >
+                            {submitting ? 'Saving…' : 'Save'}
+                        </button>
+                        <button
+                            className="btn btn-xs btn-ghost"
+                            onClick={cancelEditing}
+                            disabled={submitting}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </td>
+            </tr>
+        );
+    }
+
+    return (
+        <tr>
+            <td className="font-mono text-sm">{name}</td>
+            <td className="text-base-content/70">{description}</td>
+            <td className="text-right">
+                <div className="flex gap-1 justify-end">
+                    <button
+                        className="btn btn-xs btn-outline"
+                        onClick={startEditing}
+                        aria-label={`Edit description for ${name}`}
+                    >
+                        Edit
+                    </button>
+                    <button
+                        className="btn btn-xs btn-error btn-outline"
+                        onClick={() => onRequestDelete(name)}
+                        aria-label={`Delete namespace ${name}`}
+                    >
+                        Delete
+                    </button>
+                </div>
+            </td>
+        </tr>
+    );
+}

--- a/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.test.ts
+++ b/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useDeleteConfirmation } from './useDeleteConfirmation.js';
+
+describe('useDeleteConfirmation', () => {
+    it('starts with nothing pending', () => {
+        const { result } = renderHook(() => useDeleteConfirmation(vi.fn(), vi.fn()));
+        expect(result.current.pending).toBeNull();
+        expect(result.current.deleting).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('sets pending when requestDelete is called', () => {
+        const { result } = renderHook(() => useDeleteConfirmation(vi.fn(), vi.fn()));
+        act(() => result.current.requestDelete('finos'));
+        expect(result.current.pending).toBe('finos');
+    });
+
+    it('clears pending on cancelDelete without calling deleteFn', () => {
+        const deleteFn = vi.fn();
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, vi.fn()));
+        act(() => result.current.requestDelete('finos'));
+        act(() => result.current.cancelDelete());
+        expect(result.current.pending).toBeNull();
+        expect(deleteFn).not.toHaveBeenCalled();
+    });
+
+    it('calls deleteFn with the pending name and onDeleted on confirmDelete success', async () => {
+        const deleteFn = vi.fn().mockResolvedValue(undefined);
+        const onDeleted = vi.fn();
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, onDeleted));
+
+        act(() => result.current.requestDelete('finos'));
+        await act(async () => result.current.confirmDelete());
+
+        expect(deleteFn).toHaveBeenCalledWith('finos');
+        expect(onDeleted).toHaveBeenCalled();
+        expect(result.current.pending).toBeNull();
+        expect(result.current.deleting).toBe(false);
+    });
+
+    it('awaits onDeleted, surfacing its rejection as the error rather than firing it and forgetting', async () => {
+        const deleteFn = vi.fn().mockResolvedValue(undefined);
+        const onDeleted = vi.fn().mockRejectedValue(new Error('refresh failed'));
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, onDeleted));
+
+        act(() => result.current.requestDelete('finos'));
+        await act(async () => result.current.confirmDelete());
+
+        expect(onDeleted).toHaveBeenCalled();
+        expect(result.current.error).toBe('refresh failed');
+    });
+
+    it('sets error and keeps pending when deleteFn rejects with an Error', async () => {
+        const deleteFn = vi.fn().mockRejectedValue(new Error('cannot delete: not empty'));
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, vi.fn()));
+
+        act(() => result.current.requestDelete('finos'));
+        await act(async () => result.current.confirmDelete());
+
+        expect(result.current.pending).toBe('finos');
+        expect(result.current.error).toBe('cannot delete: not empty');
+        expect(result.current.deleting).toBe(false);
+    });
+
+    it('falls back to the default error message when the rejection is not an Error', async () => {
+        const deleteFn = vi.fn().mockRejectedValue('nope');
+        const { result } = renderHook(() =>
+            useDeleteConfirmation(deleteFn, vi.fn(), 'Failed to delete namespace.')
+        );
+
+        act(() => result.current.requestDelete('finos'));
+        await act(async () => result.current.confirmDelete());
+
+        expect(result.current.error).toBe('Failed to delete namespace.');
+    });
+
+    it('is a no-op when confirmDelete is called with nothing pending', async () => {
+        const deleteFn = vi.fn();
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, vi.fn()));
+        await act(async () => result.current.confirmDelete());
+        expect(deleteFn).not.toHaveBeenCalled();
+    });
+
+    it('clears a previous error when a new delete is requested', async () => {
+        const deleteFn = vi.fn().mockRejectedValue(new Error('boom'));
+        const { result } = renderHook(() => useDeleteConfirmation(deleteFn, vi.fn()));
+
+        act(() => result.current.requestDelete('finos'));
+        await act(async () => result.current.confirmDelete());
+        await waitFor(() => expect(result.current.error).toBe('boom'));
+
+        act(() => result.current.requestDelete('finos'));
+        expect(result.current.error).toBeNull();
+    });
+});

--- a/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.test.ts
+++ b/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.test.ts
@@ -49,6 +49,10 @@ describe('useDeleteConfirmation', () => {
 
         expect(onDeleted).toHaveBeenCalled();
         expect(result.current.error).toBe('refresh failed');
+        // Regression check: pending must stay set when onDeleted rejects, since
+        // ConfirmDeleteDialog is only rendered (and so the error only visible) while
+        // pending is non-null.
+        expect(result.current.pending).toBe('finos');
     });
 
     it('sets error and keeps pending when deleteFn rejects with an Error', async () => {

--- a/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.ts
+++ b/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.ts
@@ -31,8 +31,8 @@ export function useDeleteConfirmation(
         setError(null);
         try {
             await deleteFn(pending);
-            setPending(null);
             await onDeleted();
+            setPending(null);
         } catch (err) {
             setError(err instanceof Error ? err.message : fallbackErrorMessage);
         } finally {

--- a/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.ts
+++ b/calm-hub-ui/src/admin/hooks/useDeleteConfirmation.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+/**
+ * Drives a request-confirm-delete flow for a single named item: tracks which item is
+ * pending confirmation, the in-flight/error state of the delete call, and exposes the
+ * three handlers a confirm dialog needs. Shared by NamespacesPanel and DomainsPanel
+ * (and mirrors the equivalent revoke-confirmation state in NamespaceAccessPanel).
+ */
+export function useDeleteConfirmation(
+    deleteFn: (name: string) => Promise<void>,
+    onDeleted: () => void | Promise<void>,
+    fallbackErrorMessage = 'Failed to delete.'
+) {
+    const [pending, setPending] = useState<string | null>(null);
+    const [deleting, setDeleting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    function requestDelete(name: string) {
+        setError(null);
+        setPending(name);
+    }
+
+    function cancelDelete() {
+        setPending(null);
+        setError(null);
+    }
+
+    async function confirmDelete() {
+        if (!pending) return;
+        setDeleting(true);
+        setError(null);
+        try {
+            await deleteFn(pending);
+            setPending(null);
+            await onDeleted();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : fallbackErrorMessage);
+        } finally {
+            setDeleting(false);
+        }
+    }
+
+    return { pending, deleting, error, requestDelete, cancelDelete, confirmDelete };
+}

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
@@ -200,7 +200,7 @@ describe('DomainsPanel', () => {
         it('shows a server error and keeps the dialog open when delete fails', async () => {
             const svc = mockService(['retail']);
             vi.spyOn(svc, 'deleteDomain').mockRejectedValue(
-                new Error("Domain 'retail' contains controls and cannot be deleted")
+                new Error('Domain retail contains controls and cannot be deleted')
             );
             renderPanel(svc);
             await screen.findByText('retail');

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DomainsPanel } from './DomainsPanel.js';
 import { CalmService } from '../../service/calm-service.js';
@@ -7,8 +7,9 @@ function mockService(domains: string[], createResult: 'ok' | 'fail' = 'ok') {
     const svc = new CalmService();
     vi.spyOn(svc, 'fetchDomains').mockResolvedValue(domains);
     vi.spyOn(svc, 'createDomain').mockImplementation(() =>
-        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('fail'))
+        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('Domain already exists'))
     );
+    vi.spyOn(svc, 'deleteDomain').mockResolvedValue(undefined);
     return svc;
 }
 
@@ -37,7 +38,7 @@ describe('DomainsPanel', () => {
     });
 
     describe('existing domains list', () => {
-        it('renders each domain as a badge', async () => {
+        it('renders each domain as a row', async () => {
             const svc = mockService(['retail', 'wholesale']);
             renderPanel(svc);
             expect(await screen.findByText('retail')).toBeInTheDocument();
@@ -146,7 +147,7 @@ describe('DomainsPanel', () => {
             expect(await screen.findByText('retail')).toBeInTheDocument();
         });
 
-        it('shows error message when creation fails', async () => {
+        it('shows the specific server error message when creation fails', async () => {
             const svc = mockService([], 'fail');
             renderPanel(svc);
             await screen.findByLabelText('Domain name');
@@ -157,7 +158,59 @@ describe('DomainsPanel', () => {
             fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
             await waitFor(() =>
-                expect(screen.getByRole('alert')).toHaveTextContent(/failed to create domain/i)
+                expect(screen.getByRole('alert')).toHaveTextContent('Domain already exists')
+            );
+        });
+    });
+
+    describe('deleting a domain', () => {
+        it('opens a confirmation dialog when the delete button is clicked', async () => {
+            const svc = mockService(['retail']);
+            renderPanel(svc);
+            await screen.findByText('retail');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete domain retail/i }));
+
+            expect(within(screen.getByRole('dialog')).getByText(/retail/)).toBeInTheDocument();
+        });
+
+        it('calls deleteDomain and refreshes the list on confirm', async () => {
+            const svc = mockService(['retail']);
+            renderPanel(svc);
+            await screen.findByText('retail');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete domain retail/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^delete$/i }));
+
+            await waitFor(() => expect(svc.deleteDomain).toHaveBeenCalledWith('retail'));
+        });
+
+        it('closes the dialog on Cancel without deleting', async () => {
+            const svc = mockService(['retail']);
+            renderPanel(svc);
+            await screen.findByText('retail');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete domain retail/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i }));
+
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            expect(svc.deleteDomain).not.toHaveBeenCalled();
+        });
+
+        it('shows a server error and keeps the dialog open when delete fails', async () => {
+            const svc = mockService(['retail']);
+            vi.spyOn(svc, 'deleteDomain').mockRejectedValue(
+                new Error("Domain 'retail' contains controls and cannot be deleted")
+            );
+            renderPanel(svc);
+            await screen.findByText('retail');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete domain retail/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^delete$/i }));
+
+            await waitFor(() =>
+                expect(within(screen.getByRole('dialog')).getByRole('alert'))
+                    .toHaveTextContent('contains controls')
             );
         });
     });

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
+import { DomainRow } from '../components/domains/DomainRow.js';
 
 interface DomainsPanelProps {
     calmService?: CalmService;
@@ -16,6 +17,10 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
+
+    const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+    const [deleting, setDeleting] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
 
     const load = useCallback(() => {
         setLoading(true);
@@ -38,10 +43,35 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
             setSuccess(`Domain '${name.trim()}' created.`);
             setName('');
             load();
-        } catch {
-            setSubmitError('Failed to create domain.');
+        } catch (err) {
+            setSubmitError(err instanceof Error ? err.message : 'Failed to create domain.');
         } finally {
             setSubmitting(false);
+        }
+    }
+
+    function handleRequestDelete(domainName: string) {
+        setDeleteError(null);
+        setPendingDelete(domainName);
+    }
+
+    function handleCancelDelete() {
+        setPendingDelete(null);
+        setDeleteError(null);
+    }
+
+    async function handleConfirmDelete() {
+        if (!pendingDelete) return;
+        setDeleting(true);
+        setDeleteError(null);
+        try {
+            await svc.deleteDomain(pendingDelete);
+            setPendingDelete(null);
+            load();
+        } catch (err) {
+            setDeleteError(err instanceof Error ? err.message : 'Failed to delete domain.');
+        } finally {
+            setDeleting(false);
         }
     }
 
@@ -82,13 +112,55 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
                     <p className="text-base-content/50 text-sm italic">No domains yet.</p>
                 )}
                 {!loading && domains.length > 0 && (
-                    <ul className="flex flex-wrap gap-2">
-                        {domains.map((d) => (
-                            <li key={d} className="badge badge-ghost badge-lg">{d}</li>
-                        ))}
-                    </ul>
+                    <div className="overflow-x-auto">
+                        <table className="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {domains.map((d) => (
+                                    <DomainRow key={d} name={d} onRequestDelete={handleRequestDelete} />
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
                 )}
             </section>
+
+            {pendingDelete && (
+                <dialog open className="modal modal-open">
+                    <div className="modal-box">
+                        <h3 className="font-bold text-lg">Confirm delete</h3>
+                        <p className="py-4">
+                            Delete domain <span className="font-mono font-semibold">{pendingDelete}</span>?
+                            This also removes all user-access grants for it. This cannot be undone.
+                        </p>
+                        {deleteError && <p className="text-error text-sm mb-2" role="alert">{deleteError}</p>}
+                        <div className="modal-action">
+                            <button
+                                className="btn btn-error"
+                                onClick={handleConfirmDelete}
+                                disabled={deleting}
+                            >
+                                {deleting ? 'Deleting…' : 'Delete'}
+                            </button>
+                            <button
+                                className="btn btn-ghost"
+                                onClick={handleCancelDelete}
+                                disabled={deleting}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                    <form method="dialog" className="modal-backdrop">
+                        <button onClick={handleCancelDelete}>close</button>
+                    </form>
+                </dialog>
+            )}
         </div>
     );
 }

--- a/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/DomainsPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
 import { DomainRow } from '../components/domains/DomainRow.js';
+import { ConfirmDeleteDialog } from '../components/ConfirmDeleteDialog.js';
+import { useDeleteConfirmation } from '../hooks/useDeleteConfirmation.js';
 
 interface DomainsPanelProps {
     calmService?: CalmService;
@@ -18,20 +20,25 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
-    const [pendingDelete, setPendingDelete] = useState<string | null>(null);
-    const [deleting, setDeleting] = useState(false);
-    const [deleteError, setDeleteError] = useState<string | null>(null);
-
     const load = useCallback(() => {
         setLoading(true);
         setLoadError(null);
-        svc.fetchDomains()
+        return svc.fetchDomains()
             .then(setDomains)
             .catch(() => setLoadError('Failed to load domains.'))
             .finally(() => setLoading(false));
     }, [svc]);
 
     useEffect(() => { load(); }, [load]);
+
+    const {
+        pending: pendingDelete,
+        deleting,
+        error: deleteError,
+        requestDelete: handleRequestDelete,
+        cancelDelete: handleCancelDelete,
+        confirmDelete: handleConfirmDelete,
+    } = useDeleteConfirmation((domainName) => svc.deleteDomain(domainName), load, 'Failed to delete domain.');
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -42,36 +49,11 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
             await svc.createDomain(name.trim());
             setSuccess(`Domain '${name.trim()}' created.`);
             setName('');
-            load();
+            await load();
         } catch (err) {
             setSubmitError(err instanceof Error ? err.message : 'Failed to create domain.');
         } finally {
             setSubmitting(false);
-        }
-    }
-
-    function handleRequestDelete(domainName: string) {
-        setDeleteError(null);
-        setPendingDelete(domainName);
-    }
-
-    function handleCancelDelete() {
-        setPendingDelete(null);
-        setDeleteError(null);
-    }
-
-    async function handleConfirmDelete() {
-        if (!pendingDelete) return;
-        setDeleting(true);
-        setDeleteError(null);
-        try {
-            await svc.deleteDomain(pendingDelete);
-            setPendingDelete(null);
-            load();
-        } catch (err) {
-            setDeleteError(err instanceof Error ? err.message : 'Failed to delete domain.');
-        } finally {
-            setDeleting(false);
         }
     }
 
@@ -130,37 +112,19 @@ export function DomainsPanel({ calmService }: DomainsPanelProps) {
                 )}
             </section>
 
-            {pendingDelete && (
-                <dialog open className="modal modal-open">
-                    <div className="modal-box">
-                        <h3 className="font-bold text-lg">Confirm delete</h3>
-                        <p className="py-4">
-                            Delete domain <span className="font-mono font-semibold">{pendingDelete}</span>?
-                            This also removes all user-access grants for it. This cannot be undone.
-                        </p>
-                        {deleteError && <p className="text-error text-sm mb-2" role="alert">{deleteError}</p>}
-                        <div className="modal-action">
-                            <button
-                                className="btn btn-error"
-                                onClick={handleConfirmDelete}
-                                disabled={deleting}
-                            >
-                                {deleting ? 'Deleting…' : 'Delete'}
-                            </button>
-                            <button
-                                className="btn btn-ghost"
-                                onClick={handleCancelDelete}
-                                disabled={deleting}
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
-                    <form method="dialog" className="modal-backdrop">
-                        <button onClick={handleCancelDelete}>close</button>
-                    </form>
-                </dialog>
-            )}
+            <ConfirmDeleteDialog
+                open={!!pendingDelete}
+                message={
+                    <>
+                        Delete domain <span className="font-mono font-semibold">{pendingDelete}</span>?
+                        This also removes all user-access grants for it. This cannot be undone.
+                    </>
+                }
+                error={deleteError}
+                deleting={deleting}
+                onConfirm={handleConfirmDelete}
+                onCancel={handleCancelDelete}
+            />
         </div>
     );
 }

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
@@ -1,14 +1,19 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NamespacesPanel } from './NamespacesPanel.js';
 import { CalmService } from '../../service/calm-service.js';
 
-function mockService(namespaces: string[], createResult: 'ok' | 'fail' = 'ok') {
+function mockService(
+    namespaces: { name: string; description: string }[],
+    createResult: 'ok' | 'fail' = 'ok'
+) {
     const svc = new CalmService();
-    vi.spyOn(svc, 'fetchNamespaces').mockResolvedValue(namespaces);
+    vi.spyOn(svc, 'fetchNamespaceDetails').mockResolvedValue(namespaces);
     vi.spyOn(svc, 'createNamespace').mockImplementation(() =>
-        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('fail'))
+        createResult === 'ok' ? Promise.resolve() : Promise.reject(new Error('Namespace already exists'))
     );
+    vi.spyOn(svc, 'updateNamespace').mockResolvedValue(undefined);
+    vi.spyOn(svc, 'deleteNamespace').mockResolvedValue(undefined);
     return svc;
 }
 
@@ -28,7 +33,7 @@ describe('NamespacesPanel', () => {
         });
 
         it('hides the spinner after loading', async () => {
-            const svc = mockService(['finos']);
+            const svc = mockService([{ name: 'finos', description: 'FINOS namespace' }]);
             renderPanel(svc);
             await waitFor(() =>
                 expect(screen.queryByLabelText('Loading namespaces')).not.toBeInTheDocument()
@@ -37,11 +42,16 @@ describe('NamespacesPanel', () => {
     });
 
     describe('existing namespaces list', () => {
-        it('renders each namespace as a badge', async () => {
-            const svc = mockService(['finos', 'finos.payments']);
+        it('renders each namespace with its name and description', async () => {
+            const svc = mockService([
+                { name: 'finos', description: 'FINOS namespace' },
+                { name: 'finos.payments', description: 'Payments sub-namespace' },
+            ]);
             renderPanel(svc);
             expect(await screen.findByText('finos')).toBeInTheDocument();
-            expect(await screen.findByText('finos.payments')).toBeInTheDocument();
+            expect(screen.getByText('FINOS namespace')).toBeInTheDocument();
+            expect(screen.getByText('finos.payments')).toBeInTheDocument();
+            expect(screen.getByText('Payments sub-namespace')).toBeInTheDocument();
         });
 
         it('shows empty state message when no namespaces exist', async () => {
@@ -52,7 +62,7 @@ describe('NamespacesPanel', () => {
 
         it('shows a load error when fetch fails', async () => {
             const svc = new CalmService();
-            vi.spyOn(svc, 'fetchNamespaces').mockRejectedValue(new Error('fail'));
+            vi.spyOn(svc, 'fetchNamespaceDetails').mockRejectedValue(new Error('fail'));
             renderPanel(svc);
             await waitFor(() =>
                 expect(screen.getByRole('alert')).toHaveTextContent(/failed to load namespaces/i)
@@ -61,12 +71,12 @@ describe('NamespacesPanel', () => {
     });
 
     describe('create namespace form', () => {
-        it('renders the name and description inputs', async () => {
+        it('renders the name and description inputs, both required', async () => {
             const svc = mockService([]);
             renderPanel(svc);
             await screen.findByLabelText('Namespace name');
-            expect(screen.getByLabelText('Namespace name')).toBeInTheDocument();
-            expect(screen.getByLabelText('Namespace description')).toBeInTheDocument();
+            expect(screen.getByLabelText('Namespace name')).toBeRequired();
+            expect(screen.getByLabelText('Namespace description')).toBeRequired();
         });
 
         it('disables the create button when name is empty', async () => {
@@ -76,12 +86,25 @@ describe('NamespacesPanel', () => {
             expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
         });
 
-        it('enables the create button when name is filled', async () => {
+        it('disables the create button when description is empty', async () => {
             const svc = mockService([]);
             renderPanel(svc);
             await screen.findByLabelText('Namespace name');
             fireEvent.change(screen.getByLabelText('Namespace name'), {
                 target: { value: 'my-ns' },
+            });
+            expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
+        });
+
+        it('enables the create button when both fields are filled', async () => {
+            const svc = mockService([]);
+            renderPanel(svc);
+            await screen.findByLabelText('Namespace name');
+            fireEvent.change(screen.getByLabelText('Namespace name'), {
+                target: { value: 'my-ns' },
+            });
+            fireEvent.change(screen.getByLabelText('Namespace description'), {
+                target: { value: 'desc' },
             });
             expect(screen.getByRole('button', { name: /create/i })).not.toBeDisabled();
         });
@@ -109,9 +132,8 @@ describe('NamespacesPanel', () => {
             renderPanel(svc);
             await screen.findByLabelText('Namespace name');
 
-            fireEvent.change(screen.getByLabelText('Namespace name'), {
-                target: { value: 'my-ns' },
-            });
+            fireEvent.change(screen.getByLabelText('Namespace name'), { target: { value: 'my-ns' } });
+            fireEvent.change(screen.getByLabelText('Namespace description'), { target: { value: 'desc' } });
             fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
             await waitFor(() =>
@@ -124,9 +146,7 @@ describe('NamespacesPanel', () => {
             renderPanel(svc);
             await screen.findByLabelText('Namespace name');
 
-            fireEvent.change(screen.getByLabelText('Namespace name'), {
-                target: { value: 'my-ns' },
-            });
+            fireEvent.change(screen.getByLabelText('Namespace name'), { target: { value: 'my-ns' } });
             fireEvent.change(screen.getByLabelText('Namespace description'), {
                 target: { value: 'some description' },
             });
@@ -139,33 +159,102 @@ describe('NamespacesPanel', () => {
 
         it('refreshes the namespace list after successful creation', async () => {
             const svc = new CalmService();
-            vi.spyOn(svc, 'fetchNamespaces')
+            vi.spyOn(svc, 'fetchNamespaceDetails')
                 .mockResolvedValueOnce([])
-                .mockResolvedValueOnce(['my-ns']);
+                .mockResolvedValueOnce([{ name: 'my-ns', description: 'desc' }]);
             vi.spyOn(svc, 'createNamespace').mockResolvedValue();
             renderPanel(svc);
             await screen.findByText(/no namespaces yet/i);
 
-            fireEvent.change(screen.getByLabelText('Namespace name'), {
-                target: { value: 'my-ns' },
-            });
+            fireEvent.change(screen.getByLabelText('Namespace name'), { target: { value: 'my-ns' } });
+            fireEvent.change(screen.getByLabelText('Namespace description'), { target: { value: 'desc' } });
             fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
             expect(await screen.findByText('my-ns')).toBeInTheDocument();
         });
 
-        it('shows error message when creation fails', async () => {
+        it('shows the specific server error message when creation fails', async () => {
             const svc = mockService([], 'fail');
             renderPanel(svc);
             await screen.findByLabelText('Namespace name');
 
-            fireEvent.change(screen.getByLabelText('Namespace name'), {
-                target: { value: 'my-ns' },
-            });
+            fireEvent.change(screen.getByLabelText('Namespace name'), { target: { value: 'my-ns' } });
+            fireEvent.change(screen.getByLabelText('Namespace description'), { target: { value: 'desc' } });
             fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
             await waitFor(() =>
-                expect(screen.getByRole('alert')).toHaveTextContent(/failed to create namespace/i)
+                expect(screen.getByRole('alert')).toHaveTextContent('Namespace already exists')
+            );
+        });
+    });
+
+    describe('editing a namespace description', () => {
+        it('saves the new description and refreshes the list', async () => {
+            const svc = mockService([{ name: 'finos', description: 'old desc' }]);
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+            fireEvent.change(screen.getByLabelText('Description for finos'), {
+                target: { value: 'new desc' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+            await waitFor(() =>
+                expect(svc.updateNamespace).toHaveBeenCalledWith('finos', 'new desc')
+            );
+            expect(svc.fetchNamespaceDetails).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('deleting a namespace', () => {
+        it('opens a confirmation dialog when Delete is clicked', async () => {
+            const svc = mockService([{ name: 'finos', description: 'desc' }]);
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete namespace finos/i }));
+
+            expect(within(screen.getByRole('dialog')).getByText(/finos/)).toBeInTheDocument();
+        });
+
+        it('calls deleteNamespace and refreshes the list on confirm', async () => {
+            const svc = mockService([{ name: 'finos', description: 'desc' }]);
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete namespace finos/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^delete$/i }));
+
+            await waitFor(() => expect(svc.deleteNamespace).toHaveBeenCalledWith('finos'));
+        });
+
+        it('closes the dialog on Cancel without deleting', async () => {
+            const svc = mockService([{ name: 'finos', description: 'desc' }]);
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete namespace finos/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i }));
+
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            expect(svc.deleteNamespace).not.toHaveBeenCalled();
+        });
+
+        it('shows a server error and keeps the dialog open when delete fails', async () => {
+            const svc = mockService([{ name: 'finos', description: 'desc' }]);
+            vi.spyOn(svc, 'deleteNamespace').mockRejectedValue(
+                new Error('Namespace finos contains resources and cannot be deleted')
+            );
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /delete namespace finos/i }));
+            fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^delete$/i }));
+
+            await waitFor(() =>
+                expect(within(screen.getByRole('dialog')).getByRole('alert'))
+                    .toHaveTextContent('contains resources')
             );
         });
     });

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.test.tsx
@@ -205,6 +205,30 @@ describe('NamespacesPanel', () => {
             );
             expect(svc.fetchNamespaceDetails).toHaveBeenCalledTimes(2);
         });
+
+        it('shows the freshly-saved description, never the stale pre-edit value, once saving settles', async () => {
+            const svc = mockService([{ name: 'finos', description: 'old desc' }]);
+            vi.spyOn(svc, 'fetchNamespaceDetails')
+                .mockResolvedValueOnce([{ name: 'finos', description: 'old desc' }])
+                .mockResolvedValueOnce([{ name: 'finos', description: 'new desc' }]);
+
+            renderPanel(svc);
+            await screen.findByText('finos');
+
+            fireEvent.click(screen.getByRole('button', { name: /edit description for finos/i }));
+            fireEvent.change(screen.getByLabelText('Description for finos'), {
+                target: { value: 'new desc' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+            // handleSaveDescription awaits the refetch before NamespaceRow exits edit mode,
+            // so by the time editing mode is gone, the row must already show the fresh value.
+            await waitFor(() =>
+                expect(screen.queryByLabelText('Description for finos')).not.toBeInTheDocument()
+            );
+            expect(screen.getByText('new desc')).toBeInTheDocument();
+            expect(screen.queryByText('old desc')).not.toBeInTheDocument();
+        });
     });
 
     describe('deleting a namespace', () => {

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
 import { NamespaceRow } from '../components/namespaces/NamespaceRow.js';
+import { ConfirmDeleteDialog } from '../components/ConfirmDeleteDialog.js';
+import { useDeleteConfirmation } from '../hooks/useDeleteConfirmation.js';
 
 interface NamespacesPanelProps {
     calmService?: CalmService;
@@ -24,20 +26,25 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
-    const [pendingDelete, setPendingDelete] = useState<string | null>(null);
-    const [deleting, setDeleting] = useState(false);
-    const [deleteError, setDeleteError] = useState<string | null>(null);
-
     const load = useCallback(() => {
         setLoading(true);
         setLoadError(null);
-        svc.fetchNamespaceDetails()
+        return svc.fetchNamespaceDetails()
             .then(setNamespaces)
             .catch(() => setLoadError('Failed to load namespaces.'))
             .finally(() => setLoading(false));
     }, [svc]);
 
     useEffect(() => { load(); }, [load]);
+
+    const {
+        pending: pendingDelete,
+        deleting,
+        error: deleteError,
+        requestDelete: handleRequestDelete,
+        cancelDelete: handleCancelDelete,
+        confirmDelete: handleConfirmDelete,
+    } = useDeleteConfirmation((namespaceName) => svc.deleteNamespace(namespaceName), load, 'Failed to delete namespace.');
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -49,7 +56,7 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
             setSuccess(`Namespace '${name.trim()}' created.`);
             setName('');
             setDescription('');
-            load();
+            await load();
         } catch (err) {
             setSubmitError(err instanceof Error ? err.message : 'Failed to create namespace.');
         } finally {
@@ -59,32 +66,10 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
 
     async function handleSaveDescription(namespaceName: string, newDescription: string) {
         await svc.updateNamespace(namespaceName, newDescription);
-        load();
-    }
-
-    function handleRequestDelete(namespaceName: string) {
-        setDeleteError(null);
-        setPendingDelete(namespaceName);
-    }
-
-    function handleCancelDelete() {
-        setPendingDelete(null);
-        setDeleteError(null);
-    }
-
-    async function handleConfirmDelete() {
-        if (!pendingDelete) return;
-        setDeleting(true);
-        setDeleteError(null);
-        try {
-            await svc.deleteNamespace(pendingDelete);
-            setPendingDelete(null);
-            load();
-        } catch (err) {
-            setDeleteError(err instanceof Error ? err.message : 'Failed to delete namespace.');
-        } finally {
-            setDeleting(false);
-        }
+        // Awaited so NamespaceRow doesn't flip back to display mode (via its own
+        // `await onSave(...)`) until the refetched description has actually landed —
+        // otherwise it would briefly render the stale pre-edit value.
+        await load();
     }
 
     return (
@@ -157,37 +142,19 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
                 )}
             </section>
 
-            {pendingDelete && (
-                <dialog open className="modal modal-open">
-                    <div className="modal-box">
-                        <h3 className="font-bold text-lg">Confirm delete</h3>
-                        <p className="py-4">
-                            Delete namespace <span className="font-mono font-semibold">{pendingDelete}</span>?
-                            This also removes all user-access grants for it. This cannot be undone.
-                        </p>
-                        {deleteError && <p className="text-error text-sm mb-2" role="alert">{deleteError}</p>}
-                        <div className="modal-action">
-                            <button
-                                className="btn btn-error"
-                                onClick={handleConfirmDelete}
-                                disabled={deleting}
-                            >
-                                {deleting ? 'Deleting…' : 'Delete'}
-                            </button>
-                            <button
-                                className="btn btn-ghost"
-                                onClick={handleCancelDelete}
-                                disabled={deleting}
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
-                    <form method="dialog" className="modal-backdrop">
-                        <button onClick={handleCancelDelete}>close</button>
-                    </form>
-                </dialog>
-            )}
+            <ConfirmDeleteDialog
+                open={!!pendingDelete}
+                message={
+                    <>
+                        Delete namespace <span className="font-mono font-semibold">{pendingDelete}</span>?
+                        This also removes all user-access grants for it. This cannot be undone.
+                    </>
+                }
+                error={deleteError}
+                deleting={deleting}
+                onConfirm={handleConfirmDelete}
+                onCancel={handleCancelDelete}
+            />
         </div>
     );
 }

--- a/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
+++ b/calm-hub-ui/src/admin/panels/NamespacesPanel.tsx
@@ -1,14 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
+import { NamespaceRow } from '../components/namespaces/NamespaceRow.js';
 
 interface NamespacesPanelProps {
     calmService?: CalmService;
 }
 
+interface NamespaceDetails {
+    name: string;
+    description: string;
+}
+
 export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
     const svc = useMemo(() => calmService ?? new CalmService(), [calmService]);
 
-    const [namespaces, setNamespaces] = useState<string[]>([]);
+    const [namespaces, setNamespaces] = useState<NamespaceDetails[]>([]);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -18,10 +24,14 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
 
+    const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+    const [deleting, setDeleting] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
     const load = useCallback(() => {
         setLoading(true);
         setLoadError(null);
-        svc.fetchNamespaces()
+        svc.fetchNamespaceDetails()
             .then(setNamespaces)
             .catch(() => setLoadError('Failed to load namespaces.'))
             .finally(() => setLoading(false));
@@ -40,10 +50,40 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
             setName('');
             setDescription('');
             load();
-        } catch {
-            setSubmitError('Failed to create namespace.');
+        } catch (err) {
+            setSubmitError(err instanceof Error ? err.message : 'Failed to create namespace.');
         } finally {
             setSubmitting(false);
+        }
+    }
+
+    async function handleSaveDescription(namespaceName: string, newDescription: string) {
+        await svc.updateNamespace(namespaceName, newDescription);
+        load();
+    }
+
+    function handleRequestDelete(namespaceName: string) {
+        setDeleteError(null);
+        setPendingDelete(namespaceName);
+    }
+
+    function handleCancelDelete() {
+        setPendingDelete(null);
+        setDeleteError(null);
+    }
+
+    async function handleConfirmDelete() {
+        if (!pendingDelete) return;
+        setDeleting(true);
+        setDeleteError(null);
+        try {
+            await svc.deleteNamespace(pendingDelete);
+            setPendingDelete(null);
+            load();
+        } catch (err) {
+            setDeleteError(err instanceof Error ? err.message : 'Failed to delete namespace.');
+        } finally {
+            setDeleting(false);
         }
     }
 
@@ -65,9 +105,10 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
                         />
                         <input
                             className="input input-bordered input-sm"
-                            placeholder="Description (optional)"
+                            placeholder="Description"
                             value={description}
                             onChange={(e) => setDescription(e.target.value)}
+                            required
                             aria-label="Namespace description"
                         />
                         {submitError && <p className="text-error text-sm" role="alert">{submitError}</p>}
@@ -75,7 +116,7 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
                         <button
                             className="btn btn-primary btn-sm self-start"
                             type="submit"
-                            disabled={submitting || !name.trim()}
+                            disabled={submitting || !name.trim() || !description.trim()}
                         >
                             {submitting ? 'Creating…' : 'Create'}
                         </button>
@@ -91,13 +132,62 @@ export function NamespacesPanel({ calmService }: NamespacesPanelProps) {
                     <p className="text-base-content/50 text-sm italic">No namespaces yet.</p>
                 )}
                 {!loading && namespaces.length > 0 && (
-                    <ul className="flex flex-wrap gap-2">
-                        {namespaces.map((ns) => (
-                            <li key={ns} className="badge badge-ghost badge-lg">{ns}</li>
-                        ))}
-                    </ul>
+                    <div className="overflow-x-auto">
+                        <table className="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Description</th>
+                                    <th />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {namespaces.map((ns) => (
+                                    <NamespaceRow
+                                        key={ns.name}
+                                        name={ns.name}
+                                        description={ns.description}
+                                        onSave={handleSaveDescription}
+                                        onRequestDelete={handleRequestDelete}
+                                    />
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
                 )}
             </section>
+
+            {pendingDelete && (
+                <dialog open className="modal modal-open">
+                    <div className="modal-box">
+                        <h3 className="font-bold text-lg">Confirm delete</h3>
+                        <p className="py-4">
+                            Delete namespace <span className="font-mono font-semibold">{pendingDelete}</span>?
+                            This also removes all user-access grants for it. This cannot be undone.
+                        </p>
+                        {deleteError && <p className="text-error text-sm mb-2" role="alert">{deleteError}</p>}
+                        <div className="modal-action">
+                            <button
+                                className="btn btn-error"
+                                onClick={handleConfirmDelete}
+                                disabled={deleting}
+                            >
+                                {deleting ? 'Deleting…' : 'Delete'}
+                            </button>
+                            <button
+                                className="btn btn-ghost"
+                                onClick={handleCancelDelete}
+                                disabled={deleting}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                    <form method="dialog" className="modal-backdrop">
+                        <button onClick={handleCancelDelete}>close</button>
+                    </form>
+                </dialog>
+            )}
         </div>
     );
 }

--- a/calm-hub-ui/src/service/calm-service.test.tsx
+++ b/calm-hub-ui/src/service/calm-service.test.tsx
@@ -56,7 +56,79 @@ describe('CalmService', () => {
         });
     });
 
+    describe('fetchNamespaceDetails', () => {
+        it('should retrieve namespace name and description pairs', async () => {
+            const expectedNamespaces = [
+                { name: 'ns1', description: 'namespace 1' },
+                { name: 'ns2', description: 'namespace 2' },
+            ];
+            mock.onGet('/api/calm/namespaces').reply(200, { values: expectedNamespaces });
+            const actual = await calmService.fetchNamespaceDetails();
+            expect(actual).toEqual(expectedNamespaces);
+        });
+
+        it('should throw an error when backend returns error status', async () => {
+            mock.onGet('/api/calm/namespaces').reply(500, { message: 'Error' });
+            await expect(calmService.fetchNamespaceDetails()).rejects.toThrowError();
+        });
+    });
+
+    describe('createNamespace', () => {
+        it('should post the name and description', async () => {
+            mock.onPost('/api/calm/namespaces', { name: 'ns1', description: 'desc' }).reply(201);
+            await expect(calmService.createNamespace('ns1', 'desc')).resolves.toBeUndefined();
+        });
+
+        it('should surface the server-provided error message from a JSON error body', async () => {
+            mock.onPost('/api/calm/namespaces').reply(409, { error: 'Namespace already exists' });
+            await expect(calmService.createNamespace('ns1', 'desc')).rejects.toThrowError('Namespace already exists');
+        });
+
+        it('should surface the server-provided error message from a plain-text error body', async () => {
+            mock.onPost('/api/calm/namespaces').reply(404, 'Invalid namespace provided: ns1');
+            await expect(calmService.createNamespace('ns1', 'desc')).rejects.toThrowError('Invalid namespace provided: ns1');
+        });
+
+        it('should fall back to a generic error message when the body has no error text', async () => {
+            mock.onPost('/api/calm/namespaces').reply(500, { message: 'unexpected' });
+            await expect(calmService.createNamespace('ns1', 'desc')).rejects.toThrowError('Error creating namespace ns1:');
+        });
+    });
+
+    describe('updateNamespace', () => {
+        it('should put the new description', async () => {
+            mock.onPut('/api/calm/namespaces/ns1', { description: 'new desc' }).reply(204);
+            await expect(calmService.updateNamespace('ns1', 'new desc')).resolves.toBeUndefined();
+        });
+
+        it('should surface the server-provided error message when the namespace is missing', async () => {
+            mock.onPut('/api/calm/namespaces/missing').reply(404, 'Invalid namespace provided: missing');
+            await expect(calmService.updateNamespace('missing', 'desc'))
+                .rejects.toThrowError('Invalid namespace provided: missing');
+        });
+    });
+
+    describe('deleteNamespace', () => {
+        it('should delete the namespace', async () => {
+            mock.onDelete('/api/calm/namespaces/ns1').reply(204);
+            await expect(calmService.deleteNamespace('ns1')).resolves.toBeUndefined();
+        });
+
+        it('should surface the server-provided error message when the namespace is not empty', async () => {
+            mock.onDelete('/api/calm/namespaces/ns1')
+                .reply(409, 'Namespace ns1 contains resources and cannot be deleted');
+            await expect(calmService.deleteNamespace('ns1'))
+                .rejects.toThrowError('Namespace ns1 contains resources and cannot be deleted');
+        });
+    });
+
     describe('fetchDomains', () => {
+        it('should retrieve all domains', async () => {
+            mock.onGet('/api/calm/domains').reply(200, { values: ['retail', 'wholesale'] });
+            const actual = await calmService.fetchDomains();
+            expect(actual).toEqual(['retail', 'wholesale']);
+        });
+
         it('should return domains in alphabetical order regardless of API response order', async () => {
             mock.onGet('/api/calm/domains').reply(200, { values: ['wholesale', 'retail'] });
             const actual = await calmService.fetchDomains();
@@ -66,6 +138,32 @@ describe('CalmService', () => {
         it('should throw an error when backend returns error status', async () => {
             mock.onGet('/api/calm/domains').reply(500, { message: 'Error' });
             await expect(calmService.fetchDomains()).rejects.toThrowError();
+        });
+    });
+
+    describe('createDomain', () => {
+        it('should post the name', async () => {
+            mock.onPost('/api/calm/domains', { name: 'retail' }).reply(201);
+            await expect(calmService.createDomain('retail')).resolves.toBeUndefined();
+        });
+
+        it('should surface the server-provided error message on conflict', async () => {
+            mock.onPost('/api/calm/domains').reply(409, { error: 'Domain already exists' });
+            await expect(calmService.createDomain('retail')).rejects.toThrowError('Domain already exists');
+        });
+    });
+
+    describe('deleteDomain', () => {
+        it('should delete the domain', async () => {
+            mock.onDelete('/api/calm/domains/retail').reply(204);
+            await expect(calmService.deleteDomain('retail')).resolves.toBeUndefined();
+        });
+
+        it('should surface the server-provided error message when the domain is not empty', async () => {
+            mock.onDelete('/api/calm/domains/retail')
+                .reply(409, "Domain 'retail' contains controls and cannot be deleted");
+            await expect(calmService.deleteDomain('retail'))
+                .rejects.toThrowError("Domain 'retail' contains controls and cannot be deleted");
         });
     });
 

--- a/calm-hub-ui/src/service/calm-service.test.tsx
+++ b/calm-hub-ui/src/service/calm-service.test.tsx
@@ -161,9 +161,9 @@ describe('CalmService', () => {
 
         it('should surface the server-provided error message when the domain is not empty', async () => {
             mock.onDelete('/api/calm/domains/retail')
-                .reply(409, "Domain 'retail' contains controls and cannot be deleted");
+                .reply(409, 'Domain retail contains controls and cannot be deleted');
             await expect(calmService.deleteDomain('retail'))
-                .rejects.toThrowError("Domain 'retail' contains controls and cannot be deleted");
+                .rejects.toThrowError('Domain retail contains controls and cannot be deleted');
         });
     });
 

--- a/calm-hub-ui/src/service/calm-service.test.tsx
+++ b/calm-hub-ui/src/service/calm-service.test.tsx
@@ -67,6 +67,18 @@ describe('CalmService', () => {
             expect(actual).toEqual(expectedNamespaces);
         });
 
+        it('should return namespaces in alphabetical order regardless of API response order', async () => {
+            mock.onGet('/api/calm/namespaces').reply(200, {
+                values: [
+                    { name: 'zebra', description: '' },
+                    { name: 'apple', description: '' },
+                    { name: 'mango', description: '' },
+                ],
+            });
+            const actual = await calmService.fetchNamespaceDetails();
+            expect(actual.map((ns) => ns.name)).toEqual(['apple', 'mango', 'zebra']);
+        });
+
         it('should throw an error when backend returns error status', async () => {
             mock.onGet('/api/calm/namespaces').reply(500, { message: 'Error' });
             await expect(calmService.fetchNamespaceDetails()).rejects.toThrowError();

--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -88,7 +88,9 @@ export class CalmService {
         return this.ax
             .get('/api/calm/namespaces', { headers })
             .then((res) => {
-                return Array.isArray(res.data?.values) ? res.data.values : [];
+                const namespaces: { name: string; description: string }[] =
+                    Array.isArray(res.data?.values) ? res.data.values : [];
+                return namespaces.sort((a, b) => a.name.localeCompare(b.name));
             })
             .catch((error) => {
                 const errorMessage = 'Error fetching namespaces:';

--- a/calm-hub-ui/src/service/calm-service.tsx
+++ b/calm-hub-ui/src/service/calm-service.tsx
@@ -29,8 +29,27 @@ function summaryPageQuery(limit?: number, offset?: number): string {
 }
 
 /**
+ * Extracts a server-provided error message from a failed request, falling back to
+ * `fallback` when the response body doesn't carry one. Namespace/domain mutation
+ * endpoints return either a plain-text body (e.g. "Invalid namespace provided: x")
+ * or a `{"error": "..."}` JSON body, depending on the failure — this normalizes both
+ * so the UI can surface the specific reason instead of one generic message for
+ * every failure.
+ */
+function extractServerErrorMessage(error: unknown, fallback: string): string {
+    const data = (error as { response?: { data?: unknown } })?.response?.data;
+    if (typeof data === 'string' && data.trim()) {
+        return data;
+    }
+    if (data && typeof data === 'object' && typeof (data as { error?: unknown }).error === 'string') {
+        return (data as { error: string }).error;
+    }
+    return fallback;
+}
+
+/**
  * Service for interacting with CALM API endpoints.
- * 
+ *
  * TODO: Add type safety for API responses by:
  * - Defining response interfaces (e.g., NamespacesResponse, PatternIDsResponse)
  * - Validating responses at runtime (e.g., with Zod or similar validation library)
@@ -64,6 +83,20 @@ export class CalmService {
             });
     }
 
+    public async fetchNamespaceDetails(): Promise<{ name: string; description: string }[]> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .get('/api/calm/namespaces', { headers })
+            .then((res) => {
+                return Array.isArray(res.data?.values) ? res.data.values : [];
+            })
+            .catch((error) => {
+                const errorMessage = 'Error fetching namespaces:';
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
     public async fetchDomains(): Promise<string[]> {
         const headers = await getAuthHeaders();
         return this.ax
@@ -85,7 +118,31 @@ export class CalmService {
             .post('/api/calm/namespaces', { name, description }, { headers })
             .then(() => undefined)
             .catch((error) => {
-                const errorMessage = `Error creating namespace ${name}:`;
+                const errorMessage = extractServerErrorMessage(error, `Error creating namespace ${name}:`);
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async updateNamespace(name: string, description: string): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .put(`/api/calm/namespaces/${encodeURIComponent(name)}`, { description }, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = extractServerErrorMessage(error, `Error updating namespace ${name}:`);
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async deleteNamespace(name: string): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .delete(`/api/calm/namespaces/${encodeURIComponent(name)}`, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = extractServerErrorMessage(error, `Error deleting namespace ${name}:`);
                 console.error('%s', errorMessage, error);
                 return Promise.reject(new Error(errorMessage));
             });
@@ -97,7 +154,19 @@ export class CalmService {
             .post('/api/calm/domains', { name }, { headers })
             .then(() => undefined)
             .catch((error) => {
-                const errorMessage = `Error creating domain ${name}:`;
+                const errorMessage = extractServerErrorMessage(error, `Error creating domain ${name}:`);
+                console.error('%s', errorMessage, error);
+                return Promise.reject(new Error(errorMessage));
+            });
+    }
+
+    public async deleteDomain(name: string): Promise<void> {
+        const headers = await getAuthHeaders();
+        return this.ax
+            .delete(`/api/calm/domains/${encodeURIComponent(name)}`, { headers })
+            .then(() => undefined)
+            .catch((error) => {
+                const errorMessage = extractServerErrorMessage(error, `Error deleting domain ${name}:`);
                 console.error('%s', errorMessage, error);
                 return Promise.reject(new Error(errorMessage));
             });

--- a/calm-hub/src/main/java/org/finos/calm/domain/UpdateNamespaceRequest.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/UpdateNamespaceRequest.java
@@ -1,0 +1,18 @@
+package org.finos.calm.domain;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class UpdateNamespaceRequest {
+    @NotNull(message = "Description must not be null")
+    @NotBlank(message = "Description must not be blank")
+    private String description;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/domain/audit/AuditAction.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/audit/AuditAction.java
@@ -6,6 +6,7 @@ package org.finos.calm.domain.audit;
 public enum AuditAction {
     CREATE,
     UPDATE,
+    DELETE,
     GRANT,
     REVOKE
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/DomainNotEmptyException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/DomainNotEmptyException.java
@@ -1,0 +1,7 @@
+package org.finos.calm.domain.exception;
+
+public class DomainNotEmptyException extends Exception {
+    public DomainNotEmptyException(String message) {
+        super(message);
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/DomainNotEmptyException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/DomainNotEmptyException.java
@@ -1,7 +1,24 @@
 package org.finos.calm.domain.exception;
 
+/**
+ * Thrown when a domain cannot be deleted because it still has controls associated
+ * with it. Carries the raw domain name as a field rather than a formatted message —
+ * the resource layer (see {@code CalmResourceErrorResponses.domainNotEmptyResponse})
+ * is solely responsible for composing and sanitizing the user-facing message, so it
+ * isn't duplicated here.
+ */
 public class DomainNotEmptyException extends Exception {
-    public DomainNotEmptyException(String message) {
-        super(message);
+    private final String domain;
+
+    /**
+     * @param domain the domain that could not be deleted because it still has controls
+     */
+    public DomainNotEmptyException(String domain) {
+        super("Domain not empty: " + domain);
+        this.domain = domain;
+    }
+
+    public String getDomain() {
+        return domain;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceNotEmptyException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceNotEmptyException.java
@@ -1,0 +1,44 @@
+package org.finos.calm.domain.exception;
+
+/**
+ * Thrown when a namespace cannot be deleted because it still has content or child
+ * namespaces. Carries the raw namespace name and (if applicable) a child-namespace
+ * count as separate fields rather than a single pre-formatted message, so the resource
+ * layer can sanitize the user-derived namespace name and compose the response body
+ * around it. Only a count is carried for children — not their names — since a
+ * namespace can have arbitrarily many children and enumerating them all would make
+ * the error response unbounded in size.
+ */
+public class NamespaceNotEmptyException extends Exception {
+    private final String namespace;
+    private final int childNamespaceCount;
+
+    /**
+     * @param namespace the namespace that could not be deleted because it has child namespaces
+     * @param childNamespaceCount the number of child namespaces blocking deletion (greater than 0)
+     */
+    public NamespaceNotEmptyException(String namespace, int childNamespaceCount) {
+        super("Namespace " + namespace + " has " + childNamespaceCount
+                + " child namespace(s) and cannot be deleted");
+        this.namespace = namespace;
+        this.childNamespaceCount = childNamespaceCount;
+    }
+
+    /**
+     * @param namespace the namespace that could not be deleted because it still has content
+     */
+    public NamespaceNotEmptyException(String namespace) {
+        super("Namespace " + namespace + " contains resources and cannot be deleted");
+        this.namespace = namespace;
+        this.childNamespaceCount = 0;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /** Zero when the namespace was rejected for having content rather than children. */
+    public int getChildNamespaceCount() {
+        return childNamespaceCount;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceNotEmptyException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/NamespaceNotEmptyException.java
@@ -3,9 +3,10 @@ package org.finos.calm.domain.exception;
 /**
  * Thrown when a namespace cannot be deleted because it still has content or child
  * namespaces. Carries the raw namespace name and (if applicable) a child-namespace
- * count as separate fields rather than a single pre-formatted message, so the resource
- * layer can sanitize the user-derived namespace name and compose the response body
- * around it. Only a count is carried for children — not their names — since a
+ * count as separate fields rather than a formatted message — the resource layer
+ * (see {@code CalmResourceErrorResponses.namespaceNotEmptyResponse}) is solely
+ * responsible for composing and sanitizing the user-facing message, so it isn't
+ * duplicated here. Only a count is carried for children — not their names — since a
  * namespace can have arbitrarily many children and enumerating them all would make
  * the error response unbounded in size.
  */
@@ -18,8 +19,7 @@ public class NamespaceNotEmptyException extends Exception {
      * @param childNamespaceCount the number of child namespaces blocking deletion (greater than 0)
      */
     public NamespaceNotEmptyException(String namespace, int childNamespaceCount) {
-        super("Namespace " + namespace + " has " + childNamespaceCount
-                + " child namespace(s) and cannot be deleted");
+        super("Namespace not empty: " + namespace);
         this.namespace = namespace;
         this.childNamespaceCount = childNamespaceCount;
     }
@@ -28,9 +28,7 @@ public class NamespaceNotEmptyException extends Exception {
      * @param namespace the namespace that could not be deleted because it still has content
      */
     public NamespaceNotEmptyException(String namespace) {
-        super("Namespace " + namespace + " contains resources and cannot be deleted");
-        this.namespace = namespace;
-        this.childNamespaceCount = 0;
+        this(namespace, 0);
     }
 
     public String getNamespace() {

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -4,7 +4,9 @@ import jakarta.ws.rs.core.Response;
 
 public class CalmResourceErrorResponses {
     public static Response invalidNamespaceResponse(String namespace) {
-        return Response.status(Response.Status.NOT_FOUND).entity("Invalid namespace provided: " + namespace).build();
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity("Invalid namespace provided: " + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
+                .build();
     }
 
     public static Response invalidDomainResponse(String domain) {

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -30,4 +30,32 @@ public class CalmResourceErrorResponses {
     public static Response invalidDecoratorJsonResponse(String message) {
         return Response.status(Response.Status.BAD_REQUEST).entity("Invalid decorator JSON: " + message).build();
     }
+
+    /**
+     * Returns a 409 response for a namespace-deletion attempt that was refused because the
+     * namespace still has content or child namespaces. Only the namespace name — the
+     * user-derived value — is sanitized; the surrounding literal text is trusted and left
+     * untouched, so sanitization doesn't HTML-entity-encode ordinary punctuation in the
+     * message. Child namespaces are reported as a count rather than enumerated by name,
+     * since a namespace can have arbitrarily many children.
+     */
+    public static Response namespaceNotEmptyResponse(String namespace, int childNamespaceCount) {
+        String sanitizedNamespace = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace);
+        String message = childNamespaceCount > 0
+                ? "Namespace " + sanitizedNamespace + " has " + childNamespaceCount
+                        + " child namespace(s) and cannot be deleted"
+                : "Namespace " + sanitizedNamespace + " contains resources and cannot be deleted";
+        return Response.status(Response.Status.CONFLICT).entity(message).build();
+    }
+
+    /**
+     * Returns a 409 response for a domain-deletion attempt that was refused because the
+     * domain still has controls associated with it.
+     */
+    public static Response domainNotEmptyResponse(String domain) {
+        return Response.status(Response.Status.CONFLICT)
+                .entity("Domain '" + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(domain)
+                        + "' contains controls and cannot be deleted")
+                .build();
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -50,12 +50,13 @@ public class CalmResourceErrorResponses {
 
     /**
      * Returns a 409 response for a domain-deletion attempt that was refused because the
-     * domain still has controls associated with it.
+     * domain still has controls associated with it. Formatted to match
+     * {@link #namespaceNotEmptyResponse(String, int)} — no quotes around the entity name.
      */
     public static Response domainNotEmptyResponse(String domain) {
+        String sanitizedDomain = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(domain);
         return Response.status(Response.Status.CONFLICT)
-                .entity("Domain '" + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(domain)
-                        + "' contains controls and cannot be deleted")
+                .entity("Domain " + sanitizedDomain + " contains controls and cannot be deleted")
                 .build();
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
@@ -135,7 +135,7 @@ public class DomainResource {
         } catch (DomainNotFoundException e) {
             return invalidDomainResponse(domain);
         } catch (DomainNotEmptyException e) {
-            return domainNotEmptyResponse(domain);
+            return domainNotEmptyResponse(e.getDomain());
         }
         return Response.noContent().build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DomainResource.java
@@ -7,6 +7,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -17,6 +18,8 @@ import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.controls.DomainControlCount;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotEmptyException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.security.CalmHubPermissionChecker;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.security.UserAccessValidator;
@@ -26,6 +29,11 @@ import org.finos.calm.services.DomainService;
 import java.net.URI;
 import java.util.Optional;
 import java.util.Set;
+
+import static org.finos.calm.resources.CalmResourceErrorResponses.domainNotEmptyResponse;
+import static org.finos.calm.resources.CalmResourceErrorResponses.invalidDomainResponse;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.DOMAIN_REGEX;
 
 /**
  * REST resource for managing domains.
@@ -110,6 +118,26 @@ public class DomainResource {
             return Response.status(Response.Status.CONFLICT).entity("{\"error\":\"Domain already exists\"}").build();
         }
         return Response.created(URI.create("/api/calm/domains/" + domainName)).build();
+    }
+
+    @DELETE
+    @Path("{domain}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete Domain",
+            description = "Deletes a domain, provided it has no controls. Also removes all user-access grants for the domain."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteDomain(
+            @PathParam("domain") @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE) String domain) {
+        try {
+            service.deleteDomain(domain);
+        } catch (DomainNotFoundException e) {
+            return invalidDomainResponse(domain);
+        } catch (DomainNotEmptyException e) {
+            return domainNotEmptyResponse(domain);
+        }
+        return Response.noContent().build();
     }
 
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -1,11 +1,13 @@
 package org.finos.calm.resources;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -13,15 +15,19 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.NamespaceRequest;
+import org.finos.calm.domain.UpdateNamespaceRequest;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.audit.AuditAction;
 import org.finos.calm.domain.audit.AuditEntityType;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotEmptyException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceCounts;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.security.AuditRequestFilter;
 import org.finos.calm.security.CalmHubPermissionChecker;
+import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.security.UserAccessValidator;
 import org.finos.calm.services.CountsService;
 import org.finos.calm.services.NamespaceService;
@@ -30,6 +36,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Set;
+
+import static org.finos.calm.resources.CalmResourceErrorResponses.invalidNamespaceResponse;
+import static org.finos.calm.resources.CalmResourceErrorResponses.namespaceNotEmptyResponse;
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
 
 @Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
 @Path("/api/calm/namespaces")
@@ -141,6 +152,46 @@ public class NamespaceResource {
         }
 
         return Response.created(new URI("/api/calm/namespaces/" + name)).build();
+    }
+
+    @PUT
+    @Path("{namespace}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Update Namespace Description",
+            description = "Updates the description of an existing namespace"
+    )
+    @PermissionsAllowed(CalmHubScopes.ADMIN)
+    public Response updateNamespace(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @Valid @NotNull(message = "Request must not be null") UpdateNamespaceRequest request) {
+        try {
+            namespaceService.updateNamespaceDescription(namespace, request.getDescription().trim());
+        } catch (NamespaceNotFoundException e) {
+            return invalidNamespaceResponse(namespace);
+        }
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("{namespace}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete Namespace",
+            description = "Deletes a namespace, provided it has no content and no child namespaces. Also removes all user-access grants for the namespace."
+    )
+    @PermissionsAllowed(CalmHubScopes.ADMIN)
+    public Response deleteNamespace(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace) {
+        try {
+            namespaceService.deleteNamespace(namespace);
+        } catch (NamespaceNotFoundException e) {
+            return invalidNamespaceResponse(namespace);
+        } catch (NamespaceNotEmptyException e) {
+            return namespaceNotEmptyResponse(e.getNamespace(), e.getChildNamespaceCount());
+        }
+        return Response.noContent().build();
     }
 
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/NamespaceResource.java
@@ -126,7 +126,7 @@ public class NamespaceResource {
         // since the namespace name lives in the body) so AuditRequestFilter can record a
         // fully-identified DENIED entry, not just an anonymous 403.
         AuditRequestFilter.stage(new AuditRequestFilter.AuditContext(
-                AuditEntityType.NAMESPACE, AuditAction.CREATE, null, null, name, null));
+                AuditEntityType.NAMESPACE, AuditAction.CREATE, name, null, null, null));
 
         boolean isGlobalAdmin = permissionChecker.hasGlobalAdmin(identity);
         boolean isChildNamespace = name.contains(".");

--- a/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
@@ -320,6 +320,16 @@ public class AuditRequestFilter implements ContainerResponseFilter {
             }
         }
 
+        // A domain has no separate parent scope — it IS the scope, the same way namespace
+        // creation reports its name via `namespace`, not `entityId` (see NamespaceResource
+        // #createNamespace). Without this, DomainResource#createDomain would be the only
+        // domain-scoped action reporting the domain's name via entityId instead of domain,
+        // splitting a single domain's audit trail across two fields depending on action.
+        if (entityType == AuditEntityType.DOMAIN && domain == null) {
+            domain = entityId;
+            entityId = null;
+        }
+
         return new AuditContext(entityType, action, namespace, domain, entityId, version);
     }
 
@@ -383,6 +393,14 @@ public class AuditRequestFilter implements ContainerResponseFilter {
             LocationSegmentParser.LocationIds ids = LocationSegmentParser.parse(entityType, locationPath(responseContext));
             entityId = ids.entityId();
             version = ids.version();
+        }
+        // See the matching comment in resolveGeneric: a domain IS the scope, so its name
+        // belongs in `domain`, not `entityId` — MappingControllerResource#createDomain
+        // is the only caller of this method with entityType DOMAIN, and always passes
+        // domain == null, so this never overrides a real parent-domain scope.
+        if (entityType == AuditEntityType.DOMAIN && domain == null) {
+            domain = entityId;
+            entityId = null;
         }
         return new AuditContext(entityType, AuditAction.CREATE, null, domain, entityId, version);
     }

--- a/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
@@ -300,6 +300,8 @@ public class AuditRequestFilter implements ContainerResponseFilter {
             action = "POST".equals(method) ? AuditAction.GRANT : AuditAction.REVOKE;
         } else if ("POST".equals(method)) {
             action = pathEntityId != null ? AuditAction.UPDATE : AuditAction.CREATE;
+        } else if ("DELETE".equals(method)) {
+            action = AuditAction.DELETE;
         } else {
             return null;
         }

--- a/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
@@ -4,6 +4,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotEmptyException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
+import org.finos.calm.store.ControlStore;
 import org.finos.calm.store.DomainStore;
 import org.finos.calm.store.UserAccessStore;
 import org.slf4j.Logger;
@@ -18,11 +21,13 @@ public class DomainService {
 
     private final DomainStore domainStore;
     private final UserAccessStore userAccessStore;
+    private final ControlStore controlStore;
 
     @Inject
-    public DomainService(DomainStore domainStore, UserAccessStore userAccessStore) {
+    public DomainService(DomainStore domainStore, UserAccessStore userAccessStore, ControlStore controlStore) {
         this.domainStore = domainStore;
         this.userAccessStore = userAccessStore;
+        this.controlStore = controlStore;
     }
 
     public List<String> getDomains() {
@@ -32,6 +37,20 @@ public class DomainService {
     public void createDomain(String name) throws DomainAlreadyExistsException {
         domainStore.createDomain(name);
         insertPublicReadGrant(name);
+    }
+
+    public void deleteDomain(String name) throws DomainNotFoundException, DomainNotEmptyException {
+        if (!domainStore.domainExists(name)) {
+            throw new DomainNotFoundException(name);
+        }
+
+        if (!controlStore.getControlsForDomain(name).isEmpty()) {
+            throw new DomainNotEmptyException("Domain '" + name + "' contains controls and cannot be deleted");
+        }
+
+        domainStore.deleteDomain(name);
+        userAccessStore.deleteAllUserAccessForDomain(name);
+        LOG.info("Deleted domain [{}] and its user-access grants", name);
     }
 
     private void insertPublicReadGrant(String domain) {

--- a/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/DomainService.java
@@ -45,7 +45,7 @@ public class DomainService {
         }
 
         if (!controlStore.getControlsForDomain(name).isEmpty()) {
-            throw new DomainNotEmptyException("Domain '" + name + "' contains controls and cannot be deleted");
+            throw new DomainNotEmptyException(name);
         }
 
         domainStore.deleteDomain(name);

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
@@ -11,8 +11,6 @@ import org.finos.calm.store.InterfaceStore;
 import org.finos.calm.store.PatternStore;
 import org.finos.calm.store.StandardStore;
 import org.finos.calm.store.TimelineStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -24,8 +22,6 @@ import java.util.List;
  */
 @ApplicationScoped
 public class NamespaceContentService {
-
-    private static final Logger logger = LoggerFactory.getLogger(NamespaceContentService.class);
 
     private final ArchitectureStore architectureStore;
     private final PatternStore patternStore;
@@ -73,16 +69,18 @@ public class NamespaceContentService {
     }
 
     /**
-     * Sizes a store list, treating a missing namespace as empty (mirrors
-     * {@code CountsService.sizeOrZero}) so one store's not-found never fails the whole check.
+     * Sizes a store list, treating a missing namespace as empty so one store's not-found
+     * never fails the whole check. Unlike {@code CountsService.sizeOrZero} — which backs a
+     * read-only display count, where treating a store failure as zero is a harmless
+     * undercount — this method gates an irreversible namespace deletion, so any other
+     * failure (a store timeout, a locked file, etc.) is deliberately NOT swallowed here:
+     * it propagates so the delete fails loudly instead of silently proceeding against
+     * content that was never actually confirmed absent.
      */
     private boolean isNotEmpty(NamespaceListSupplier supplier) {
         try {
             return !supplier.get().isEmpty();
         } catch (NamespaceNotFoundException e) {
-            return false;
-        } catch (RuntimeException e) {
-            logger.warn("Failed to check a resource list while checking namespace content; treating as empty", e);
             return false;
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
@@ -1,0 +1,94 @@
+package org.finos.calm.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.AdrStore;
+import org.finos.calm.store.ArchitectureStore;
+import org.finos.calm.store.DecoratorStore;
+import org.finos.calm.store.FlowStore;
+import org.finos.calm.store.InterfaceStore;
+import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.StandardStore;
+import org.finos.calm.store.TimelineStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Checks whether a namespace holds any content, across every namespace-scoped resource
+ * type. Used to guard namespace deletion — a namespace may only be deleted once it is
+ * confirmed empty. Unlike {@link CountsService}, this short-circuits on the first
+ * non-empty store instead of exhaustively counting every type.
+ */
+@ApplicationScoped
+public class NamespaceContentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(NamespaceContentService.class);
+
+    private final ArchitectureStore architectureStore;
+    private final PatternStore patternStore;
+    private final FlowStore flowStore;
+    private final StandardStore standardStore;
+    private final AdrStore adrStore;
+    private final InterfaceStore interfaceStore;
+    private final TimelineStore timelineStore;
+    private final DecoratorStore decoratorStore;
+
+    @Inject
+    @SuppressWarnings("java:S107") // emptiness check legitimately needs every namespace-scoped store
+    public NamespaceContentService(ArchitectureStore architectureStore,
+                                   PatternStore patternStore,
+                                   FlowStore flowStore,
+                                   StandardStore standardStore,
+                                   AdrStore adrStore,
+                                   InterfaceStore interfaceStore,
+                                   TimelineStore timelineStore,
+                                   DecoratorStore decoratorStore) {
+        this.architectureStore = architectureStore;
+        this.patternStore = patternStore;
+        this.flowStore = flowStore;
+        this.standardStore = standardStore;
+        this.adrStore = adrStore;
+        this.interfaceStore = interfaceStore;
+        this.timelineStore = timelineStore;
+        this.decoratorStore = decoratorStore;
+    }
+
+    /**
+     * @param namespace the namespace to check
+     * @return true if the namespace holds any architecture, pattern, flow, standard, adr,
+     *         interface, timeline, or decorator
+     */
+    public boolean hasContent(String namespace) {
+        return isNotEmpty(() -> architectureStore.getArchitecturesForNamespace(namespace))
+                || isNotEmpty(() -> patternStore.getPatternsForNamespace(namespace))
+                || isNotEmpty(() -> flowStore.getFlowsForNamespace(namespace))
+                || isNotEmpty(() -> standardStore.getStandardsForNamespace(namespace))
+                || isNotEmpty(() -> adrStore.getAdrsForNamespace(namespace))
+                || isNotEmpty(() -> interfaceStore.getInterfacesForNamespace(namespace))
+                || isNotEmpty(() -> timelineStore.getTimelinesForNamespace(namespace))
+                || isNotEmpty(() -> decoratorStore.getDecoratorsForNamespace(namespace, null, null));
+    }
+
+    /**
+     * Sizes a store list, treating a missing namespace as empty (mirrors
+     * {@code CountsService.sizeOrZero}) so one store's not-found never fails the whole check.
+     */
+    private boolean isNotEmpty(NamespaceListSupplier supplier) {
+        try {
+            return !supplier.get().isEmpty();
+        } catch (NamespaceNotFoundException e) {
+            return false;
+        } catch (RuntimeException e) {
+            logger.warn("Failed to check a resource list while checking namespace content; treating as empty", e);
+            return false;
+        }
+    }
+
+    @FunctionalInterface
+    private interface NamespaceListSupplier {
+        List<?> get() throws NamespaceNotFoundException;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
@@ -58,16 +58,25 @@ public class NamespaceService {
             throw new NamespaceNotFoundException();
         }
 
+        if (namespaceContentService.hasContent(name)) {
+            throw new NamespaceNotEmptyException(name);
+        }
+
+        // Checked last, immediately before the delete, rather than first — this shrinks the
+        // window in which a concurrent createNamespace(name + ".child", ...) could slip in
+        // between this check and the delete below, from "the whole content scan above" down
+        // to "the gap between these two store calls". It does not close that window entirely:
+        // neither store backend holds a lock/transaction spanning both calls (Nitrite's
+        // ReentrantLock only guards each individual store operation, and Mongo has no
+        // equivalent at all), so a namespace could in principle still gain a child in that
+        // narrow gap and be deleted anyway, orphaning it. Fully eliminating the race would
+        // require the store layer itself to check-and-delete atomically.
         int childNamespaceCount = (int) namespaceStore.getNamespaces().stream()
                 .map(NamespaceInfo::getName)
                 .filter(ns -> ns.startsWith(name + "."))
                 .count();
         if (childNamespaceCount > 0) {
             throw new NamespaceNotEmptyException(name, childNamespaceCount);
-        }
-
-        if (namespaceContentService.hasContent(name)) {
-            throw new NamespaceNotEmptyException(name);
         }
 
         namespaceStore.deleteNamespace(name);

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceService.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotEmptyException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
@@ -21,15 +22,22 @@ public class NamespaceService {
 
     private final NamespaceStore namespaceStore;
     private final UserAccessStore userAccessStore;
+    private final NamespaceContentService namespaceContentService;
 
     @Inject
-    public NamespaceService(NamespaceStore namespaceStore, UserAccessStore userAccessStore) {
+    public NamespaceService(NamespaceStore namespaceStore, UserAccessStore userAccessStore,
+                            NamespaceContentService namespaceContentService) {
         this.namespaceStore = namespaceStore;
         this.userAccessStore = userAccessStore;
+        this.namespaceContentService = namespaceContentService;
     }
 
     public List<NamespaceInfo> getNamespaces() {
         return namespaceStore.getNamespaces();
+    }
+
+    public void updateNamespaceDescription(String name, String description) throws NamespaceNotFoundException {
+        namespaceStore.updateNamespaceDescription(name, description);
     }
 
     public void createNamespace(String name, String description) throws NamespaceAlreadyExistsException {
@@ -43,6 +51,28 @@ public class NamespaceService {
         }
         namespaceStore.createNamespace(name, description);
         insertPublicReadGrant(name);
+    }
+
+    public void deleteNamespace(String name) throws NamespaceNotFoundException, NamespaceNotEmptyException {
+        if (!namespaceStore.namespaceExists(name)) {
+            throw new NamespaceNotFoundException();
+        }
+
+        int childNamespaceCount = (int) namespaceStore.getNamespaces().stream()
+                .map(NamespaceInfo::getName)
+                .filter(ns -> ns.startsWith(name + "."))
+                .count();
+        if (childNamespaceCount > 0) {
+            throw new NamespaceNotEmptyException(name, childNamespaceCount);
+        }
+
+        if (namespaceContentService.hasContent(name)) {
+            throw new NamespaceNotEmptyException(name);
+        }
+
+        namespaceStore.deleteNamespace(name);
+        userAccessStore.deleteAllUserAccessForNamespace(name);
+        LOG.info("Deleted namespace [{}] and its user-access grants", name);
     }
 
     private void insertPublicReadGrant(String namespace) {

--- a/calm-hub/src/main/java/org/finos/calm/store/DomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/DomainStore.java
@@ -2,6 +2,7 @@ package org.finos.calm.store;
 
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 
 import java.util.List;
 
@@ -33,4 +34,13 @@ public interface DomainStore {
      * @return true if the domain exists, false otherwise
      */
     boolean domainExists(String name);
+
+    /**
+     * Deletes a domain. Callers are responsible for verifying the domain is empty
+     * (no controls) before calling this — this method performs no such checks itself.
+     *
+     * @param name the name of the domain to delete
+     * @throws DomainNotFoundException if no domain with the given name exists
+     */
+    void deleteDomain(String name) throws DomainNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/NamespaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/NamespaceStore.java
@@ -1,6 +1,7 @@
 package org.finos.calm.store;
 
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 
 import java.util.List;
@@ -9,4 +10,24 @@ public interface NamespaceStore {
     List<NamespaceInfo> getNamespaces();
     boolean namespaceExists(String namespaceName);
     void createNamespace(String name, String description) throws NamespaceAlreadyExistsException;
+
+    /**
+     * Updates the description of an existing namespace. The namespace name itself is
+     * immutable — only the description can be changed.
+     *
+     * @param name        the name of the namespace to update
+     * @param description the new description
+     * @throws NamespaceNotFoundException if no namespace with the given name exists
+     */
+    void updateNamespaceDescription(String name, String description) throws NamespaceNotFoundException;
+
+    /**
+     * Deletes a namespace. Callers are responsible for verifying the namespace is empty
+     * (no content, no child namespaces) before calling this — this method performs no such
+     * checks itself.
+     *
+     * @param name the name of the namespace to delete
+     * @throws NamespaceNotFoundException if no namespace with the given name exists
+     */
+    void deleteNamespace(String name) throws NamespaceNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/UserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/UserAccessStore.java
@@ -92,6 +92,14 @@ public interface UserAccessStore {
     void deleteUserAccessForNamespace(String namespace, Integer userAccessId) throws NamespaceNotFoundException, UserAccessNotFoundException;
 
     /**
+     * Deletes every UserAccess grant scoped to a namespace, e.g. as part of deleting the
+     * namespace itself. Idempotent — deleting zero grants is not an error.
+     *
+     * @param namespace the namespace whose grants should all be removed.
+     */
+    void deleteAllUserAccessForNamespace(String namespace);
+
+    /**
      * Delete a domain-scoped UserAccess grant by domain and id.
      *
      * @param domain       the domain the grant belongs to.
@@ -99,4 +107,12 @@ public interface UserAccessStore {
      * @throws UserAccessNotFoundException if no grant exists for that id in the domain.
      */
     void deleteUserAccessForDomain(String domain, Integer userAccessId) throws UserAccessNotFoundException;
+
+    /**
+     * Deletes every UserAccess grant scoped to a domain, e.g. as part of deleting the
+     * domain itself. Idempotent — deleting zero grants is not an error.
+     *
+     * @param domain the domain whose grants should all be removed.
+     */
+    void deleteAllUserAccessForDomain(String domain);
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
@@ -5,11 +5,13 @@ import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.result.DeleteResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.store.DomainStore;
 
 import java.util.ArrayList;
@@ -69,6 +71,14 @@ public class MongoDomainStore implements DomainStore {
                 throw new DomainAlreadyExistsException("Domain already exists: " + name);
             }
             throw e;
+        }
+    }
+
+    @Override
+    public void deleteDomain(String name) throws DomainNotFoundException {
+        DeleteResult result = domainsCollection.deleteOne(Filters.eq("name", name));
+        if (result.getDeletedCount() == 0) {
+            throw new DomainNotFoundException(name);
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
@@ -4,10 +4,15 @@ import com.mongodb.ErrorCategory;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 
@@ -77,6 +82,24 @@ public class MongoNamespaceStore implements NamespaceStore {
                 throw new NamespaceAlreadyExistsException("Namespace already exists: " + name);
             }
             throw e;
+        }
+    }
+
+    @Override
+    public void updateNamespaceDescription(String name, String description) throws NamespaceNotFoundException {
+        UpdateResult result = namespaceCollection.updateOne(
+                Filters.eq("name", name),
+                Updates.set("description", description));
+        if (result.getMatchedCount() == 0) {
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    @Override
+    public void deleteNamespace(String name) throws NamespaceNotFoundException {
+        DeleteResult result = namespaceCollection.deleteOne(Filters.eq("name", name));
+        if (result.getDeletedCount() == 0) {
+            throw new NamespaceNotFoundException();
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -200,6 +200,16 @@ public class MongoUserAccessStore implements UserAccessStore {
         }
     }
 
+    @Override
+    public void deleteAllUserAccessForNamespace(String namespace) {
+        userAccessCollection.deleteMany(Filters.eq("namespace", namespace));
+    }
+
+    @Override
+    public void deleteAllUserAccessForDomain(String domain) {
+        userAccessCollection.deleteMany(Filters.eq("domain", domain));
+    }
+
     private Document findExistingGrant(Bson scopeFilter, UserAccess userAccess) {
         return userAccessCollection.find(Filters.and(
                 Filters.eq("username", userAccess.getUsername()),

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDomainStore.java
@@ -10,6 +10,7 @@ import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.store.DomainStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,5 +93,25 @@ public class NitriteDomainStore implements DomainStore {
     public boolean domainExists(String name) {
         Filter filter = where(NAME_FIELD).eq(name);
         return domainCollection.find(filter).firstOrNull() != null;
+    }
+
+    /**
+     * Deletes a domain, guarded by the same {@link ReentrantLock} used by
+     * {@link #createDomain} to serialize writes against concurrent create/delete races.
+     */
+    @Override
+    public void deleteDomain(String name) throws DomainNotFoundException {
+        lock.lock();
+        try {
+            Filter filter = where(NAME_FIELD).eq(name);
+            Document existing = domainCollection.find(filter).firstOrNull();
+            if (existing == null) {
+                throw new DomainNotFoundException(name);
+            }
+            domainCollection.remove(existing);
+            LOG.info("Deleted domain: {}", name);
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteNamespaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteNamespaceStore.java
@@ -9,6 +9,7 @@ import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.finos.calm.store.NamespaceStore;
 import org.slf4j.Logger;
@@ -97,6 +98,47 @@ public class NitriteNamespaceStore implements NamespaceStore {
                     .put(DESCRIPTION_FIELD, description);
             namespaceCollection.insert(namespaceDoc);
             LOG.info("Created namespace: {}", name);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Updates a namespace's description, guarded by the same {@link ReentrantLock} used by
+     * {@link #createNamespace} to serialize writes against concurrent create/update races.
+     */
+    @Override
+    public void updateNamespaceDescription(String name, String description) throws NamespaceNotFoundException {
+        lock.lock();
+        try {
+            Filter filter = where(NAME_FIELD).eq(name);
+            Document doc = namespaceCollection.find(filter).firstOrNull();
+            if (doc == null) {
+                throw new NamespaceNotFoundException();
+            }
+            doc.put(DESCRIPTION_FIELD, description);
+            namespaceCollection.update(filter, doc);
+            LOG.info("Updated description for namespace: {}", name);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Deletes a namespace, guarded by the same {@link ReentrantLock} used by
+     * {@link #createNamespace} to serialize writes against concurrent create/delete races.
+     */
+    @Override
+    public void deleteNamespace(String name) throws NamespaceNotFoundException {
+        lock.lock();
+        try {
+            Filter filter = where(NAME_FIELD).eq(name);
+            Document existing = namespaceCollection.find(filter).firstOrNull();
+            if (existing == null) {
+                throw new NamespaceNotFoundException();
+            }
+            namespaceCollection.remove(existing);
+            LOG.info("Deleted namespace: {}", name);
         } finally {
             lock.unlock();
         }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -244,28 +244,19 @@ public class NitriteUserAccessStore implements UserAccessStore {
 
     @Override
     public void deleteAllUserAccessForNamespace(String namespace) {
-        lock.lock();
-        try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            // Materialize matches before removing — mutating the collection while its
-            // cursor is still being iterated is unsafe.
-            List<Document> matches = new ArrayList<>();
-            for (Document doc : userAccessCollection.find(filter)) {
-                matches.add(doc);
-            }
-            for (Document doc : matches) {
-                userAccessCollection.remove(doc);
-            }
-        } finally {
-            lock.unlock();
-        }
+        deleteAllMatching(where(NAMESPACE_FIELD).eq(namespace));
     }
 
     @Override
     public void deleteAllUserAccessForDomain(String domain) {
+        deleteAllMatching(where(DOMAIN_FIELD).eq(domain));
+    }
+
+    private void deleteAllMatching(Filter filter) {
         lock.lock();
         try {
-            Filter filter = where(DOMAIN_FIELD).eq(domain);
+            // Materialize matches before removing — mutating the collection while its
+            // cursor is still being iterated is unsafe.
             List<Document> matches = new ArrayList<>();
             for (Document doc : userAccessCollection.find(filter)) {
                 matches.add(doc);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -242,6 +242,42 @@ public class NitriteUserAccessStore implements UserAccessStore {
         }
     }
 
+    @Override
+    public void deleteAllUserAccessForNamespace(String namespace) {
+        lock.lock();
+        try {
+            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
+            // Materialize matches before removing — mutating the collection while its
+            // cursor is still being iterated is unsafe.
+            List<Document> matches = new ArrayList<>();
+            for (Document doc : userAccessCollection.find(filter)) {
+                matches.add(doc);
+            }
+            for (Document doc : matches) {
+                userAccessCollection.remove(doc);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void deleteAllUserAccessForDomain(String domain) {
+        lock.lock();
+        try {
+            Filter filter = where(DOMAIN_FIELD).eq(domain);
+            List<Document> matches = new ArrayList<>();
+            for (Document doc : userAccessCollection.find(filter)) {
+                matches.add(doc);
+            }
+            for (Document doc : matches) {
+                userAccessCollection.remove(doc);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private UserAccess buildUserAccessFromDocument(Document doc) {
         return new UserAccess.UserAccessBuilder()
                 .setUsername(doc.get(USERNAME_FIELD, String.class))

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
@@ -185,7 +185,7 @@ public class TestDomainResourceShould {
 
     @Test
     void return_409_when_deleting_a_domain_that_is_not_empty() throws Exception {
-        doThrow(new DomainNotEmptyException("Domain '" + TEST_DOMAIN + "' contains controls and cannot be deleted"))
+        doThrow(new DomainNotEmptyException(TEST_DOMAIN))
                 .when(mockDomainService).deleteDomain(TEST_DOMAIN);
 
         given()

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDomainResourceShould.java
@@ -6,6 +6,8 @@ import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.controls.DomainControlCount;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotEmptyException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.finos.calm.services.CountsService;
 import org.finos.calm.services.DomainService;
 import org.junit.jupiter.api.Test;
@@ -158,5 +160,49 @@ public class TestDomainResourceShould {
                 .statusCode(409);
 
         verify(mockDomainService).createDomain(TEST_DOMAIN);
+    }
+
+    @Test
+    void delete_a_domain_successfully() throws Exception {
+        given()
+                .when().delete(CALM_DOMAINS + "/" + TEST_DOMAIN)
+                .then()
+                .statusCode(204);
+
+        verify(mockDomainService).deleteDomain(TEST_DOMAIN);
+    }
+
+    @Test
+    void return_404_when_deleting_a_missing_domain() throws Exception {
+        doThrow(new DomainNotFoundException("missing"))
+                .when(mockDomainService).deleteDomain("missing");
+
+        given()
+                .when().delete(CALM_DOMAINS + "/missing")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_409_when_deleting_a_domain_that_is_not_empty() throws Exception {
+        doThrow(new DomainNotEmptyException("Domain '" + TEST_DOMAIN + "' contains controls and cannot be deleted"))
+                .when(mockDomainService).deleteDomain(TEST_DOMAIN);
+
+        given()
+                .when().delete(CALM_DOMAINS + "/" + TEST_DOMAIN)
+                .then()
+                .statusCode(409)
+                .body(containsString("contains controls"));
+    }
+
+    @Test
+    void return_400_when_deleting_domain_with_invalid_format() throws Exception {
+        given()
+                .when().delete(CALM_DOMAINS + "/invalid_domain")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+
+        verify(mockDomainService, never()).deleteDomain(any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestNamespaceResourceShould.java
@@ -4,6 +4,8 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotEmptyException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceCounts;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
@@ -22,6 +24,7 @@ import static io.restassured.RestAssured.given;
 import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -348,5 +351,122 @@ public class TestNamespaceResourceShould {
                 .body(containsString("Insufficient permissions"));
 
         verify(namespaceService, never()).createNamespace(any(), any());
+    }
+
+    @Test
+    void update_namespace_description_successfully() throws Exception {
+        given()
+                .contentType("application/json")
+                .body("{\"description\":\"updated description\"}")
+                .when()
+                .put("/api/calm/namespaces/finos")
+                .then()
+                .statusCode(204);
+
+        verify(namespaceService).updateNamespaceDescription("finos", "updated description");
+    }
+
+    @Test
+    void return_404_when_updating_description_of_missing_namespace() throws Exception {
+        doThrow(new NamespaceNotFoundException())
+                .when(namespaceService).updateNamespaceDescription("missing", "desc");
+
+        given()
+                .contentType("application/json")
+                .body("{\"description\":\"desc\"}")
+                .when()
+                .put("/api/calm/namespaces/missing")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_400_when_updating_namespace_with_blank_description() throws Exception {
+        given()
+                .contentType("application/json")
+                .body("{\"description\":\"\"}")
+                .when()
+                .put("/api/calm/namespaces/finos")
+                .then()
+                .statusCode(400)
+                .body(containsString("Description must not be blank"));
+
+        verify(namespaceService, never()).updateNamespaceDescription(any(), any());
+    }
+
+    @Test
+    void return_400_when_updating_namespace_with_invalid_format() throws Exception {
+        given()
+                .contentType("application/json")
+                .body("{\"description\":\"desc\"}")
+                .when()
+                .put("/api/calm/namespaces/fin_os")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+
+        verify(namespaceService, never()).updateNamespaceDescription(any(), any());
+    }
+
+    @Test
+    void delete_namespace_successfully() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos")
+                .then()
+                .statusCode(204);
+
+        verify(namespaceService).deleteNamespace("finos");
+    }
+
+    @Test
+    void return_404_when_deleting_missing_namespace() throws Exception {
+        doThrow(new NamespaceNotFoundException())
+                .when(namespaceService).deleteNamespace("missing");
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/missing")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_409_when_deleting_a_namespace_that_is_not_empty() throws Exception {
+        doThrow(new NamespaceNotEmptyException("finos"))
+                .when(namespaceService).deleteNamespace("finos");
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos")
+                .then()
+                .statusCode(409)
+                .body(containsString("contains resources"));
+    }
+
+    @Test
+    void return_409_with_child_count_when_deleting_a_namespace_with_children() throws Exception {
+        doThrow(new NamespaceNotEmptyException("org", 2))
+                .when(namespaceService).deleteNamespace("org");
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/org")
+                .then()
+                .statusCode(409)
+                .body(containsString("2 child namespace(s)"))
+                .body(not(containsString("&#39;")));
+    }
+
+    @Test
+    void return_400_when_deleting_namespace_with_invalid_format() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+
+        verify(namespaceService, never()).deleteNamespace(any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
@@ -208,6 +208,23 @@ public class TestAuditRequestFilterShould {
         assertThat(captureRecordedEntry().getAction(), is(AuditAction.UPDATE));
     }
 
+    @Test
+    void treat_delete_as_delete_for_generic_resources() {
+        when(resourceInfo.getResourceClass()).thenReturn((Class) NamespaceResource.class);
+        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+        pathParams.putSingle("namespace", "finos");
+        ContainerRequestContext requestContext = mockRequest("DELETE", pathParams);
+        ContainerResponseContext responseContext = mockResponse(204, null);
+
+        filter.filter(requestContext, responseContext);
+
+        AuditLogEntry entry = captureRecordedEntry();
+        assertThat(entry.getEntityType(), is(AuditEntityType.NAMESPACE));
+        assertThat(entry.getAction(), is(AuditAction.DELETE));
+        assertThat(entry.getNamespace(), is("finos"));
+        assertThat(entry.getOutcome(), is(AuditOutcome.SUCCESS));
+    }
+
     // --- Location-header fallback for server-generated IDs --------------------
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
@@ -260,6 +260,24 @@ public class TestAuditRequestFilterShould {
     }
 
     @Test
+    void resolve_domain_creation_via_location_into_domain_field_not_entity_id() {
+        // DomainResource.createDomain: no domain-name path param, resolved generically —
+        // a domain is its own scope, so its name belongs in `domain`, matching how
+        // DomainResource.deleteDomain reports it via the {domain} path param.
+        when(resourceInfo.getResourceClass()).thenReturn((Class) DomainResource.class);
+        ContainerRequestContext requestContext = mockRequest("POST", new MultivaluedHashMap<>());
+        ContainerResponseContext responseContext = mockResponse(201, "/api/calm/domains/payments");
+
+        filter.filter(requestContext, responseContext);
+
+        AuditLogEntry entry = captureRecordedEntry();
+        assertThat(entry.getEntityType(), is(AuditEntityType.DOMAIN));
+        assertThat(entry.getAction(), is(AuditAction.CREATE));
+        assertThat(entry.getDomain(), is("payments"));
+        assertNull(entry.getEntityId());
+    }
+
+    @Test
     void resolve_adr_create_via_revisions_location() {
         when(resourceInfo.getResourceClass()).thenReturn((Class) AdrResource.class);
         MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
@@ -446,7 +464,8 @@ public class TestAuditRequestFilterShould {
 
         AuditLogEntry entry = captureRecordedEntry();
         assertThat(entry.getEntityType(), is(AuditEntityType.DOMAIN));
-        assertThat(entry.getEntityId(), is("payments"));
+        assertThat(entry.getDomain(), is("payments"));
+        assertNull(entry.getEntityId());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
@@ -116,7 +116,8 @@ class TestDomainServiceShould {
         when(mockControlStore.getControlsForDomain("retail"))
                 .thenReturn(List.of(new ControlDetail(1, "control", "description")));
 
-        assertThrows(DomainNotEmptyException.class, () -> service.deleteDomain("retail"));
+        DomainNotEmptyException ex = assertThrows(DomainNotEmptyException.class, () -> service.deleteDomain("retail"));
+        assertThat(ex.getDomain(), is("retail"));
 
         verify(mockDomainStore, never()).deleteDomain(any());
         verify(mockUserAccessStore, never()).deleteAllUserAccessForDomain(any());

--- a/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestDomainServiceShould.java
@@ -1,7 +1,11 @@
 package org.finos.calm.services;
 
 import org.finos.calm.domain.UserAccess;
+import org.finos.calm.domain.controls.ControlDetail;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotEmptyException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
+import org.finos.calm.store.ControlStore;
 import org.finos.calm.store.DomainStore;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,11 +33,14 @@ class TestDomainServiceShould {
     @Mock
     UserAccessStore mockUserAccessStore;
 
+    @Mock
+    ControlStore mockControlStore;
+
     DomainService service;
 
     @BeforeEach
     void setUp() {
-        service = new DomainService(mockDomainStore, mockUserAccessStore);
+        service = new DomainService(mockDomainStore, mockUserAccessStore, mockControlStore);
     }
 
     @Test
@@ -80,5 +87,38 @@ class TestDomainServiceShould {
         service.createDomain("retail");
 
         verify(mockDomainStore).createDomain("retail");
+    }
+
+    @Test
+    void delete_domain_and_cascade_delete_grants_when_empty() throws Exception {
+        when(mockDomainStore.domainExists("retail")).thenReturn(true);
+        when(mockControlStore.getControlsForDomain("retail")).thenReturn(List.of());
+
+        service.deleteDomain("retail");
+
+        verify(mockDomainStore).deleteDomain("retail");
+        verify(mockUserAccessStore).deleteAllUserAccessForDomain("retail");
+    }
+
+    @Test
+    void throw_domain_not_found_when_deleting_missing_domain() {
+        when(mockDomainStore.domainExists("missing")).thenReturn(false);
+
+        assertThrows(DomainNotFoundException.class, () -> service.deleteDomain("missing"));
+
+        verify(mockDomainStore, never()).deleteDomain(any());
+        verify(mockUserAccessStore, never()).deleteAllUserAccessForDomain(any());
+    }
+
+    @Test
+    void throw_domain_not_empty_and_skip_delete_when_domain_has_controls() {
+        when(mockDomainStore.domainExists("retail")).thenReturn(true);
+        when(mockControlStore.getControlsForDomain("retail"))
+                .thenReturn(List.of(new ControlDetail(1, "control", "description")));
+
+        assertThrows(DomainNotEmptyException.class, () -> service.deleteDomain("retail"));
+
+        verify(mockDomainStore, never()).deleteDomain(any());
+        verify(mockUserAccessStore, never()).deleteAllUserAccessForDomain(any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,10 +101,10 @@ class TestNamespaceContentServiceShould {
     }
 
     @Test
-    void treat_a_runtime_failure_from_a_store_as_empty() throws Exception {
+    void propagate_a_runtime_failure_from_a_store_instead_of_treating_it_as_empty() throws Exception {
         when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE))
                 .thenThrow(new RuntimeException("store unavailable"));
 
-        assertThat(service.hasContent(NAMESPACE), is(false));
+        assertThrows(RuntimeException.class, () -> service.hasContent(NAMESPACE));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
@@ -1,0 +1,109 @@
+package org.finos.calm.services;
+
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.AdrStore;
+import org.finos.calm.store.ArchitectureStore;
+import org.finos.calm.store.DecoratorStore;
+import org.finos.calm.store.FlowStore;
+import org.finos.calm.store.InterfaceStore;
+import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.StandardStore;
+import org.finos.calm.store.TimelineStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestNamespaceContentServiceShould {
+
+    private static final String NAMESPACE = "finos";
+
+    @Mock
+    ArchitectureStore mockArchitectureStore;
+    @Mock
+    PatternStore mockPatternStore;
+    @Mock
+    FlowStore mockFlowStore;
+    @Mock
+    StandardStore mockStandardStore;
+    @Mock
+    AdrStore mockAdrStore;
+    @Mock
+    InterfaceStore mockInterfaceStore;
+    @Mock
+    TimelineStore mockTimelineStore;
+    @Mock
+    DecoratorStore mockDecoratorStore;
+
+    NamespaceContentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NamespaceContentService(
+                mockArchitectureStore, mockPatternStore, mockFlowStore, mockStandardStore,
+                mockAdrStore, mockInterfaceStore, mockTimelineStore, mockDecoratorStore);
+    }
+
+    @Test
+    void return_false_when_namespace_has_no_content_in_any_store() throws Exception {
+        assertThat(service.hasContent(NAMESPACE), is(false));
+
+        verify(mockArchitectureStore).getArchitecturesForNamespace(NAMESPACE);
+        verify(mockPatternStore).getPatternsForNamespace(NAMESPACE);
+        verify(mockFlowStore).getFlowsForNamespace(NAMESPACE);
+        verify(mockStandardStore).getStandardsForNamespace(NAMESPACE);
+        verify(mockAdrStore).getAdrsForNamespace(NAMESPACE);
+        verify(mockInterfaceStore).getInterfacesForNamespace(NAMESPACE);
+        verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
+        verify(mockDecoratorStore).getDecoratorsForNamespace(NAMESPACE, null, null);
+    }
+
+    @Test
+    void return_true_and_short_circuit_when_architecture_store_has_content() throws Exception {
+        when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE))
+                .thenReturn(List.of(new NamespaceResourceSummary("a1", "desc", 1, 0)));
+
+        assertThat(service.hasContent(NAMESPACE), is(true));
+
+        verify(mockPatternStore, never()).getPatternsForNamespace(NAMESPACE);
+        verify(mockDecoratorStore, never()).getDecoratorsForNamespace(NAMESPACE, null, null);
+    }
+
+    @Test
+    void return_true_when_only_the_last_checked_store_has_content() throws Exception {
+        when(mockDecoratorStore.getDecoratorsForNamespace(NAMESPACE, null, null))
+                .thenReturn(List.of(1));
+
+        assertThat(service.hasContent(NAMESPACE), is(true));
+
+        verify(mockArchitectureStore).getArchitecturesForNamespace(NAMESPACE);
+        verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
+    }
+
+    @Test
+    void treat_namespace_not_found_from_a_store_as_empty() throws Exception {
+        when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE))
+                .thenThrow(new NamespaceNotFoundException());
+
+        assertThat(service.hasContent(NAMESPACE), is(false));
+    }
+
+    @Test
+    void treat_a_runtime_failure_from_a_store_as_empty() throws Exception {
+        when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE))
+                .thenThrow(new RuntimeException("store unavailable"));
+
+        assertThat(service.hasContent(NAMESPACE), is(false));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
@@ -185,11 +185,11 @@ class TestNamespaceServiceShould {
     @Test
     void throw_namespace_not_empty_and_skip_delete_when_namespace_has_content() throws NamespaceNotFoundException {
         when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
-        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("finos", "desc")));
         when(mockNamespaceContentService.hasContent("finos")).thenReturn(true);
 
         assertThrows(NamespaceNotEmptyException.class, () -> service.deleteNamespace("finos"));
 
+        verify(mockNamespaceStore, never()).getNamespaces();
         verify(mockNamespaceStore, never()).deleteNamespace(any());
         verify(mockUserAccessStore, never()).deleteAllUserAccessForNamespace(any());
     }

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceServiceShould.java
@@ -2,6 +2,7 @@ package org.finos.calm.services;
 
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotEmptyException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.NamespaceParentNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
@@ -33,11 +34,14 @@ class TestNamespaceServiceShould {
     @Mock
     UserAccessStore mockUserAccessStore;
 
+    @Mock
+    NamespaceContentService mockNamespaceContentService;
+
     NamespaceService service;
 
     @BeforeEach
     void setUp() {
-        service = new NamespaceService(mockNamespaceStore, mockUserAccessStore);
+        service = new NamespaceService(mockNamespaceStore, mockUserAccessStore, mockNamespaceContentService);
     }
 
     @Test
@@ -122,5 +126,71 @@ class TestNamespaceServiceShould {
 
         verify(mockNamespaceStore, never()).getNamespaces();
         verify(mockNamespaceStore).createNamespace("newteam", "desc");
+    }
+
+    @Test
+    void update_namespace_description_delegates_to_store() throws NamespaceNotFoundException {
+        service.updateNamespaceDescription("finos", "new description");
+
+        verify(mockNamespaceStore).updateNamespaceDescription("finos", "new description");
+    }
+
+    @Test
+    void propagate_namespace_not_found_when_updating_missing_namespace_description() throws NamespaceNotFoundException {
+        doThrow(new NamespaceNotFoundException())
+                .when(mockNamespaceStore).updateNamespaceDescription("missing", "desc");
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> service.updateNamespaceDescription("missing", "desc"));
+    }
+
+    @Test
+    void delete_namespace_and_cascade_delete_grants_when_empty() throws Exception {
+        when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("finos", "desc")));
+        when(mockNamespaceContentService.hasContent("finos")).thenReturn(false);
+
+        service.deleteNamespace("finos");
+
+        verify(mockNamespaceStore).deleteNamespace("finos");
+        verify(mockUserAccessStore).deleteAllUserAccessForNamespace("finos");
+    }
+
+    @Test
+    void throw_namespace_not_found_when_deleting_missing_namespace() throws NamespaceNotFoundException {
+        when(mockNamespaceStore.namespaceExists("missing")).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> service.deleteNamespace("missing"));
+
+        verify(mockNamespaceStore, never()).deleteNamespace(any());
+        verify(mockUserAccessStore, never()).deleteAllUserAccessForNamespace(any());
+    }
+
+    @Test
+    void throw_namespace_not_empty_and_skip_delete_when_child_namespaces_exist() throws NamespaceNotFoundException {
+        when(mockNamespaceStore.namespaceExists("org")).thenReturn(true);
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(
+                new NamespaceInfo("org", "desc"),
+                new NamespaceInfo("org.finos", "child desc")));
+
+        NamespaceNotEmptyException ex = assertThrows(NamespaceNotEmptyException.class,
+                () -> service.deleteNamespace("org"));
+        assertThat(ex.getNamespace(), is("org"));
+        assertThat(ex.getChildNamespaceCount(), is(1));
+
+        verify(mockNamespaceStore, never()).deleteNamespace(any());
+        verify(mockUserAccessStore, never()).deleteAllUserAccessForNamespace(any());
+    }
+
+    @Test
+    void throw_namespace_not_empty_and_skip_delete_when_namespace_has_content() throws NamespaceNotFoundException {
+        when(mockNamespaceStore.namespaceExists("finos")).thenReturn(true);
+        when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("finos", "desc")));
+        when(mockNamespaceContentService.hasContent("finos")).thenReturn(true);
+
+        assertThrows(NamespaceNotEmptyException.class, () -> service.deleteNamespace("finos"));
+
+        verify(mockNamespaceStore, never()).deleteNamespace(any());
+        verify(mockUserAccessStore, never()).deleteAllUserAccessForNamespace(any());
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDomainStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDomainStoreShould.java
@@ -4,12 +4,15 @@ import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteError;
 import com.mongodb.client.*;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.result.DeleteResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -94,6 +97,26 @@ public class TestMongoDomainStoreShould {
         List<String> domains = mongoDomainStore.getDomains();
 
         assertThat(domains, is(empty()));
+    }
+
+    @Test
+    void delete_domain_when_it_exists() throws DomainNotFoundException {
+        DeleteResult deleteResult = Mockito.mock(DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(domainsCollection.deleteOne(Filters.eq("name", "security"))).thenReturn(deleteResult);
+
+        mongoDomainStore.deleteDomain("security");
+
+        verify(domainsCollection).deleteOne(Filters.eq("name", "security"));
+    }
+
+    @Test
+    void throw_exception_when_deleting_missing_domain() {
+        DeleteResult deleteResult = Mockito.mock(DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(0L);
+        when(domainsCollection.deleteOne(Filters.eq("name", "missing"))).thenReturn(deleteResult);
+
+        assertThrows(DomainNotFoundException.class, () -> mongoDomainStore.deleteDomain("missing"));
     }
 
     private FindIterable<Document> emptyFindIterableSetup() {

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoNamespaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoNamespaceStoreShould.java
@@ -4,11 +4,16 @@ import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteError;
 import com.mongodb.client.*;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,6 +128,53 @@ public class TestMongoNamespaceStoreShould {
 
         assertThrows(NamespaceAlreadyExistsException.class, () ->
                 mongoNamespaceStore.createNamespace(namespace, "desc"));
+    }
+
+    @Test
+    void update_namespace_description_when_it_exists() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        UpdateResult updateResult = Mockito.mock(UpdateResult.class);
+        when(updateResult.getMatchedCount()).thenReturn(1L);
+        when(namespaceCollection.updateOne(Filters.eq("name", namespace), Updates.set("description", "new desc")))
+                .thenReturn(updateResult);
+
+        mongoNamespaceStore.updateNamespaceDescription(namespace, "new desc");
+
+        verify(namespaceCollection).updateOne(Filters.eq("name", namespace), Updates.set("description", "new desc"));
+    }
+
+    @Test
+    void throw_exception_when_updating_description_of_missing_namespace() {
+        String namespace = "missing";
+        UpdateResult updateResult = Mockito.mock(UpdateResult.class);
+        when(updateResult.getMatchedCount()).thenReturn(0L);
+        when(namespaceCollection.updateOne(Filters.eq("name", namespace), Updates.set("description", "desc")))
+                .thenReturn(updateResult);
+
+        assertThrows(NamespaceNotFoundException.class, () ->
+                mongoNamespaceStore.updateNamespaceDescription(namespace, "desc"));
+    }
+
+    @Test
+    void delete_namespace_when_it_exists() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        DeleteResult deleteResult = Mockito.mock(DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(namespaceCollection.deleteOne(Filters.eq("name", namespace))).thenReturn(deleteResult);
+
+        mongoNamespaceStore.deleteNamespace(namespace);
+
+        verify(namespaceCollection).deleteOne(Filters.eq("name", namespace));
+    }
+
+    @Test
+    void throw_exception_when_deleting_missing_namespace() {
+        String namespace = "missing";
+        DeleteResult deleteResult = Mockito.mock(DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(0L);
+        when(namespaceCollection.deleteOne(Filters.eq("name", namespace))).thenReturn(deleteResult);
+
+        assertThrows(NamespaceNotFoundException.class, () -> mongoNamespaceStore.deleteNamespace(namespace));
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -562,6 +562,20 @@ public class TestMongoUserAccessStoreShould {
                 () -> mongoUserAccessStore.deleteUserAccessForNamespace(namespace, userAccessId));
     }
 
+    @Test
+    void delete_all_user_access_for_namespace() {
+        mongoUserAccessStore.deleteAllUserAccessForNamespace("finos");
+
+        verify(userAccessCollection).deleteMany(Filters.eq("namespace", "finos"));
+    }
+
+    @Test
+    void delete_all_user_access_for_domain() {
+        mongoUserAccessStore.deleteAllUserAccessForDomain("payments");
+
+        verify(userAccessCollection).deleteMany(Filters.eq("domain", "payments"));
+    }
+
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteDomainStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteDomainStoreShould.java
@@ -7,6 +7,7 @@ import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.Domain;
 import org.finos.calm.domain.exception.DomainAlreadyExistsException;
+import org.finos.calm.domain.exception.DomainNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -122,5 +123,33 @@ public class TestNitriteDomainStoreShould {
 
         // Assert
         verify(mockCollection).insert(any(Document.class));
+    }
+
+    @Test
+    public void testDeleteDomain_whenDomainExists_removesDomain() throws DomainNotFoundException {
+        // Arrange
+        Document existingDomain = Document.createDocument().put("name", TEST_DOMAIN_NAME);
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(existingDomain);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act
+        domainStore.deleteDomain(TEST_DOMAIN_NAME);
+
+        // Assert
+        verify(mockCollection).remove(existingDomain);
+    }
+
+    @Test
+    public void testDeleteDomain_whenDomainMissing_throwsException() {
+        // Arrange
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act & Assert
+        assertThrows(DomainNotFoundException.class, () -> domainStore.deleteDomain(TEST_DOMAIN_NAME));
+
+        verify(mockCollection, never()).remove(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteNamespaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteNamespaceStoreShould.java
@@ -6,6 +6,7 @@ import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -134,7 +135,64 @@ public class TestNitriteNamespaceStoreShould {
         // Act & Assert
         assertThrows(NamespaceAlreadyExistsException.class, () ->
                 namespaceStore.createNamespace("existing-namespace","desc"));
-        
+
         verify(mockCollection, never()).insert(any(Document.class));
+    }
+
+    @Test
+    public void testUpdateNamespaceDescription_whenNamespaceExists_updatesDescription() throws NamespaceNotFoundException {
+        // Arrange
+        Document existingDoc = Document.createDocument("name", "finos").put("description", "old desc");
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(existingDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act
+        namespaceStore.updateNamespaceDescription("finos", "new desc");
+
+        // Assert
+        verify(mockCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void testUpdateNamespaceDescription_whenNamespaceMissing_throwsException() {
+        // Arrange
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act & Assert
+        assertThrows(NamespaceNotFoundException.class, () ->
+                namespaceStore.updateNamespaceDescription("missing", "desc"));
+
+        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void testDeleteNamespace_whenNamespaceExists_removesNamespace() throws NamespaceNotFoundException {
+        // Arrange
+        Document existingDoc = Document.createDocument("name", "finos");
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(existingDoc);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act
+        namespaceStore.deleteNamespace("finos");
+
+        // Assert
+        verify(mockCollection).remove(existingDoc);
+    }
+
+    @Test
+    public void testDeleteNamespace_whenNamespaceMissing_throwsException() {
+        // Arrange
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        // Act & Assert
+        assertThrows(NamespaceNotFoundException.class, () -> namespaceStore.deleteNamespace("missing"));
+
+        verify(mockCollection, never()).remove(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
@@ -397,4 +397,50 @@ public class TestNitriteUserAccessStoreShould {
         verify(mockNamespaceStore, never()).namespaceExists("GLOBAL");
         verify(mockCollection).remove(mockDoc);
     }
+
+    @Test
+    public void deleteAllUserAccessForNamespace_removesEveryMatchingGrant() {
+        Document doc1 = mock(Document.class);
+        Document doc2 = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(List.of(doc1, doc2).iterator());
+
+        userAccessStore.deleteAllUserAccessForNamespace("finos");
+
+        verify(mockCollection).remove(doc1);
+        verify(mockCollection).remove(doc2);
+    }
+
+    @Test
+    public void deleteAllUserAccessForNamespace_removesNothingWhenNoGrantsExist() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(Collections.emptyIterator());
+
+        userAccessStore.deleteAllUserAccessForNamespace("finos");
+
+        verify(mockCollection, never()).remove(any(Document.class));
+    }
+
+    @Test
+    public void deleteAllUserAccessForDomain_removesEveryMatchingGrant() {
+        Document doc1 = mock(Document.class);
+        Document doc2 = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(List.of(doc1, doc2).iterator());
+
+        userAccessStore.deleteAllUserAccessForDomain("payments");
+
+        verify(mockCollection).remove(doc1);
+        verify(mockCollection).remove(doc2);
+    }
+
+    @Test
+    public void deleteAllUserAccessForDomain_removesNothingWhenNoGrantsExist() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.iterator()).thenReturn(Collections.emptyIterator());
+
+        userAccessStore.deleteAllUserAccessForDomain("payments");
+
+        verify(mockCollection, never()).remove(any(Document.class));
+    }
 }


### PR DESCRIPTION
## Description
Adds the ability to edit a namespace's description and to delete namespaces/domains from the CALM Hub admin panel and REST API. No support is added for deleting architecture artefacts such as architectures or patterns, only these containers (current deliberate design choice).

- `PUT /api/calm/namespaces/{namespace}` — update a namespace's description.
- `DELETE /api/calm/namespaces/{namespace}` — delete a namespace, provided it has no content and no child namespaces (namespace hierarchy is dot-notation-derived). Cascades to remove all associated `UserAccess` grants.
- `DELETE /api/calm/domains/{domain}` — delete a domain, provided it has no controls associated with it. Cascades to remove all associated `UserAccess` grants. Domains have no description field, so they get delete only (no edit).
- Admin UI: the Namespaces panel now requires a description on create (previously optional-looking but actually required server-side, producing an unclear generic failure), shows name+description per row with inline edit and delete (with a confirm dialog), and the Domains panel gets the matching table layout and delete flow.
- New mutating endpoints get automatic audit-trail coverage via the existing `AuditRequestFilter` mapping — no filter changes needed.

Also includes fixes from a self-review pass after the initial implementation:
- `NamespaceContentService`'s emptiness check no longer fails open on a transient store error (it previously treated any `RuntimeException` from a content-check store call as "empty", which could let a delete proceed against undetected content).
- Narrowed (though did not fully eliminate) a TOCTOU race in `deleteNamespace` by reordering the child-namespace check to run immediately before the physical delete.
- Fixed a missing sanitization gap in the shared `invalidNamespaceResponse` error helper (used by ~15 resource classes).
- Fixed a UI regression where the new `fetchNamespaceDetails()` call returned unsorted results, undoing a namespace/domain alphabetical-sort fix merged just before this branch.
- Fixed a stale-description flash in the edit flow, and extracted a shared `useDeleteConfirmation` hook / `ConfirmDeleteDialog` component to remove duplication between the Namespaces and Domains panels.
- Deduplicated the two new Nitrite bulk-delete-grants methods.
- Aligned `NamespaceNotEmptyException`/`DomainNotEmptyException` to carry raw entity fields instead of pre-formatted messages, and aligned the two not-empty error message formats with each other.

## Screenshots

- Edit/delete namespace (delete domain is similar):
  - <img width="1051" height="620" alt="image" src="https://github.com/user-attachments/assets/da1b9c2f-cdb3-4a58-b079-8d054413ee9f" />
- Refusal to delete:
  - <img width="538" height="267" alt="image" src="https://github.com/user-attachments/assets/9dadae99-86c1-40ba-b8d2-185d794e6a7a" />
  - <img width="528" height="262" alt="image" src="https://github.com/user-attachments/assets/b198678c-46f0-41d6-a0e1-d611b7b372ca" />
  - <img width="536" height="259" alt="image" src="https://github.com/user-attachments/assets/7614d309-b4cb-412b-98c0-13cb0a06a63f" />
- Cannot create without a description:
  - <img width="357" height="176" alt="image" src="https://github.com/user-attachments/assets/293d23e4-85e3-40b6-b7fa-df1af925b349" />
- Audit log:
  - <img width="807" height="162" alt="image" src="https://github.com/user-attachments/assets/569f926c-d1eb-4cb7-8b85-49bde5d7debd" />


## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅
All commits follow the conventional commit format (`feat`/`fix`/`refactor` with `calm-hub`/`calm-hub-ui` scope).

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Full backend suite (`mvnw clean verify`, 2284 tests) and full frontend suite (`npx vitest run`, 1270 tests) pass, plus lint. Also manually smoke-tested the create/edit/delete flows for namespaces (including the child-namespace and content delete-guards) and domains against a running standalone (NitriteDB) instance.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards