### PR TITLE
docs: rebrand site to CALM blue and restructure navbar (redesign 1/3)

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -51,7 +51,7 @@ const config = {
     ],
 
     stylesheets: [
-        'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;600&display=swap',
+        'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap',
     ],
 
     presets: [

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -39,6 +39,21 @@ const config = {
         }
     },
 
+    headTags: [
+        {
+            tagName: 'link',
+            attributes: {rel: 'preconnect', href: 'https://fonts.googleapis.com'},
+        },
+        {
+            tagName: 'link',
+            attributes: {rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: 'anonymous'},
+        },
+    ],
+
+    stylesheets: [
+        'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;600&display=swap',
+    ],
+
     presets: [
         [
             'classic',
@@ -83,19 +98,37 @@ const config = {
                     {
                         type: 'docSidebar',
                         sidebarId: 'learningSidebar',
-                        label: '📚 Learning',
+                        label: 'Learn',
                         position: 'left',
                     },
                     {
-                        to: '/talks/',
-                        label: '🎤 Talks',
+                        to: '/core-concepts/',
+                        label: 'Reference',
                         position: 'left',
-                        activeBaseRegex: `/talks/`,
+                        activeBaseRegex: '/(core-concepts|introduction)/',
+                    },
+                    {
+                        to: '/working-with-calm/',
+                        label: 'Tools',
+                        position: 'left',
+                        activeBaseRegex: '/(working-with-calm|calm-hub)/',
+                    },
+                    {
+                        to: '/talks/',
+                        label: 'Community',
+                        position: 'left',
+                        activeBaseRegex: '/talks/',
                     },
                     {
                         href: 'https://github.com/finos/architecture-as-code',
                         label: 'GitHub',
                         position: 'right',
+                    },
+                    {
+                        to: '/tutorials/',
+                        label: 'Get started',
+                        position: 'right',
+                        className: 'calm-navbar-cta',
                     },
                 ],
             },

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -29,9 +29,8 @@
   --ifm-font-family-monospace: "IBM Plex Mono", SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --ifm-heading-font-family: "Space Grotesk", var(--ifm-font-family-base);
-  --ifm-heading-font-weight: 700;
 
-  --ifm-navbar-height: 64px;
+  --ifm-navbar-height: 4rem;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -74,9 +73,10 @@ h3 {
   border-bottom-color: var(--ifm-color-primary);
 }
 
-/* "Get started" call-to-action in the navbar. */
-.navbar .calm-navbar-cta {
-  background: var(--ifm-color-primary);
+/* "Get started" call-to-action in the navbar (desktop items only — the
+   mobile drawer renders this item as a plain menu link). */
+.navbar__items .calm-navbar-cta {
+  background: var(--ifm-color-primary-darker);
   color: #fff;
   border-radius: 9px;
   padding: 0.45rem 1rem;
@@ -85,7 +85,17 @@ h3 {
   border-bottom: none;
 }
 
-.navbar .calm-navbar-cta:hover {
-  background: var(--ifm-color-primary-dark);
+.navbar__items .calm-navbar-cta:hover {
+  background: var(--ifm-color-primary-darkest);
   color: #fff;
+}
+
+[data-theme="dark"] .navbar__items .calm-navbar-cta {
+  background: var(--ifm-color-primary);
+  color: var(--calm-ink);
+}
+
+[data-theme="dark"] .navbar__items .calm-navbar-cta:hover {
+  background: var(--ifm-color-primary-light);
+  color: var(--calm-ink);
 }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -47,7 +47,9 @@
   --calm-heading-color: #e6ecff;
 }
 
-/* Headings pick up the display face and the brand navy. */
+/* Top-level headings (h1-h3) take the brand navy and tighter tracking;
+   all heading levels already get the display face via
+   --ifm-heading-font-family above. */
 h1,
 h2,
 h3 {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -4,27 +4,88 @@
  * work well for content-centric websites.
  */
 
-/* You can override the default Infima variables here. */
+/**
+ * CALM brand tokens.
+ * Brand: CALM blue #007dff · navy #000063
+ * Type:  Space Grotesk (headings) · IBM Plex Sans (body) · IBM Plex Mono (code)
+ */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #007dff;
+  --ifm-color-primary-dark: #0071e6;
+  --ifm-color-primary-darker: #006bd9;
+  --ifm-color-primary-darkest: #0058b3;
+  --ifm-color-primary-light: #1a8aff;
+  --ifm-color-primary-lighter: #2690ff;
+  --ifm-color-primary-lightest: #4da3ff;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --calm-navy: #000063;
+  --calm-ink: #0b1020;
+  --calm-heading-color: var(--calm-navy);
+
+  --ifm-font-family-base: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI",
+    Roboto, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  --ifm-font-family-monospace: "IBM Plex Mono", SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+  --ifm-heading-font-family: "Space Grotesk", var(--ifm-font-family-base);
+  --ifm-heading-font-weight: 700;
+
+  --ifm-navbar-height: 64px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #4da3ff;
+  --ifm-color-primary-dark: #2e93ff;
+  --ifm-color-primary-darker: #1f8bff;
+  --ifm-color-primary-darkest: #0071e6;
+  --ifm-color-primary-light: #6cb3ff;
+  --ifm-color-primary-lighter: #7bbaff;
+  --ifm-color-primary-lightest: #a8d1ff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --calm-heading-color: #e6ecff;
+}
+
+/* Headings pick up the display face and the brand navy. */
+h1,
+h2,
+h3 {
+  color: var(--calm-heading-color);
+  letter-spacing: -0.01em;
+}
+
+/* Navbar: brand-weight title, active item underlined in CALM blue. */
+.navbar__title {
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--calm-heading-color);
+}
+
+.navbar__link {
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+}
+
+.navbar__link--active {
+  color: var(--ifm-color-primary);
+  border-bottom-color: var(--ifm-color-primary);
+}
+
+/* "Get started" call-to-action in the navbar. */
+.navbar .calm-navbar-cta {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  border-radius: 9px;
+  padding: 0.45rem 1rem;
+  margin-left: 0.5rem;
+  font-weight: 600;
+  border-bottom: none;
+}
+
+.navbar .calm-navbar-cta:hover {
+  background: var(--ifm-color-primary-dark);
+  color: #fff;
 }

--- a/docs/talks/index.md
+++ b/docs/talks/index.md
@@ -8,12 +8,6 @@ sidebar_position: 1
 
 Here you can find talks that our members have given.
 
-### Keep CALM & Carry On Approving Change
-
-#### Matthew Bain and Aidan McPhelim, Open Source in Finance Forum, London 2024
-
-<iframe width="640px" height="480px" src="https://www.youtube.com/embed/pKjRSMQjy6E?si=JBvRTIpG0UZrXXDq" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-
 ### Observable, Secure Architectures Using FINOS Architecture as Code
 
 #### James Gough and Nick Ebbitt, Architecture as Code Working Group, September 2024


### PR DESCRIPTION
## Description

**🔍 Live preview:** https://calm-docs-redesign-phase1.vercel.app — a static Vercel deployment of this branch's build, so you can click through the result instead of reading screenshots.

Phase 1 of 3 of the docs-site redesign proposed in #2873 (design prototype linked there). This phase is chrome-only — no new pages, no route changes:

- **Rebrand** `docs/src/css/custom.css` from stock Docusaurus green to CALM's own brand palette (`#007dff` blue / `#000063` navy) and load the brand type stack — Space Grotesk (headings), IBM Plex Sans (body), IBM Plex Mono (code) — with light- and dark-mode variants.
- **Navbar restructure** from the current logo-entry + `📚 Learning` + `🎤 Talks` layout to four labelled sections — **Learn · Reference · Tools · Community** — with GitHub and a **Get started** call-to-action as right-aligned utilities next to the existing Algolia search.
- Learn keeps the existing `learningSidebar`; Reference and Tools route to the existing `/core-concepts/` and `/working-with-calm/` content. **Community temporarily points at `/talks/`** until the dedicated `/community` landing ships in phase 2, so talks stay reachable while the nav takes its final shape.

Stack: this is the base PR. Phase 2 (homepage + Learn hub + journeys) and phase 3 (doc-page reading UX) are stacked on top and will follow.

### Before / after

| Before (current site) | After (phase 1) |
|---|---|
| ![Current docs homepage](https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/calm-docs-redesign/implementation/before-prod-home.png) | ![Rebranded docs with new navbar](https://raw.githubusercontent.com/rocketstack-matt/architecture-as-code/assets/calm-docs-redesign/implementation/phase1-reference.png) |

### Notes for reviewers (deliberate decisions)

- **Rider:** the "Keep CALM & Carry On Approving Change" talk was removed from `/talks/` — its recording has been made private, so the embed no longer plays.
- **Fonts are loaded from Google Fonts** (matching the design prototype). If serving visitor requests to `fonts.googleapis.com` is a concern for a FINOS-hosted site (GDPR/IP exposure), self-hosting via `@fontsource/*` packages is a straightforward follow-up — happy to switch in this PR if preferred.
- The Get started CTA uses a slightly darker blue than the brand primary (`--ifm-color-primary-darker`) so white button text meets WCAG AA contrast; dark mode uses ink-on-light-blue for the same reason.
- The tutorial sidebar's level emoji (🟢🟡🔴🛠️) are kept — they are part of the prototype's level colour language.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [x] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

Conventional commits: `docs: rebrand site to CALM blue and restructure navbar`, `docs: fix navbar CTA contrast and mobile-drawer styling`.

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

`npm run build --workspace docs` passes on Node 26.3.1 with `onBrokenLinks: 'throw'` (the regression guard for a static-site change — every nav target verified to resolve). Manually verified light/dark themes and navbar active states on `/`, `/core-concepts/`, `/working-with-calm/`, `/tutorials/` and `/talks/`. No unit-testable logic is introduced (theme tokens + config), so no new automated coverage.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
