### PR TITLE
fix(shared): don't swallow malformed 200 bodies into [] in calm-hub-client

### DIFF
--- a/shared/src/hub/calm-hub-client.spec.ts
+++ b/shared/src/hub/calm-hub-client.spec.ts
@@ -91,6 +91,12 @@ describe('CalmHubClient', () => {
                 request: 'GET /api/calm/namespaces'
             });
         });
+
+        it('throws HubClientError instead of returning [] when the 200 body is a literal null', async () => {
+            mock.onGet('/api/calm/namespaces').reply(200, null);
+
+            await expect(client.listNamespaces()).rejects.toBeInstanceOf(HubClientError);
+        });
     });
 
     // ── auth plugin ──────────────────────────────────────────────────────────

--- a/shared/src/hub/calm-hub-client.spec.ts
+++ b/shared/src/hub/calm-hub-client.spec.ts
@@ -82,6 +82,15 @@ describe('CalmHubClient', () => {
                 request: 'GET /api/calm/namespaces'
             });
         });
+
+        it('throws HubClientError instead of returning [] when the 200 body is not an object (e.g. an auth gateway login page)', async () => {
+            mock.onGet('/api/calm/namespaces').reply(200, '<html>please log in</html>');
+
+            await expect(client.listNamespaces()).rejects.toBeInstanceOf(HubClientError);
+            await expect(client.listNamespaces()).rejects.toMatchObject({
+                request: 'GET /api/calm/namespaces'
+            });
+        });
     });
 
     // ── auth plugin ──────────────────────────────────────────────────────────
@@ -138,6 +147,23 @@ describe('CalmHubClient', () => {
             const [, requestBody] = getAuthHeaders.mock.calls[0];
             expect(requestBody).toMatchObject(body);
         });
+
+        it('rejects (rather than resolving with []) when the auth plugin fails to produce credentials', async () => {
+            getAuthHeaders.mockRejectedValue(new Error('failed to refresh token'));
+            // No mock registered for the endpoint: if the failure were swallowed and the request
+            // went out anyway, axios-mock-adapter would 404 rather than the assertion catching it -
+            // asserting on the rejection itself is what proves the plugin failure surfaces.
+            await expect(authClient.listNamespaces()).rejects.toThrow('failed to refresh token');
+        });
+
+        it('surfaces a real 401 from the Hub as an error, not an empty result', async () => {
+            authMock.onGet('/api/calm/namespaces').reply(401, { error: 'Unauthorized' });
+
+            await expect(authClient.listNamespaces()).rejects.toMatchObject({
+                status: 401,
+                error: 'Unauthorized'
+            });
+        });
     });
 
     // ── createDomain ─────────────────────────────────────────────────────────
@@ -180,6 +206,11 @@ describe('CalmHubClient', () => {
             const result = await client.listDomains();
             expect(result).toEqual([]);
         });
+
+        it('throws HubClientError instead of returning [] when the 200 body is not an object', async () => {
+            mock.onGet('/calm/domains').reply(200, '<html>please log in</html>');
+            await expect(client.listDomains()).rejects.toBeInstanceOf(HubClientError);
+        });
     });
 
     // ── listControls ───────────────────────────────────────────────────────────
@@ -213,6 +244,11 @@ describe('CalmHubClient', () => {
                 request: 'GET /calm/domains/security/controls'
             });
         });
+
+        it('throws HubClientError instead of returning [] when the 200 body is not an object', async () => {
+            mock.onGet('/calm/domains/security/controls').reply(200, '<html>please log in</html>');
+            await expect(client.listControls('security')).rejects.toBeInstanceOf(HubClientError);
+        });
     });
 
     // ── listControlConfigurations ──────────────────────────────────────────────
@@ -231,6 +267,11 @@ describe('CalmHubClient', () => {
             mock.onGet('/calm/domains/security/controls/access-control/configurations').reply(200, {});
             const result = await client.listControlConfigurations('security', 'access-control');
             expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError instead of returning [] when the 200 body is not an object', async () => {
+            mock.onGet('/calm/domains/security/controls/access-control/configurations').reply(200, '<html>please log in</html>');
+            await expect(client.listControlConfigurations('security', 'access-control')).rejects.toBeInstanceOf(HubClientError);
         });
     });
 
