### PR TITLE
docs: add third timeline moment for CalmStudio and CALM Server

### DIFF
--- a/calm/architecture/calm-1.json
+++ b/calm/architecture/calm-1.json
@@ -89,7 +89,7 @@
                     },
                     "destination": {
                         "node": "calm-hub",
-                        "interface": "calm-hub-rest-api"
+                        "interfaces": ["calm-hub-rest-api"]
                     }
                 }
             },
@@ -105,7 +105,7 @@
                     },
                     "destination": {
                         "node": "mongodb",
-                        "interface": "mongodb-port"
+                        "interfaces": ["mongodb-port"]
                     }
                 }
             },
@@ -121,7 +121,7 @@
                     },
                     "destination": {
                         "node": "calm-hub",
-                        "interface": "calm-hub-rest-api"
+                        "interfaces": ["calm-hub-rest-api"]
                     }
                 }
             },

--- a/calm/architecture/calm-3.json
+++ b/calm/architecture/calm-3.json
@@ -22,11 +22,34 @@
             "development-language": "TypeScript"
         },
         {
+            "unique-id": "calm-studio",
+            "node-type": "system",
+            "name": "CalmStudio",
+            "description": "Browser-based visual CALM architecture editor (SvelteKit) for creating and editing architectures with built-in CALM 1.2 validation",
+            "development-language": "TypeScript"
+        },
+        {
+            "unique-id": "calm-server",
+            "node-type": "service",
+            "name": "CALM Server",
+            "description": "Standalone HTTP server exposing CALM architecture validation as a REST API, independent of the CALM Hub",
+            "development-language": "TypeScript",
+            "interfaces": [
+                {
+                    "unique-id": "calm-server-validate-api",
+                    "type": "api"
+                }
+            ]
+        },
+        {
             "unique-id": "calm-hub",
             "node-type": "service",
             "name": "CALM Hub API",
             "description": "Central registry and API service for CALM architectures, patterns, and standards built with Quarkus",
             "development-language": "Java",
+            "details": {
+                "detailed-architecture": "calm-hub-detail.architecture.json"
+            },
             "interfaces": [
                 {
                     "unique-id": "calm-hub-rest-api",
@@ -100,6 +123,30 @@
                     "actor": "calm-user",
                     "nodes": [
                         "calm-vscode"
+                    ]
+                }
+            }
+        },
+        {
+            "unique-id": "user-interacts-with-studio",
+            "description": "CALM user interacts with CalmStudio through a web browser",
+            "relationship-type": {
+                "interacts": {
+                    "actor": "calm-user",
+                    "nodes": [
+                        "calm-studio"
+                    ]
+                }
+            }
+        },
+        {
+            "unique-id": "user-interacts-with-calm-server",
+            "description": "CALM user or CI pipeline invokes CALM Server's validation API directly",
+            "relationship-type": {
+                "interacts": {
+                    "actor": "calm-user",
+                    "nodes": [
+                        "calm-server"
                     ]
                 }
             }
@@ -233,6 +280,30 @@
                     "relationship-unique-id": "user-interacts-with-vscode",
                     "sequence-number": 1,
                     "description": "User opens a CALM file in VS Code and triggers validation"
+                }
+            ]
+        },
+        {
+            "unique-id": "flow-edit-in-studio",
+            "name": "Edit Architecture in CalmStudio",
+            "description": "User visually creates or edits a CALM architecture in the browser using CalmStudio",
+            "transitions": [
+                {
+                    "relationship-unique-id": "user-interacts-with-studio",
+                    "sequence-number": 1,
+                    "description": "User opens a CALM architecture in CalmStudio and edits it visually"
+                }
+            ]
+        },
+        {
+            "unique-id": "flow-validate-via-api",
+            "name": "Validate Architecture via CALM Server",
+            "description": "User or automated pipeline validates a CALM architecture by calling CALM Server's REST API",
+            "transitions": [
+                {
+                    "relationship-unique-id": "user-interacts-with-calm-server",
+                    "sequence-number": 1,
+                    "description": "Caller POSTs an architecture to CALM Server's /calm/validate endpoint and receives validation results"
                 }
             ]
         }

--- a/calm/architecture/calm-hub-detail.architecture.json
+++ b/calm/architecture/calm-hub-detail.architecture.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+    "nodes": [
+        {
+            "unique-id": "calm-hub-resources",
+            "node-type": "service",
+            "name": "REST Resources Layer",
+            "description": "JAX-RS resource classes under org.finos.calm.resources exposing namespace-scoped endpoints for architectures, patterns, controls, ADRs, decorators, domains, flows, interfaces, standards, timelines, search, and user access",
+            "development-language": "Java",
+            "interfaces": [
+                {
+                    "unique-id": "calm-hub-rest-api",
+                    "type": "api"
+                }
+            ]
+        },
+        {
+            "unique-id": "calm-hub-services",
+            "node-type": "service",
+            "name": "Services Layer",
+            "description": "Business logic under org.finos.calm.services that orchestrates store access on behalf of the REST resources layer",
+            "development-language": "Java"
+        },
+        {
+            "unique-id": "calm-hub-storage",
+            "node-type": "service",
+            "name": "Storage Layer",
+            "description": "Store abstraction under org.finos.calm.store, with CDI producers that select a MongoDB or NitriteDB implementation at runtime based on the calm.database.mode configuration property",
+            "development-language": "Java"
+        },
+        {
+            "unique-id": "mongodb",
+            "node-type": "database",
+            "name": "MongoDB",
+            "description": "Production storage backend, used when calm.database.mode is mongo (the default)",
+            "interfaces": [
+                {
+                    "unique-id": "mongodb-port",
+                    "type": "port-interface",
+                    "port": 27017
+                }
+            ]
+        },
+        {
+            "unique-id": "nitritedb",
+            "node-type": "database",
+            "name": "NitriteDB",
+            "description": "Embedded, file-based document database used in standalone and read-only deployment modes (calm.database.mode=standalone), avoiding the need for an external database"
+        }
+    ],
+    "relationships": [
+        {
+            "unique-id": "resources-to-services",
+            "description": "Delegates business logic for validated requests to",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub-resources"
+                    },
+                    "destination": {
+                        "node": "calm-hub-services"
+                    }
+                }
+            }
+        },
+        {
+            "unique-id": "services-to-storage",
+            "description": "Reads and writes CALM resources via",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub-services"
+                    },
+                    "destination": {
+                        "node": "calm-hub-storage"
+                    }
+                }
+            }
+        },
+        {
+            "unique-id": "storage-to-mongo",
+            "description": "Persists to, when calm.database.mode is mongo",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub-storage"
+                    },
+                    "destination": {
+                        "node": "mongodb",
+                        "interfaces": ["mongodb-port"]
+                    }
+                }
+            },
+            "protocol": "TCP"
+        },
+        {
+            "unique-id": "storage-to-nitrite",
+            "description": "Persists to, when calm.database.mode is standalone or read-only",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub-storage"
+                    },
+                    "destination": {
+                        "node": "nitritedb"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/calm/architecture/calm-hub-detail.architecture.json
+++ b/calm/architecture/calm-hub-detail.architecture.json
@@ -95,7 +95,7 @@
         },
         {
             "unique-id": "storage-to-nitrite",
-            "description": "Persists to, when calm.database.mode is standalone or read-only",
+            "description": "Persists to, when calm.database.mode is standalone, including read-only deployments using calm.readonly=true",
             "relationship-type": {
                 "connects": {
                     "source": {

--- a/calm/architecture/calm.timeline.json
+++ b/calm/architecture/calm.timeline.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://calm.finos.org/release/1.2/meta/calm-timeline.json",
-    "current-moment": "calm-2",
+    "current-moment": "calm-3",
     "moments": [
         {
             "unique-id": "calm-1",
@@ -19,6 +19,16 @@
             "valid-from": "2025-09-30",
             "details": {
                 "detailed-architecture": "calm-2.json"
+            }
+        },
+        {
+            "unique-id": "calm-3",
+            "node-type": "moment",
+            "name": "CALM with CalmStudio and CALM Server",
+            "description": "The FINOS CALM architecture including CLI, VSCode extension, CalmStudio, CALM Server, Hub API, and Hub UI. The CALM Hub API now also links out to a detailed architecture of its own internal layering",
+            "valid-from": "2026-04-11",
+            "details": {
+                "detailed-architecture": "calm-3.json"
             }
         }
     ],


### PR DESCRIPTION
## Description
Adds a third moment (`calm-3`) to the FINOS CALM ecosystem timeline (`calm/architecture/`), bringing it up to date with the current repo: CalmStudio and CALM Server join the CLI, VSCode extension, and Hub. The CALM Hub node also gains a `detailed-architecture` link (`calm-hub-detail.architecture.json`) breaking down its internal layering (REST resources, services, storage) and its dual MongoDB/NitriteDB backends — demonstrating the `details.detailed-architecture` node property.

Also fixes `calm-1.json` and `calm-2.json` to use the schema-correct `"interfaces"` array on `connects` destinations instead of the singular `"interface"` string, which the CALM 1.2 interface schema does not define.

This PR is intended to contribute an example toward the improved documentation tracked in #1568.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] Schema (`calm/`)

## Commit Message Format ✅
- Single commit: `docs: add third timeline moment for CalmStudio and CALM Server`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Validated with the CLI (`calm validate`) against every architecture file and the timeline — all report `hasErrors: false`, `hasWarnings: false`.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards