### PR TITLE
docs(calm-ai): warn agents against self-installing a browser for --export-diagrams

### DIFF
--- a/calm-ai/tools/calm-cli-instructions.md
+++ b/calm-ai/tools/calm-cli-instructions.md
@@ -166,6 +166,7 @@ calm docify -a architecture.json -o docs/output --export-diagrams svg
 - `--diagram-render-timeout <ms>`: per-diagram render timeout (default `30000`).
 - Adds roughly 10-40 seconds to the command depending on the number of diagrams.
 - If no browser is found, or a diagram fails to render (timeout/invalid syntax), that diagram is left as a Mermaid code block with a warning logged; the rest of the documentation is unaffected. An invalid `--browser-path` is a fatal error.
+- On headless or locked-down Linux dev boxes (common in corporate environments), automatic detection will usually fail because no GUI browser is installed — this is expected and non-fatal. **Do not attempt to install a browser (e.g. `apt-get install chromium`) yourself.** Tell the user, and let them decide whether to supply `--browser-path` to an existing browser or skip diagram export.
 
 ### Using `--url-to-local-file-mapping`
 


### PR DESCRIPTION
## Description
Follow-up to #2810. On headless or locked-down Linux dev boxes (common in corporate environments), `calm docify --export-diagrams` automatic browser detection will usually fail because no GUI browser is installed. This is expected and non-fatal (the command still succeeds, diagrams are just left as Mermaid code blocks), but the CLI's own diagnostic hints are written for a human troubleshooting the issue and do not say "don't install one yourself" - an AI agent under task-completion pressure could reasonably read them as license to attempt a system-level browser install (e.g. `apt-get install chromium`) without asking.

This adds one bullet to the `calm-ai` docify instructions making explicit that agents should recognize this failure mode, not attempt to install a browser themselves, and ask the user how they want to proceed (supply `--browser-path` or skip diagram export).

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [x] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format
`docs(calm-ai): warn agents against self-installing a browser for --export-diagrams`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Documentation-only change (markdown consumed as-is by `calm init-ai`); no code paths affected.

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
