### PR TITLE
fix(calm-hub): map Mongo write failures honestly instead of a false 404

### DIFF
--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -76,16 +76,20 @@ public class MongoDocumentSizeLimitIntegration {
         // HTTP body-size limit.
         String largeArchitectureJson = OBJECT_MAPPER.writeValueAsString(Map.of("data", "A".repeat(2_000_000)));
 
+        // The request body is identical on every iteration (only the path's version differs),
+        // so serialize it once rather than re-serializing the ~2MB payload each time.
+        String requestBody = OBJECT_MAPPER.writeValueAsString(Map.of(
+                "name", "size-limit-test-architecture",
+                "description", "for document size limit test",
+                "architectureJson", largeArchitectureJson
+        ));
+
         Response lastResponse = null;
         int version = 2;
         for (; version < MAX_VERSION_ATTEMPTS; version++) {
             lastResponse = given()
                     .contentType(ContentType.JSON)
-                    .body(OBJECT_MAPPER.writeValueAsString(Map.of(
-                            "name", "size-limit-test-architecture",
-                            "description", "for document size limit test",
-                            "architectureJson", largeArchitectureJson
-                    )))
+                    .body(requestBody)
                     .when().put("/api/calm/namespaces/finos/architectures/" + architectureId + "/versions/" + version + ".0.0")
                     .thenReturn();
 

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -1,0 +1,103 @@
+package integration.performance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import integration.IntegrationTestProfile;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static integration.MongoSetup.counterSetup;
+import static integration.MongoSetup.domainSetup;
+import static integration.MongoSetup.namespaceSetup;
+import static integration.performance.ConcurrencyTestHelper.extractIdsFromLocations;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for issue #2884: a MongoDB write that fails because the namespace's
+ * one-document-per-namespace shape has exceeded the 16MB BSON document limit must surface as
+ * an honest {@code 413} (via {@link org.finos.calm.domain.exception.StorageWriteException}),
+ * not the misleading {@code 404} the store used to throw for any {@code MongoWriteException}.
+ *
+ * <p>Grows a single architecture's version history against a real MongoDB instance until a
+ * write is rejected for exceeding the document size limit, then asserts the response is 413.
+ */
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+public class MongoDocumentSizeLimitIntegration {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    // Comfortably above the ~12-15 versions expected to be needed to cross the 16MB ceiling
+    // with ~2MB versions, without letting a stuck test run indefinitely.
+    private static final int MAX_VERSION_ATTEMPTS = 20;
+
+    @BeforeEach
+    public void setup() {
+        String mongoUri = ConfigProvider.getConfig().getValue("quarkus.mongodb.connection-string", String.class);
+        String mongoDatabase = ConfigProvider.getConfig().getValue("quarkus.mongodb.database", String.class);
+
+        try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
+            MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
+            namespaceSetup(database);
+            domainSetup(database);
+            counterSetup(database);
+        }
+    }
+
+    @Test
+    void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
+        Response createResponse = given()
+                .contentType(ContentType.JSON)
+                .body(OBJECT_MAPPER.writeValueAsString(Map.of(
+                        "name", "size-limit-test-architecture",
+                        "description", "for document size limit test",
+                        "architectureJson", "{\"v\":\"1.0.0\"}"
+                )))
+                .when().post("/api/calm/namespaces/finos/architectures")
+                .thenReturn();
+        assertEquals(201, createResponse.getStatusCode());
+
+        List<Integer> architectureIds = extractIdsFromLocations(List.of(createResponse), "architectures/(\\d+)");
+        int architectureId = architectureIds.get(0);
+
+        // Roughly 2MB of content per version; large enough to cross the 16MB document ceiling
+        // in a handful of writes without either request individually tripping an unrelated
+        // HTTP body-size limit.
+        String largeArchitectureJson = OBJECT_MAPPER.writeValueAsString(Map.of("data", "A".repeat(2_000_000)));
+
+        Response lastResponse = null;
+        int version = 2;
+        for (; version < MAX_VERSION_ATTEMPTS; version++) {
+            lastResponse = given()
+                    .contentType(ContentType.JSON)
+                    .body(OBJECT_MAPPER.writeValueAsString(Map.of(
+                            "name", "size-limit-test-architecture",
+                            "description", "for document size limit test",
+                            "architectureJson", largeArchitectureJson
+                    )))
+                    .when().put("/api/calm/namespaces/finos/architectures/" + architectureId + "/versions/" + version + ".0.0")
+                    .thenReturn();
+
+            if (lastResponse.getStatusCode() != 201) {
+                break;
+            }
+        }
+
+        assertTrue(version < MAX_VERSION_ATTEMPTS,
+                "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS + " versions were written");
+        assertEquals(413, lastResponse.getStatusCode(),
+                "Expected 413 (capacity exceeded) once the document exceeds MongoDB's 16MB limit, got: "
+                        + lastResponse.getStatusCode() + " body=" + lastResponse.getBody().asString());
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/StorageWriteException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/StorageWriteException.java
@@ -1,0 +1,29 @@
+package org.finos.calm.domain.exception;
+
+/**
+ * Thrown when a write to the backing store fails for an operational reason (as opposed to the
+ * resource simply not existing). Distinguishes the specific "storage capacity exceeded" case
+ * (e.g. MongoDB's 16MB BSON document limit) from other write failures so callers can respond
+ * with an accurate status code rather than a misleading not-found error.
+ */
+public class StorageWriteException extends RuntimeException {
+
+    private final boolean capacityExceeded;
+
+    private StorageWriteException(String message, Throwable cause, boolean capacityExceeded) {
+        super(message, cause);
+        this.capacityExceeded = capacityExceeded;
+    }
+
+    public static StorageWriteException capacityExceeded(Throwable cause) {
+        return new StorageWriteException("Storage capacity exceeded", cause, true);
+    }
+
+    public static StorageWriteException writeFailed(Throwable cause) {
+        return new StorageWriteException("Storage write failed", cause, false);
+    }
+
+    public boolean isCapacityExceeded() {
+        return capacityExceeded;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
@@ -310,7 +310,8 @@ public class AdrResource {
                 AdrRevisionNotFoundException.class, ex -> handleAdrRevisionNotFoundException(adrId, revision, ex),
                 AdrParseException.class, this::handleAdrParseException,
                 AdrPersistenceException.class, ex -> handleAdrPersistenceException(adrId, ex),
-                AdrRevisionExistsException.class, ex -> handleAdrRevisionExistsException(adrId, ex)
+                AdrRevisionExistsException.class, ex -> handleAdrRevisionExistsException(adrId, ex),
+                StorageWriteException.class, ex -> handleStorageWriteException((StorageWriteException) ex)
         );
 
         return handlers.getOrDefault(e.getClass(), ex -> {
@@ -347,6 +348,18 @@ public class AdrResource {
     private Response handleAdrPersistenceException(int adrId, Exception ex) {
         logger.error("Could not persist update of ADR [{}]", adrId, ex);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not persist update of ADR: [{}]:" + adrId).build();
+    }
+
+    private Response handleStorageWriteException(StorageWriteException ex) {
+        logger.error("Storage write failed", ex);
+        if (ex.isCapacityExceeded()) {
+            return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+                    .entity("This resource has reached the maximum storage size and cannot accept further versions")
+                    .build();
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("The write could not be completed due to a storage error")
+                .build();
     }
 
     private Response handleAdrRevisionExistsException(int adrId, Exception ex) {

--- a/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
@@ -40,11 +40,13 @@ import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REG
 public class AdrResource {
 
     private final AdrStore store;
+    private final StorageWriteExceptionMapper storageWriteExceptionMapper;
     private final Logger logger = LoggerFactory.getLogger(AdrResource.class);
 
     @Inject
-    public AdrResource(AdrStore store) {
+    public AdrResource(AdrStore store, StorageWriteExceptionMapper storageWriteExceptionMapper) {
         this.store = store;
+        this.storageWriteExceptionMapper = storageWriteExceptionMapper;
     }
 
     /**
@@ -311,7 +313,7 @@ public class AdrResource {
                 AdrParseException.class, this::handleAdrParseException,
                 AdrPersistenceException.class, ex -> handleAdrPersistenceException(adrId, ex),
                 AdrRevisionExistsException.class, ex -> handleAdrRevisionExistsException(adrId, ex),
-                StorageWriteException.class, ex -> handleStorageWriteException((StorageWriteException) ex)
+                StorageWriteException.class, ex -> storageWriteExceptionMapper.toResponse((StorageWriteException) ex)
         );
 
         return handlers.getOrDefault(e.getClass(), ex -> {
@@ -348,18 +350,6 @@ public class AdrResource {
     private Response handleAdrPersistenceException(int adrId, Exception ex) {
         logger.error("Could not persist update of ADR [{}]", adrId, ex);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Could not persist update of ADR: [{}]:" + adrId).build();
-    }
-
-    private Response handleStorageWriteException(StorageWriteException ex) {
-        logger.error("Storage write failed", ex);
-        if (ex.isCapacityExceeded()) {
-            return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
-                    .entity("This resource has reached the maximum storage size and cannot accept further versions")
-                    .build();
-        }
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .entity("The write could not be completed due to a storage error")
-                .build();
     }
 
     private Response handleAdrRevisionExistsException(int adrId, Exception ex) {

--- a/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
@@ -25,7 +25,9 @@ public class StorageWriteExceptionMapper implements ExceptionMapper<StorageWrite
 
     @Override
     public Response toResponse(StorageWriteException e) {
-        LOG.error("Storage write failed", e);
+        // The store layer already logs the underlying cause with its stack trace, so only a
+        // concise summary is logged here to avoid doubling it for every failure.
+        LOG.error("Storage write failed: {}", e.getMessage());
         if (e.isCapacityExceeded()) {
             return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
                     .entity("This resource has reached the maximum storage size and cannot accept further versions")

--- a/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
@@ -1,5 +1,6 @@
 package org.finos.calm.resources;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
@@ -11,7 +12,12 @@ import org.slf4j.LoggerFactory;
  * Maps {@link StorageWriteException} to an honest HTTP response instead of letting a write
  * failure surface as a misleading not-found error or an undiagnostic generic 500. The full
  * cause is logged server-side only, never echoed to the client.
+ *
+ * <p>{@code @ApplicationScoped} makes this injectable directly (e.g. by {@link AdrResource},
+ * whose per-endpoint blanket exception catch would otherwise shadow this mapper), so the
+ * 413/500 mapping logic has a single definition instead of being duplicated.
  */
+@ApplicationScoped
 @Provider
 public class StorageWriteExceptionMapper implements ExceptionMapper<StorageWriteException> {
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StorageWriteExceptionMapper.java
@@ -1,0 +1,32 @@
+package org.finos.calm.resources;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.finos.calm.domain.exception.StorageWriteException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maps {@link StorageWriteException} to an honest HTTP response instead of letting a write
+ * failure surface as a misleading not-found error or an undiagnostic generic 500. The full
+ * cause is logged server-side only, never echoed to the client.
+ */
+@Provider
+public class StorageWriteExceptionMapper implements ExceptionMapper<StorageWriteException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StorageWriteExceptionMapper.class);
+
+    @Override
+    public Response toResponse(StorageWriteException e) {
+        LOG.error("Storage write failed", e);
+        if (e.isCapacityExceeded()) {
+            return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+                    .entity("This resource has reached the maximum storage size and cannot accept further versions")
+                    .build();
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("The write could not be completed due to a storage error")
+                .build();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -155,7 +155,9 @@ public class MongoAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(adrMeta.getRevision()));
-        log.info("RevisionDoc: [{}], Revision: [{}]", adrDoc.get("revisions"), adrMeta.getRevision());
+        // Pre-existing bug: this used to log the entire revisions map (every revision's full
+        // content) rather than just the requested one — log identifying info only.
+        log.info("Revision [{}] found: {}", adrMeta.getRevision(), revisionDoc != null);
         if(revisionDoc == null) {
             throw new AdrRevisionNotFoundException();
         }
@@ -249,7 +251,9 @@ public class MongoAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(latestRevision));
-        log.info("RevisionDoc: [{}], Revision: [{}]", revisionDoc, latestRevision);
+        // Pre-existing bug: this used to log the full revision content rather than just
+        // identifying it — log the revision number only.
+        log.info("Resolved latest revision: [{}]", latestRevision);
         try {
             return new AdrMeta.AdrMetaBuilder()
                     .setNamespace(adrMeta.getNamespace())
@@ -283,10 +287,13 @@ public class MongoAdrStore implements AdrStore {
                 throw new AdrRevisionExistsException();
             }
         } catch(MongoWriteException ex) {
-            log.error("Failed to write ADR to mongo [{}]", adrMeta, ex);
+            // Log identifying fields only, not the full adrMeta object — its toString()
+            // includes the entire nested ADR content.
             // Both callers (updateAdrForNamespace/updateAdrStatus) already verify the ADR
             // entity exists via retrieveAdrDoc/retrieveLatestRevision before reaching this
             // write, so any MongoWriteException here is a genuine write failure.
+            log.error("Failed to write ADR [namespace={}, id={}, revision={}] to mongo",
+                    adrMeta.getNamespace(), adrMeta.getId(), adrMeta.getRevision(), ex);
             throw MongoWriteFailures.toStorageWriteException(ex);
         } catch(JsonProcessingException e) {
             log.error("Could not write ADR Content to String", e);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -19,6 +19,7 @@ import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.*;
 import org.finos.calm.store.AdrStore;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -283,7 +284,10 @@ public class MongoAdrStore implements AdrStore {
             }
         } catch(MongoWriteException ex) {
             log.error("Failed to write ADR to mongo [{}]", adrMeta, ex);
-            throw new AdrPersistenceException();
+            // Both callers (updateAdrForNamespace/updateAdrStatus) already verify the ADR
+            // entity exists via retrieveAdrDoc/retrieveLatestRevision before reaching this
+            // write, so any MongoWriteException here is a genuine write failure.
+            throw MongoWriteFailures.toStorageWriteException(ex);
         } catch(JsonProcessingException e) {
             log.error("Could not write ADR Content to String", e);
             throw new AdrParseException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -155,8 +155,6 @@ public class MongoAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(adrMeta.getRevision()));
-        // Pre-existing bug: this used to log the entire revisions map (every revision's full
-        // content) rather than just the requested one — log identifying info only.
         log.info("Revision [{}] found: {}", adrMeta.getRevision(), revisionDoc != null);
         if(revisionDoc == null) {
             throw new AdrRevisionNotFoundException();
@@ -251,8 +249,6 @@ public class MongoAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(latestRevision));
-        // Pre-existing bug: this used to log the full revision content rather than just
-        // identifying it — log the revision number only.
         log.info("Resolved latest revision: [{}]", latestRevision);
         try {
             return new AdrMeta.AdrMetaBuilder()

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Architecture;
@@ -238,7 +239,10 @@ public class MongoArchitectureStore implements ArchitectureStore {
     }
 
     private void writeArchitectureToMongo(Architecture architecture) throws ArchitectureNotFoundException, NamespaceNotFoundException {
-        retrieveArchitectureVersions(architecture);
+        // Verifies the namespace AND the specific architecture entity exist, so any
+        // MongoWriteException from the update below is a genuine write failure, not a
+        // disguised not-found.
+        getArchitectureVersions(architecture);
 
         Document filter = new Document("namespace", architecture.getNamespace())
                 .append("architectures.architectureId", architecture.getId());
@@ -252,7 +256,7 @@ public class MongoArchitectureStore implements ArchitectureStore {
             architectureCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
             log.error("Failed to write architecture to mongo [{}]", architecture, ex);
-            throw new ArchitectureNotFoundException();
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -194,7 +194,9 @@ public class MongoArchitectureStore implements ArchitectureStore {
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(architecture.getMongoVersion());
-                log.info("VersionDoc: [{}], Mongo Version: [{}]", architectureDoc.get("versions"), architecture.getMongoVersion());
+                // Pre-existing bug: this used to log the entire versions map (every version's
+                // full content) rather than just the requested one — log identifying info only.
+                log.info("Version [{}] found: {}", architecture.getMongoVersion(), versionDoc != null);
                 if (versionDoc == null) {
                     throw new ArchitectureVersionNotFoundException();
                 }
@@ -255,7 +257,10 @@ public class MongoArchitectureStore implements ArchitectureStore {
         try {
             architectureCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
-            log.error("Failed to write architecture to mongo [{}]", architecture, ex);
+            // Log identifying fields only, not the full architecture object — its toString()
+            // includes the entire (potentially near-16MB) architectureJson payload.
+            log.error("Failed to write architecture [namespace={}, id={}, version={}] to mongo",
+                    architecture.getNamespace(), architecture.getId(), architecture.getMongoVersion(), ex);
             throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -179,6 +179,17 @@ public class MongoArchitectureStore implements ArchitectureStore {
         return result;
     }
 
+    private void verifyArchitectureExists(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        Document result = retrieveArchitectureVersions(architecture);
+        List<Document> architectures = result.getList("architectures", Document.class);
+        for (Document architectureDoc : architectures) {
+            if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
+                return;
+            }
+        }
+        throw new ArchitectureNotFoundException();
+    }
+
     @Override
     public String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
         Document result = retrieveArchitectureVersions(architecture);
@@ -242,7 +253,7 @@ public class MongoArchitectureStore implements ArchitectureStore {
         // Verifies the namespace AND the specific architecture entity exist, so any
         // MongoWriteException from the update below is a genuine write failure, not a
         // disguised not-found.
-        getArchitectureVersions(architecture);
+        verifyArchitectureExists(architecture);
 
         Document filter = new Document("namespace", architecture.getNamespace())
                 .append("architectures.architectureId", architecture.getId());

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -194,8 +194,6 @@ public class MongoArchitectureStore implements ArchitectureStore {
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(architecture.getMongoVersion());
-                // Pre-existing bug: this used to log the entire versions map (every version's
-                // full content) rather than just the requested one — log identifying info only.
                 log.info("Version [{}] found: {}", architecture.getMongoVersion(), versionDoc != null);
                 if (versionDoc == null) {
                     throw new ArchitectureVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -1,5 +1,6 @@
 package org.finos.calm.store.mongo;
 
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -21,8 +22,10 @@ import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
 import org.finos.calm.domain.exception.DomainNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.ControlStore;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -257,8 +260,15 @@ public class MongoControlStore implements ControlStore {
         }
         Document update = new Document("$set", setFields);
 
-        if (controlCollection.updateOne(filter, update).getMatchedCount() == 0) {
-            throw new ControlRequirementVersionExistsException();
+        try {
+            if (controlCollection.updateOne(filter, update).getMatchedCount() == 0) {
+                throw new ControlRequirementVersionExistsException();
+            }
+        } catch (MongoWriteException ex) {
+            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
+                throw StorageWriteException.capacityExceeded(ex);
+            }
+            throw ex;
         }
     }
 
@@ -313,16 +323,23 @@ public class MongoControlStore implements ControlStore {
                 )
         );
 
-        if (controlCollection.updateOne(
-                filter,
-                Updates.set("controls.$[ctrl].configurations.$[cfg].versions." + mongoVersion,
-                        Document.parse(request.getConfigurationJson())),
-                new UpdateOptions().arrayFilters(List.of(
-                        Filters.eq("ctrl.controlId", controlId),
-                        Filters.eq("cfg.configurationId", configurationId)
-                ))
-        ).getMatchedCount() == 0) {
-            throw new ControlConfigurationVersionExistsException();
+        try {
+            if (controlCollection.updateOne(
+                    filter,
+                    Updates.set("controls.$[ctrl].configurations.$[cfg].versions." + mongoVersion,
+                            Document.parse(request.getConfigurationJson())),
+                    new UpdateOptions().arrayFilters(List.of(
+                            Filters.eq("ctrl.controlId", controlId),
+                            Filters.eq("cfg.configurationId", configurationId)
+                    ))
+            ).getMatchedCount() == 0) {
+                throw new ControlConfigurationVersionExistsException();
+            }
+        } catch (MongoWriteException ex) {
+            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
+                throw StorageWriteException.capacityExceeded(ex);
+            }
+            throw ex;
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -22,10 +22,11 @@ import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
 import org.finos.calm.domain.exception.DomainNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.ControlStore;
 import org.finos.calm.store.util.MongoUpsertPush;
 import org.finos.calm.store.util.MongoWriteFailures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +69,7 @@ import org.finos.calm.store.util.VersionKeySelector;
 @Typed(MongoControlStore.class)
 public class MongoControlStore implements ControlStore {
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
     private final MongoCollection<Document> controlCollection;
     private final MongoCounterStore counterStore;
     private final MongoDomainStore domainStore;
@@ -265,10 +267,9 @@ public class MongoControlStore implements ControlStore {
                 throw new ControlRequirementVersionExistsException();
             }
         } catch (MongoWriteException ex) {
-            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
-                throw StorageWriteException.capacityExceeded(ex);
-            }
-            throw ex;
+            log.error("Failed to write control requirement [domain={}, controlId={}, version={}] to mongo",
+                    domain, controlId, version, ex);
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 
@@ -336,10 +337,9 @@ public class MongoControlStore implements ControlStore {
                 throw new ControlConfigurationVersionExistsException();
             }
         } catch (MongoWriteException ex) {
-            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
-                throw StorageWriteException.capacityExceeded(ex);
-            }
-            throw ex;
+            log.error("Failed to write control configuration [domain={}, controlId={}, configurationId={}, version={}] to mongo",
+                    domain, controlId, configurationId, version, ex);
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -156,6 +156,17 @@ public class MongoFlowStore implements FlowStore {
         return result;
     }
 
+    private void verifyFlowExists(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
+        Document result = retrieveFlowVersions(flow);
+        List<Document> flows = result.getList("flows", Document.class);
+        for (Document flowDoc : flows) {
+            if (flow.getId() == flowDoc.getInteger("flowId")) {
+                return;
+            }
+        }
+        throw new FlowNotFoundException();
+    }
+
     @Override
     public String getFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException {
         Document result = retrieveFlowVersions(flow);
@@ -212,7 +223,7 @@ public class MongoFlowStore implements FlowStore {
         // Verifies the namespace AND the specific flow entity exist, so any
         // MongoWriteException from the update below is a genuine write failure, not a
         // disguised not-found.
-        getFlowVersions(flow);
+        verifyFlowExists(flow);
 
         Document filter = new Document("namespace", flow.getNamespace())
                 .append("flows.flowId", flow.getId());

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -168,8 +168,6 @@ public class MongoFlowStore implements FlowStore {
 
                 // Return the flow JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(flow.getMongoVersion());
-                // Pre-existing bug: this used to log the entire versions map (every version's
-                // full content) rather than just the requested one — log identifying info only.
                 log.info("Version [{}] found: {}", flow.getMongoVersion(), versionDoc != null);
                 if(versionDoc == null) {
                     throw new FlowVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -168,7 +168,9 @@ public class MongoFlowStore implements FlowStore {
 
                 // Return the flow JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(flow.getMongoVersion());
-                log.info("VersionDoc: [{}], Mongo Version: [{}]", flowDoc.get("versions"), flow.getMongoVersion());
+                // Pre-existing bug: this used to log the entire versions map (every version's
+                // full content) rather than just the requested one — log identifying info only.
+                log.info("Version [{}] found: {}", flow.getMongoVersion(), versionDoc != null);
                 if(versionDoc == null) {
                     throw new FlowVersionNotFoundException();
                 }
@@ -221,7 +223,10 @@ public class MongoFlowStore implements FlowStore {
         try {
             flowCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
-            log.error("Failed to write flow to mongo [{}]", flow, ex);
+            // Log identifying fields only, not the full flow object — its toString()
+            // includes the entire (potentially near-16MB) flowJson payload.
+            log.error("Failed to write flow [namespace={}, id={}, version={}] to mongo",
+                    flow.getNamespace(), flow.getId(), flow.getMongoVersion(), ex);
             throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.Flow;
 import org.finos.calm.domain.exception.FlowNotFoundException;
@@ -208,7 +209,10 @@ public class MongoFlowStore implements FlowStore {
     }
 
     private void writeFlowToMongo(Flow flow) throws FlowNotFoundException, NamespaceNotFoundException {
-        retrieveFlowVersions(flow);
+        // Verifies the namespace AND the specific flow entity exist, so any
+        // MongoWriteException from the update below is a genuine write failure, not a
+        // disguised not-found.
+        getFlowVersions(flow);
 
         Document filter = new Document("namespace", flow.getNamespace())
                 .append("flows.flowId", flow.getId());
@@ -218,7 +222,7 @@ public class MongoFlowStore implements FlowStore {
             flowCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
             log.error("Failed to write flow to mongo [{}]", flow, ex);
-            throw new FlowNotFoundException();
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -190,10 +190,9 @@ public class MongoInterfaceStore implements InterfaceStore {
                 throw new InterfaceVersionExistsException();
             }
         } catch (MongoWriteException ex) {
-            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
-                throw StorageWriteException.capacityExceeded(ex);
-            }
-            throw ex;
+            logger.error("Failed to write interface [namespace={}, id={}, version={}] to mongo",
+                    namespace, interfaceId, version, ex);
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
 
         CalmInterface calmInterface = new CalmInterface(interfaceRequest);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -12,6 +12,7 @@ import org.bson.conversions.Bson;
 import org.finos.calm.domain.CalmInterface;
 import org.finos.calm.domain.exception.*;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.store.InterfaceStore;
@@ -184,8 +185,15 @@ public class MongoInterfaceStore implements InterfaceStore {
                 .append("interfaces.$.description", interfaceRequest.getDescription())
                 .append("interfaces.$.versions." + mongoVersion, Document.parse(interfaceRequest.getInterfaceJson())));
 
-        if (interfaceCollection.updateOne(filter, update).getMatchedCount() == 0) {
-            throw new InterfaceVersionExistsException();
+        try {
+            if (interfaceCollection.updateOne(filter, update).getMatchedCount() == 0) {
+                throw new InterfaceVersionExistsException();
+            }
+        } catch (MongoWriteException ex) {
+            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
+                throw StorageWriteException.capacityExceeded(ex);
+            }
+            throw ex;
         }
 
         CalmInterface calmInterface = new CalmInterface(interfaceRequest);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -183,7 +183,9 @@ public class MongoPatternStore implements PatternStore {
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(pattern.getMongoVersion());
-                log.info("VersionDoc: [{}], Mongo Version: [{}]", patternDoc.get("versions"), pattern.getMongoVersion());
+                // Pre-existing bug: this used to log the entire versions map (every version's
+                // full content) rather than just the requested one — log identifying info only.
+                log.info("Version [{}] found: {}", pattern.getMongoVersion(), versionDoc != null);
                 if(versionDoc == null) {
                     throw new PatternVersionNotFoundException();
                 }
@@ -257,7 +259,10 @@ public class MongoPatternStore implements PatternStore {
         try {
             patternCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
-            log.error("Failed to write pattern to mongo [{}]", pattern, ex);
+            // Log identifying fields only, not the full pattern object — its toString()
+            // includes the entire (potentially near-16MB) patternJson payload.
+            log.error("Failed to write pattern [namespace={}, id={}, version={}] to mongo",
+                    pattern.getNamespace(), pattern.getId(), pattern.getMongoVersion(), ex);
             throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -183,8 +183,6 @@ public class MongoPatternStore implements PatternStore {
 
                 // Return the pattern JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(pattern.getMongoVersion());
-                // Pre-existing bug: this used to log the entire versions map (every version's
-                // full content) rather than just the requested one — log identifying info only.
                 log.info("Version [{}] found: {}", pattern.getMongoVersion(), versionDoc != null);
                 if(versionDoc == null) {
                     throw new PatternVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -168,6 +168,17 @@ public class MongoPatternStore implements PatternStore {
         return result;
     }
 
+    private void verifyPatternExists(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException {
+        Document result = retrievePatternVersions(pattern);
+        List<Document> patterns = result.getList("patterns", Document.class);
+        for (Document patternDoc : patterns) {
+            if (pattern.getId() == patternDoc.getInteger("patternId")) {
+                return;
+            }
+        }
+        throw new PatternNotFoundException();
+    }
+
     @Override
     public String getPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException {
         Document result = retrievePatternVersions(pattern);
@@ -238,7 +249,7 @@ public class MongoPatternStore implements PatternStore {
         // Verifies the namespace AND the specific pattern entity exist, so any
         // MongoWriteException from the update below is a genuine write failure, not a
         // disguised not-found.
-        getPatternVersions(pattern);
+        verifyPatternExists(pattern);
 
         Document patternDocument = Document.parse(pattern.getPatternJson());
         Document filter = new Document("namespace", pattern.getNamespace())

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -12,6 +12,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Pattern;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
@@ -234,7 +235,10 @@ public class MongoPatternStore implements PatternStore {
     }
 
     private void writePatternToMongo(Pattern pattern) throws PatternNotFoundException, NamespaceNotFoundException {
-        retrievePatternVersions(pattern);
+        // Verifies the namespace AND the specific pattern entity exist, so any
+        // MongoWriteException from the update below is a genuine write failure, not a
+        // disguised not-found.
+        getPatternVersions(pattern);
 
         Document patternDocument = Document.parse(pattern.getPatternJson());
         Document filter = new Document("namespace", pattern.getNamespace())
@@ -254,7 +258,7 @@ public class MongoPatternStore implements PatternStore {
             patternCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
             log.error("Failed to write pattern to mongo [{}]", pattern, ex);
-            throw new PatternNotFoundException();
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -17,6 +17,8 @@ import org.finos.calm.domain.exception.*;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.StandardStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +44,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 @Typed(MongoStandardStore.class)
 public class MongoStandardStore implements StandardStore {
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
     private final MongoCollection<Document> standardCollection;
@@ -196,10 +199,9 @@ public class MongoStandardStore implements StandardStore {
                 throw new StandardVersionExistsException();
             }
         } catch (MongoWriteException ex) {
-            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
-                throw StorageWriteException.capacityExceeded(ex);
-            }
-            throw ex;
+            log.error("Failed to write standard [namespace={}, id={}, version={}] to mongo",
+                    namespace, standardId, version, ex);
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
 
         Standard standard = new Standard(standardRequest);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -11,6 +11,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.exception.*;
 import org.finos.calm.domain.standards.CreateStandardRequest;
@@ -190,8 +191,15 @@ public class MongoStandardStore implements StandardStore {
                 .append("standards.$.description", standardRequest.getDescription())
                 .append("standards.$.versions." + mongoVersion, Document.parse(standardRequest.getStandardJson())));
 
-        if (standardCollection.updateOne(filter, update).getMatchedCount() == 0) {
-            throw new StandardVersionExistsException();
+        try {
+            if (standardCollection.updateOne(filter, update).getMatchedCount() == 0) {
+                throw new StandardVersionExistsException();
+            }
+        } catch (MongoWriteException ex) {
+            if (MongoWriteFailures.isDocumentTooLarge(ex)) {
+                throw StorageWriteException.capacityExceeded(ex);
+            }
+            throw ex;
         }
 
         Standard standard = new Standard(standardRequest);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -151,6 +151,17 @@ public class MongoTimelineStore implements TimelineStore {
         return result;
     }
 
+    private void verifyTimelineExists(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
+        Document result = retrieveTimelineVersions(timeline);
+        List<Document> timelines = result.getList("timelines", Document.class);
+        for (Document timelineDoc : timelines) {
+            if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
+                return;
+            }
+        }
+        throw new TimelineNotFoundException();
+    }
+
     @Override
     public String getTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
         Document result = retrieveTimelineVersions(timeline);
@@ -210,7 +221,7 @@ public class MongoTimelineStore implements TimelineStore {
         // Verifies the namespace AND the specific timeline entity exist, so any
         // MongoWriteException from the update below is a genuine write failure, not a
         // disguised not-found.
-        getTimelineVersions(timeline);
+        verifyTimelineExists(timeline);
 
         Document filter = new Document("namespace", timeline.getNamespace())
                 .append("timelines.timelineId", timeline.getId());

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -166,8 +166,6 @@ public class MongoTimelineStore implements TimelineStore {
 
                 // Return the timeline JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(timeline.getMongoVersion());
-                // Pre-existing bug: this used to log the entire versions map (every version's
-                // full content) rather than just the requested one — log identifying info only.
                 log.info("Version [{}] found: {}", timeline.getMongoVersion(), versionDoc != null);
                 if (versionDoc == null) {
                     throw new TimelineVersionNotFoundException();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -19,6 +19,7 @@ import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
 import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.store.TimelineStore;
 import org.finos.calm.store.util.MongoUpsertPush;
+import org.finos.calm.store.util.MongoWriteFailures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,7 +207,10 @@ public class MongoTimelineStore implements TimelineStore {
     }
 
     private void writeTimelineToMongo(Timeline timeline) throws TimelineNotFoundException, NamespaceNotFoundException {
-        retrieveTimelineVersions(timeline);
+        // Verifies the namespace AND the specific timeline entity exist, so any
+        // MongoWriteException from the update below is a genuine write failure, not a
+        // disguised not-found.
+        getTimelineVersions(timeline);
 
         Document filter = new Document("namespace", timeline.getNamespace())
                 .append("timelines.timelineId", timeline.getId());
@@ -216,7 +220,7 @@ public class MongoTimelineStore implements TimelineStore {
             timelineCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
             log.error("Failed to write timeline to mongo [{}]", timeline, ex);
-            throw new TimelineNotFoundException();
+            throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -166,7 +166,9 @@ public class MongoTimelineStore implements TimelineStore {
 
                 // Return the timeline JSON blob for the specified version
                 Document versionDoc = (Document) versions.get(timeline.getMongoVersion());
-                log.info("VersionDoc: [{}], Mongo Version: [{}]", timelineDoc.get("versions"), timeline.getMongoVersion());
+                // Pre-existing bug: this used to log the entire versions map (every version's
+                // full content) rather than just the requested one — log identifying info only.
+                log.info("Version [{}] found: {}", timeline.getMongoVersion(), versionDoc != null);
                 if (versionDoc == null) {
                     throw new TimelineVersionNotFoundException();
                 }
@@ -219,7 +221,10 @@ public class MongoTimelineStore implements TimelineStore {
         try {
             timelineCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
         } catch (MongoWriteException ex) {
-            log.error("Failed to write timeline to mongo [{}]", timeline, ex);
+            // Log identifying fields only, not the full timeline object — its toString()
+            // includes the entire (potentially near-16MB) timelineJson payload.
+            log.error("Failed to write timeline [namespace={}, id={}, version={}] to mongo",
+                    timeline.getNamespace(), timeline.getId(), timeline.getMongoVersion(), ex);
             throw MongoWriteFailures.toStorageWriteException(ex);
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -215,7 +215,9 @@ public class NitriteAdrStore implements AdrStore {
 
             // Return the ADR JSON blob for the specified revision
             String adrStr = revisionsDoc.get(String.valueOf(adrMeta.getRevision()), String.class);
-            LOG.info("RevisionDoc: [{}], Revision: [{}]", revisionsDoc, adrMeta.getRevision());
+            // Pre-existing bug: this used to log the entire revisions map (every revision's full
+            // content) rather than just the requested one — log identifying info only.
+            LOG.info("Revision [{}] found: {}", adrMeta.getRevision(), adrStr != null);
 
             if (adrStr == null) {
                 LOG.warn("Revision {} not found for ADR {} in namespace '{}'",
@@ -339,7 +341,9 @@ public class NitriteAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         String adrStr = revisionsDoc.get(String.valueOf(latestRevision), String.class);
-        LOG.info("RevisionDoc: [{}], Revision: [{}]", adrStr, latestRevision);
+        // Pre-existing bug: this used to log the full revision content rather than just
+        // identifying it — log the revision number only.
+        LOG.info("Resolved latest revision: [{}]", latestRevision);
 
         try {
             return new AdrMeta.AdrMetaBuilder()

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -215,8 +215,6 @@ public class NitriteAdrStore implements AdrStore {
 
             // Return the ADR JSON blob for the specified revision
             String adrStr = revisionsDoc.get(String.valueOf(adrMeta.getRevision()), String.class);
-            // Pre-existing bug: this used to log the entire revisions map (every revision's full
-            // content) rather than just the requested one — log identifying info only.
             LOG.info("Revision [{}] found: {}", adrMeta.getRevision(), adrStr != null);
 
             if (adrStr == null) {
@@ -341,8 +339,6 @@ public class NitriteAdrStore implements AdrStore {
 
         // Return the ADR JSON blob for the specified revision
         String adrStr = revisionsDoc.get(String.valueOf(latestRevision), String.class);
-        // Pre-existing bug: this used to log the full revision content rather than just
-        // identifying it — log the revision number only.
         LOG.info("Resolved latest revision: [{}]", latestRevision);
 
         try {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -227,7 +227,9 @@ public class NitriteArchitectureStore implements ArchitectureStore {
                     // Return the architecture JSON blob for the specified version
                     String mongoVersion = architecture.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+                    // Pre-existing bug: this used to log the entire versions map (every version's
+                    // full content) rather than just the requested one — log identifying info only.
+                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
 
                     if (!(versionObj instanceof String)) {
                         LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -227,8 +227,6 @@ public class NitriteArchitectureStore implements ArchitectureStore {
                     // Return the architecture JSON blob for the specified version
                     String mongoVersion = architecture.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    // Pre-existing bug: this used to log the entire versions map (every version's
-                    // full content) rather than just the requested one — log identifying info only.
                     LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
 
                     if (!(versionObj instanceof String)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -226,7 +226,9 @@ public class NitriteFlowStore implements FlowStore {
                     // Return the flow JSON blob for the specified version
                     String mongoVersion = flow.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+                    // Pre-existing bug: this used to log the entire versions map (every version's
+                    // full content) rather than just the requested one — log identifying info only.
+                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj != null);
 
                     if (versionObj == null) {
                         LOG.warn("Version '{}' not found for flow {} in namespace '{}'",

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -226,8 +226,6 @@ public class NitriteFlowStore implements FlowStore {
                     // Return the flow JSON blob for the specified version
                     String mongoVersion = flow.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    // Pre-existing bug: this used to log the entire versions map (every version's
-                    // full content) rather than just the requested one — log identifying info only.
                     LOG.info("Version [{}] found: {}", mongoVersion, versionObj != null);
 
                     if (versionObj == null) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -217,8 +217,6 @@ public class NitriteTimelineStore implements TimelineStore {
                     // Return the timeline JSON blob for the specified version
                     String mongoVersion = timeline.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    // Pre-existing bug: this used to log the entire versions map (every version's
-                    // full content) rather than just the requested one — log identifying info only.
                     LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
 
                     if (!(versionObj instanceof String)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -217,7 +217,9 @@ public class NitriteTimelineStore implements TimelineStore {
                     // Return the timeline JSON blob for the specified version
                     String mongoVersion = timeline.getMongoVersion();
                     Object versionObj = versions.get(mongoVersion);
-                    LOG.info("VersionDoc: [{}], Mongo Version: [{}]", versions, mongoVersion);
+                    // Pre-existing bug: this used to log the entire versions map (every version's
+                    // full content) rather than just the requested one — log identifying info only.
+                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
 
                     if (!(versionObj instanceof String)) {
                         LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoWriteFailures.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoWriteFailures.java
@@ -1,0 +1,35 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.MongoWriteException;
+import org.finos.calm.domain.exception.StorageWriteException;
+
+/**
+ * Classifies a {@link MongoWriteException} that occurred while writing a version's content
+ * (as opposed to the "duplicate key on namespace/domain creation" race handled by
+ * {@link MongoUpsertPush}), so callers can surface an accurate error rather than mismapping
+ * every write failure to a not-found response.
+ *
+ * <h2>Why {@code getCode()} and not {@link com.mongodb.ErrorCategory}</h2>
+ * The driver's {@code ErrorCategory} enum only distinguishes {@code DUPLICATE_KEY} and
+ * {@code EXECUTION_TIMEOUT} — there is no category for "document too large", so the specific
+ * MongoDB error code must be checked directly.
+ */
+public final class MongoWriteFailures {
+
+    /** MongoDB's {@code BSONObjectTooLarge} error code — the 16MB-per-document ceiling. */
+    private static final int DOCUMENT_TOO_LARGE_ERROR_CODE = 10334;
+
+    private MongoWriteFailures() {
+    }
+
+    public static StorageWriteException toStorageWriteException(MongoWriteException ex) {
+        if (isDocumentTooLarge(ex)) {
+            return StorageWriteException.capacityExceeded(ex);
+        }
+        return StorageWriteException.writeFailed(ex);
+    }
+
+    public static boolean isDocumentTooLarge(MongoWriteException ex) {
+        return ex.getError().getCode() == DOCUMENT_TOO_LARGE_ERROR_CODE;
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
@@ -137,6 +137,8 @@ public class TestAdrResourceShould {
                 Arguments.of("valid", new AdrParseException(), 500),
                 Arguments.of("valid", new AdrPersistenceException(), 500),
                 Arguments.of("valid", new AdrRevisionExistsException(), 409),
+                Arguments.of("valid", StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of("valid", StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of("valid", null, 201)
         );
     }
@@ -327,6 +329,8 @@ public class TestAdrResourceShould {
                 Arguments.of("valid", new AdrParseException(), 500),
                 Arguments.of("valid", new AdrPersistenceException(), 500),
                 Arguments.of("valid", new AdrRevisionExistsException(), 409),
+                Arguments.of("valid", StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of("valid", StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of("valid", null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourcePutEnabledShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourcePutEnabledShould.java
@@ -11,6 +11,7 @@ import org.finos.calm.domain.architecture.ArchitectureRequest;
 import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.ArchitectureStore;
 import org.bson.json.JsonParseException;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,8 @@ public class TestArchitectureResourcePutEnabledShould {
                 Arguments.of(new NamespaceNotFoundException(), 404),
                 Arguments.of(new ArchitectureNotFoundException(), 404),
                 Arguments.of(new JsonParseException(), 400),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
@@ -453,6 +453,8 @@ public class TestControlResourceShould {
                 Arguments.of(new ControlNotFoundException(), 404),
                 Arguments.of(new ControlRequirementVersionExistsException(), 409),
                 Arguments.of(new JsonParseException(), 400),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }
@@ -580,6 +582,8 @@ public class TestControlResourceShould {
                 Arguments.of(new ControlConfigurationNotFoundException(), 404),
                 Arguments.of(new ControlConfigurationVersionExistsException(), 409),
                 Arguments.of(new JsonParseException(), 400),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourcePutEnabledShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourcePutEnabledShould.java
@@ -7,6 +7,7 @@ import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.Flow;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.FlowStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +50,8 @@ public class TestFlowResourcePutEnabledShould {
         return Stream.of(
                 Arguments.of( new NamespaceNotFoundException(), 404),
                 Arguments.of( new FlowNotFoundException(), 404),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
@@ -11,6 +11,7 @@ import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.store.InterfaceStore;
@@ -317,6 +318,8 @@ public class TestInterfaceResourceShould {
                 Arguments.of("valid", new InterfaceNotFoundException(), 404),
                 Arguments.of("valid", new InterfaceVersionExistsException(), 409),
                 Arguments.of("valid", new JsonParseException(), 400),
+                Arguments.of("valid", StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of("valid", StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of("valid", null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourcePutEnabledShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourcePutEnabledShould.java
@@ -7,6 +7,7 @@ import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.Pattern;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.PatternStore;
 import org.bson.json.JsonParseException;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,8 @@ public class TestPatternResourcePutEnabledShould {
                 Arguments.of( new NamespaceNotFoundException(), 404),
                 Arguments.of( new PatternNotFoundException(), 404),
                 Arguments.of(new JsonParseException(), 400),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
@@ -10,6 +10,7 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.StandardStore;
@@ -298,6 +299,8 @@ public class TestStandardResourceShould {
                 Arguments.of("invalid", new NamespaceNotFoundException(), 404),
                 Arguments.of("valid", new StandardNotFoundException(), 404),
                 Arguments.of("valid", new StandardVersionExistsException(), 409),
+                Arguments.of("valid", StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of("valid", StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of("valid", null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestStorageWriteExceptionMapperShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestStorageWriteExceptionMapperShould.java
@@ -1,0 +1,27 @@
+package org.finos.calm.resources;
+
+import jakarta.ws.rs.core.Response;
+import org.finos.calm.domain.exception.StorageWriteException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TestStorageWriteExceptionMapperShould {
+
+    private final StorageWriteExceptionMapper mapper = new StorageWriteExceptionMapper();
+
+    @Test
+    void return_413_when_capacity_exceeded() {
+        try (Response response = mapper.toResponse(StorageWriteException.capacityExceeded(new RuntimeException("too big")))) {
+            assertThat(response.getStatus(), equalTo(413));
+        }
+    }
+
+    @Test
+    void return_500_for_other_write_failures() {
+        try (Response response = mapper.toResponse(StorageWriteException.writeFailed(new RuntimeException("write failed")))) {
+            assertThat(response.getStatus(), equalTo(500));
+        }
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestTimelineResourcePutEnabledShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestTimelineResourcePutEnabledShould.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.security.TestSecurity;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.store.TimelineStore;
@@ -51,6 +52,8 @@ public class TestTimelineResourcePutEnabledShould {
                 Arguments.of(new NamespaceNotFoundException(), 404),
                 Arguments.of(new TimelineNotFoundException(), 404),
                 Arguments.of(new JsonParseException(), 400),
+                Arguments.of(StorageWriteException.capacityExceeded(new RuntimeException("too big")), 413),
+                Arguments.of(StorageWriteException.writeFailed(new RuntimeException("write failed")), 500),
                 Arguments.of(null, 201)
         );
     }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -448,7 +448,7 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
-    void throw_an_exception_when_updating_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
+    void throw_a_storage_write_exception_without_capacity_exceeded_when_updating_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
         when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
@@ -459,8 +459,26 @@ public class TestMongoAdrStoreShould {
                 .setAdr(new Adr.AdrBuilder().build())
                 .build();
 
-        assertThrows(AdrPersistenceException.class,
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+        assertThat(exception.isCapacityExceeded(), is(false));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_an_adr_hits_the_document_size_limit() throws JsonProcessingException {
+        mockSetupAdrDocumentWithRevisions();
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(new MongoWriteException(new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of()));
+
+        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(42)
+                .setAdr(new Adr.AdrBuilder().build())
+                .build();
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+        assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test
@@ -541,7 +559,7 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
-    void throw_an_exception_when_updating_the_status_of_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
+    void throw_a_storage_write_exception_without_capacity_exceeded_when_updating_the_status_of_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
         mockSetupAdrDocumentWithRevisions();
         when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
@@ -551,8 +569,25 @@ public class TestMongoAdrStoreShould {
                 .setId(42)
                 .build();
 
-        assertThrows(AdrPersistenceException.class,
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.proposed));
+        assertThat(exception.isCapacityExceeded(), is(false));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_the_status_of_an_adr_hits_the_document_size_limit() throws JsonProcessingException {
+        mockSetupAdrDocumentWithRevisions();
+        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(new MongoWriteException(new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of()));
+
+        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(42)
+                .build();
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.proposed));
+        assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -23,6 +23,7 @@ import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -508,22 +510,55 @@ public class TestMongoArchitectureStoreShould {
     }
 
     @Test
-    void throw_an_architecture_not_found_exception_when_creating_or_updating_a_version() {
+    void throw_an_architecture_not_found_exception_when_creating_or_updating_a_version_for_a_missing_architecture() {
         mockSetupArchitectureDocumentWithVersions();
         Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
                 .setId(50).setVersion("1.0.1")
                 .setArchitecture(validJson).build();
 
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
-
         assertThrows(ArchitectureNotFoundException.class,
                 () -> mongoArchitectureStore.createArchitectureForVersion(architecture));
         assertThrows(ArchitectureNotFoundException.class,
                 () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+
+        // The entity-existence pre-check catches the missing architecture before any write is
+        // attempted, so no update is ever sent to Mongo.
+        verify(architectureCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
+        mockSetupArchitectureDocumentWithVersions();
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setArchitecture(validJson).build();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
+        mockSetupArchitectureDocumentWithVersions();
+        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setArchitecture(validJson).build();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -522,9 +522,11 @@ public class TestMongoArchitectureStoreShould {
                 () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
 
         // The entity-existence pre-check catches the missing architecture before any write is
-        // attempted, so no update is ever sent to Mongo.
+        // attempted, so no update is ever sent to Mongo (either overload).
         verify(architectureCollection, never())
                 .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(architectureCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
@@ -24,6 +24,7 @@ import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
 import org.finos.calm.domain.exception.DomainNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -32,6 +33,7 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -515,6 +517,32 @@ public class TestMongoControlStoreShould {
     }
 
     @Test
+    void create_requirement_for_version_throws_storage_write_exception_with_capacity_exceeded_when_document_size_limit_hit() {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+
+        Document requirement = new Document("1-0-0", new Document("type", "req"));
+        Document controlDoc = new Document("controlId", 1)
+                .append("name", "Test")
+                .append("description", "Test Desc")
+                .append("requirement", requirement)
+                .append("configurations", new ArrayList<>());
+        Document domainDoc = new Document("domain", "security")
+                .append("controls", List.of(controlDoc));
+
+        FindIterable<Document> findIterable = mockFindIterable();
+        when(controlCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(domainDoc);
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(controlCollection.updateOne(any(Document.class), any(Document.class))).thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class, () ->
+                mongoControlStore.createRequirementForVersion("security", 1, "2.0.0", new CreateControlRequirement("n", "d", "{\"type\": \"req-v2\"}")));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
     void create_requirement_for_version_throws_when_version_already_exists() {
         when(domainStore.getDomains()).thenReturn(List.of("security"));
 
@@ -641,6 +669,35 @@ public class TestMongoControlStoreShould {
         mongoControlStore.createConfigurationForVersion("security", 1, 10, "2.0.0", new CreateControlConfiguration("{\"setting\": \"b\"}"));
 
         verify(controlCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void create_configuration_for_version_throws_storage_write_exception_with_capacity_exceeded_when_document_size_limit_hit() {
+        when(domainStore.getDomains()).thenReturn(List.of("security"));
+
+        Document config = new Document("configurationId", 10)
+                .append("versions", new Document("1-0-0", new Document("setting", "a")));
+
+        Document controlDoc = new Document("controlId", 1)
+                .append("name", "Test")
+                .append("description", "Desc")
+                .append("requirement", new Document("1-0-0", new Document()))
+                .append("configurations", List.of(config));
+        Document domainDoc = new Document("domain", "security")
+                .append("controls", List.of(controlDoc));
+
+        FindIterable<Document> findIterable = mockFindIterable();
+        when(controlCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(domainDoc);
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(controlCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class, () ->
+                mongoControlStore.createConfigurationForVersion("security", 1, 10, "2.0.0", new CreateControlConfiguration("{\"setting\": \"b\"}")));
+        assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
@@ -22,6 +22,7 @@ import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.junit.jupiter.api.BeforeEach;
@@ -385,22 +386,55 @@ public class TestMongoFlowStoreShould {
     }
 
     @Test
-    void throw_an_flow_not_found_exception_when_creating_or_updating_a_version() {
+    void throw_a_flow_not_found_exception_when_creating_or_updating_a_version_for_a_missing_flow() {
         mockSetupFlowDocumentWithVersions();
         Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
                 .setId(50).setVersion("1.0.1")
                 .setFlow(validJson).build();
 
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
-
         assertThrows(FlowNotFoundException.class,
                 () -> mongoFlowStore.createFlowForVersion(flow));
         assertThrows(FlowNotFoundException.class,
                 () -> mongoFlowStore.updateFlowForVersion(flow));
+
+        // The entity-existence pre-check catches the missing flow before any write is
+        // attempted, so no update is ever sent to Mongo.
+        verify(flowCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
+        mockSetupFlowDocumentWithVersions();
+        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setFlow(validJson).build();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoFlowStore.updateFlowForVersion(flow));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
+        mockSetupFlowDocumentWithVersions();
+        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setFlow(validJson).build();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoFlowStore.updateFlowForVersion(flow));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
@@ -398,9 +398,11 @@ public class TestMongoFlowStoreShould {
                 () -> mongoFlowStore.updateFlowForVersion(flow));
 
         // The entity-existence pre-check catches the missing flow before any write is
-        // attempted, so no update is ever sent to Mongo.
+        // attempted, so no update is ever sent to Mongo (either overload).
         verify(flowCollection, never())
                 .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(flowCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -21,6 +21,7 @@ import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.junit.jupiter.api.BeforeEach;
@@ -362,6 +363,33 @@ public class TestMongoInterfaceStoreShould {
                 .thenReturn(UpdateResult.acknowledged(0, 0L, null));
 
         assertThrows(InterfaceVersionExistsException.class, () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.0"));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_creating_a_version_hits_the_document_size_limit() {
+        mockSetupInterfaceDocumentWithVersions();
+        CreateInterfaceRequest interfaceRequest = interfaceToStore();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1"));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void propagate_other_write_failures_raw_when_creating_a_version() {
+        mockSetupInterfaceDocumentWithVersions();
+        CreateInterfaceRequest interfaceRequest = interfaceToStore();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -380,7 +380,7 @@ public class TestMongoInterfaceStoreShould {
     }
 
     @Test
-    void propagate_other_write_failures_raw_when_creating_a_version() {
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_creating_a_version() {
         mockSetupInterfaceDocumentWithVersions();
         CreateInterfaceRequest interfaceRequest = interfaceToStore();
 
@@ -388,8 +388,9 @@ public class TestMongoInterfaceStoreShould {
         MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
         when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
 
-        assertThrows(MongoWriteException.class,
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1"));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -22,6 +22,7 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.domain.exception.PatternVersionExistsException;
 import org.finos.calm.domain.exception.PatternVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
@@ -468,22 +469,55 @@ public class TestMongoPatternStoreShould {
     }
 
     @Test
-    void throw_a_pattern_not_found_exception_when_creating_or_updating_a_version() {
+    void throw_a_pattern_not_found_exception_when_creating_or_updating_a_version_for_a_missing_pattern() {
         mockSetupPatternDocumentWithVersions();
         Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
                 .setId(50).setVersion("1.0.1")
                 .setPattern(validJson).build();
 
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-
-        when(patternCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
-
         assertThrows(PatternNotFoundException.class,
                 () -> mongoPatternStore.createPatternForVersion(pattern));
         assertThrows(PatternNotFoundException.class,
                 () -> mongoPatternStore.updatePatternForVersion(pattern));
+
+        // The entity-existence pre-check catches the missing pattern before any write is
+        // attempted, so no update is ever sent to Mongo.
+        verify(patternCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
+        mockSetupPatternDocumentWithVersions();
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
+                .setId(42).setVersion("1.0.1")
+                .setPattern(validJson).build();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(patternCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoPatternStore.updatePatternForVersion(pattern));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
+        mockSetupPatternDocumentWithVersions();
+        Pattern pattern = new Pattern.PatternBuilder().setNamespace("finos")
+                .setId(42).setVersion("1.0.1")
+                .setPattern(validJson).build();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(patternCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoPatternStore.updatePatternForVersion(pattern));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -481,9 +481,11 @@ public class TestMongoPatternStoreShould {
                 () -> mongoPatternStore.updatePatternForVersion(pattern));
 
         // The entity-existence pre-check catches the missing pattern before any write is
-        // attempted, so no update is ever sent to Mongo.
+        // attempted, so no update is ever sent to Mongo (either overload).
         verify(patternCollection, never())
                 .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(patternCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -20,6 +20,7 @@ import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
@@ -391,6 +392,33 @@ public class TestMongoStandardStoreShould {
                 .thenReturn(UpdateResult.acknowledged(0, 0L, null));
 
         assertThrows(StandardVersionExistsException.class, () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.0"));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_creating_a_version_hits_the_document_size_limit() {
+        mockSetupStandardDocumentWithVersions();
+        CreateStandardRequest standard = standardToStore();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(standardCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1"));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void propagate_other_write_failures_raw_when_creating_a_version() {
+        mockSetupStandardDocumentWithVersions();
+        CreateStandardRequest standard = standardToStore();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(standardCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
+
+        assertThrows(MongoWriteException.class,
+                () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -409,7 +409,7 @@ public class TestMongoStandardStoreShould {
     }
 
     @Test
-    void propagate_other_write_failures_raw_when_creating_a_version() {
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_creating_a_version() {
         mockSetupStandardDocumentWithVersions();
         CreateStandardRequest standard = standardToStore();
 
@@ -417,8 +417,9 @@ public class TestMongoStandardStoreShould {
         MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
         when(standardCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
 
-        assertThrows(MongoWriteException.class,
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1"));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -18,6 +18,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
@@ -396,22 +397,55 @@ public class TestMongoTimelineStoreShould {
     }
 
     @Test
-    void throw_a_timeline_not_found_exception_when_creating_or_updating_a_version() {
+    void throw_a_timeline_not_found_exception_when_creating_or_updating_a_version_for_a_missing_timeline() {
         mockSetupTimelineDocumentWithVersions();
         Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
                 .setId(50).setVersion("1.0.1")
                 .setTimeline(validJson).build();
 
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
-
         assertThrows(TimelineNotFoundException.class,
                 () -> mongoTimelineStore.createTimelineForVersion(timeline));
         assertThrows(TimelineNotFoundException.class,
                 () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+
+        // The entity-existence pre-check catches the missing timeline before any write is
+        // attempted, so no update is ever sent to Mongo.
+        verify(timelineCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
+        mockSetupTimelineDocumentWithVersions();
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setTimeline(validJson).build();
+
+        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+        assertThat(exception.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
+        mockSetupTimelineDocumentWithVersions();
+        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
+                .setId(42).setVersion("1.0.1")
+                .setTimeline(validJson).build();
+
+        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
+        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
+        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(mongoWriteException);
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+        assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -409,9 +409,11 @@ public class TestMongoTimelineStoreShould {
                 () -> mongoTimelineStore.updateTimelineForVersion(timeline));
 
         // The entity-existence pre-check catches the missing timeline before any write is
-        // attempted, so no update is ever sent to Mongo.
+        // attempted, so no update is ever sent to Mongo (either overload).
         verify(timelineCollection, never())
                 .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        verify(timelineCollection, never())
+                .updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoWriteFailuresShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoWriteFailuresShould.java
@@ -1,0 +1,52 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import org.bson.BsonDocument;
+import org.finos.calm.domain.exception.StorageWriteException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class TestMongoWriteFailuresShould {
+
+    @Test
+    void identify_document_too_large_errors() {
+        MongoWriteException ex = new MongoWriteException(
+                new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of());
+
+        assertThat(MongoWriteFailures.isDocumentTooLarge(ex), is(true));
+    }
+
+    @Test
+    void not_identify_other_write_errors_as_document_too_large() {
+        MongoWriteException ex = new MongoWriteException(
+                new WriteError(2, "some other error", new BsonDocument()), new ServerAddress(), List.of());
+
+        assertThat(MongoWriteFailures.isDocumentTooLarge(ex), is(false));
+    }
+
+    @Test
+    void map_document_too_large_errors_to_a_capacity_exceeded_storage_write_exception() {
+        MongoWriteException ex = new MongoWriteException(
+                new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of());
+
+        StorageWriteException result = MongoWriteFailures.toStorageWriteException(ex);
+
+        assertThat(result.isCapacityExceeded(), is(true));
+    }
+
+    @Test
+    void map_other_write_errors_to_a_non_capacity_exceeded_storage_write_exception() {
+        MongoWriteException ex = new MongoWriteException(
+                new WriteError(2, "some other error", new BsonDocument()), new ServerAddress(), List.of());
+
+        StorageWriteException result = MongoWriteFailures.toStorageWriteException(ex);
+
+        assertThat(result.isCapacityExceeded(), is(false));
+    }
+}


### PR DESCRIPTION
## Description

Several MongoDB stores in calm-hub caught any `MongoWriteException` during a version write and unconditionally rethrew it as a `*NotFoundException`, producing a misleading 404 for a resource that actually exists. This hid the real cause — most acutely, MongoDB's 16MB `BSONObjectTooLarge` document limit, which is the core problem #2884 describes for the one-doc-per-namespace storage shape.

This PR fixes the exception mapping so a genuine write failure is reported honestly (413 when it's specifically the document-size limit, 500 otherwise) instead of a false 404. It does **not** redesign the underlying storage shape
(one document per namespace/domain) — that's a larger, separate piece of work tracked against #2884; this is scoped to making the current failure mode diagnosable (and proving the bug exists).

**Changes:**
- `Architecture`/`Pattern`/`Flow`/`Timeline`/`Adr` stores: added an entity-existence pre-check before the update-in-place write, so a genuinely missing entity is still a clean 404 — then map any *other* write failure to a new `StorageWriteException` instead of reusing the not-found exception.
- `Standard`/`Interface`/`Control` stores: added the same capacity-exceeded detection to their create-version paths (no mismap bug there, just an undiagnostic generic 500 for document-too-large — now precise).
- New `StorageWriteExceptionMapper` — calm-hub's first global JAX-RS `ExceptionMapper` — returns `413` for capacity-exceeded, `500` otherwise.
- `AdrResource` gets one extra handler-map entry, since its per-endpoint blanket exception catch would otherwise shadow the global mapper.
- New TestContainers-backed integration test (`MongoDocumentSizeLimitIntegration`) that grows a real MongoDB document past 16MB and asserts the `413` response.

**This integration test also stands as concrete proof that #2884's core claim is real, not theoretical**: it runs against an actual MongoDB instance and demonstrably fails a write once the namespace's document crosses the 16MB
BSON limit — confirming the ceiling is reachable today, not just a calculated risk.

Related to #2884 — addresses the exception-mismapping symptom called out there; the underlying storage-shape redesign is a separate follow-up.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Full unit suite (2328 tests) and full integration suite against real MongoDB + NitriteDB (498 tests) pass, including the new integration test. JaCoCo 90% per-class coverage gate passes (`../mvnw clean verify -P integration -Ddependency-check.skip=true`).

## Checklist
- [x] My commits follow the conventional commit format
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
