### PR TITLE
fix(calm-widgets): resolve node names instead of raw ids in related-nodes diagrams

### DIFF
--- a/calm-widgets/README.md
+++ b/calm-widgets/README.md
@@ -124,25 +124,26 @@ Renders relationships as Mermaid graph diagrams, showing connections between nod
 - For `relationship-id`: The specified relationship must exist in the `relationships` array.
 
 **Supported relationship types:**
-- **Interacts**: Actor-to-node interactions (e.g., "User -- Interacts --> Frontend")
-- **Connects**: Direct connections between services (e.g., "API -- Connects --> Database")
-- **Composed-of**: Container composition relationships (e.g., "System -- Composed Of --> Service")
-- **Deployed-in**: Deployment relationships (e.g., "Cluster -- Deployed In --> Service")
+- **Interacts**: Actor-to-node interactions (e.g., "User[User] -- Interacts --> Frontend[Frontend App]")
+- **Connects**: Direct connections between services (e.g., "api[API] -- Connects --> db[Database]")
+- **Composed-of**: Container composition relationships (e.g., "sys[System] -- Composed Of --> svc[Service]")
+- **Deployed-in**: Deployment relationships (e.g., "cluster[Cluster] -- Deployed In --> svc[Service]")
 
 **Output behavior:**
 - **Node perspective**: When using `node-id`, shows the node highlighted with all its related connections
 - **Relationship perspective**: When using `relationship-id`, shows just that specific relationship
 - **Container filtering**: Automatically filters relationships based on the focus node (container vs. service perspective)
+- **Labels**: Every node reference is labeled with its `name`
 
 **Example outputs:**
 
 *Node view (`node-id="load-balancer"`)* - Shows the load balancer and all its connections:
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-k8s-cluster -- Deployed In --> load-balancer;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+k8s-cluster[Kubernetes Cluster] -- Deployed In --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/calm-widgets/README.md
+++ b/calm-widgets/README.md
@@ -127,7 +127,7 @@ Renders relationships as Mermaid graph diagrams, showing connections between nod
 - **Interacts**: Actor-to-node interactions (e.g., "User[User] -- Interacts --> Frontend[Frontend App]")
 - **Connects**: Direct connections between services (e.g., "api[API] -- Connects --> db[Database]")
 - **Composed-of**: Container composition relationships (e.g., "sys[System] -- Composed Of --> svc[Service]")
-- **Deployed-in**: Deployment relationships (e.g., "cluster[Cluster] -- Deployed In --> svc[Service]")
+- **Deployed-in**: Deployment relationships (e.g., "svc[Service] -- Deployed In --> cluster[Cluster]")
 
 **Output behavior:**
 - **Node perspective**: When using `node-id`, shows the node highlighted with all its related connections
@@ -143,7 +143,7 @@ graph TD;
 load-balancer[Load Balancer]:::highlight;
 conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
-k8s-cluster[Kubernetes Cluster] -- Deployed In --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/calm-widgets/src/widget-helpers.spec.ts
+++ b/calm-widgets/src/widget-helpers.spec.ts
@@ -37,6 +37,30 @@ describe('Widget Helpers', () => {
         });
     });
 
+    describe('nodeLabel helper', () => {
+        it('returns the mapped name when the id is present in the map', () => {
+            expect(helpers.nodeLabel('svc-a', { 'svc-a': 'Service Alpha' })).toBe('Service Alpha');
+        });
+
+        it('falls back to the id when the map has no entry for it', () => {
+            expect(helpers.nodeLabel('svc-a', { 'svc-b': 'Service Beta' })).toBe('svc-a');
+        });
+
+        it('falls back to the id when no map is provided', () => {
+            expect(helpers.nodeLabel('svc-a', undefined)).toBe('svc-a');
+        });
+
+        it('falls back to the id when the mapped value is not a non-empty string', () => {
+            expect(helpers.nodeLabel('svc-a', { 'svc-a': '' })).toBe('svc-a');
+            expect(helpers.nodeLabel('svc-a', { 'svc-a': 42 })).toBe('svc-a');
+        });
+
+        it('returns an empty string for a non-string id', () => {
+            expect(helpers.nodeLabel(undefined, { x: 'X' })).toBe('');
+            expect(helpers.nodeLabel(42, { x: 'X' })).toBe('');
+        });
+    });
+
     describe('currentTimestamp helper', () => {
         it('returns ISO timestamp string', () => {
             const timestamp = helpers.currentTimestamp();

--- a/calm-widgets/src/widget-helpers.ts
+++ b/calm-widgets/src/widget-helpers.ts
@@ -124,6 +124,14 @@ export function registerGlobalTemplateHelpers(): Record<string, (...args: unknow
                 .replace(/"/g, '#quot;');
         },
         ne: (a: unknown, b: unknown): boolean => a !== b,
+        nodeLabel: (id: unknown, nodeNames: unknown): string => {
+            if (typeof id !== 'string' || !id) return '';
+            if (nodeNames && typeof nodeNames === 'object') {
+                const name = (nodeNames as Record<string, unknown>)[id];
+                if (typeof name === 'string' && name) return name;
+            }
+            return id;
+        },
         notEmpty: (value: unknown): boolean => {
             if (value == null) return false;
             if (Array.isArray(value)) return value.length > 0;

--- a/calm-widgets/src/widgets/related-nodes/composed-of-relationship.hbs
+++ b/calm-widgets/src/widgets/related-nodes/composed-of-relationship.hbs
@@ -2,18 +2,18 @@
   {{!-- Path 1: Show what's composed OF this container (when viewing from container perspective) --}}
   {{#if (eq container ../id)}}
     {{#each nodes}}
-{{{mermaidId ../container}}} -- Composed Of --> {{{mermaidId this}}};
+{{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}] -- Composed Of --> {{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}];
     {{/each}}
   {{/if}}
   {{!-- Path 2: Show what container this node is composed OF (when viewing from node perspective) --}}
   {{#each nodes}}
     {{#if (eq this ../../id)}}
-{{{mermaidId ../container}}} -- Composed Of --> {{{mermaidId this}}};
+{{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}] -- Composed Of --> {{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}];
     {{/if}}
   {{/each}}
 {{else}}
   {{!-- Path 3: Show all composition relationships (no specific focus) --}}
   {{#each nodes}}
-{{{mermaidId ../container}}} -- Composed Of --> {{{mermaidId this}}};
+{{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}] -- Composed Of --> {{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}];
   {{/each}}
 {{/if}}

--- a/calm-widgets/src/widgets/related-nodes/connects-relationship.hbs
+++ b/calm-widgets/src/widgets/related-nodes/connects-relationship.hbs
@@ -1,1 +1,1 @@
-{{{mermaidId source.node}}} -- Connects --> {{{mermaidId destination.node}}};
+{{{mermaidId source.node}}}[{{{mermaidText (nodeLabel source.node @root.nodeNames)}}}] -- Connects --> {{{mermaidId destination.node}}}[{{{mermaidText (nodeLabel destination.node @root.nodeNames)}}}];

--- a/calm-widgets/src/widgets/related-nodes/deployed-in-relationship.hbs
+++ b/calm-widgets/src/widgets/related-nodes/deployed-in-relationship.hbs
@@ -2,18 +2,18 @@
   {{!-- Path 1: Show what's deployed in this container (when viewing from container perspective) --}}
   {{#if (eq container ../id)}}
     {{#each nodes}}
-{{{mermaidId this}}} -- Deployed In --> {{{mermaidId ../container}}};
+{{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}] -- Deployed In --> {{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}];
     {{/each}}
   {{/if}}
   {{!-- Path 2: Show what container this node is deployed IN (when viewing from node perspective) --}}
   {{#each nodes}}
     {{#if (eq this ../../id)}}
-{{{mermaidId this}}} -- Deployed In --> {{{mermaidId ../container}}};
+{{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}] -- Deployed In --> {{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}];
     {{/if}}
   {{/each}}
 {{else}}
   {{!-- Path 3: Show all deployment relationships (no specific focus) --}}
   {{#each nodes}}
-{{{mermaidId this}}} -- Deployed In --> {{{mermaidId ../container}}};
+{{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}] -- Deployed In --> {{{mermaidId ../container}}}[{{{mermaidText (nodeLabel ../container @root.nodeNames)}}}];
   {{/each}}
 {{/if}}

--- a/calm-widgets/src/widgets/related-nodes/index.spec.ts
+++ b/calm-widgets/src/widgets/related-nodes/index.spec.ts
@@ -29,6 +29,13 @@ const mkRel = (
     controls: {},
 });
 
+const mkNode = (id: string, name: string): CalmNodeCanonicalModel => ({
+    'unique-id': id,
+    'node-type': 'service',
+    name,
+    description: '',
+});
+
 describe('RelatedNodesWidget', () => {
     describe('validateContext', () => {
         it('rejects null and non-architectures; accepts minimal CalmCoreCanonicalModel (nodes+relationships)', () => {
@@ -169,6 +176,42 @@ describe('RelatedNodesWidget', () => {
             ]);
             const vm = RelatedNodesWidget.transformToViewModel!(arch, { 'node-id': 'AnyNode' });
             expect(vm.relatedRelationships).toEqual([]);
+        });
+    });
+
+    describe('transformToViewModel – nodeNames', () => {
+        it('builds an id -> name map from context.nodes on the node-id path', () => {
+            const arch = mkArch(
+                [mkRel('r1', { connects: { source: { node: 'svc-a' }, destination: { node: 'svc-b' } } })],
+                [mkNode('svc-a', 'Service Alpha'), mkNode('svc-b', 'Service Beta')]
+            );
+            const vm = RelatedNodesWidget.transformToViewModel!(arch, { 'node-id': 'svc-a' });
+            expect(vm.nodeNames).toEqual({ 'svc-a': 'Service Alpha', 'svc-b': 'Service Beta' });
+        });
+
+        it('builds an id -> name map from context.nodes on the relationship-id path', () => {
+            const arch = mkArch(
+                [mkRel('r1', { connects: { source: { node: 'svc-a' }, destination: { node: 'svc-b' } } })],
+                [mkNode('svc-a', 'Service Alpha'), mkNode('svc-b', 'Service Beta')]
+            );
+            const vm = RelatedNodesWidget.transformToViewModel!(arch, { 'relationship-id': 'r1' });
+            expect(vm.nodeNames).toEqual({ 'svc-a': 'Service Alpha', 'svc-b': 'Service Beta' });
+        });
+
+        it('does not include a name for nodes that are referenced but not defined', () => {
+            const arch = mkArch(
+                [mkRel('r1', { interacts: { actor: 'User', nodes: ['svc-a'] } })],
+                [mkNode('svc-a', 'Service Alpha')]
+            );
+            const vm = RelatedNodesWidget.transformToViewModel!(arch, { 'node-id': 'svc-a' });
+            expect(vm.nodeNames).toEqual({ 'svc-a': 'Service Alpha' });
+            expect(vm.nodeNames?.['User']).toBeUndefined();
+        });
+
+        it('returns an empty map when context has no nodes', () => {
+            const arch = mkArch([mkRel('r1', { connects: { source: { node: 'A' }, destination: { node: 'B' } } })]);
+            const vm = RelatedNodesWidget.transformToViewModel!(arch, { 'node-id': 'A' });
+            expect(vm.nodeNames).toEqual({});
         });
     });
 

--- a/calm-widgets/src/widgets/related-nodes/index.ts
+++ b/calm-widgets/src/widgets/related-nodes/index.ts
@@ -13,6 +13,7 @@ type RelatedNodesViewModel = {
     nodeId?: string;
     relationshipId?: string;
     relatedRelationships: CalmRelationshipTypeKindView[];
+    nodeNames?: Record<string, string>;
 };
 
 interface RelatedNodesOptions {
@@ -33,6 +34,9 @@ const findById = (
     id: string
 ): CalmRelationshipCanonicalModel | undefined =>
     rels.find(r => r['unique-id'] === id);
+
+const buildNodeNames = (context: CalmCoreCanonicalModel): Record<string, string> =>
+    Object.fromEntries(context.nodes.map(n => [n['unique-id'], n.name]));
 
 const filterContainerRelationshipForNode = (
     rt: CalmRelationshipTypeCanonicalModel,
@@ -111,12 +115,13 @@ export const RelatedNodesWidget: CalmWidget<CalmCoreCanonicalModel, RelatedNodes
         const relId = options?.['relationship-id'];
 
         const relationships = context.relationships;
+        const nodeNames = buildNodeNames(context);
 
         if (relId) {
             const found = findById(relationships, relId);
             return found
-                ? { relationshipId: relId, relatedRelationships: [toKindView(found['relationship-type'])] }
-                : { relationshipId: relId, relatedRelationships: [] };
+                ? { relationshipId: relId, relatedRelationships: [toKindView(found['relationship-type'])], nodeNames }
+                : { relationshipId: relId, relatedRelationships: [], nodeNames };
         }
 
         if (nodeId) {
@@ -124,11 +129,12 @@ export const RelatedNodesWidget: CalmWidget<CalmCoreCanonicalModel, RelatedNodes
             return {
                 id: nodeId,
                 nodeId,
-                relatedRelationships: filteredRels.map(r => toKindView(r['relationship-type']))
+                relatedRelationships: filteredRels.map(r => toKindView(r['relationship-type'])),
+                nodeNames
             };
         }
 
-        return { relatedRelationships: [] };
+        return { relatedRelationships: [], nodeNames };
     },
 
     validateContext: isCalmCoreCanonicalModel,

--- a/calm-widgets/src/widgets/related-nodes/interacts-relationship.hbs
+++ b/calm-widgets/src/widgets/related-nodes/interacts-relationship.hbs
@@ -1,3 +1,3 @@
 {{#each nodes}}
-{{{mermaidId ../actor}}} -- Interacts --> {{{mermaidId this}}};
+{{{mermaidId ../actor}}}[{{{mermaidText (nodeLabel ../actor @root.nodeNames)}}}] -- Interacts --> {{{mermaidId this}}}[{{{mermaidText (nodeLabel this @root.nodeNames)}}}];
 {{/each}}

--- a/calm-widgets/src/widgets/related-nodes/related-nodes-template.hbs
+++ b/calm-widgets/src/widgets/related-nodes/related-nodes-template.hbs
@@ -1,7 +1,7 @@
 ```mermaid
 graph TD;
 {{#if id}}
-{{{mermaidId id}}}[{{id}}]:::highlight;
+{{{mermaidId id}}}[{{{mermaidText (nodeLabel id @root.nodeNames)}}}]:::highlight;
 {{/if}}
 {{#each relatedRelationships}}
 {{#if (eq kind "interacts")}}

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/context.json
@@ -1,17 +1,17 @@
 {
   "nodes": [
-    { "unique-id": "ServiceA", "name": "ServiceA" },
-    { "unique-id": "ServiceB", "name": "ServiceB" },
-    { "unique-id": "SystemC", "name": "SystemC" }
+    { "unique-id": "svc-a", "name": "Service Alpha" },
+    { "unique-id": "svc-b", "name": "Service Beta" },
+    { "unique-id": "system-c", "name": "Backend System" }
   ],
   "relationships": [
     {
       "unique-id": "r1",
-      "relationship-type": { "connects": { "source": { "node": "ServiceA" }, "destination": { "node": "ServiceB" } } }
+      "relationship-type": { "connects": { "source": { "node": "svc-a" }, "destination": { "node": "svc-b" } } }
     },
     {
       "unique-id": "r2",
-      "relationship-type": { "composed-of": { "container": "SystemC", "nodes": ["ServiceA", "ServiceB"] } }
+      "relationship-type": { "composed-of": { "container": "system-c", "nodes": ["svc-a", "svc-b"] } }
     }
   ]
 }

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/expected.md
@@ -1,7 +1,7 @@
 ```mermaid
 graph TD;
-SystemC[SystemC]:::highlight;
-SystemC -- Composed Of --> ServiceA;
-SystemC -- Composed Of --> ServiceB;
+system-c[Backend System]:::highlight;
+system-c[Backend System] -- Composed Of --> svc-a[Service Alpha];
+system-c[Backend System] -- Composed Of --> svc-b[Service Beta];
 classDef highlight fill:#f2bbae;
 ```

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/template.hbs
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-composed-connects/template.hbs
@@ -1,2 +1,2 @@
-{{related-nodes this node-id="SystemC"}}
+{{related-nodes this node-id="system-c"}}
 

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/context.json
@@ -1,20 +1,20 @@
 {
   "nodes": [
-    { "unique-id": "ServiceA", "name": "ServiceA" },
-    { "unique-id": "ServiceB", "name": "ServiceB" },
-    { "unique-id": "SystemC", "name": "SystemC" }
+    { "unique-id": "svc-a", "name": "Service Alpha" },
+    { "unique-id": "svc-b", "name": "Service Beta" },
+    { "unique-id": "system-c", "name": "Backend System" }
   ],
   "relationships": [
     {
       "unique-id": "r1",
       "relationship-type": {
-        "connects": { "source": { "node": "ServiceA" }, "destination": { "node": "ServiceB" } }
+        "connects": { "source": { "node": "svc-a" }, "destination": { "node": "svc-b" } }
       }
     },
     {
       "unique-id": "r2",
       "relationship-type": {
-        "composed-of": { "container": "SystemC", "nodes": ["ServiceA"] }
+        "composed-of": { "container": "system-c", "nodes": ["svc-a"] }
       }
     }
   ]

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/expected.md
@@ -1,7 +1,7 @@
 ```mermaid
 graph TD;
-ServiceA[ServiceA]:::highlight;
-ServiceA -- Connects --> ServiceB;
-SystemC -- Composed Of --> ServiceA;
+svc-a[Service Alpha]:::highlight;
+svc-a[Service Alpha] -- Connects --> svc-b[Service Beta];
+system-c[Backend System] -- Composed Of --> svc-a[Service Alpha];
 classDef highlight fill:#f2bbae;
 ```

--- a/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/template.hbs
+++ b/calm-widgets/test-fixtures/related-nodes-widget/node-with-related/template.hbs
@@ -1,2 +1,2 @@
-{{related-nodes this node-id="ServiceA"}}
+{{related-nodes this node-id="svc-a"}}
 

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-composed/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-composed/context.json
@@ -1,13 +1,13 @@
 {
   "nodes": [
-    { "unique-id": "ServiceA", "name": "ServiceA" },
-    { "unique-id": "ServiceB", "name": "ServiceB" },
-    { "unique-id": "SystemC", "name": "SystemC" }
+    { "unique-id": "svc-a", "name": "Service Alpha" },
+    { "unique-id": "svc-b", "name": "Service Beta" },
+    { "unique-id": "system-c", "name": "Backend System" }
   ],
   "relationships": [
     {
       "unique-id": "r1",
-      "relationship-type": { "composed-of": { "container": "SystemC", "nodes": ["ServiceA"] } }
+      "relationship-type": { "composed-of": { "container": "system-c", "nodes": ["svc-a"] } }
     }
   ]
 }

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-composed/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-composed/expected.md
@@ -1,5 +1,5 @@
 ```mermaid
 graph TD;
-SystemC -- Composed Of --> ServiceA;
+system-c[Backend System] -- Composed Of --> svc-a[Service Alpha];
 classDef highlight fill:#f2bbae;
 ```

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-connects/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-connects/context.json
@@ -1,15 +1,15 @@
 {
   "nodes": [
-    { "unique-id": "ServiceA", "name": "ServiceA" },
-    { "unique-id": "ServiceB", "name": "ServiceB" }
+    { "unique-id": "svc-a", "name": "Service Alpha" },
+    { "unique-id": "svc-b", "name": "Service Beta" }
   ],
   "relationships": [
     {
       "unique-id": "rel-connects-1",
       "relationship-type": {
         "connects": {
-          "source": { "node": "ServiceA" },
-          "destination": { "node": "ServiceB" }
+          "source": { "node": "svc-a" },
+          "destination": { "node": "svc-b" }
         }
       }
     }

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-connects/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-connects/expected.md
@@ -1,6 +1,6 @@
 ```mermaid
 graph TD;
-ServiceA -- Connects --> ServiceB;
+svc-a[Service Alpha] -- Connects --> svc-b[Service Beta];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-deployed/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-deployed/context.json
@@ -1,13 +1,13 @@
 {
   "nodes": [
-    { "unique-id": "ClusterX", "name": "ClusterX" },
-    { "unique-id": "App1", "name": "App1" }
+    { "unique-id": "cluster-x", "name": "Cluster X Prod" },
+    { "unique-id": "app-1", "name": "Application One" }
   ],
   "relationships": [
     {
       "unique-id": "rel-deployed-1",
       "relationship-type": {
-        "deployed-in": { "container": "ClusterX", "nodes": ["App1"] }
+        "deployed-in": { "container": "cluster-x", "nodes": ["app-1"] }
       }
     }
   ]

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-deployed/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-deployed/expected.md
@@ -1,5 +1,5 @@
 ```mermaid
 graph TD;
-App1 -- Deployed In --> ClusterX;
+app-1[Application One] -- Deployed In --> cluster-x[Cluster X Prod];
 classDef highlight fill:#f2bbae;
 ```

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-interacts/context.json
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-interacts/context.json
@@ -1,15 +1,13 @@
 {
   "nodes": [
-    { "unique-id": "Frontend", "name": "Frontend" }
+    { "unique-id": "frontend-svc", "name": "Frontend App" }
   ],
   "relationships": [
     {
       "unique-id": "rel-interacts-1",
       "relationship-type": {
-        "interacts": { "actor": "User", "nodes": ["Frontend"] }
+        "interacts": { "actor": "User", "nodes": ["frontend-svc"] }
       }
     }
   ]
 }
-
-

--- a/calm-widgets/test-fixtures/related-nodes-widget/relationship-interacts/expected.md
+++ b/calm-widgets/test-fixtures/related-nodes-widget/relationship-interacts/expected.md
@@ -1,6 +1,6 @@
 ```mermaid
 graph TD;
-User -- Interacts --> Frontend;
+User[User] -- Interacts --> frontend-svc[Frontend App];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/attendees-store.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/attendees-store.md
@@ -60,9 +60,9 @@ title: "Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees-store[attendees-store]:::highlight;
-attendees -- Connects --> attendees-store;
-attendees-store -- Deployed In --> k8s-cluster;
+attendees-store[Attendees Store]:::highlight;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/attendees.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/attendees.md
@@ -60,10 +60,10 @@ title: "Attendees Service"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees[attendees]:::highlight;
-load-balancer -- Connects --> attendees;
-attendees -- Connects --> attendees-store;
-attendees -- Deployed In --> k8s-cluster;
+attendees[Attendees Service]:::highlight;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/conference-website.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/conference-website.md
@@ -91,8 +91,8 @@ title: "Conference Website"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website[conference-website]:::highlight;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/k8s-cluster.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/k8s-cluster.md
@@ -38,10 +38,10 @@ title: "Kubernetes Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-k8s-cluster[k8s-cluster]:::highlight;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+k8s-cluster[Kubernetes Cluster]:::highlight;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/load-balancer.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/nodes/load-balancer.md
@@ -55,10 +55,10 @@ title: "Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/attendees-attendees-store.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/attendees-attendees-store.md
@@ -31,7 +31,7 @@ title: "Attendees Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees -- Connects --> attendees-store;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/conference-website-load-balancer.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/conference-website-load-balancer.md
@@ -31,7 +31,7 @@ title: "Conference Website Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/deployed-in-k8s-cluster.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/deployed-in-k8s-cluster.md
@@ -27,9 +27,9 @@ title: "Deployed In K8s Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/load-balancer-attendees.md
+++ b/cli/test_fixtures/getting-started/STEP-2/website/docs/relationships/load-balancer-attendees.md
@@ -31,7 +31,7 @@ title: "Load Balancer Attendees"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Connects --> attendees;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/attendees-store.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/attendees-store.md
@@ -60,9 +60,9 @@ title: "Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees-store[attendees-store]:::highlight;
-attendees -- Connects --> attendees-store;
-attendees-store -- Deployed In --> k8s-cluster;
+attendees-store[Attendees Store]:::highlight;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/attendees.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/attendees.md
@@ -60,10 +60,10 @@ title: "Attendees Service"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees[attendees]:::highlight;
-load-balancer -- Connects --> attendees;
-attendees -- Connects --> attendees-store;
-attendees -- Deployed In --> k8s-cluster;
+attendees[Attendees Service]:::highlight;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/conference-website.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/conference-website.md
@@ -91,8 +91,8 @@ title: "Conference Website"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website[conference-website]:::highlight;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/k8s-cluster.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/k8s-cluster.md
@@ -38,10 +38,10 @@ title: "Kubernetes Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-k8s-cluster[k8s-cluster]:::highlight;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+k8s-cluster[Kubernetes Cluster]:::highlight;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/load-balancer.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/nodes/load-balancer.md
@@ -55,10 +55,10 @@ title: "Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/attendees-attendees-store.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/attendees-attendees-store.md
@@ -31,7 +31,7 @@ title: "Attendees Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees -- Connects --> attendees-store;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/conference-website-load-balancer.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/conference-website-load-balancer.md
@@ -31,7 +31,7 @@ title: "Conference Website Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/deployed-in-k8s-cluster.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/deployed-in-k8s-cluster.md
@@ -27,9 +27,9 @@ title: "Deployed In K8s Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/load-balancer-attendees.md
+++ b/cli/test_fixtures/getting-started/STEP-3/website/docs/relationships/load-balancer-attendees.md
@@ -31,7 +31,7 @@ title: "Load Balancer Attendees"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Connects --> attendees;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/template/expected-output/widget-tests/related-nodes-test.md
+++ b/cli/test_fixtures/template/expected-output/widget-tests/related-nodes-test.md
@@ -5,27 +5,27 @@ url-to-local-file-mapping: ../../../getting-started/url-to-local-file-mapping.js
 ### Show relationships for a specific relationship ID
 ```mermaid
 graph TD;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 
 ### Show relationships for a specific node ID
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 
 ### Show relationships for a container node
 ```mermaid
 graph TD;
-k8s-cluster[k8s-cluster]:::highlight;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+k8s-cluster[Kubernetes Cluster]:::highlight;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/cli/test_fixtures/template/expected-output/widget-tests/sad-test.md
+++ b/cli/test_fixtures/template/expected-output/widget-tests/sad-test.md
@@ -1014,10 +1014,10 @@ The system is deployed across a Kubernetes cluster with the following deployment
 ### Container Deployment
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/attendees-store.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/attendees-store.md
@@ -59,9 +59,9 @@ title: "Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees-store[attendees-store]:::highlight;
-attendees -- Connects --> attendees-store;
-attendees-store -- Deployed In --> k8s-cluster;
+attendees-store[Attendees Store]:::highlight;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/attendees.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/attendees.md
@@ -59,10 +59,10 @@ title: "Attendees Service"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees[attendees]:::highlight;
-load-balancer -- Connects --> attendees;
-attendees -- Connects --> attendees-store;
-attendees -- Deployed In --> k8s-cluster;
+attendees[Attendees Service]:::highlight;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/conference-website.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/conference-website.md
@@ -90,8 +90,8 @@ title: "Conference Website"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website[conference-website]:::highlight;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/k8s-cluster.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/k8s-cluster.md
@@ -37,10 +37,10 @@ title: "Kubernetes Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-k8s-cluster[k8s-cluster]:::highlight;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+k8s-cluster[Kubernetes Cluster]:::highlight;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/load-balancer.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/nodes/load-balancer.md
@@ -54,10 +54,10 @@ title: "Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/attendees-attendees-store.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/attendees-attendees-store.md
@@ -30,7 +30,7 @@ title: "Attendees Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees -- Connects --> attendees-store;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/conference-website-load-balancer.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/conference-website-load-balancer.md
@@ -30,7 +30,7 @@ title: "Conference Website Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/deployed-in-k8s-cluster.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/deployed-in-k8s-cluster.md
@@ -26,9 +26,9 @@ title: "Deployed In K8s Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/load-balancer-attendees-service.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/non-secure/docs/relationships/load-balancer-attendees-service.md
@@ -30,7 +30,7 @@ title: "Load Balancer Attendees Service"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Connects --> attendees;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/attendees-store.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/attendees-store.md
@@ -60,9 +60,9 @@ title: "Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees-store[attendees-store]:::highlight;
-attendees -- Connects --> attendees-store;
-attendees-store -- Deployed In --> k8s-cluster;
+attendees-store[Attendees Store]:::highlight;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/attendees.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/attendees.md
@@ -60,10 +60,10 @@ title: "Attendees Service"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees[attendees]:::highlight;
-load-balancer -- Connects --> attendees;
-attendees -- Connects --> attendees-store;
-attendees -- Deployed In --> k8s-cluster;
+attendees[Attendees Service]:::highlight;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/conference-website.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/conference-website.md
@@ -91,8 +91,8 @@ title: "Conference Website"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website[conference-website]:::highlight;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/k8s-cluster.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/k8s-cluster.md
@@ -38,10 +38,10 @@ title: "Kubernetes Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-k8s-cluster[k8s-cluster]:::highlight;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+k8s-cluster[Kubernetes Cluster]:::highlight;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/load-balancer.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/nodes/load-balancer.md
@@ -55,10 +55,10 @@ title: "Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer[load-balancer]:::highlight;
-conference-website -- Connects --> load-balancer;
-load-balancer -- Connects --> attendees;
-load-balancer -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer]:::highlight;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/attendees-attendees-store.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/attendees-attendees-store.md
@@ -31,7 +31,7 @@ title: "Attendees Attendees Store"
 ## Related Nodes
 ```mermaid
 graph TD;
-attendees -- Connects --> attendees-store;
+attendees[Attendees Service] -- Connects --> attendees-store[Attendees Store];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/conference-website-load-balancer.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/conference-website-load-balancer.md
@@ -31,7 +31,7 @@ title: "Conference Website Load Balancer"
 ## Related Nodes
 ```mermaid
 graph TD;
-conference-website -- Connects --> load-balancer;
+conference-website[Conference Website] -- Connects --> load-balancer[Load Balancer];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/deployed-in-k8s-cluster.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/deployed-in-k8s-cluster.md
@@ -27,9 +27,9 @@ title: "Deployed In K8s Cluster"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Deployed In --> k8s-cluster;
-attendees -- Deployed In --> k8s-cluster;
-attendees-store -- Deployed In --> k8s-cluster;
+load-balancer[Load Balancer] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees[Attendees Service] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
+attendees-store[Attendees Store] -- Deployed In --> k8s-cluster[Kubernetes Cluster];
 classDef highlight fill:#f2bbae;
 ```
 

--- a/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/load-balancer-attendees.md
+++ b/shared/test_fixtures/docify/workshop/expected-output/secure/docs/relationships/load-balancer-attendees.md
@@ -31,7 +31,7 @@ title: "Load Balancer Attendees"
 ## Related Nodes
 ```mermaid
 graph TD;
-load-balancer -- Connects --> attendees;
+load-balancer[Load Balancer] -- Connects --> attendees[Attendees Service];
 classDef highlight fill:#f2bbae;
 ```
 


### PR DESCRIPTION
## Description
Fixes #2343. The `related-nodes` widget never read `context.nodes`, so every relationship kind (`interacts`, `connects`, `composed-of`, `deployed-in`) and the highlighted focus node rendered a node's raw `unique-id` in the Mermaid diagram instead of its `name` — not just the `composed-of`/`deployed-in` container case originally reported (see [comment on #2343](https://github.com/finos/architecture-as-code/issues/2343#issuecomment-5083239101)).

- `RelatedNodesWidget.transformToViewModel` now builds an `id -> name` map from `context.nodes`.
- A new `nodeLabel` Handlebars helper resolves that map (falling back to the id), and all four relationship partials plus the focus-node line now emit `id[name]` instead of a bare id.
- Labels are passed through the existing `mermaidText` helper so names containing parentheses/quotes/brackets don't break the diagram syntax.
- All `related-nodes-widget` fixtures were reworked so `unique-id != name`, closing the test gap the issue called out (fixtures previously all had `name == unique-id`, which is why this wasn't caught).
- Downstream fixtures that bake in this widget's Mermaid output (`cli/test_fixtures/template`, `cli/test_fixtures/getting-started`, `shared/test_fixtures/docify/workshop`) were regenerated and diffed to confirm only the label text changed.

#### Out of Scope

I also noted that the rendering (theming) of the related nodes section in the VSCode extension is different to the architecture / interface view.

I have deliberately *not* fixed that given the potential VSCode extension changes in #2869 . This PR is scoped only to `calm-widgets` plus any test output impacts

### Screenshots

**Before:**
<img width="281" height="520" alt="image" src="https://github.com/user-attachments/assets/683ae3e3-373e-4944-bde4-c99bbfaafd44" />


**After:**
<img width="326" height="572" alt="image" src="https://github.com/user-attachments/assets/d1c5e79e-debd-4fb2-bc20-7456b1ed6738" />


## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Widgets (`calm-widgets/`)

## Commit Message Format ✅
- Single commit: `fix(calm-widgets): resolve node names instead of raw ids in related-nodes diagrams`

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Verified visually in the VSCode extension's node Focus preview (Related Nodes diagram), and via the full `calm-widgets`, `cli`, and `shared` test suites (all green).

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards