### PR TITLE
feat(calm-suite): @calmstudio/docusaurus-plugin — embed CALM diagrams in Docusaurus MDX

### DIFF
--- a/.github/workflows/automated-release-calm-studio.yml
+++ b/.github/workflows/automated-release-calm-studio.yml
@@ -49,6 +49,7 @@ jobs:
                   npm run build --if-present --workspace=calmstudio
                   npm run build --if-present --workspace=@calmstudio/github-action
                   npm run build --if-present --workspace=@calmstudio/diagram
+                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
 
             - name: Release
               # Run multi-semantic-release from calm-studio dir so it scopes to @calmstudio/*

--- a/.github/workflows/automated-release-calm-studio.yml
+++ b/.github/workflows/automated-release-calm-studio.yml
@@ -49,11 +49,13 @@ jobs:
                   npm run build --if-present --workspace=calmstudio
                   npm run build --if-present --workspace=@calmstudio/github-action
                   npm run build --if-present --workspace=@calmstudio/diagram
-                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run build --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Release
-              # Run multi-semantic-release from calm-studio dir so it scopes to @calmstudio/*
-              # packages only and does not accidentally release @finos/* siblings.
+              # Run multi-semantic-release from calm-studio dir so it scopes to the
+              # calm-studio workspaces only (all @calmstudio/* plus
+              # @finos/calm-docusaurus-plugin) and does not accidentally release
+              # other @finos/* siblings from the repo root.
               working-directory: calm-studio
               run: npx multi-semantic-release
               env:

--- a/.github/workflows/build-calm-studio.yml
+++ b/.github/workflows/build-calm-studio.yml
@@ -49,6 +49,7 @@ jobs:
                   npm run build --if-present --workspace=@calmstudio/studio
                   npm run build --if-present --workspace=calmstudio
                   npm run build --if-present --workspace=@calmstudio/github-action
+                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
 
             - name: Lint
               run: |
@@ -56,6 +57,7 @@ jobs:
                   npm run lint --if-present --workspace=@calmstudio/extensions
                   npm run lint --if-present --workspace=@calmstudio/mcp
                   npm run lint --if-present --workspace=@calmstudio/studio
+                  npm run lint --if-present --workspace=@calmstudio/docusaurus-plugin
 
             - name: Typecheck
               run: |
@@ -63,6 +65,7 @@ jobs:
                   npm run typecheck --if-present --workspace=@calmstudio/extensions
                   npm run typecheck --if-present --workspace=@calmstudio/mcp
                   npm run typecheck --if-present --workspace=@calmstudio/github-action
+                  npm run typecheck --if-present --workspace=@calmstudio/docusaurus-plugin
 
             - name: Test
               run: |
@@ -70,6 +73,8 @@ jobs:
                   npm run test --if-present --workspace=@calmstudio/extensions
                   npm run test --if-present --workspace=@calmstudio/mcp
                   npm run test --if-present --workspace=@calmstudio/studio
+                  npm run test --if-present --workspace=@calmstudio/diagram
+                  npm run test --if-present --workspace=@calmstudio/docusaurus-plugin
 
     e2e-tests:
         name: E2E Tests

--- a/.github/workflows/build-calm-studio.yml
+++ b/.github/workflows/build-calm-studio.yml
@@ -49,7 +49,7 @@ jobs:
                   npm run build --if-present --workspace=@calmstudio/studio
                   npm run build --if-present --workspace=calmstudio
                   npm run build --if-present --workspace=@calmstudio/github-action
-                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run build --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Lint
               run: |
@@ -57,7 +57,7 @@ jobs:
                   npm run lint --if-present --workspace=@calmstudio/extensions
                   npm run lint --if-present --workspace=@calmstudio/mcp
                   npm run lint --if-present --workspace=@calmstudio/studio
-                  npm run lint --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run lint --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Typecheck
               run: |
@@ -65,7 +65,7 @@ jobs:
                   npm run typecheck --if-present --workspace=@calmstudio/extensions
                   npm run typecheck --if-present --workspace=@calmstudio/mcp
                   npm run typecheck --if-present --workspace=@calmstudio/github-action
-                  npm run typecheck --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run typecheck --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Test
               run: |
@@ -74,7 +74,7 @@ jobs:
                   npm run test --if-present --workspace=@calmstudio/mcp
                   npm run test --if-present --workspace=@calmstudio/studio
                   npm run test --if-present --workspace=@calmstudio/diagram
-                  npm run test --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run test --if-present --workspace=@finos/calm-docusaurus-plugin
 
     e2e-tests:
         name: E2E Tests

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -38,7 +38,7 @@ jobs:
                   npm run build --if-present --workspace=@calmstudio/calm-core
                   npm run build --if-present --workspace=@calmstudio/extensions
                   npm run build --if-present --workspace=@calmstudio/diagram
-                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run build --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Build Docs
               run: npm run build:docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -32,5 +32,13 @@ jobs:
             - name: Install workspace
               run: npm ci
 
+            - name: Build CALM diagram packages (docs plugin deps)
+              run: |
+                  npm run build --if-present --workspace=@finos/calm-models
+                  npm run build --if-present --workspace=@calmstudio/calm-core
+                  npm run build --if-present --workspace=@calmstudio/extensions
+                  npm run build --if-present --workspace=@calmstudio/diagram
+                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+
             - name: Build Docs
               run: npm run build:docs

--- a/.github/workflows/s3-docs-sync.yml
+++ b/.github/workflows/s3-docs-sync.yml
@@ -23,7 +23,15 @@ jobs:
 
             - name: Install dependencies
               run: npm ci
-              
+
+            - name: Build CALM diagram packages (docs plugin deps)
+              run: |
+                  npm run build --if-present --workspace=@finos/calm-models
+                  npm run build --if-present --workspace=@calmstudio/calm-core
+                  npm run build --if-present --workspace=@calmstudio/extensions
+                  npm run build --if-present --workspace=@calmstudio/diagram
+                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+
             - name: Build website
               run: npm run build
               working-directory: "docs"

--- a/.github/workflows/s3-docs-sync.yml
+++ b/.github/workflows/s3-docs-sync.yml
@@ -30,7 +30,7 @@ jobs:
                   npm run build --if-present --workspace=@calmstudio/calm-core
                   npm run build --if-present --workspace=@calmstudio/extensions
                   npm run build --if-present --workspace=@calmstudio/diagram
-                  npm run build --if-present --workspace=@calmstudio/docusaurus-plugin
+                  npm run build --if-present --workspace=@finos/calm-docusaurus-plugin
 
             - name: Build website
               run: npm run build

--- a/calm-studio/package.json
+++ b/calm-studio/package.json
@@ -13,7 +13,8 @@
     "packages/mcp-server",
     "packages/github-action",
     "packages/vscode-extension",
-    "packages/web-component"
+    "packages/web-component",
+    "packages/docusaurus-plugin"
   ],
   "scripts": {
     "prepare": "husky || true",

--- a/calm-studio/packages/docusaurus-plugin/README.md
+++ b/calm-studio/packages/docusaurus-plugin/README.md
@@ -1,0 +1,78 @@
+# @calmstudio/docusaurus-plugin
+
+Embed [FINOS CALM](https://calm.finos.org) architecture diagrams in
+Docusaurus MDX pages — like Mermaid, but driven by your real, validatable
+architecture files.
+
+Diagrams are pre-rendered to static SVG at build time (SEO-friendly, works
+without JavaScript, instant paint) and upgrade in the browser to the
+interactive [`@calmstudio/diagram`](https://www.npmjs.com/package/@calmstudio/diagram)
+web component: zoom, pan, node tooltips, and animated flow highlighting.
+
+## Install
+
+```bash
+npm install @calmstudio/docusaurus-plugin
+```
+
+## Configure
+
+`docusaurus.config.js`:
+
+```js
+import calmRemark from '@calmstudio/docusaurus-plugin/remark';
+
+export default {
+  plugins: ['@calmstudio/docusaurus-plugin'],
+  presets: [
+    [
+      'classic',
+      {
+        docs: {
+          // Enables <CalmDiagram src="./relative/path.calm.json" />
+          beforeDefaultRemarkPlugins: [calmRemark],
+        },
+      },
+    ],
+  ],
+};
+```
+
+(CJS configs: `beforeDefaultRemarkPlugins: [require('@calmstudio/docusaurus-plugin/remark')]` —
+add `.default` if your bundler surfaces the module namespace object.)
+
+The plugin registers a webpack loader that pre-renders `*.calm.json`
+imports to SVG. The remark plugin rewrites relative `src` paths into those
+imports; Docusaurus has no API for a plugin to extend another plugin's
+remark chain, hence the one extra config line.
+
+## Use
+
+```mdx
+import { CalmDiagram } from '@calmstudio/docusaurus-plugin'
+
+# My System
+
+<CalmDiagram src="./architectures/loan-approval.calm.json" />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `src` | `string` | — | Relative path to a `.calm.json` file (pre-rendered at build time), or an `https://` URL (fetched client-side, no static SVG). |
+| `data` | `object` | — | Inline CALM architecture. Client-rendered only. |
+| `theme` | `'light' \| 'dark'` | follows `html[data-theme]` | Force a theme. |
+| `flow` | `string` | — | Flow `unique-id` to highlight (applied after hydration). |
+| `interactive` | `boolean` | `true` | `false` keeps the static SVG and skips the client-side JavaScript entirely. |
+
+## Error behavior
+
+- Invalid or unrenderable `.calm.json` files **fail the docs build** with
+  the offending file path — broken diagrams are caught in CI, not by readers.
+- If the interactive component fails to load at runtime, the static SVG
+  simply stays in place.
+
+## License
+
+Apache-2.0. Part of the [FINOS architecture-as-code](https://github.com/finos/architecture-as-code) project.

--- a/calm-studio/packages/docusaurus-plugin/README.md
+++ b/calm-studio/packages/docusaurus-plugin/README.md
@@ -1,4 +1,4 @@
-# @calmstudio/docusaurus-plugin
+# @finos/calm-docusaurus-plugin
 
 Embed [FINOS CALM](https://calm.finos.org) architecture diagrams in
 Docusaurus MDX pages — like Mermaid, but driven by your real, validatable
@@ -12,7 +12,7 @@ web component: zoom, pan, node tooltips, and animated flow highlighting.
 ## Install
 
 ```bash
-npm install @calmstudio/docusaurus-plugin
+npm install @finos/calm-docusaurus-plugin
 ```
 
 ## Configure
@@ -20,10 +20,10 @@ npm install @calmstudio/docusaurus-plugin
 `docusaurus.config.js`:
 
 ```js
-import calmRemark from '@calmstudio/docusaurus-plugin/remark';
+import calmRemark from '@finos/calm-docusaurus-plugin/remark';
 
 export default {
-  plugins: ['@calmstudio/docusaurus-plugin'],
+  plugins: ['@finos/calm-docusaurus-plugin'],
   presets: [
     [
       'classic',
@@ -38,7 +38,7 @@ export default {
 };
 ```
 
-(CJS configs: `beforeDefaultRemarkPlugins: [require('@calmstudio/docusaurus-plugin/remark')]` —
+(CJS configs: `beforeDefaultRemarkPlugins: [require('@finos/calm-docusaurus-plugin/remark')]` —
 add `.default` if your bundler surfaces the module namespace object.)
 
 The plugin registers a webpack loader that pre-renders `*.calm.json`
@@ -49,7 +49,7 @@ remark chain, hence the one extra config line.
 ## Use
 
 ```mdx
-import { CalmDiagram } from '@calmstudio/docusaurus-plugin'
+import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
 
 # My System
 

--- a/calm-studio/packages/docusaurus-plugin/package.json
+++ b/calm-studio/packages/docusaurus-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@calmstudio/docusaurus-plugin",
+  "name": "@finos/calm-docusaurus-plugin",
   "version": "0.0.0",
   "private": false,
   "description": "Embed CALM architecture diagrams in Docusaurus MDX — build-time SVG with client-side interactive hydration",

--- a/calm-studio/packages/docusaurus-plugin/package.json
+++ b/calm-studio/packages/docusaurus-plugin/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@calmstudio/docusaurus-plugin",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Embed CALM architecture diagrams in Docusaurus MDX — build-time SVG with client-side interactive hydration",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./loader": {
+      "import": "./dist/loader.js",
+      "require": "./dist/loader.cjs"
+    },
+    "./remark": {
+      "import": "./dist/remark.js",
+      "require": "./dist/remark.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "echo \"no-op\" && exit 0",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@calmstudio/diagram": "*",
+    "unist-util-visit": "^5.0.0"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": ">=3.0.0",
+    "react": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@docusaurus/types": "3.9.2",
+    "@mdx-js/mdx": "^3.1.0",
+    "@types/mdast": "^4.0.4",
+    "@types/react": "^19.1.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "mdast-util-mdx-jsx": "^3.2.0",
+    "mdast-util-mdxjs-esm": "^2.0.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "^11.0.5",
+    "vitest": "^4.1.0",
+    "webpack": "^5.99.5"
+  }
+}

--- a/calm-studio/packages/docusaurus-plugin/src/__fixtures__/two-node.calm.json
+++ b/calm-studio/packages/docusaurus-plugin/src/__fixtures__/two-node.calm.json
@@ -1,0 +1,15 @@
+{
+  "nodes": [
+    { "unique-id": "web", "node-type": "actor", "name": "Web Client", "description": "Browser UI" },
+    { "unique-id": "api", "node-type": "service", "name": "Trade API", "description": "Backend trade service" }
+  ],
+  "relationships": [
+    {
+      "unique-id": "web-to-api",
+      "relationship-type": "connects",
+      "source": "web",
+      "destination": "api",
+      "protocol": "HTTPS"
+    }
+  ]
+}

--- a/calm-studio/packages/docusaurus-plugin/src/__fixtures__/two-node.calm.json
+++ b/calm-studio/packages/docusaurus-plugin/src/__fixtures__/two-node.calm.json
@@ -6,9 +6,12 @@
   "relationships": [
     {
       "unique-id": "web-to-api",
-      "relationship-type": "connects",
-      "source": "web",
-      "destination": "api",
+      "relationship-type": {
+        "connects": {
+          "source": { "node": "web" },
+          "destination": { "node": "api" }
+        }
+      },
       "protocol": "HTTPS"
     }
   ]

--- a/calm-studio/packages/docusaurus-plugin/src/calmstudio-diagram-render.d.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/calmstudio-diagram-render.d.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+declare module '@calmstudio/diagram/render' {
+  export interface RenderOptions {
+    theme?: 'light' | 'dark';
+    direction?: 'DOWN' | 'RIGHT';
+    flow?: string;
+  }
+  export function renderELKDiagram(arch: unknown, options?: RenderOptions): Promise<string>;
+}
+
+declare module '@calmstudio/diagram' {
+  export interface CalmDiagramProps {
+    src?: string;
+    data?: string;
+    theme?: 'light' | 'dark';
+    flow?: string;
+  }
+}

--- a/calm-studio/packages/docusaurus-plugin/src/index.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/index.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This is a placeholder entry point for the main docusaurus plugin.
-// Full implementation coming in subsequent tasks.
-
-export const pluginName = '@calmstudio/docusaurus-plugin';
+export { CalmDiagram } from './theme/CalmDiagram/index.js';
+export type { CalmDiagramProps, CalmDiagramBundle } from './theme/CalmDiagram/types.js';
+export { default } from './plugin.js';

--- a/calm-studio/packages/docusaurus-plugin/src/index.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/index.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a placeholder entry point for the main docusaurus plugin.
+// Full implementation coming in subsequent tasks.
+
+export const pluginName = '@calmstudio/docusaurus-plugin';

--- a/calm-studio/packages/docusaurus-plugin/src/loader.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/loader.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { buildCalmModule } from './loader.js';
+
+const fixturePath = fileURLToPath(new URL('./__fixtures__/two-node.calm.json', import.meta.url));
+const fixtureRaw = readFileSync(fixturePath, 'utf8');
+
+describe('buildCalmModule', () => {
+  it('emits an ES module with architecture, svg, size and a default export', async () => {
+    const code = await buildCalmModule(fixtureRaw, fixturePath);
+    expect(code).toContain('export const architecture =');
+    expect(code).toContain('export const svg =');
+    expect(code).toContain('export const size =');
+    expect(code).toContain('export default { architecture, svg, size };');
+    expect(code).toContain('Web Client'); // node name baked into the SVG
+  });
+
+  it('emitted module source is valid JavaScript', async () => {
+    const code = await buildCalmModule(fixtureRaw, fixturePath);
+    // Throws SyntaxError if the emitted source does not parse as a module
+    expect(() => new Function(code.replace(/export (const|default)/g, 'void 0,'))).not.toThrow();
+  });
+
+  it('throws with the file path on invalid JSON', async () => {
+    await expect(buildCalmModule('{ not json', '/docs/broken.calm.json')).rejects.toThrow(
+      /\/docs\/broken\.calm\.json/
+    );
+  });
+
+  it('throws with the file path when rendering fails', async () => {
+    await expect(buildCalmModule('{"nodes": "bad"}', '/docs/bad-arch.calm.json')).rejects.toThrow(
+      /\/docs\/bad-arch\.calm\.json/
+    );
+  });
+});

--- a/calm-studio/packages/docusaurus-plugin/src/loader.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/loader.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a placeholder loader for webpack integration.
+// Full implementation coming in subsequent tasks.
+
+export const loaderName = 'calm-diagram-loader';

--- a/calm-studio/packages/docusaurus-plugin/src/loader.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/loader.ts
@@ -2,7 +2,45 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This is a placeholder loader for webpack integration.
-// Full implementation coming in subsequent tasks.
+import type { LoaderContext } from 'webpack';
+import { prerenderCalmSvg } from './prerender.js';
 
-export const loaderName = 'calm-diagram-loader';
+/**
+ * Turn raw .calm.json source into an ES module exporting the parsed
+ * architecture plus pre-rendered light/dark SVG. Pure — separated from the
+ * webpack callback plumbing for direct testing.
+ */
+export async function buildCalmModule(source: string, resourcePath: string): Promise<string> {
+  let architecture: unknown;
+  try {
+    architecture = JSON.parse(source);
+  } catch (err) {
+    throw new Error(
+      `[@calmstudio/docusaurus-plugin] Invalid JSON in ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  let bundle;
+  try {
+    bundle = await prerenderCalmSvg(architecture);
+  } catch (err) {
+    throw new Error(
+      `[@calmstudio/docusaurus-plugin] Failed to render ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return [
+    `export const architecture = ${JSON.stringify(architecture)};`,
+    `export const svg = ${JSON.stringify(bundle.svg)};`,
+    `export const size = ${JSON.stringify(bundle.size)};`,
+    `export default { architecture, svg, size };`,
+  ].join('\n');
+}
+
+export default function calmJsonLoader(this: LoaderContext<unknown>, source: string): void {
+  const callback = this.async();
+  buildCalmModule(source, this.resourcePath).then(
+    (code) => callback(null, code),
+    (err) => callback(err instanceof Error ? err : new Error(String(err)))
+  );
+}

--- a/calm-studio/packages/docusaurus-plugin/src/loader.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/loader.ts
@@ -16,7 +16,7 @@ export async function buildCalmModule(source: string, resourcePath: string): Pro
     architecture = JSON.parse(source);
   } catch (err) {
     throw new Error(
-      `[@calmstudio/docusaurus-plugin] Invalid JSON in ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
+      `[@finos/calm-docusaurus-plugin] Invalid JSON in ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 
@@ -25,7 +25,7 @@ export async function buildCalmModule(source: string, resourcePath: string): Pro
     bundle = await prerenderCalmSvg(architecture);
   } catch (err) {
     throw new Error(
-      `[@calmstudio/docusaurus-plugin] Failed to render ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
+      `[@finos/calm-docusaurus-plugin] Failed to render ${resourcePath}: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
@@ -25,6 +25,10 @@ describe('calmstudioDocusaurusPlugin', () => {
   });
 
   it('ships its stylesheet as a client module', () => {
-    expect(plugin.getClientModules?.()).toEqual(['@calmstudio/docusaurus-plugin/styles.css']);
+    // Docusaurus resolves getClientModules() entries with
+    // path.resolve(plugin.path, entry) — plugin.path is the resolved entry
+    // file's directory (dist/), so the path must be relative to dist/, not
+    // a package-exports specifier.
+    expect(plugin.getClientModules?.()).toEqual(['./styles.css']);
   });
 });

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
@@ -9,7 +9,7 @@ describe('calmstudioDocusaurusPlugin', () => {
   const plugin = calmstudioDocusaurusPlugin();
 
   it('declares its name', () => {
-    expect(plugin.name).toBe('@calmstudio/docusaurus-plugin');
+    expect(plugin.name).toBe('@finos/calm-docusaurus-plugin');
   });
 
   it('registers a webpack rule routing *.calm.json through the package loader', () => {
@@ -21,7 +21,7 @@ describe('calmstudioDocusaurusPlugin', () => {
     expect(rules[0].test.test('package.json')).toBe(false);
     expect(rules[0].test.test('demo.calm.json.bak')).toBe(false);
     expect(rules[0].type).toBe('javascript/auto');
-    expect(rules[0].use).toBe('@calmstudio/docusaurus-plugin/loader');
+    expect(rules[0].use).toBe('@finos/calm-docusaurus-plugin/loader');
   });
 
   it('ships its stylesheet as a client module', () => {

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import calmstudioDocusaurusPlugin from './plugin.js';
+
+describe('calmstudioDocusaurusPlugin', () => {
+  const plugin = calmstudioDocusaurusPlugin();
+
+  it('declares its name', () => {
+    expect(plugin.name).toBe('@calmstudio/docusaurus-plugin');
+  });
+
+  it('registers a webpack rule routing *.calm.json through the package loader', () => {
+    const config = plugin.configureWebpack?.({}, false, { currentBundler: { name: 'webpack' } } as never);
+    const rules = (config as { module: { rules: Array<{ test: RegExp; type: string; use: string }> } })
+      .module.rules;
+    expect(rules).toHaveLength(1);
+    expect(rules[0].test.test('demo.calm.json')).toBe(true);
+    expect(rules[0].test.test('package.json')).toBe(false);
+    expect(rules[0].test.test('demo.calm.json.bak')).toBe(false);
+    expect(rules[0].type).toBe('javascript/auto');
+    expect(rules[0].use).toBe('@calmstudio/docusaurus-plugin/loader');
+  });
+
+  it('ships its stylesheet as a client module', () => {
+    expect(plugin.getClientModules?.()).toEqual(['@calmstudio/docusaurus-plugin/styles.css']);
+  });
+});

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.ts
@@ -12,14 +12,14 @@ import type { Plugin } from '@docusaurus/types';
  * webpack's enhanced-resolve against this package's `exports` map) so this
  * entry needs no Node built-ins and stays safe to import from MDX.
  *
- * Note: the remark plugin (`@calmstudio/docusaurus-plugin/remark`) must be
+ * Note: the remark plugin (`@finos/calm-docusaurus-plugin/remark`) must be
  * registered separately via `beforeDefaultRemarkPlugins` in the preset
  * config — Docusaurus has no API for one plugin to extend another plugin's
  * remark chain. See README.
  */
 export default function calmstudioDocusaurusPlugin(): Plugin<void> {
   return {
-    name: '@calmstudio/docusaurus-plugin',
+    name: '@finos/calm-docusaurus-plugin',
     configureWebpack() {
       return {
         module: {
@@ -27,7 +27,7 @@ export default function calmstudioDocusaurusPlugin(): Plugin<void> {
             {
               test: /\.calm\.json$/,
               type: 'javascript/auto',
-              use: '@calmstudio/docusaurus-plugin/loader',
+              use: '@finos/calm-docusaurus-plugin/loader',
             },
           ],
         },

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.ts
@@ -34,7 +34,13 @@ export default function calmstudioDocusaurusPlugin(): Plugin<void> {
       };
     },
     getClientModules() {
-      return ['@calmstudio/docusaurus-plugin/styles.css'];
+      // Docusaurus resolves getClientModules() entries with
+      // `path.resolve(plugin.path, entry)`, where `plugin.path` is the
+      // directory of this plugin's resolved entry file (i.e. `dist/`) — NOT
+      // a module specifier lookup through the package's `exports` map. A
+      // package-specifier string here silently resolves to a bogus nested
+      // path. Use a path relative to `dist/` instead.
+      return ['./styles.css'];
     },
   };
 }

--- a/calm-studio/packages/docusaurus-plugin/src/plugin.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/plugin.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Plugin } from '@docusaurus/types';
+
+/**
+ * Docusaurus plugin: routes *.calm.json imports through the pre-rendering
+ * webpack loader and injects the CalmDiagram stylesheet.
+ *
+ * The loader and stylesheet are referenced as package subpaths (resolved by
+ * webpack's enhanced-resolve against this package's `exports` map) so this
+ * entry needs no Node built-ins and stays safe to import from MDX.
+ *
+ * Note: the remark plugin (`@calmstudio/docusaurus-plugin/remark`) must be
+ * registered separately via `beforeDefaultRemarkPlugins` in the preset
+ * config — Docusaurus has no API for one plugin to extend another plugin's
+ * remark chain. See README.
+ */
+export default function calmstudioDocusaurusPlugin(): Plugin<void> {
+  return {
+    name: '@calmstudio/docusaurus-plugin',
+    configureWebpack() {
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.calm\.json$/,
+              type: 'javascript/auto',
+              use: '@calmstudio/docusaurus-plugin/loader',
+            },
+          ],
+        },
+      };
+    },
+    getClientModules() {
+      return ['@calmstudio/docusaurus-plugin/styles.css'];
+    },
+  };
+}

--- a/calm-studio/packages/docusaurus-plugin/src/prerender.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/prerender.test.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { prerenderCalmSvg } from './prerender.js';
+import fixture from './__fixtures__/two-node.calm.json';
+
+describe('prerenderCalmSvg', () => {
+  it('renders light and dark SVG variants', async () => {
+    const bundle = await prerenderCalmSvg(fixture);
+    expect(bundle.svg.light).toContain('<svg');
+    expect(bundle.svg.light).toContain('Web Client');
+    expect(bundle.svg.dark).toContain('<svg');
+    expect(bundle.svg.light).not.toEqual(bundle.svg.dark);
+  });
+
+  it('extracts intrinsic size from the SVG', async () => {
+    const bundle = await prerenderCalmSvg(fixture);
+    expect(bundle.size.width).toBeGreaterThan(0);
+    expect(bundle.size.height).toBeGreaterThan(0);
+  });
+
+  it('rejects on a broken architecture', async () => {
+    await expect(prerenderCalmSvg({ nodes: 'not-an-array' })).rejects.toThrow();
+  });
+});

--- a/calm-studio/packages/docusaurus-plugin/src/prerender.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/prerender.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderELKDiagram } from '@calmstudio/diagram/render';
+
+export interface CalmSvgBundle {
+  svg: { light: string; dark: string };
+  size: { width: number; height: number };
+}
+
+const SVG_SIZE_RE = /<svg[^>]*\bwidth="(\d+(?:\.\d+)?)"[^>]*\bheight="(\d+(?:\.\d+)?)"/;
+
+const FALLBACK_SIZE = { width: 800, height: 480 };
+
+/**
+ * Render a CALM architecture to light + dark SVG strings at build time,
+ * and extract the diagram's intrinsic pixel size from the SVG root.
+ */
+export async function prerenderCalmSvg(architecture: unknown): Promise<CalmSvgBundle> {
+  const [light, dark] = await Promise.all([
+    renderELKDiagram(architecture, { theme: 'light' }),
+    renderELKDiagram(architecture, { theme: 'dark' }),
+  ]);
+  const match = SVG_SIZE_RE.exec(light);
+  const size = match
+    ? { width: Number(match[1]), height: Number(match[2]) }
+    : FALLBACK_SIZE;
+  return { svg: { light, dark }, size };
+}

--- a/calm-studio/packages/docusaurus-plugin/src/remark.test.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/remark.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { compile } from '@mdx-js/mdx';
+import remarkCalmDiagram from './remark.js';
+
+async function compileMdx(source: string): Promise<string> {
+  const file = await compile(source, { remarkPlugins: [remarkCalmDiagram] });
+  return String(file);
+}
+
+describe('remarkCalmDiagram', () => {
+  it('rewrites a relative src into a hoisted import + __bundle prop', async () => {
+    const out = await compileMdx('<CalmDiagram src="./arch/demo.calm.json" />');
+    expect(out).toContain('from "./arch/demo.calm.json"');
+    expect(out).toContain('__bundle:');
+    expect(out).not.toContain('src:');
+  });
+
+  it('handles multiple diagrams with distinct identifiers', async () => {
+    const out = await compileMdx(
+      '<CalmDiagram src="./a.calm.json" />\n\n<CalmDiagram src="../b.calm.json" />'
+    );
+    expect(out).toContain('from "./a.calm.json"');
+    expect(out).toContain('from "../b.calm.json"');
+    expect(out).toContain('__calmDiagramBundle0');
+    expect(out).toContain('__calmDiagramBundle1');
+  });
+
+  it('preserves other props alongside the rewrite', async () => {
+    const out = await compileMdx('<CalmDiagram src="./a.calm.json" flow="checkout" interactive={false} />');
+    expect(out).toContain('flow:');
+    expect(out).toContain('interactive:');
+    expect(out).toContain('__bundle:');
+  });
+
+  it('leaves http(s) src untouched', async () => {
+    const out = await compileMdx('<CalmDiagram src="https://example.com/a.calm.json" />');
+    expect(out).toContain('src:');
+    expect(out).not.toContain('__bundle:');
+  });
+
+  it('leaves data-only usage untouched', async () => {
+    const out = await compileMdx('<CalmDiagram data={{ nodes: [] }} />');
+    expect(out).not.toContain('__bundle:');
+  });
+
+  it('ignores other components with src attrs', async () => {
+    const out = await compileMdx('<img src="./photo.png" />');
+    expect(out).not.toContain('__bundle:');
+  });
+});

--- a/calm-studio/packages/docusaurus-plugin/src/remark.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/remark.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a placeholder for the remark plugin.
+// Full implementation coming in subsequent tasks.
+
+export const remarkPluginName = 'remark-calm-diagram';

--- a/calm-studio/packages/docusaurus-plugin/src/remark.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/remark.ts
@@ -2,7 +2,97 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This is a placeholder for the remark plugin.
-// Full implementation coming in subsequent tasks.
+import { visit } from 'unist-util-visit';
+import type { Root } from 'mdast';
+import type { Plugin } from 'unified';
+import type { MdxJsxFlowElement, MdxJsxTextElement, MdxJsxAttribute } from 'mdast-util-mdx-jsx';
+import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
 
-export const remarkPluginName = 'remark-calm-diagram';
+const COMPONENT_NAME = 'CalmDiagram';
+
+function isRelativePath(value: string): boolean {
+  return value.startsWith('./') || value.startsWith('../');
+}
+
+function bundleAttribute(identifier: string): MdxJsxAttribute {
+  const attr = {
+    type: 'mdxJsxAttribute',
+    name: '__bundle',
+    value: {
+      type: 'mdxJsxAttributeValueExpression',
+      value: identifier,
+      data: {
+        estree: {
+          type: 'Program',
+          sourceType: 'module',
+          body: [
+            {
+              type: 'ExpressionStatement',
+              expression: { type: 'Identifier', name: identifier },
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as MdxJsxAttribute;
+  return attr;
+}
+
+function hoistedImports(entries: Array<{ identifier: string; path: string }>): MdxjsEsm {
+  const imports = {
+    type: 'mdxjsEsm',
+    value: entries.map((e) => `import ${e.identifier} from '${e.path}';`).join('\n'),
+    data: {
+      estree: {
+        type: 'Program',
+        sourceType: 'module',
+        body: entries.map((e) => ({
+          type: 'ImportDeclaration',
+          specifiers: [
+            {
+              type: 'ImportDefaultSpecifier',
+              local: { type: 'Identifier', name: e.identifier },
+            },
+          ],
+          source: { type: 'Literal', value: e.path, raw: JSON.stringify(e.path) },
+          attributes: [],
+        })),
+      },
+    },
+  } as unknown as MdxjsEsm;
+  return imports;
+}
+
+/**
+ * Rewrites <CalmDiagram src="./x.calm.json"> (relative paths only) into a
+ * hoisted default import of the .calm.json module (processed by this
+ * package's webpack loader) passed as the __bundle prop. Absolute and
+ * http(s) src values pass through untouched (remote mode).
+ */
+const remarkCalmDiagram: Plugin<[], Root> = () => {
+  return (tree) => {
+    let counter = 0;
+    const entries: Array<{ identifier: string; path: string }> = [];
+
+    visit(tree, ['mdxJsxFlowElement', 'mdxJsxTextElement'], (node) => {
+      const el = node as MdxJsxFlowElement | MdxJsxTextElement;
+      if (el.name !== COMPONENT_NAME) return;
+      const srcAttr = el.attributes.find(
+        (attr): attr is MdxJsxAttribute => attr.type === 'mdxJsxAttribute' && attr.name === 'src'
+      );
+      if (!srcAttr || typeof srcAttr.value !== 'string' || !isRelativePath(srcAttr.value)) return;
+
+      const identifier = `__calmDiagramBundle${counter}`;
+      counter += 1;
+      entries.push({ identifier, path: srcAttr.value });
+      el.attributes = el.attributes.filter((attr) => attr !== srcAttr);
+      el.attributes.push(bundleAttribute(identifier));
+    });
+
+    if (entries.length > 0) {
+      tree.children.unshift(hoistedImports(entries));
+    }
+  };
+};
+
+export default remarkCalmDiagram;

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.ssr.test.tsx
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.ssr.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { CalmDiagram } from './index.js';
+import type { CalmDiagramBundle } from './types.js';
+
+const bundle: CalmDiagramBundle = {
+  architecture: { nodes: [], relationships: [] },
+  svg: {
+    light: '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150"><text>LIGHT</text></svg>',
+    dark: '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150"><text>DARK</text></svg>',
+  },
+  size: { width: 300, height: 150 },
+};
+
+describe('CalmDiagram SSR', () => {
+  it('renders both theme variants when no theme prop is set', () => {
+    const html = renderToString(<CalmDiagram __bundle={bundle} />);
+    expect(html).toContain('LIGHT');
+    expect(html).toContain('DARK');
+    expect(html).toContain('calm-diagram-static-light');
+    expect(html).toContain('calm-diagram-static-dark');
+  });
+
+  it('renders only the forced variant when theme is set', () => {
+    const html = renderToString(<CalmDiagram __bundle={bundle} theme="dark" />);
+    expect(html).toContain('DARK');
+    expect(html).not.toContain('LIGHT');
+  });
+
+  it('renders a placeholder for remote src (no bundle)', () => {
+    const html = renderToString(<CalmDiagram src="https://example.com/a.calm.json" />);
+    expect(html).toContain('calm-diagram-placeholder');
+  });
+
+  it('renders a placeholder for inline data (client-rendered mode)', () => {
+    const html = renderToString(<CalmDiagram data={{ nodes: [] }} />);
+    expect(html).toContain('calm-diagram-placeholder');
+  });
+
+  it('renders a visible error box when nothing is provided (non-production)', () => {
+    const html = renderToString(<CalmDiagram />);
+    expect(html).toContain('calm-diagram-error');
+    expect(html).toContain('no architecture provided');
+  });
+});

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
@@ -38,7 +38,7 @@ export function CalmDiagram(props: CalmDiagramProps): React.ReactElement | null 
       })
       .catch((err: unknown) => {
         // Static SVG stays in place — degradation is graceful by construction.
-        console.error('[@calmstudio/docusaurus-plugin] failed to load interactive renderer:', err);
+        console.error('[@finos/calm-docusaurus-plugin] failed to load interactive renderer:', err);
       });
     return () => {
       cancelled = true;
@@ -58,7 +58,7 @@ export function CalmDiagram(props: CalmDiagramProps): React.ReactElement | null 
 
   if (!hasInput) {
     console.error(
-      '[@calmstudio/docusaurus-plugin] <CalmDiagram> needs `src` (relative .calm.json path or URL) or `data`.'
+      '[@finos/calm-docusaurus-plugin] <CalmDiagram> needs `src` (relative .calm.json path or URL) or `data`.'
     );
     if (process.env.NODE_ENV !== 'production') {
       return (

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useEffect, useState } from 'react';
+import type { CalmDiagramProps } from './types.js';
+
+export type { CalmDiagramBundle, CalmDiagramProps } from './types.js';
+
+function isRemoteUrl(value: string | undefined): value is string {
+  return typeof value === 'string' && /^https?:\/\//.test(value);
+}
+
+/**
+ * CALM architecture diagram for Docusaurus MDX.
+ *
+ * Build/SSR: emits the pre-rendered static SVG (light + dark variants,
+ * toggled by html[data-theme] CSS) so diagrams work without JavaScript.
+ * Client: lazily loads the @calmstudio/diagram web component and swaps it
+ * in for zoom/pan/tooltips/flow animation, unless interactive={false}.
+ */
+export function CalmDiagram(props: CalmDiagramProps): React.ReactElement | null {
+  const { src, data, theme, flow, interactive = true, __bundle } = props;
+  const [upgraded, setUpgraded] = useState(false);
+  const [domTheme, setDomTheme] = useState<'light' | 'dark'>('light');
+
+  const architecture = __bundle ? __bundle.architecture : data;
+  const remote = !architecture && isRemoteUrl(src);
+  const hasInput = Boolean(architecture) || remote;
+
+  // Lazily load the interactive web component on the client.
+  useEffect(() => {
+    if (!interactive || !hasInput) return;
+    let cancelled = false;
+    import('@calmstudio/diagram')
+      .then(() => {
+        if (!cancelled) setUpgraded(true);
+      })
+      .catch((err: unknown) => {
+        // Static SVG stays in place — degradation is graceful by construction.
+        console.error('[@calmstudio/docusaurus-plugin] failed to load interactive renderer:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [interactive, hasInput]);
+
+  // Follow the Docusaurus color mode via html[data-theme] (no dependency on
+  // @docusaurus/theme-common, keeps SSR clean).
+  useEffect(() => {
+    const root = document.documentElement;
+    const update = () => setDomTheme(root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light');
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+
+  if (!hasInput) {
+    console.error(
+      '[@calmstudio/docusaurus-plugin] <CalmDiagram> needs `src` (relative .calm.json path or URL) or `data`.'
+    );
+    if (process.env.NODE_ENV !== 'production') {
+      return (
+        <div className="calm-diagram calm-diagram-error">
+          CalmDiagram: no architecture provided — pass `src` or `data`.
+        </div>
+      );
+    }
+    return null;
+  }
+
+  if (upgraded) {
+    const effectiveTheme = theme ?? domTheme;
+    const height = __bundle ? __bundle.size.height : 480;
+    return (
+      <div className="calm-diagram" style={{ width: '100%', height }}>
+        <calm-diagram
+          data={architecture ? JSON.stringify(architecture) : undefined}
+          src={remote ? src : undefined}
+          theme={effectiveTheme}
+          flow={flow || undefined}
+        />
+      </div>
+    );
+  }
+
+  if (__bundle) {
+    if (theme) {
+      return (
+        <div
+          className="calm-diagram"
+          dangerouslySetInnerHTML={{ __html: __bundle.svg[theme] }}
+        />
+      );
+    }
+    return (
+      <div className="calm-diagram">
+        <div
+          className="calm-diagram-static-light"
+          dangerouslySetInnerHTML={{ __html: __bundle.svg.light }}
+        />
+        <div
+          className="calm-diagram-static-dark"
+          dangerouslySetInnerHTML={{ __html: __bundle.svg.dark }}
+        />
+      </div>
+    );
+  }
+
+  // Inline data or remote URL: no build-time SVG exists — placeholder until hydration.
+  return (
+    <div
+      className="calm-diagram calm-diagram-placeholder"
+      style={{ minHeight: 200 }}
+      aria-label="CALM diagram loads after page hydration"
+    />
+  );
+}

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/styles.css
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/styles.css
@@ -1,0 +1,34 @@
+/* SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.calm-diagram svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.calm-diagram-static-dark {
+  display: none;
+}
+
+html[data-theme='dark'] .calm-diagram-static-dark {
+  display: block;
+}
+
+html[data-theme='dark'] .calm-diagram-static-light {
+  display: none;
+}
+
+.calm-diagram-placeholder {
+  background: rgba(127, 127, 127, 0.08);
+  border-radius: 4px;
+}
+
+.calm-diagram-error {
+  border: 1px solid #dc2626;
+  color: #dc2626;
+  padding: 12px;
+  border-radius: 4px;
+  font-size: 14px;
+}

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type * as React from 'react';
+
+export interface CalmDiagramBundle {
+  architecture: unknown;
+  svg: { light: string; dark: string };
+  size: { width: number; height: number };
+}
+
+export interface CalmDiagramProps {
+  /** Relative .calm.json path (rewritten to __bundle by the remark plugin) or http(s) URL (remote mode). */
+  src?: string;
+  /** Inline CALM architecture object. Client-rendered only (no build-time SVG). */
+  data?: object;
+  /** Force a theme; defaults to following the site's html[data-theme]. */
+  theme?: 'light' | 'dark';
+  /** Flow unique-id to highlight (applied after hydration). */
+  flow?: string;
+  /** Set false to keep the static SVG and skip loading the interactive web component. */
+  interactive?: boolean;
+  /** Injected by the remark plugin — do not set manually. */
+  __bundle?: CalmDiagramBundle;
+}
+
+declare module 'react' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'calm-diagram': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        src?: string;
+        data?: string;
+        theme?: string;
+        flow?: string;
+      };
+    }
+  }
+}

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
@@ -26,7 +26,6 @@ export interface CalmDiagramProps {
 }
 
 declare module 'react' {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
       'calm-diagram': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {

--- a/calm-studio/packages/docusaurus-plugin/tsconfig.json
+++ b/calm-studio/packages/docusaurus-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/calm-studio/packages/docusaurus-plugin/tsup.config.ts
+++ b/calm-studio/packages/docusaurus-plugin/tsup.config.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    loader: 'src/loader.ts',
+    remark: 'src/remark.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  external: ['@calmstudio/diagram', '@calmstudio/diagram/render', 'react', 'react/jsx-runtime'],
+});

--- a/calm-studio/packages/docusaurus-plugin/tsup.config.ts
+++ b/calm-studio/packages/docusaurus-plugin/tsup.config.ts
@@ -14,4 +14,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   external: ['@calmstudio/diagram', '@calmstudio/diagram/render', 'react', 'react/jsx-runtime'],
+  // TODO(docusaurus-plugin Task 5): restore `onSuccess: 'cp src/theme/CalmDiagram/styles.css dist/styles.css'`
+  // once styles.css exists — the package.json `./styles.css` export has no producer until then.
 });

--- a/calm-studio/packages/docusaurus-plugin/tsup.config.ts
+++ b/calm-studio/packages/docusaurus-plugin/tsup.config.ts
@@ -14,6 +14,5 @@ export default defineConfig({
   dts: true,
   clean: true,
   external: ['@calmstudio/diagram', '@calmstudio/diagram/render', 'react', 'react/jsx-runtime'],
-  // TODO(docusaurus-plugin Task 5): restore `onSuccess: 'cp src/theme/CalmDiagram/styles.css dist/styles.css'`
-  // once styles.css exists — the package.json `./styles.css` export has no producer until then.
+  onSuccess: 'cp src/theme/CalmDiagram/styles.css dist/styles.css',
 });

--- a/calm-studio/packages/docusaurus-plugin/vitest.config.ts
+++ b/calm-studio/packages/docusaurus-plugin/vitest.config.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/calm-studio/packages/web-component/package.json
+++ b/calm-studio/packages/web-component/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "build": "vite build && vite build --config vite.config.iife.ts && vite build --config vite.config.render-cjs.ts",
+    "build": "vite build && vite build --config vite.config.iife.ts && vite build --config vite.config.render-es.ts && vite build --config vite.config.render-cjs.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/calm-studio/packages/web-component/package.json
+++ b/calm-studio/packages/web-component/package.json
@@ -9,10 +9,13 @@
     ".": {
       "import": "./dist/calm-diagram.es.js",
       "require": "./dist/calm-diagram.iife.js"
+    },
+    "./render": {
+      "import": "./dist/render.es.js"
     }
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build --config vite.config.iife.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/calm-studio/packages/web-component/package.json
+++ b/calm-studio/packages/web-component/package.json
@@ -11,11 +11,12 @@
       "require": "./dist/calm-diagram.iife.js"
     },
     "./render": {
-      "import": "./dist/render.es.js"
+      "import": "./dist/render.es.js",
+      "require": "./dist/render.cjs"
     }
   },
   "scripts": {
-    "build": "vite build && vite build --config vite.config.iife.ts",
+    "build": "vite build && vite build --config vite.config.iife.ts && vite build --config vite.config.render-cjs.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -121,8 +121,10 @@ export async function renderELKDiagram(
   }
 
   const relTypeMap = new Map<string, string>();
+  const relIdByRenderId = new Map<string, string>();
   for (const e of diagramEdges) {
     relTypeMap.set(e.id, e.variant);
+    relIdByRenderId.set(e.id, e.relationshipId);
   }
 
   // Compute canvas dimensions
@@ -168,8 +170,9 @@ export async function renderELKDiagram(
     ? getFlowNodeIds(arch, activeFlow)
     : new Set<string>();
 
-  // Build edge layout map for flow overlay path rendering
-  const edgeLayouts = new Map<string, EdgeLayout>();
+  // Edge layouts grouped by source relationship id, so the flow overlay can
+  // animate every render edge a fanned-out relationship expands into.
+  const edgeLayoutsByRelationship = new Map<string, EdgeLayout[]>();
 
   // Draw edges first (behind nodes)
   for (const edge of layouted.edges ?? []) {
@@ -186,10 +189,15 @@ export async function renderELKDiagram(
       }
       if (points.length >= 2) {
         // Store layout for flow overlay before rendering edge
-        edgeLayouts.set(edge.id, { id: edge.id, points });
+        const relationshipId = relIdByRenderId.get(edge.id) ?? edge.id;
+        const layouts = edgeLayoutsByRelationship.get(relationshipId) ?? [];
+        layouts.push({ id: edge.id, points });
+        edgeLayoutsByRelationship.set(relationshipId, layouts);
 
         const relType = relTypeMap.get(edge.id);
-        const edgeOpacity = applyFlowDimming(edge.id, activeFlowEdgeIds, true);
+        // Flows reference the relationship's unique-id — match on that, not the
+        // render id, so fan-out edges (`uid__N`) dim and animate correctly.
+        const edgeOpacity = applyFlowDimming(relationshipId, activeFlowEdgeIds, true);
         const edgeSvg = renderEdgeSvg({
           id: edge.id,
           points,
@@ -244,7 +252,7 @@ export async function renderELKDiagram(
 
   // Append flow overlay ABOVE edges and nodes so animated dots are not dimmed
   if (activeFlow) {
-    parts.push(renderFlowOverlay(activeFlow, edgeLayouts));
+    parts.push(renderFlowOverlay(activeFlow, edgeLayoutsByRelationship));
   }
 
   parts.push('</svg>');

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -10,6 +10,7 @@ import type { CalmArchitecture } from '@calmstudio/calm-core';
 import { renderNodeSvg } from './nodeRenderer.js';
 import { renderEdgeSvg, renderEdgeMarkers } from './edgeRenderer.js';
 import { renderFlowOverlay, applyFlowDimming, getFlowNodeIds, type EdgeLayout } from './flowOverlay.js';
+import { relationshipToEdges, type DiagramEdge } from './relationshipEdges.js';
 
 // ---------------------------------------------------------------------------
 // ELK type helpers
@@ -74,6 +75,9 @@ export async function renderELKDiagram(
     );
   }
 
+  // Expand relationships (nested or legacy flat) into renderable edges
+  const diagramEdges: DiagramEdge[] = arch.relationships.flatMap((r) => relationshipToEdges(r));
+
   // Build ELK graph
   const NODE_WIDTH = 180;
   const NODE_HEIGHT = 70;
@@ -92,10 +96,10 @@ export async function renderELKDiagram(
       height: NODE_HEIGHT,
       labels: [{ text: n.name }],
     })),
-    edges: arch.relationships.map((r) => ({
-      id: r['unique-id'],
-      sources: [r.source],
-      targets: [r.destination],
+    edges: diagramEdges.map((e) => ({
+      id: e.id,
+      sources: [e.source],
+      targets: [e.target],
     })),
   };
 
@@ -111,8 +115,8 @@ export async function renderELKDiagram(
   }
 
   const relTypeMap = new Map<string, string>();
-  for (const r of arch.relationships) {
-    relTypeMap.set(r['unique-id'], r['relationship-type']);
+  for (const e of diagramEdges) {
+    relTypeMap.set(e.id, e.variant);
   }
 
   // Compute canvas dimensions

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -64,8 +64,14 @@ export async function renderELKDiagram(
 ): Promise<string> {
   const { theme = 'light', direction = 'DOWN', flow: flowId } = options;
 
+  // CALM's meta-schema requires no top-level properties, so `nodes` and
+  // `relationships` may both be absent on a valid architecture document.
+  // Normalize once and use these locals throughout.
+  const nodes = arch.nodes ?? [];
+  const relationships = arch.relationships ?? [];
+
   // Handle empty architecture
-  if (arch.nodes.length === 0) {
+  if (nodes.length === 0) {
     const bgColor = theme === 'dark' ? '#1e1e1e' : '#f5f5f5';
     const textColor = theme === 'dark' ? '#ccc' : '#999';
     return (
@@ -76,7 +82,7 @@ export async function renderELKDiagram(
   }
 
   // Expand relationships (nested or legacy flat) into renderable edges
-  const diagramEdges: DiagramEdge[] = arch.relationships.flatMap((r) => relationshipToEdges(r));
+  const diagramEdges: DiagramEdge[] = relationships.flatMap((r) => relationshipToEdges(r));
 
   // Build ELK graph
   const NODE_WIDTH = 180;
@@ -90,7 +96,7 @@ export async function renderELKDiagram(
       'elk.layered.spacing.nodeNodeBetweenLayers': '80',
       'elk.spacing.nodeNode': '60',
     },
-    children: arch.nodes.map((n) => ({
+    children: nodes.map((n) => ({
       id: n['unique-id'],
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
@@ -109,7 +115,7 @@ export async function renderELKDiagram(
   // Build lookup maps
   const nodeTypeMap = new Map<string, string>();
   const nodeDescMap = new Map<string, string>();
-  for (const n of arch.nodes) {
+  for (const n of nodes) {
     nodeTypeMap.set(n['unique-id'], n['node-type']);
     nodeDescMap.set(n['unique-id'], n.description ?? '');
   }

--- a/calm-studio/packages/web-component/src/render/flowOverlay.test.ts
+++ b/calm-studio/packages/web-component/src/render/flowOverlay.test.ts
@@ -13,35 +13,35 @@ import type { CalmFlow, CalmArchitecture } from '@calmstudio/calm-core';
 const twoEdgeLayouts = new Map([
   [
     'rel-1',
-    {
+    [{
       id: 'rel-1',
       points: [
         { x: 10, y: 20 },
         { x: 100, y: 20 },
         { x: 200, y: 80 },
       ],
-    },
+    }],
   ],
   [
     'rel-2',
-    {
+    [{
       id: 'rel-2',
       points: [
         { x: 200, y: 80 },
         { x: 300, y: 80 },
       ],
-    },
+    }],
   ],
   [
     'rel-3',
-    {
+    [{
       id: 'rel-3',
       points: [
         { x: 300, y: 80 },
         { x: 350, y: 150 },
         { x: 400, y: 200 },
       ],
-    },
+    }],
   ],
 ]);
 
@@ -161,6 +161,50 @@ describe('renderFlowOverlay', () => {
     // Sequence numbers 1 and 2 should appear in badge text elements
     expect(svg).toContain('>1<');
     expect(svg).toContain('>2<');
+  });
+
+  it('animates along every fan-out edge of a multi-node relationship and renders one badge', () => {
+    const fanOutLayouts = new Map([
+      [
+        'rel-fan',
+        [
+          {
+            id: 'rel-fan__0',
+            points: [
+              { x: 0, y: 0 },
+              { x: 50, y: 50 },
+            ],
+          },
+          {
+            id: 'rel-fan__1',
+            points: [
+              { x: 0, y: 0 },
+              { x: 50, y: 100 },
+            ],
+          },
+        ],
+      ],
+    ]);
+    const fanFlow: CalmFlow = {
+      'unique-id': 'fan-flow',
+      name: 'Fan Flow',
+      description: 'Flow over a fan-out relationship',
+      transitions: [
+        {
+          'relationship-unique-id': 'rel-fan',
+          'sequence-number': 1,
+          summary: 'Actor interacts with both services',
+          direction: 'source-to-destination',
+        },
+      ],
+    };
+    const svg = renderFlowOverlay(fanFlow, fanOutLayouts);
+    const animCount = (svg.match(/<animateMotion/g) ?? []).length;
+    expect(animCount).toBe(2);
+    expect(svg).toContain('flow-path-rel-fan__0');
+    expect(svg).toContain('flow-path-rel-fan__1');
+    const badgeCount = (svg.match(/class="flow-badge"/g) ?? []).length;
+    expect(badgeCount).toBe(1);
   });
 
   it('Test 7: handles flow with 3+ transitions (multi-edge flow)', () => {

--- a/calm-studio/packages/web-component/src/render/flowOverlay.ts
+++ b/calm-studio/packages/web-component/src/render/flowOverlay.ts
@@ -116,7 +116,7 @@ export function getFlowNodeIds(
 ): Set<string> {
   const nodeIds = new Set<string>();
   const flowEdgeIds = new Set(flow.transitions.map((t) => t['relationship-unique-id']));
-  for (const rel of arch.relationships) {
+  for (const rel of arch.relationships ?? []) {
     if (flowEdgeIds.has(rel['unique-id'])) {
       for (const nodeId of getReferencedNodeIdsWithFlatFallback(rel)) {
         nodeIds.add(nodeId);

--- a/calm-studio/packages/web-component/src/render/flowOverlay.ts
+++ b/calm-studio/packages/web-component/src/render/flowOverlay.ts
@@ -22,50 +22,61 @@ export interface EdgeLayout {
  * Returns SVG string to be appended AFTER edge and node layers so animated dots are
  * always on top and not subject to edge/node dimming.
  *
+ * A relationship that fans out to multiple render edges (multi-node interacts /
+ * composed-of / deployed-in) contributes one animated dot per edge, but a single
+ * sequence badge (placed on its first edge).
+ *
  * @param flow - The active CalmFlow to render
- * @param edgeLayouts - Map from relationship-unique-id to EdgeLayout (id + points array)
+ * @param edgeLayoutsByRelationship - Map from relationship-unique-id to the EdgeLayouts
+ *   of every render edge expanded from that relationship
  * @returns SVG group string containing animated dots and sequence badge circles
  */
 export function renderFlowOverlay(
   flow: CalmFlow,
-  edgeLayouts: Map<string, EdgeLayout>
+  edgeLayoutsByRelationship: Map<string, EdgeLayout[]>
 ): string {
   const parts: string[] = ['<g class="flow-overlay">'];
 
   for (const transition of flow.transitions) {
-    const edge = edgeLayouts.get(transition['relationship-unique-id']);
-    if (!edge || edge.points.length < 2) continue;
+    const layouts = (edgeLayoutsByRelationship.get(transition['relationship-unique-id']) ?? []).filter(
+      (l) => l.points.length >= 2
+    );
+    const badgeEdge = layouts[0];
+    if (badgeEdge === undefined) continue;
 
-    const pathId = `flow-path-${edge.id}`;
     const direction = transition.direction ?? 'source-to-destination';
     const keyPoints = direction === 'destination-to-source' ? '1;0' : '0;1';
 
-    // Build SVG path from edge points (M x,y L x,y L x,y ...)
-    const pathD = edge.points
-      .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`)
-      .join(' ');
+    for (const edge of layouts) {
+      const pathId = `flow-path-${edge.id}`;
 
-    // Hidden path for animateMotion reference
-    parts.push(
-      `<path id="${pathId}" d="${pathD}" fill="none" stroke="none"/>`
-    );
+      // Build SVG path from edge points (M x,y L x,y L x,y ...)
+      const pathD = edge.points
+        .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`)
+        .join(' ');
 
-    // Animated dot travelling along the edge path
-    parts.push(
-      `<circle r="5" fill="#3b82f6" stroke="#fff" stroke-width="1.5">`,
-      `  <animateMotion dur="1.8s" repeatCount="indefinite" keyPoints="${keyPoints}" keyTimes="0;1" calcMode="linear">`,
-      `    <mpath href="#${pathId}"/>`,
-      `  </animateMotion>`,
-      `</circle>`
-    );
+      // Hidden path for animateMotion reference
+      parts.push(
+        `<path id="${pathId}" d="${pathD}" fill="none" stroke="none"/>`
+      );
 
-    // Compute midpoint for badge placement
-    const midIdx = Math.floor(edge.points.length / 2);
-    const midPoint = edge.points[midIdx];
+      // Animated dot travelling along the edge path
+      parts.push(
+        `<circle r="5" fill="#3b82f6" stroke="#fff" stroke-width="1.5">`,
+        `  <animateMotion dur="1.8s" repeatCount="indefinite" keyPoints="${keyPoints}" keyTimes="0;1" calcMode="linear">`,
+        `    <mpath href="#${pathId}"/>`,
+        `  </animateMotion>`,
+        `</circle>`
+      );
+    }
+
+    // One sequence badge per transition, placed at the first edge's midpoint
+    const midIdx = Math.floor(badgeEdge.points.length / 2);
+    const midPoint = badgeEdge.points[midIdx] ?? badgeEdge.points[0];
+    if (midPoint === undefined) continue;
     const midX = midPoint.x;
     const midY = midPoint.y;
 
-    // Sequence badge (numbered circle with tooltip)
     parts.push(
       `<g class="flow-badge" data-summary="${escapeAttr(transition.summary)}">`,
       `  <circle cx="${midX}" cy="${midY}" r="10" fill="#3b82f6"/>`,

--- a/calm-studio/packages/web-component/src/render/flowOverlay.ts
+++ b/calm-studio/packages/web-component/src/render/flowOverlay.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CalmArchitecture, CalmFlow } from '@calmstudio/calm-core';
+import { getReferencedNodeIds, type CalmArchitecture, type CalmFlow, type CalmRelationship } from '@calmstudio/calm-core';
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -118,11 +118,29 @@ export function getFlowNodeIds(
   const flowEdgeIds = new Set(flow.transitions.map((t) => t['relationship-unique-id']));
   for (const rel of arch.relationships) {
     if (flowEdgeIds.has(rel['unique-id'])) {
-      nodeIds.add(rel.source);
-      nodeIds.add(rel.destination);
+      for (const nodeId of getReferencedNodeIdsWithFlatFallback(rel)) {
+        nodeIds.add(nodeId);
+      }
     }
   }
   return nodeIds;
+}
+
+/**
+ * Resolve the node ids referenced by a relationship, supporting both the
+ * canonical nested `relationship-type` object and the legacy flat
+ * CalmStudio shape (`relationship-type` as a string plus sibling
+ * `source`/`destination` strings) as a fallback.
+ */
+function getReferencedNodeIdsWithFlatFallback(rel: CalmRelationship): string[] {
+  const raw = rel as unknown as Record<string, unknown>;
+  if (typeof raw['relationship-type'] === 'string') {
+    const out: string[] = [];
+    if (typeof raw.source === 'string') out.push(raw.source);
+    if (typeof raw.destination === 'string') out.push(raw.destination);
+    return out;
+  }
+  return getReferencedNodeIds(rel);
 }
 
 // ---------------------------------------------------------------------------

--- a/calm-studio/packages/web-component/src/render/index.test.ts
+++ b/calm-studio/packages/web-component/src/render/index.test.ts
@@ -39,4 +39,24 @@ describe('render entry', () => {
     const dark = await renderELKDiagram(fixture, { theme: 'dark' });
     expect(light).not.toEqual(dark);
   });
+
+  it('renders nodes-only architecture (no relationships key) without crashing', async () => {
+    const nodesOnly = {
+      nodes: [
+        { 'unique-id': 'solo', 'node-type': 'system', name: 'Solo System', description: 'Standalone' },
+      ],
+    } as unknown as CalmArchitecture;
+
+    const svg = await renderELKDiagram(nodesOnly, { theme: 'light' });
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('Solo System');
+  });
+
+  it('renders fully empty architecture (no nodes/relationships keys) as the "No nodes" placeholder', async () => {
+    const empty = {} as unknown as CalmArchitecture;
+
+    const svg = await renderELKDiagram(empty, { theme: 'light' });
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('No nodes');
+  });
 });

--- a/calm-studio/packages/web-component/src/render/index.test.ts
+++ b/calm-studio/packages/web-component/src/render/index.test.ts
@@ -14,9 +14,12 @@ const fixture = {
   relationships: [
     {
       'unique-id': 'web-to-api',
-      'relationship-type': 'connects',
-      source: 'web',
-      destination: 'api',
+      'relationship-type': {
+        connects: {
+          source: { node: 'web' },
+          destination: { node: 'api' },
+        },
+      },
       protocol: 'HTTPS',
     },
   ],

--- a/calm-studio/packages/web-component/src/render/index.test.ts
+++ b/calm-studio/packages/web-component/src/render/index.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { renderELKDiagram } from './index.js';
+import type { CalmArchitecture } from '@calmstudio/calm-core';
+
+const fixture = {
+  nodes: [
+    { 'unique-id': 'web', 'node-type': 'actor', name: 'Web Client', description: 'Browser UI' },
+    { 'unique-id': 'api', 'node-type': 'service', name: 'Trade API', description: 'Backend trade service' },
+  ],
+  relationships: [
+    {
+      'unique-id': 'web-to-api',
+      'relationship-type': 'connects',
+      source: 'web',
+      destination: 'api',
+      protocol: 'HTTPS',
+    },
+  ],
+} as CalmArchitecture;
+
+describe('render entry', () => {
+  it('renders an SVG string in a Node environment (no customElements)', async () => {
+    expect(typeof globalThis.customElements).toBe('undefined');
+    const svg = await renderELKDiagram(fixture, { theme: 'light' });
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('Web Client');
+    expect(svg).toContain('Trade API');
+  });
+
+  it('produces different output for light and dark themes', async () => {
+    const light = await renderELKDiagram(fixture, { theme: 'light' });
+    const dark = await renderELKDiagram(fixture, { theme: 'dark' });
+    expect(light).not.toEqual(dark);
+  });
+});

--- a/calm-studio/packages/web-component/src/render/index.ts
+++ b/calm-studio/packages/web-component/src/render/index.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { initAllPacks } from '@calmstudio/extensions';
+
+// Register extension packs so pack-aware node colors/icons resolve.
+// Pure data registration — safe in Node (mcp-server does the same).
+initAllPacks();
+
+export { renderELKDiagram } from './elkRender.js';
+export type { RenderOptions } from './elkRender.js';

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
@@ -17,7 +17,7 @@ describe('relationshipToEdges', () => {
     } as unknown as CalmRelationship;
 
     const edges = relationshipToEdges(rel);
-    expect(edges).toEqual([{ id: 'rel-flat', source: 'a', target: 'b', variant: 'connects' }]);
+    expect(edges).toEqual([{ id: 'rel-flat', relationshipId: 'rel-flat', source: 'a', target: 'b', variant: 'connects' }]);
   });
 
   it('rule 2: nested connects produces one edge via getConnectsEndpoints', () => {
@@ -33,7 +33,7 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-connects', source: 'web', target: 'api', variant: 'connects' },
+      { id: 'rel-connects', relationshipId: 'rel-connects', source: 'web', target: 'api', variant: 'connects' },
     ]);
   });
 
@@ -50,8 +50,8 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-interacts__0', source: 'user', target: 'svc-a', variant: 'interacts' },
-      { id: 'rel-interacts__1', source: 'user', target: 'svc-b', variant: 'interacts' },
+      { id: 'rel-interacts__0', relationshipId: 'rel-interacts', source: 'user', target: 'svc-a', variant: 'interacts' },
+      { id: 'rel-interacts__1', relationshipId: 'rel-interacts', source: 'user', target: 'svc-b', variant: 'interacts' },
     ]);
   });
 
@@ -68,7 +68,7 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-interacts-single', source: 'user', target: 'svc-a', variant: 'interacts' },
+      { id: 'rel-interacts-single', relationshipId: 'rel-interacts-single', source: 'user', target: 'svc-a', variant: 'interacts' },
     ]);
   });
 
@@ -85,8 +85,8 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-composed__0', source: 'system', target: 'svc-a', variant: 'composed-of' },
-      { id: 'rel-composed__1', source: 'system', target: 'svc-b', variant: 'composed-of' },
+      { id: 'rel-composed__0', relationshipId: 'rel-composed', source: 'system', target: 'svc-a', variant: 'composed-of' },
+      { id: 'rel-composed__1', relationshipId: 'rel-composed', source: 'system', target: 'svc-b', variant: 'composed-of' },
     ]);
   });
 
@@ -103,7 +103,7 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-deployed', source: 'cluster', target: 'svc-a', variant: 'deployed-in' },
+      { id: 'rel-deployed', relationshipId: 'rel-deployed', source: 'cluster', target: 'svc-a', variant: 'deployed-in' },
     ]);
   });
 
@@ -138,8 +138,8 @@ describe('relationshipToEdges', () => {
 
     const edges = relationshipToEdges(rel);
     expect(edges).toEqual([
-      { id: 'rel-interacts-blank__0', source: 'user', target: 'svc-a', variant: 'interacts' },
-      { id: 'rel-interacts-blank__1', source: 'user', target: 'svc-b', variant: 'interacts' },
+      { id: 'rel-interacts-blank__0', relationshipId: 'rel-interacts-blank', source: 'user', target: 'svc-a', variant: 'interacts' },
+      { id: 'rel-interacts-blank__1', relationshipId: 'rel-interacts-blank', source: 'user', target: 'svc-b', variant: 'interacts' },
     ]);
     expect(edges.every((e) => e.target.length > 0)).toBe(true);
   });
@@ -185,5 +185,48 @@ describe('renderELKDiagram with nested relationship-type (integration)', () => {
     expect(svg).toContain('<svg');
     // The nested connects relationship must expand into an actual rendered edge.
     expect(svg).toContain('<polyline');
+  });
+
+  it('flow over a multi-node interacts relationship animates all fan-out edges undimmed', async () => {
+    const arch: CalmArchitecture = {
+      nodes: [
+        { 'unique-id': 'user', 'node-type': 'actor', name: 'User', description: 'End user' },
+        { 'unique-id': 'svc-a', 'node-type': 'service', name: 'Service A', description: 'A' },
+        { 'unique-id': 'svc-b', 'node-type': 'service', name: 'Service B', description: 'B' },
+      ],
+      relationships: [
+        {
+          'unique-id': 'user-uses',
+          'relationship-type': {
+            interacts: {
+              actor: 'user',
+              nodes: ['svc-a', 'svc-b'],
+            },
+          },
+        },
+      ],
+      flows: [
+        {
+          'unique-id': 'usage-flow',
+          name: 'Usage Flow',
+          description: 'User interacts with both services',
+          transitions: [
+            {
+              'relationship-unique-id': 'user-uses',
+              'sequence-number': 1,
+              summary: 'User calls both services',
+              direction: 'source-to-destination',
+            },
+          ],
+        },
+      ],
+    };
+
+    const svg = await renderELKDiagram(arch, { theme: 'light', flow: 'usage-flow' });
+    // Both fan-out edges (ids user-uses__0 / user-uses__1) must carry the animation...
+    const animCount = (svg.match(/<animateMotion/g) ?? []).length;
+    expect(animCount).toBe(2);
+    // ...and neither may be dimmed: the only relationship present IS the flow.
+    expect(svg).not.toContain('opacity="0.3"');
   });
 });

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { relationshipToEdges } from './relationshipEdges.js';
+import { renderELKDiagram } from './elkRender.js';
+import type { CalmArchitecture, CalmRelationship } from '@calmstudio/calm-core';
+
+describe('relationshipToEdges', () => {
+  it('rule 1: legacy flat form produces one edge with the flat relationship-type as variant', () => {
+    const rel = {
+      'unique-id': 'rel-flat',
+      'relationship-type': 'connects',
+      source: 'a',
+      destination: 'b',
+    } as unknown as CalmRelationship;
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([{ id: 'rel-flat', source: 'a', target: 'b', variant: 'connects' }]);
+  });
+
+  it('rule 2: nested connects produces one edge via getConnectsEndpoints', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-connects',
+      'relationship-type': {
+        connects: {
+          source: { node: 'web' },
+          destination: { node: 'api' },
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-connects', source: 'web', target: 'api', variant: 'connects' },
+    ]);
+  });
+
+  it('rule 3: nested interacts with 2 nodes produces 2 edges with __0/__1 ids', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-interacts',
+      'relationship-type': {
+        interacts: {
+          actor: 'user',
+          nodes: ['svc-a', 'svc-b'],
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-interacts__0', source: 'user', target: 'svc-a', variant: 'interacts' },
+      { id: 'rel-interacts__1', source: 'user', target: 'svc-b', variant: 'interacts' },
+    ]);
+  });
+
+  it('rule 3: nested interacts with 1 node produces a single edge with the plain uid', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-interacts-single',
+      'relationship-type': {
+        interacts: {
+          actor: 'user',
+          nodes: ['svc-a'],
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-interacts-single', source: 'user', target: 'svc-a', variant: 'interacts' },
+    ]);
+  });
+
+  it('rule 4: nested composed-of produces container->node edges', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-composed',
+      'relationship-type': {
+        'composed-of': {
+          container: 'system',
+          nodes: ['svc-a', 'svc-b'],
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-composed__0', source: 'system', target: 'svc-a', variant: 'composed-of' },
+      { id: 'rel-composed__1', source: 'system', target: 'svc-b', variant: 'composed-of' },
+    ]);
+  });
+
+  it('rule 4: nested deployed-in produces container->node edges', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-deployed',
+      'relationship-type': {
+        'deployed-in': {
+          container: 'cluster',
+          nodes: ['svc-a'],
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-deployed', source: 'cluster', target: 'svc-a', variant: 'deployed-in' },
+    ]);
+  });
+
+  it('rule 5: nested options produces no edges', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-options',
+      'relationship-type': {
+        options: [
+          {
+            description: 'option A',
+            nodes: ['svc-a'],
+            relationships: [],
+          },
+        ],
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([]);
+  });
+
+  it('rule 6: nested connects with missing destination is defensively skipped', () => {
+    const rel = {
+      'unique-id': 'rel-missing-dest',
+      'relationship-type': {
+        connects: {
+          source: { node: 'a' },
+          destination: {},
+        },
+      },
+    } as unknown as CalmRelationship;
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([]);
+  });
+});
+
+describe('renderELKDiagram with nested relationship-type (integration)', () => {
+  it('renders an edge for the canonical nested two-node connects fixture', async () => {
+    const arch: CalmArchitecture = {
+      nodes: [
+        { 'unique-id': 'web', 'node-type': 'actor', name: 'Web Client', description: 'Browser UI' },
+        { 'unique-id': 'api', 'node-type': 'service', name: 'Trade API', description: 'Backend trade service' },
+      ],
+      relationships: [
+        {
+          'unique-id': 'web-to-api',
+          'relationship-type': {
+            connects: {
+              source: { node: 'web' },
+              destination: { node: 'api' },
+            },
+          },
+          protocol: 'HTTPS',
+        },
+      ],
+    };
+
+    const svg = await renderELKDiagram(arch, { theme: 'light' });
+    expect(svg).toContain('<svg');
+    // The nested connects relationship must expand into an actual rendered edge.
+    expect(svg).toContain('<polyline');
+  });
+});

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.test.ts
@@ -125,6 +125,25 @@ describe('relationshipToEdges', () => {
     expect(edges).toEqual([]);
   });
 
+  it('rule 3b: nested interacts with an empty-string node entry filters it via validNodes', () => {
+    const rel: CalmRelationship = {
+      'unique-id': 'rel-interacts-blank',
+      'relationship-type': {
+        interacts: {
+          actor: 'user',
+          nodes: ['svc-a', '', 'svc-b'],
+        },
+      },
+    };
+
+    const edges = relationshipToEdges(rel);
+    expect(edges).toEqual([
+      { id: 'rel-interacts-blank__0', source: 'user', target: 'svc-a', variant: 'interacts' },
+      { id: 'rel-interacts-blank__1', source: 'user', target: 'svc-b', variant: 'interacts' },
+    ]);
+    expect(edges.every((e) => e.target.length > 0)).toBe(true);
+  });
+
   it('rule 6: nested connects with missing destination is defensively skipped', () => {
     const rel = {
       'unique-id': 'rel-missing-dest',

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getConnectsEndpoints,
+  getContainerAndNodes,
+  getActorAndNodes,
+  getRelationshipVariant,
+  type CalmRelationship,
+} from '@calmstudio/calm-core';
+
+/**
+ * A single renderable edge derived from a CALM relationship. One relationship
+ * can expand into zero, one, or many edges depending on its variant (e.g. an
+ * `interacts` relationship with N nodes expands into N edges).
+ */
+export interface DiagramEdge {
+  id: string;
+  source: string;
+  target: string;
+  variant: string;
+}
+
+/** True when `rel` uses the legacy flat CalmStudio shape (never valid CALM). */
+function isFlatRelationship(
+  rel: CalmRelationship
+): rel is CalmRelationship & { source: string; destination: string } {
+  const raw = rel as unknown as Record<string, unknown>;
+  return (
+    typeof raw['relationship-type'] === 'string' &&
+    typeof raw.source === 'string' &&
+    typeof raw.destination === 'string'
+  );
+}
+
+/**
+ * Expand a CALM relationship into zero or more diagram edges.
+ *
+ * Handles both the canonical nested `relationship-type` object (connects,
+ * interacts, composed-of, deployed-in, options) and the legacy flat
+ * CalmStudio shape as a fallback. Defensive: any edge with a missing
+ * endpoint id is skipped rather than emitted with an undefined id, since
+ * ELK crashes or produces garbage on undefined node references.
+ *
+ * @param rel - The CALM relationship to expand
+ * @returns Array of diagram edges (possibly empty)
+ */
+export function relationshipToEdges(rel: CalmRelationship): DiagramEdge[] {
+  const uid = rel['unique-id'];
+
+  if (isFlatRelationship(rel)) {
+    const raw = rel as unknown as Record<string, unknown>;
+    const variant = raw['relationship-type'] as string;
+    if (!rel.source || !rel.destination) return [];
+    return [{ id: uid, source: rel.source, target: rel.destination, variant }];
+  }
+
+  const rt = rel['relationship-type'];
+  const variant = getRelationshipVariant(rt);
+
+  switch (variant) {
+    case 'connects': {
+      const endpoints = getConnectsEndpoints(rel);
+      if (!endpoints || !endpoints.source || !endpoints.destination) return [];
+      return [{ id: uid, source: endpoints.source, target: endpoints.destination, variant }];
+    }
+    case 'interacts': {
+      const actorAndNodes = getActorAndNodes(rel);
+      if (!actorAndNodes || !actorAndNodes.actor) return [];
+      return buildFanOutEdges(uid, actorAndNodes.actor, actorAndNodes.nodes, variant);
+    }
+    case 'composed-of':
+    case 'deployed-in': {
+      const containerAndNodes = getContainerAndNodes(rel);
+      if (!containerAndNodes || !containerAndNodes.container) return [];
+      return buildFanOutEdges(uid, containerAndNodes.container, containerAndNodes.nodes, variant);
+    }
+    case 'options':
+    default:
+      return [];
+  }
+}
+
+/**
+ * Build one edge per target node from a single source (actor/container).
+ * Uses the plain `uid` when there is exactly one target node (preserving
+ * flow-overlay matching against `relationship-unique-id`), else suffixes
+ * with `__${index}` for each node.
+ */
+function buildFanOutEdges(
+  uid: string,
+  source: string,
+  nodes: string[],
+  variant: string
+): DiagramEdge[] {
+  const validNodes = (nodes ?? []).filter((n): n is string => typeof n === 'string' && n.length > 0);
+  if (validNodes.length === 0) return [];
+  const [firstNode] = validNodes;
+  if (validNodes.length === 1 && firstNode !== undefined) {
+    return [{ id: uid, source, target: firstNode, variant }];
+  }
+  return validNodes.map((target, index) => ({
+    id: `${uid}__${index}`,
+    source,
+    target,
+    variant,
+  }));
+}

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.ts
@@ -16,7 +16,10 @@ import {
  * `interacts` relationship with N nodes expands into N edges).
  */
 export interface DiagramEdge {
+  /** Unique render id for ELK/SVG (suffixed `__${index}` when a relationship fans out). */
   id: string;
+  /** The source relationship's `unique-id` — what flows reference. Identity survives fan-out. */
+  relationshipId: string;
   source: string;
   target: string;
   variant: string;
@@ -53,7 +56,7 @@ export function relationshipToEdges(rel: CalmRelationship): DiagramEdge[] {
     const raw = rel as unknown as Record<string, unknown>;
     const variant = raw['relationship-type'] as string;
     if (!rel.source || !rel.destination) return [];
-    return [{ id: uid, source: rel.source, target: rel.destination, variant }];
+    return [{ id: uid, relationshipId: uid, source: rel.source, target: rel.destination, variant }];
   }
 
   const rt = rel['relationship-type'];
@@ -63,7 +66,7 @@ export function relationshipToEdges(rel: CalmRelationship): DiagramEdge[] {
     case 'connects': {
       const endpoints = getConnectsEndpoints(rel);
       if (!endpoints || !endpoints.source || !endpoints.destination) return [];
-      return [{ id: uid, source: endpoints.source, target: endpoints.destination, variant }];
+      return [{ id: uid, relationshipId: uid, source: endpoints.source, target: endpoints.destination, variant }];
     }
     case 'interacts': {
       const actorAndNodes = getActorAndNodes(rel);
@@ -98,10 +101,11 @@ function buildFanOutEdges(
   if (validNodes.length === 0) return [];
   const [firstNode] = validNodes;
   if (validNodes.length === 1 && firstNode !== undefined) {
-    return [{ id: uid, source, target: firstNode, variant }];
+    return [{ id: uid, relationshipId: uid, source, target: firstNode, variant }];
   }
   return validNodes.map((target, index) => ({
     id: `${uid}__${index}`,
+    relationshipId: uid,
     source,
     target,
     variant,

--- a/calm-studio/packages/web-component/vite.config.iife.ts
+++ b/calm-studio/packages/web-component/vite.config.iife.ts
@@ -14,15 +14,13 @@ export default defineConfig({
     }),
   ],
   build: {
+    emptyOutDir: false, // ES build already wrote dist/
     lib: {
-      entry: {
-        'calm-diagram.es': 'src/index.ts',
-        'render.es': 'src/render/index.ts',
-      },
-      formats: ['es'],
-      fileName: (_format, entryName) => `${entryName}.js`,
+      entry: 'src/index.ts',
+      name: 'CalmDiagram',
+      formats: ['iife'],
+      fileName: () => 'calm-diagram.iife.js',
     },
-    // Bundle everything — zero-dependency CDN use
     rollupOptions: {},
   },
 });

--- a/calm-studio/packages/web-component/vite.config.render-cjs.ts
+++ b/calm-studio/packages/web-component/vite.config.render-cjs.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // `render` is a Node-only (no DOM) entry point used by build-time tooling
-// (e.g. @calmstudio/docusaurus-plugin's webpack loader, which is bundled as
+// (e.g. @finos/calm-docusaurus-plugin's webpack loader, which is bundled as
 // CJS). The default `vite.config.ts` only emits an ES module for `render`,
 // which is unreachable from a plain Node `require()` call. This config adds
 // a CJS build so consumers using `require('@calmstudio/diagram/render')`

--- a/calm-studio/packages/web-component/vite.config.render-cjs.ts
+++ b/calm-studio/packages/web-component/vite.config.render-cjs.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// `render` is a Node-only (no DOM) entry point used by build-time tooling
+// (e.g. @calmstudio/docusaurus-plugin's webpack loader, which is bundled as
+// CJS). The default `vite.config.ts` only emits an ES module for `render`,
+// which is unreachable from a plain Node `require()` call. This config adds
+// a CJS build so consumers using `require('@calmstudio/diagram/render')`
+// resolve correctly.
+export default defineConfig({
+  plugins: [
+    svelte({
+      compilerOptions: {
+        customElement: true,
+      },
+    }),
+  ],
+  build: {
+    emptyOutDir: false, // ES + iife builds already wrote dist/
+    lib: {
+      entry: 'src/render/index.ts',
+      formats: ['cjs'],
+      fileName: () => 'render.cjs',
+    },
+    rollupOptions: {},
+  },
+});

--- a/calm-studio/packages/web-component/vite.config.render-es.ts
+++ b/calm-studio/packages/web-component/vite.config.render-es.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // `render` is a Node-only (no DOM) entry point used by build-time tooling
-// (e.g. @calmstudio/docusaurus-plugin's remark/loader code, which imports it
+// (e.g. @finos/calm-docusaurus-plugin's remark/loader code, which imports it
 // as an ES module). Built as its own single-entry bundle so it does not share
 // a chunk with the main `calm-diagram.es.js` CDN bundle (see vite.config.ts).
 export default defineConfig({

--- a/calm-studio/packages/web-component/vite.config.render-es.ts
+++ b/calm-studio/packages/web-component/vite.config.render-es.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// `render` is a Node-only (no DOM) entry point used by build-time tooling
+// (e.g. @calmstudio/docusaurus-plugin's remark/loader code, which imports it
+// as an ES module). Built as its own single-entry bundle so it does not share
+// a chunk with the main `calm-diagram.es.js` CDN bundle (see vite.config.ts).
+export default defineConfig({
+  plugins: [
+    svelte({
+      compilerOptions: {
+        customElement: true,
+      },
+    }),
+  ],
+  build: {
+    emptyOutDir: false, // ES + iife builds already wrote dist/
+    lib: {
+      entry: 'src/render/index.ts',
+      formats: ['es'],
+      fileName: () => 'render.es.js',
+    },
+    rollupOptions: {},
+  },
+});

--- a/calm-studio/packages/web-component/vite.config.ts
+++ b/calm-studio/packages/web-component/vite.config.ts
@@ -15,12 +15,9 @@ export default defineConfig({
   ],
   build: {
     lib: {
-      entry: {
-        'calm-diagram.es': 'src/index.ts',
-        'render.es': 'src/render/index.ts',
-      },
+      entry: 'src/index.ts',
       formats: ['es'],
-      fileName: (_format, entryName) => `${entryName}.js`,
+      fileName: () => 'calm-diagram.es.js',
     },
     // Bundle everything — zero-dependency CDN use
     rollupOptions: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -804,7 +804,7 @@
             }
         },
         "calm-studio/packages/docusaurus-plugin": {
-            "name": "@calmstudio/docusaurus-plugin",
+            "name": "@finos/calm-docusaurus-plugin",
             "version": "0.0.0",
             "dependencies": {
                 "@calmstudio/diagram": "*",
@@ -3931,10 +3931,6 @@
         },
         "node_modules/@calmstudio/diagram": {
             "resolved": "calm-studio/packages/web-component",
-            "link": true
-        },
-        "node_modules/@calmstudio/docusaurus-plugin": {
-            "resolved": "calm-studio/packages/docusaurus-plugin",
             "link": true
         },
         "node_modules/@calmstudio/extensions": {
@@ -10469,6 +10465,10 @@
         },
         "node_modules/@finos/calm-cli": {
             "resolved": "cli",
+            "link": true
+        },
+        "node_modules/@finos/calm-docusaurus-plugin": {
+            "resolved": "calm-studio/packages/docusaurus-plugin",
             "link": true
         },
         "node_modules/@finos/calm-models": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -803,6 +803,34 @@
                 }
             }
         },
+        "calm-studio/packages/docusaurus-plugin": {
+            "name": "@calmstudio/docusaurus-plugin",
+            "version": "0.0.0",
+            "dependencies": {
+                "@calmstudio/diagram": "*",
+                "unist-util-visit": "^5.0.0"
+            },
+            "devDependencies": {
+                "@docusaurus/types": "3.9.2",
+                "@mdx-js/mdx": "^3.1.0",
+                "@types/mdast": "^4.0.4",
+                "@types/react": "^19.1.0",
+                "@vitest/coverage-v8": "^4.1.0",
+                "mdast-util-mdx-jsx": "^3.2.0",
+                "mdast-util-mdxjs-esm": "^2.0.1",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0",
+                "tsup": "^8.5.1",
+                "typescript": "^5.9.3",
+                "unified": "^11.0.5",
+                "vitest": "^4.1.0",
+                "webpack": "^5.99.5"
+            },
+            "peerDependencies": {
+                "@docusaurus/core": ">=3.0.0",
+                "react": ">=18.0.0"
+            }
+        },
         "calm-studio/packages/extensions": {
             "name": "@calmstudio/extensions",
             "version": "0.0.0",
@@ -3903,6 +3931,10 @@
         },
         "node_modules/@calmstudio/diagram": {
             "resolved": "calm-studio/packages/web-component",
+            "link": true
+        },
+        "node_modules/@calmstudio/docusaurus-plugin": {
+            "resolved": "calm-studio/packages/docusaurus-plugin",
             "link": true
         },
         "node_modules/@calmstudio/extensions": {


### PR DESCRIPTION
## Description

New package **`@calmstudio/docusaurus-plugin`** (under `calm-studio/packages/`) — embed CALM architecture diagrams directly in Docusaurus MDX pages, the same way Mermaid diagrams embed today, but driven by real, validatable `.calm.json` files:

```mdx
import { CalmDiagram } from '@calmstudio/docusaurus-plugin'

<CalmDiagram src="./architectures/loan-approval.calm.json" />
```

How it works:
- An async webpack loader pre-renders each `.calm.json` to static SVG at build time (light + dark variants) — SEO-friendly, works without JavaScript, instant paint, follows the site theme via `html[data-theme]` CSS.
- A remark plugin rewrites relative `src` paths into hoisted imports, so authors write plain paths.
- The React `<CalmDiagram>` component SSRs the static SVG and lazily upgrades client-side to the existing `@calmstudio/diagram` web component (zoom, pan, node tooltips, flow animation). `interactive={false}` keeps the static SVG with zero client JS.
- Invalid or unrenderable `.calm.json` fails the docs build with the offending file path — architecture drift is caught in CI, exactly like broken Mermaid.

Also includes a standalone bug fix in `@calmstudio/diagram`: the renderer only understood a legacy flat `relationship-type` shape, so **canonical CALM documents rendered with zero edges**. It now expands the nested `connects` / `interacts` / `composed-of` / `deployed-in` variants via the `@calmstudio/calm-core` accessors (flat shape kept as fallback), and tolerates schema-valid documents missing top-level `nodes` / `relationships`.

Supporting changes: node-safe `./render` (+CJS) export on `@calmstudio/diagram` so build tools can render without `customElements`; single-file ES bundle preserved for CDN use; CI wiring (release workflow, studio build workflow, and docs workflows build the new package — no-ops until the docs site adopts it in the follow-up PR).

Part of #2853. Follow-up PR dogfoods the plugin on the root `docs/` site with a real architecture (screenshot in the issue).

Notes for reviewers:
- `package-lock.json` includes removal of a stale `"extraneous": true` `calmguard-docs` ghost entry — benign npm tree recompute from registering the new workspace.
- `@calmstudio/diagram` has 17 pre-existing `tsc --noEmit` errors on `main` (legacy flat-shape test files); this PR does not add to them (net −3) and deliberately does not add that package's typecheck to CI.
- `showValidation` prop from the original idea is deferred (needs validation UI in the web component first).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components

- [x] CALM Studio (`calm-studio/`) — new `packages/docusaurus-plugin`, fixes in `packages/web-component`
- [x] CI/CD (`.github/workflows/`)

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Evidence: `@calmstudio/diagram` 31/31, `@calmstudio/docusaurus-plugin` 21/21 (loader, remark rewrite, SSR render paths, plugin wiring, relationship-edge expansion incl. defensive paths), full monorepo `npm test` exit 0, `npm run lint` 0 errors. End-to-end: root docs site built with the plugin + a real architecture — static SVG present in the emitted HTML for both themes (that adoption ships in the follow-up PR).

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary (package README with install/config/props/error behavior)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
