### PR TITLE
chore(deps): patch npm security vulnerabilities in vscode screenshots tool

### DIFF
--- a/calm-plugins/vscode/screenshots/README.md
+++ b/calm-plugins/vscode/screenshots/README.md
@@ -14,7 +14,7 @@ You **do not** need to run it for every PR — only when extension UI or documen
 
 ## Prerequisites
 
-- Node 22 (see root `AGENTS.md` for the Node-version policy).
+- Node 26 (see root `AGENTS.md` for the Node-version policy).
 - The extension must be built. From the repo root:
   ```bash
   npm run build --workspace calm-plugins/vscode

--- a/calm-plugins/vscode/screenshots/package-lock.json
+++ b/calm-plugins/vscode/screenshots/package-lock.json
@@ -549,9 +549,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -630,9 +630,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1789,16 +1789,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/call-bind": {
@@ -2517,9 +2517,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2598,9 +2598,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3669,9 +3669,9 @@
             "license": "ISC"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {

--- a/calm-plugins/vscode/screenshots/package.json
+++ b/calm-plugins/vscode/screenshots/package.json
@@ -23,5 +23,10 @@
         "tsx": "^4.19.0",
         "typescript": "^5.5.0",
         "vitest": "^4.0.0"
+    },
+    "overrides": {
+        "brace-expansion@^1.0.0": "^1.1.16",
+        "brace-expansion@^5.0.0": "^5.0.7",
+        "js-yaml@^4.0.0": "^4.3.0"
     }
 }


### PR DESCRIPTION
## Description

Patches the open Dependabot npm alerts that live in the **VSCode screenshots dev tool** (`calm-plugins/vscode/screenshots`). That tool is a deliberately **standalone, non-workspace** npm project — it is kept out of the root `workspaces` array so a plain `npm install` doesn't pull Playwright (~150 MB) into every contributor's tree (see its `AGENTS.md`). Because it has its **own** `package-lock.json`, it does **not** inherit the repo-root `overrides` (including the existing `brace-expansion@^1.0.0` root pin), so Dependabot still flagged it here.

Fixes are applied as **scoped `overrides` in that project's own `package.json`** and its lockfile regenerated. All are transitive dev-only dependencies, and each patched version sits within its parent's declared range (`minimatch` → `brace-expansion`, `@eslint/eslintrc` → `js-yaml`).

| Advisory | Package | Severity | From → To | Method |
|---|---|---|---|---|
| GHSA-3jxr-9vmj-r5cp (CVE-2026-13149) | brace-expansion (1.x line) | High | 1.1.15 → 1.1.16 | centralised override |
| GHSA-3jxr-9vmj-r5cp (CVE-2026-13149) | brace-expansion (5.x line) | High | 5.0.6 → 5.0.8 | centralised override |
| GHSA-52cp-r559-cp3m (CVE-2026-59869) | js-yaml | High | 4.2.0 → 4.3.0 | centralised override |

Also bumps a stale **Node 22 → Node 26** reference in the tool's `README.md` to match the repo's canonical Node version (`.nvmrc` → 26.3.1).

## Type of Change
- [x] 📚 Documentation update
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Documentation (`docs/`)
- [x] Dependencies
- [x] VS Code Extension (`calm-plugins/vscode/`)

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified on Node 26.3.1 from a clean worktree:
- `npm install --package-lock-only` + `npm ci` — lockfile resolves cleanly
- `npm audit` — **0 vulnerabilities** (was 3)
- `npm run typecheck` — pass
- `npm run lint` — pass

The tool's full smoke test (`npm run test`) downloads a pinned ~210 MB VSCode build and drives it via Playwright Electron; that path is unchanged by dev-dependency bumps and was not exercised in this environment.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

## Not addressed

Two open alerts are **transitive-blocked** — the patched version cannot be reached without a major upstream bump, so they are intentionally out of scope for this PR:

| Alert | Package | Chain | Why blocked |
|---|---|---|---|
| GHSA-frvp-7c67-39w9 | @hono/node-server (npm, < 2.0.5) | `@modelcontextprotocol/sdk` declares `^1.19.9` | First patched version is `2.0.5` (major bump); no 1.x backport. Forcing it via override would push the dep outside the MCP SDK's declared range with no validatable upgrade path. Needs the MCP SDK to adopt node-server 2.x upstream. |
| GHSA-wrw7-89jp-8q8g | glib (cargo, < 0.20.0) | `glib 0.18.5` ← `gtk 0.18.2` ← `tauri 2.11.5` (`gtk = "^0.18"`) | `glib 0.20` does not satisfy `^0.18`; bumping requires a coordinated gtk-rs/Tauri major bump (Linux-only soundness issue). Out of scope for a dependency-pin PR. |