### PR TITLE
docs: remove year from README copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Currently we have three typescript packages - two of which are managed via `npm 
 
 ## License
 
-Copyright 2024 FINOS
+Copyright FINOS
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 


### PR DESCRIPTION
## Description
Removes the year from the copyright notice in the root README (`Copyright 2024 FINOS` → `Copyright FINOS`) so it can't go stale. The year in a copyright notice is optional and dropping it is common FINOS/Apache practice; this avoids an annual manual bump.

Deliberately scoped to the root README only: `LICENSE`, `NOTICE`, and `calm-plugins/vscode/LICENSE` also carry years, but those are legal boilerplate read by license-scanning tooling and are left for a separate maintainer discussion if desired.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Root README only — none of the listed components are touched -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

## Testing
Text-only change to the root README; no code paths or tests affected.
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