@@ -255,6 +296,16 @@ describe('CalmHubClient', () => {
                 status: 500,
                 request: `GET ${endpoint}`
             });
+        });
+
+        it('returns [] on a genuine 404 (requirement does not exist)', async () => {
+            mock.onGet(endpoint).reply(404, 'Not found');
+            expect(await client.getControlRequirementVersions('security', 'access-control')).toEqual([]);
+        });
+
+        it('throws HubClientError instead of returning [] when a 200 body is not an object', async () => {
+            mock.onGet(endpoint).reply(200, '<html>please log in</html>');
+            await expect(client.getControlRequirementVersions('security', 'access-control')).rejects.toBeInstanceOf(HubClientError);
         });
     });
 
@@ -318,6 +369,16 @@ describe('CalmHubClient', () => {
                 status: 500,
                 request: `GET ${endpoint}`
             });
+        });
+
+        it('returns [] on a genuine 404 (configuration does not exist)', async () => {
+            mock.onGet(endpoint).reply(404, 'Not found');
+            expect(await client.getControlConfigurationVersions('security', 'access-control', 'prod')).toEqual([]);
+        });
+
+        it('throws HubClientError instead of returning [] when a 200 body is not an object', async () => {
+            mock.onGet(endpoint).reply(200, '<html>please log in</html>');
+            await expect(client.getControlConfigurationVersions('security', 'access-control', 'prod')).rejects.toBeInstanceOf(HubClientError);
         });
     });
 
@@ -396,6 +457,11 @@ describe('CalmHubClient', () => {
                 request: 'GET /calm/namespaces/finos/architectures'
             });
         });
+
+        it('throws HubClientError instead of returning [] when the 200 body is not an object', async () => {
+            mock.onGet('/calm/namespaces/finos/architectures').reply(200, '<html>please log in</html>');
+            await expect(client.getNamespaceMappings('finos', 'architectures')).rejects.toBeInstanceOf(HubClientError);
+        });
     });
 
     // ── createNewMappedResource ───────────────────────────────────────────────
@@ -472,6 +538,16 @@ describe('CalmHubClient', () => {
                 status: 500,
                 request: 'GET /calm/namespaces/finos/architectures/my-arch/versions'
             });
+        });
+
+        it('returns [] on a genuine 404 (mapping does not exist)', async () => {
+            mock.onGet('/calm/namespaces/finos/architectures/my-arch/versions').reply(404, 'Not found');
+            expect(await client.getMappedResourceVersions('finos', 'my-arch', 'architectures')).toEqual([]);
+        });
+
+        it('throws HubClientError instead of returning [] when a 200 body is not an object', async () => {
+            mock.onGet('/calm/namespaces/finos/architectures/my-arch/versions').reply(200, '<html>please log in</html>');
+            await expect(client.getMappedResourceVersions('finos', 'my-arch', 'architectures')).rejects.toBeInstanceOf(HubClientError);
         });
     });
 

--- a/shared/src/hub/calm-hub-client.ts
+++ b/shared/src/hub/calm-hub-client.ts
@@ -1,4 +1,4 @@
-import axios, { Axios, AxiosError } from 'axios';
+import axios, { Axios } from 'axios';
 import { AuthPlugin } from '../auth/auth-plugin';
 import { initLogger, Logger } from '../logger';
 import { DocumentMetadata, extractDocumentMetadata, validateDocumentId } from './document-id-utils';
@@ -128,8 +128,7 @@ export class CalmHubClient {
         const endpoint = 'GET /api/calm/namespaces';
         try {
             const response = await this.ax.get('/api/calm/namespaces');
-            const values: HubNamespaceSummary[] = response.data?.values ?? [];
-            return values;
+            return this.extractValues<HubNamespaceSummary>(response.data, endpoint);
         } catch (err) {
             throw this.wrapError(err, endpoint);
         }
@@ -160,7 +159,7 @@ export class CalmHubClient {
         const endpoint = '/calm/domains';
         try {
             const response = await this.ax.get(endpoint);
-            const names: string[] = response.data?.values ?? [];
+            const names = this.extractValues<string>(response.data, `GET ${endpoint}`);
             return names.map(name => ({ name }));
         } catch (err) {
             throw this.wrapError(err, `GET ${endpoint}`);
@@ -178,7 +177,7 @@ export class CalmHubClient {
         const endpoint = `/calm/domains/${domain}/controls`;
         try {
             const response = await this.ax.get(endpoint);
-            return (response.data?.values ?? []) as HubControlSummary[];
+            return this.extractValues<HubControlSummary>(response.data, `GET ${endpoint}`);
         } catch (err) {
             throw this.wrapError(err, `GET ${endpoint}`);
         }
@@ -194,7 +193,7 @@ export class CalmHubClient {
         const endpoint = `/calm/domains/${domain}/controls/${controlName}/configurations`;
         try {
             const response = await this.ax.get(endpoint);
-            return (response.data?.values ?? []) as HubControlSummary[];
+            return this.extractValues<HubControlSummary>(response.data, `GET ${endpoint}`);
         } catch (err) {
             throw this.wrapError(err, `GET ${endpoint}`);
         }
@@ -209,9 +208,9 @@ export class CalmHubClient {
         const endpoint = `/calm/domains/${domain}/controls/${controlName}/requirement/versions`;
         try {
             const response = await this.ax.get(endpoint);
-            return (response.data?.values ?? []) as string[];
+            return this.extractValues<string>(response.data, `GET ${endpoint}`);
         } catch (err) {
-            if (err instanceof AxiosError && err.status === 404) {
+            if (axios.isAxiosError(err) && err.status === 404) {
                 return [];
             }
             throw this.wrapError(err, `GET ${endpoint}`);
@@ -262,9 +261,9 @@ export class CalmHubClient {
         const endpoint = `/calm/domains/${domain}/controls/${controlName}/configurations/${configName}/versions`;
         try {
             const response = await this.ax.get(endpoint);
-            return (response.data?.values ?? []) as string[];
+            return this.extractValues<string>(response.data, `GET ${endpoint}`);
         } catch (err) {
-            if (err instanceof AxiosError && err.status === 404) {
+            if (axios.isAxiosError(err) && err.status === 404) {
                 return [];
             }
             throw this.wrapError(err, `GET ${endpoint}`);
@@ -313,7 +312,8 @@ export class CalmHubClient {
         try {
             const response = await this.ax.get(endpoint);
             this.logger.debug(`Received mappings response: ${JSON.stringify(response.data)}`);
-            return (response.data?.values ?? []).map((item: { customId: string }) => item.customId);
+            const items = this.extractValues<{ customId: string }>(response.data, `GET ${endpoint}`);
+            return items.map(item => item.customId);
         } catch (err) {
             throw this.wrapError(err, `GET ${endpoint}`);
         }
@@ -361,12 +361,10 @@ export class CalmHubClient {
         try {
             const response = await this.ax.get(endpoint);
             this.logger.debug(`Received mapped resource versions response: ${JSON.stringify(response.data)}`);
-            return (response.data?.values ?? []) as string[];
+            return this.extractValues<string>(response.data, `GET ${endpoint}`);
         } catch (err) {
-            if (err instanceof AxiosError) {
-                if (err.status === 404) {
-                    return [];
-                }
+            if (axios.isAxiosError(err) && err.status === 404) {
+                return [];
             }
             throw this.wrapError(err, `GET ${endpoint}`);
         }
@@ -396,6 +394,29 @@ export class CalmHubClient {
         }
     }
     
+    /**
+     * Extracts the `values` array from a Hub list-response body, treating an object with no
+     * `values` key (or no body at all) as a legitimately empty list. Anything that isn't a
+     * plain object - e.g. a string body - is rejected rather than silently swallowed, since a
+     * 200 response that doesn't look like Hub JSON is more likely an auth gateway/proxy
+     * returning a login page for a failed/expired credential than an actual empty result.
+     * @param data Response body.
+     * @param endpoint Endpoint label for error context.
+     * @returns The extracted values array, or [] when absent.
+     */
+    private extractValues<T>(data: unknown, endpoint: string): T[] {
+        if (data === undefined || data === null) {
+            return [];
+        }
+        if (typeof data !== 'object' || Array.isArray(data)) {
+            const bodyHint = typeof data === 'string'
+                ? ' - received a string body, which may indicate an auth gateway returned a login page instead of a valid response'
+                : ` - received a ${typeof data} body`;
+            throw new HubClientError(0, `Unexpected response body from CALM Hub: expected an object with a "values" array${bodyHint}`, endpoint);
+        }
+        return (data as { values?: T[] }).values ?? [];
+    }
+
     /**
      * Converts unknown errors into HubClientError with endpoint context.
      * @param err Unknown thrown value.

--- a/shared/src/hub/calm-hub-client.ts
+++ b/shared/src/hub/calm-hub-client.ts
@@ -396,22 +396,23 @@ export class CalmHubClient {
     
     /**
      * Extracts the `values` array from a Hub list-response body, treating an object with no
-     * `values` key (or no body at all) as a legitimately empty list. Anything that isn't a
-     * plain object - e.g. a string body - is rejected rather than silently swallowed, since a
-     * 200 response that doesn't look like Hub JSON is more likely an auth gateway/proxy
-     * returning a login page for a failed/expired credential than an actual empty result.
+     * `values` key (or a genuinely absent body) as a legitimately empty list. Anything else -
+     * a string, `null`, an array, or another non-object - is rejected rather than silently
+     * swallowed, since a 200 response that doesn't look like Hub JSON is more likely an auth
+     * gateway/proxy returning a login page for a failed/expired credential than an actual
+     * empty result.
      * @param data Response body.
      * @param endpoint Endpoint label for error context.
      * @returns The extracted values array, or [] when absent.
      */
     private extractValues<T>(data: unknown, endpoint: string): T[] {
-        if (data === undefined || data === null) {
+        if (data === undefined) {
             return [];
         }
-        if (typeof data !== 'object' || Array.isArray(data)) {
+        if (data === null || typeof data !== 'object' || Array.isArray(data)) {
             const bodyHint = typeof data === 'string'
                 ? ' - received a string body, which may indicate an auth gateway returned a login page instead of a valid response'
-                : ` - received a ${typeof data} body`;
+                : ` - received a ${data === null ? 'null' : typeof data} body`;
             throw new HubClientError(0, `Unexpected response body from CALM Hub: expected an object with a "values" array${bodyHint}`, endpoint);
         }
         return (data as { values?: T[] }).values ?? [];


### PR DESCRIPTION
## Description
List-style `CalmHubClient` methods (`listNamespaces`, `listDomains`, `listControls`, `listControlConfigurations`, `getNamespaceMappings`, `getControlRequirementVersions`, `getControlConfigurationVersions`, `getMappedResourceVersions`) defaulted to `[]` whenever a 200 response lacked a `values` array. That can't distinguish a genuinely empty Hub list from a 200 response that doesn't look like Hub JSON at all - e.g. an SSO gateway or reverse-proxy returning a login page instead of a real 401 when a credential/`AuthPlugin` fails. Added an `extractValues()` helper so only a plain object is treated as possibly-empty; anything else (string/array/other primitive) now throws a `HubClientError` instead of silently reporting "no results".

Also replaced the `err instanceof AxiosError` 404 checks (in `getControlRequirementVersions`, `getControlConfigurationVersions`, `getMappedResourceVersions`) with `axios.isAxiosError(err)`, matching `wrapError`'s existing duck-typed check - `instanceof` is unreliable across module-instance boundaries (reproduced with `axios-mock-adapter` under Vitest; a real risk in any bundler setup with more than one loaded copy of `axios`).

`calm-hub-client.ts`'s error propagation for genuine 401/403/500 responses was already correct - verified via source review of `calm-hub`'s security layer (always returns proper 401/403, never a disguised 404) and the client's `wrapError`. This PR is specifically about the 200-with-unexpected-body gap and the `instanceof` fragility.

Fixes #2861

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] Shared (`shared/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added regression tests in `calm-hub-client.spec.ts` covering: malformed/non-object 200 bodies now throwing for every affected method, a failing `AuthPlugin.getAuthHeaders()` correctly rejecting rather than resolving to `[]`, and a real 401 from Hub still surfacing as an error. Full `shared` (1069 tests) and `cli` (624 tests) suites pass; `npm run build:shared` and lint are clean.

## Checklist
- [x] My commits follow the conventional commit format
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards