### PR TITLE
feat(calm-hub): add calm collection with startup schema migration runner

### DIFF
--- a/calm-hub/PERMISSIONS.md
+++ b/calm-hub/PERMISSIONS.md
@@ -74,7 +74,7 @@ canWrite(username, namespace):
 | `NitriteUserAccessStore` | Nitrite implementation of `getGrantsForUser` |
 | `UserAccessValidator` | `getReadableNamespaces(username)` — exact ancestor-chain filter used by search |
 | `NamespaceService` | Orchestrates namespace creation + automatic `* read` grant insertion |
-| `NamespaceMigrationService` | StartupEvent observer; backfills `* read` grants on pre-existing namespaces |
+| `NamespaceAccessBackfillStep` | Schema migration step; backfills `* read` grants on pre-existing namespaces |
 
 ---
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -1,6 +1,10 @@
 package integration;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
@@ -24,6 +28,18 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
         String connectionString = mongoDBContainer.getReplicaSetUrl();
         logger.info("MongoDB container started at {}", connectionString);
         String databaseName = connectionString.substring(connectionString.lastIndexOf("/")+1);
+
+        // MongoIndexInitializationStep no longer runs itself under @QuarkusTest (LaunchMode.TEST
+        // can't distinguish "real Mongo, via this container" from "no Mongo at all", which is
+        // the common case for the rest of the test suite) — so integration tests that rely on
+        // unique-index enforcement (duplicate-key rejection etc.) need it created here, against
+        // the real container, before the Quarkus application under test even starts.
+        try (MongoClient mongoClient = MongoClients.create(connectionString)) {
+            MongoDatabase database = mongoClient.getDatabase(databaseName);
+            new MongoIndexInitializationStep(database).createIndexes();
+            logger.info("Ensured MongoDB indexes for integration tests");
+        }
+
         return Map.of(
                 "quarkus.mongodb.connection-string", connectionString,
                 "quarkus.mongodb.database", databaseName
@@ -35,4 +51,3 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
         mongoDBContainer.stop();
     }
 }
-

--- a/calm-hub/src/integration-test/java/integration/PermittedScopesIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/PermittedScopesIntegration.java
@@ -54,7 +54,7 @@ public class PermittedScopesIntegration {
                 );
             }
 
-            // Guard on the specific grant, not collection existence: MongoIndexInitializer's
+            // Guard on the specific grant, not collection existence: MongoIndexInitializationStep's
             // startup index creation on userAccess implicitly creates the (empty) collection
             // before this ever runs, so "does the collection exist" is never a useful check here.
             boolean grantExists = database.getCollection("userAccess").find(Filters.and(

--- a/calm-hub/src/integration-test/java/integration/ProxyAuthIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/ProxyAuthIntegration.java
@@ -94,7 +94,7 @@ public class ProxyAuthIntegration {
                 );
             }
 
-            // Guard on a specific grant, not collection existence: MongoIndexInitializer's
+            // Guard on a specific grant, not collection existence: MongoIndexInitializationStep's
             // startup index creation on userAccess implicitly creates the (empty) collection
             // before this ever runs, so "does the collection exist" is never a useful check here.
             boolean grantsExist = database.getCollection("userAccess").find(Filters.and(

--- a/calm-hub/src/integration-test/java/integration/UserAccessGrantsIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/UserAccessGrantsIntegration.java
@@ -72,7 +72,7 @@ public class UserAccessGrantsIntegration {
 
             // test-user has admin access on finos, so they can manage grants there.
             // Guarded on the specific grant (not collection existence, since
-            // MongoIndexInitializer's startup index creation on userAccess implicitly
+            // MongoIndexInitializationStep's startup index creation on userAccess implicitly
             // creates the collection before this ever runs) — this @BeforeEach runs before
             // every test in this class, so without the guard the second test's insert
             // collides with the first test's leftover document.

--- a/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
+++ b/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
@@ -108,6 +108,7 @@ public class NitriteDBConfig {
         db.getCollection("schemas");
         db.getCollection("counters");
         db.getCollection("decorators");
+        db.getCollection("calm");
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
@@ -39,6 +39,15 @@ import java.util.function.LongSupplier;
  * javadoc for the full argument. Elapsed time for the TTL is measured with
  * {@link System#nanoTime()}, not wall-clock time, so an NTP correction or manual clock
  * change can't make a stale cache entry look artificially fresh.
+ *
+ * <h2>Store failures</h2>
+ * If the store read itself fails (e.g. a transient MongoDB blip), this filter fails open —
+ * logs a warning and lets the request through — rather than letting the exception escape
+ * uncaught (no {@code ExceptionMapper} exists in this codebase for a bare store exception,
+ * so it would otherwise surface as a raw 500 on every request for the outage's duration,
+ * worse than the graceful 503 this filter exists to provide). The failure isn't cached, so
+ * the very next request retries the store rather than being stuck on a guessed answer for
+ * the TTL.
  */
 @ApplicationScoped
 @Provider
@@ -84,7 +93,13 @@ public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
         if (current != null && now - current.checkedAtNanos() <= CACHE_TTL.toNanos()) {
             return current.held();
         }
-        boolean held = schemaVersionStore.isMigrationLockHeld();
+        boolean held;
+        try {
+            held = schemaVersionStore.isMigrationLockHeld();
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to check the schema migration lock — allowing the request through", e);
+            return false;
+        }
         cache.set(new CacheEntry(held, now));
         return held;
     }

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
@@ -1,5 +1,6 @@
 package org.finos.calm.migration;
 
+import io.quarkus.runtime.LaunchMode;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -48,6 +49,17 @@ import java.util.function.LongSupplier;
  * worse than the graceful 503 this filter exists to provide). The failure isn't cached, so
  * the very next request retries the store rather than being stuck on a guessed answer for
  * the TTL.
+ *
+ * <h2>Test mode</h2>
+ * Under {@code @QuarkusTest} ({@code LaunchMode.TEST}) this filter is a no-op, matching
+ * {@link SchemaMigrationRunner}'s own test-mode skip. This is a {@code @PreMatching} filter
+ * registered application-wide, so it runs on every real HTTP request any {@code @QuarkusTest}
+ * makes (e.g. via RestAssured) — unlike the store interfaces most resource tests already
+ * mock, nothing in the existing test suite expects a request to also touch
+ * {@link SchemaVersionStore}'s backing Mongo/Nitrite store. Without this skip, any such test
+ * would hit a real (and in CI, absent) database on every request. The filter's own behaviour
+ * is still covered directly — its unit tests construct it outside CDI/{@code @QuarkusTest},
+ * so they never observe {@code LaunchMode.TEST} and exercise the real logic below.
  */
 @ApplicationScoped
 @Provider
@@ -75,6 +87,9 @@ public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        if (LaunchMode.current() == LaunchMode.TEST) {
+            return;
+        }
         if (!isMigrationLockHeld()) {
             return;
         }

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
@@ -1,0 +1,92 @@
+package org.finos.calm.migration;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.finos.calm.store.SchemaVersionStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+/**
+ * Rejects every request with {@code 503 Service Unavailable} while the schema-migration
+ * lock ({@link SchemaVersionStore#isMigrationLockHeld()}) is held.
+ *
+ * <p>The lock is held for as long as {@link SchemaMigrationRunner} is actively applying
+ * steps, however long that takes — and, if a step fails, deliberately left held
+ * afterwards pending manual resolution (see that class's javadoc). This filter is what
+ * makes that visible to callers, and makes it apply uniformly to every CalmHub instance
+ * sharing the database, not just the one that happened to run the migration.</p>
+ *
+ * <p>Runs {@code @PreMatching} at a priority before {@code ReadOnlyRequestFilter} (0), so
+ * "migration in progress" always takes precedence over every other rejection reason.</p>
+ *
+ * <h2>Caching</h2>
+ * Checking the lock is a real store read (a network round-trip in Mongo mode), and this
+ * filter runs on every single request, so the result is cached for {@link #CACHE_TTL}
+ * rather than re-checked every time. {@link SchemaMigrationRunner} deliberately waits
+ * longer than {@link #CACHE_TTL} after acquiring the lock before running any actual
+ * migration step, which guarantees every instance's cache (including this one's) has
+ * expired and been refreshed to "held" before real work starts — see that class's
+ * javadoc for the full argument.
+ */
+@ApplicationScoped
+@Provider
+@PreMatching
+@Priority(-100)
+public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaMigrationInProgressFilter.class);
+
+    static final Duration CACHE_TTL = Duration.ofSeconds(2);
+
+    private final SchemaVersionStore schemaVersionStore;
+    private final LongSupplier clockMillis;
+    private final AtomicReference<CacheEntry> cache = new AtomicReference<>(new CacheEntry(false, 0L));
+
+    @Inject
+    public SchemaMigrationInProgressFilter(SchemaVersionStore schemaVersionStore) {
+        this(schemaVersionStore, System::currentTimeMillis);
+    }
+
+    SchemaMigrationInProgressFilter(SchemaVersionStore schemaVersionStore, LongSupplier clockMillis) {
+        this.schemaVersionStore = schemaVersionStore;
+        this.clockMillis = clockMillis;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (!isMigrationLockHeld()) {
+            return;
+        }
+        LOG.warn("Rejecting {} {} — schema migration in progress or awaiting manual resolution",
+                requestContext.getMethod(), requestContext.getUriInfo().getPath());
+        requestContext.abortWith(
+                Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                        .entity("CalmHub is applying a schema migration and cannot serve requests right now. "
+                                + "If this persists, an administrator must investigate and clear the migration lock.")
+                        .build());
+    }
+
+    private boolean isMigrationLockHeld() {
+        long now = clockMillis.getAsLong();
+        CacheEntry current = cache.get();
+        if (now - current.checkedAtMillis() <= CACHE_TTL.toMillis()) {
+            return current.held();
+        }
+        boolean held = schemaVersionStore.isMigrationLockHeld();
+        cache.set(new CacheEntry(held, now));
+        return held;
+    }
+
+    private record CacheEntry(boolean held, long checkedAtMillis) {
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationInProgressFilter.java
@@ -36,7 +36,9 @@ import java.util.function.LongSupplier;
  * longer than {@link #CACHE_TTL} after acquiring the lock before running any actual
  * migration step, which guarantees every instance's cache (including this one's) has
  * expired and been refreshed to "held" before real work starts — see that class's
- * javadoc for the full argument.
+ * javadoc for the full argument. Elapsed time for the TTL is measured with
+ * {@link System#nanoTime()}, not wall-clock time, so an NTP correction or manual clock
+ * change can't make a stale cache entry look artificially fresh.
  */
 @ApplicationScoped
 @Provider
@@ -49,17 +51,17 @@ public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
     static final Duration CACHE_TTL = Duration.ofSeconds(2);
 
     private final SchemaVersionStore schemaVersionStore;
-    private final LongSupplier clockMillis;
-    private final AtomicReference<CacheEntry> cache = new AtomicReference<>(new CacheEntry(false, 0L));
+    private final LongSupplier elapsedTimeNanosSource;
+    private final AtomicReference<CacheEntry> cache = new AtomicReference<>();
 
     @Inject
     public SchemaMigrationInProgressFilter(SchemaVersionStore schemaVersionStore) {
-        this(schemaVersionStore, System::currentTimeMillis);
+        this(schemaVersionStore, System::nanoTime);
     }
 
-    SchemaMigrationInProgressFilter(SchemaVersionStore schemaVersionStore, LongSupplier clockMillis) {
+    SchemaMigrationInProgressFilter(SchemaVersionStore schemaVersionStore, LongSupplier elapsedTimeNanosSource) {
         this.schemaVersionStore = schemaVersionStore;
-        this.clockMillis = clockMillis;
+        this.elapsedTimeNanosSource = elapsedTimeNanosSource;
     }
 
     @Override
@@ -77,9 +79,9 @@ public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
     }
 
     private boolean isMigrationLockHeld() {
-        long now = clockMillis.getAsLong();
+        long now = elapsedTimeNanosSource.getAsLong();
         CacheEntry current = cache.get();
-        if (now - current.checkedAtMillis() <= CACHE_TTL.toMillis()) {
+        if (current != null && now - current.checkedAtNanos() <= CACHE_TTL.toNanos()) {
             return current.held();
         }
         boolean held = schemaVersionStore.isMigrationLockHeld();
@@ -87,6 +89,6 @@ public class SchemaMigrationInProgressFilter implements ContainerRequestFilter {
         return held;
     }
 
-    private record CacheEntry(boolean held, long checkedAtMillis) {
+    private record CacheEntry(boolean held, long checkedAtNanos) {
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
@@ -69,12 +69,17 @@ import java.util.function.LongConsumer;
  * lets an exception escape and abort Quarkus startup.
  *
  * <h2>Test mode</h2>
- * Under {@code @QuarkusTest} ({@code LaunchMode.TEST}), the lock/version-store machinery
- * above is skipped entirely — most test classes don't back {@link SchemaVersionStore} with
- * a store that supports it. Only steps that opt in via
- * {@link SchemaMigrationStep#runInTestMode()} still run (e.g. {@link MongoIndexInitializationStep},
- * matching its pre-migration-framework behaviour of creating indexes on every startup,
- * including real-MongoDB {@code -P integration} tests, which are {@code @QuarkusTest}s too).
+ * Under {@code @QuarkusTest} ({@code LaunchMode.TEST}), this runner is a no-op — most test
+ * classes don't back {@link SchemaVersionStore} with a store that supports the lock/version
+ * machinery (a mocked, unstubbed {@code MongoDatabase}/{@code Nitrite} would fail on first
+ * real use), and {@code LaunchMode.TEST} can't distinguish those from the real-MongoDB
+ * {@code -P integration} tests that could support it. Steps that genuinely need to run
+ * against a real backend in an integration test (e.g. {@link MongoIndexInitializationStep}
+ * creating the unique indexes {@code MongoDomainIntegration} and similar depend on) are
+ * applied directly by that test's own setup instead — see
+ * {@code src/integration-test/java/integration/EndToEndResource.java}, which has a genuine,
+ * live container to run them against before this runner (or anything else in the app) even
+ * starts.
  */
 @ApplicationScoped
 public class SchemaMigrationRunner {
@@ -127,7 +132,7 @@ public class SchemaMigrationRunner {
 
     void onStart(@Observes StartupEvent ev) {
         if (LaunchMode.current() == LaunchMode.TEST) {
-            runTestModeSteps();
+            LOG.debug("Schema migration skipped in test mode");
             return;
         }
         try {
@@ -140,30 +145,6 @@ public class SchemaMigrationRunner {
             // continuing keeps the instance inspectable instead.
             LOG.error("Unexpected failure while checking/running schema migrations — the application will "
                     + "continue starting, but may be unable to serve requests until this is investigated.", e);
-        }
-    }
-
-    /**
-     * In test mode, the lock/version-store machinery is skipped entirely — most
-     * {@code @QuarkusTest} classes don't back {@link SchemaVersionStore} with a store that
-     * supports it (a mocked, unstubbed {@code MongoDatabase}/{@code Nitrite} would NPE). Only
-     * steps that opt in via {@link SchemaMigrationStep#runInTestMode()} still run, each
-     * defensively isolated so one step's test-mode failure can't affect another's.
-     *
-     * <p>Package-private (not {@code private}) so tests can exercise this directly — {@code
-     * onStart} itself only reaches this branch under a real {@code LaunchMode.TEST}, which
-     * plain unit tests constructing this class directly don't run under.</p>
-     */
-    void runTestModeSteps() {
-        for (SchemaMigrationStep step : stepsByFromVersion.values()) {
-            if (!step.runInTestMode()) {
-                continue;
-            }
-            try {
-                step.apply();
-            } catch (RuntimeException e) {
-                LOG.warn("Schema migration step {} failed in test mode (ignored)", step.getClass().getSimpleName(), e);
-            }
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
@@ -6,7 +6,7 @@ import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import org.finos.calm.migration.steps.MongoIndexInitializer;
+import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.finos.calm.store.SchemaVersionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +26,7 @@ import java.util.function.LongConsumer;
  * Implement {@link SchemaMigrationStep} as a CDI bean (see that interface's javadoc for
  * the visibility requirement) declaring the next unused {@link SchemaMigrationStep#fromVersion()}.
  * It's picked up automatically — nothing here needs to change. A version with no registered
- * step (e.g. {@link MongoIndexInitializer} in standalone mode, where it isn't even a CDI
+ * step (e.g. {@link MongoIndexInitializationStep} in standalone mode, where it isn't even a CDI
  * bean) is treated as "not applicable" and the version advances anyway.
  *
  * <h2>Ordering and the latest version</h2>

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
@@ -63,7 +63,18 @@ import java.util.function.LongConsumer;
  * with 503 until an administrator investigates and manually clears the {@code holder}
  * field on the {@code migrationLock} document. The application itself is still allowed
  * to finish starting (it just won't serve traffic), so it remains inspectable (logs,
- * health/metrics endpoints not gated by the filter, etc.) while stuck.
+ * health/metrics endpoints not gated by the filter, etc.) while stuck. The same "leave the
+ * lock alone, log, and let startup continue" handling applies if the store itself fails
+ * unexpectedly (e.g. checking the version or acquiring the lock) — {@link #onStart} never
+ * lets an exception escape and abort Quarkus startup.
+ *
+ * <h2>Test mode</h2>
+ * Under {@code @QuarkusTest} ({@code LaunchMode.TEST}), the lock/version-store machinery
+ * above is skipped entirely — most test classes don't back {@link SchemaVersionStore} with
+ * a store that supports it. Only steps that opt in via
+ * {@link SchemaMigrationStep#runInTestMode()} still run (e.g. {@link MongoIndexInitializationStep},
+ * matching its pre-migration-framework behaviour of creating indexes on every startup,
+ * including real-MongoDB {@code -P integration} tests, which are {@code @QuarkusTest}s too).
  */
 @ApplicationScoped
 public class SchemaMigrationRunner {
@@ -116,9 +127,47 @@ public class SchemaMigrationRunner {
 
     void onStart(@Observes StartupEvent ev) {
         if (LaunchMode.current() == LaunchMode.TEST) {
-            LOG.debug("Schema migration skipped in test mode");
+            runTestModeSteps();
             return;
         }
+        try {
+            runWithLock();
+        } catch (RuntimeException e) {
+            // Anything unexpected here — a store failure acquiring the lock, checking the
+            // version, or recording progress — leaves us unsure whether the lock is actually
+            // held, so (consistent with a failed migration step) we do not attempt to release
+            // it. Letting this propagate would abort Quarkus startup entirely; logging and
+            // continuing keeps the instance inspectable instead.
+            LOG.error("Unexpected failure while checking/running schema migrations — the application will "
+                    + "continue starting, but may be unable to serve requests until this is investigated.", e);
+        }
+    }
+
+    /**
+     * In test mode, the lock/version-store machinery is skipped entirely — most
+     * {@code @QuarkusTest} classes don't back {@link SchemaVersionStore} with a store that
+     * supports it (a mocked, unstubbed {@code MongoDatabase}/{@code Nitrite} would NPE). Only
+     * steps that opt in via {@link SchemaMigrationStep#runInTestMode()} still run, each
+     * defensively isolated so one step's test-mode failure can't affect another's.
+     *
+     * <p>Package-private (not {@code private}) so tests can exercise this directly — {@code
+     * onStart} itself only reaches this branch under a real {@code LaunchMode.TEST}, which
+     * plain unit tests constructing this class directly don't run under.</p>
+     */
+    void runTestModeSteps() {
+        for (SchemaMigrationStep step : stepsByFromVersion.values()) {
+            if (!step.runInTestMode()) {
+                continue;
+            }
+            try {
+                step.apply();
+            } catch (RuntimeException e) {
+                LOG.warn("Schema migration step {} failed in test mode (ignored)", step.getClass().getSimpleName(), e);
+            }
+        }
+    }
+
+    private void runWithLock() {
         if (schemaVersionStore.getSchemaVersion() >= latestSchemaVersion) {
             LOG.debug("Schema already at latest version {} — no migration lock needed", latestSchemaVersion);
             return;

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationRunner.java
@@ -1,0 +1,168 @@
+package org.finos.calm.migration;
+
+import io.quarkus.arc.All;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.finos.calm.migration.steps.MongoIndexInitializer;
+import org.finos.calm.store.SchemaVersionStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.LongConsumer;
+
+/**
+ * Runs outstanding {@link SchemaMigrationStep}s once at application startup, advancing
+ * the version recorded in {@link SchemaVersionStore} one step at a time.
+ *
+ * <h2>Adding a new step</h2>
+ * Implement {@link SchemaMigrationStep} as a CDI bean (see that interface's javadoc for
+ * the visibility requirement) declaring the next unused {@link SchemaMigrationStep#fromVersion()}.
+ * It's picked up automatically — nothing here needs to change. A version with no registered
+ * step (e.g. {@link MongoIndexInitializer} in standalone mode, where it isn't even a CDI
+ * bean) is treated as "not applicable" and the version advances anyway.
+ *
+ * <h2>Ordering and the latest version</h2>
+ * All steps are collected via {@code @All List<SchemaMigrationStep>} and indexed by
+ * {@link SchemaMigrationStep#fromVersion()}. Two steps declaring the same
+ * {@code fromVersion()} is a fatal configuration error — construction fails fast rather
+ * than silently running one and dropping the other. The highest {@code fromVersion() + 1}
+ * across all registered steps is the version this runner will advance the schema to.
+ *
+ * <h2>Concurrent startup</h2>
+ * Multiple CalmHub instances may start up at the same time against the same shared
+ * database (Mongo in particular). {@link SchemaVersionStore#acquireMigrationLock} is
+ * used to ensure only one instance runs pending steps; the others skip migration on
+ * that startup and simply proceed. Acquisition is skipped entirely once the schema is
+ * already at {@link #latestSchemaVersion}, so an already-migrated deployment (in
+ * particular a pre-seeded read-only Nitrite image, whose database cannot be written to
+ * at all) never attempts a write here.
+ *
+ * <h2>Lock visibility delay</h2>
+ * {@link SchemaMigrationInProgressFilter} caches its "is the lock held?" check for
+ * {@link SchemaMigrationInProgressFilter#CACHE_TTL} to avoid a store round-trip on every
+ * request. That cache is per-instance, so right after acquiring the lock, any instance's
+ * cache (including this one's) could still be serving a stale "not held" answer for up to
+ * that TTL. To close that window, this runner waits {@link #LOCK_VISIBILITY_DELAY}
+ * (deliberately longer than the cache TTL) after acquiring the lock before running any
+ * actual migration step — guaranteeing every cache has expired and refreshed to "held"
+ * by the time real work, and therefore real risk, begins.
+ *
+ * <h2>Failure behaviour — no automatic timeout, human resolution required</h2>
+ * The lock never expires on its own (see {@link SchemaVersionStore}'s javadoc for why).
+ * If a step throws, the run stops and — deliberately — the lock is <em>not</em> released:
+ * the schema version is left at whatever it was before the failed step, and
+ * {@link SchemaMigrationInProgressFilter} makes every CalmHub instance refuse requests
+ * with 503 until an administrator investigates and manually clears the {@code holder}
+ * field on the {@code migrationLock} document. The application itself is still allowed
+ * to finish starting (it just won't serve traffic), so it remains inspectable (logs,
+ * health/metrics endpoints not gated by the filter, etc.) while stuck.
+ */
+@ApplicationScoped
+public class SchemaMigrationRunner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaMigrationRunner.class);
+
+    private static final Duration LOCK_VISIBILITY_MARGIN = Duration.ofSeconds(1);
+    private static final Duration LOCK_VISIBILITY_DELAY =
+            SchemaMigrationInProgressFilter.CACHE_TTL.plus(LOCK_VISIBILITY_MARGIN);
+
+    private final SchemaVersionStore schemaVersionStore;
+    private final Map<Integer, SchemaMigrationStep> stepsByFromVersion;
+    private final int latestSchemaVersion;
+    private final String instanceId = UUID.randomUUID().toString();
+    private final LongConsumer sleeper;
+
+    @Inject
+    public SchemaMigrationRunner(SchemaVersionStore schemaVersionStore, @All List<SchemaMigrationStep> steps) {
+        this(schemaVersionStore, steps, SchemaMigrationRunner::sleepUninterruptibly);
+    }
+
+    SchemaMigrationRunner(SchemaVersionStore schemaVersionStore, List<SchemaMigrationStep> steps, LongConsumer sleeper) {
+        this.schemaVersionStore = schemaVersionStore;
+        this.stepsByFromVersion = indexByFromVersion(steps);
+        this.latestSchemaVersion = stepsByFromVersion.keySet().stream().mapToInt(Integer::intValue).max().orElse(-1) + 1;
+        this.sleeper = sleeper;
+    }
+
+    private static Map<Integer, SchemaMigrationStep> indexByFromVersion(List<SchemaMigrationStep> steps) {
+        Map<Integer, SchemaMigrationStep> byFromVersion = new HashMap<>();
+        for (SchemaMigrationStep step : steps) {
+            SchemaMigrationStep existing = byFromVersion.putIfAbsent(step.fromVersion(), step);
+            if (existing != null) {
+                throw new IllegalStateException("Duplicate SchemaMigrationStep for fromVersion "
+                        + step.fromVersion() + ": " + existing.getClass().getName()
+                        + " and " + step.getClass().getName());
+            }
+        }
+        return byFromVersion;
+    }
+
+    private static void sleepUninterruptibly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for the migration lock to become visible to all instances — proceeding anyway");
+        }
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        if (LaunchMode.current() == LaunchMode.TEST) {
+            LOG.debug("Schema migration skipped in test mode");
+            return;
+        }
+        if (schemaVersionStore.getSchemaVersion() >= latestSchemaVersion) {
+            LOG.debug("Schema already at latest version {} — no migration lock needed", latestSchemaVersion);
+            return;
+        }
+        if (!schemaVersionStore.acquireMigrationLock(instanceId)) {
+            LOG.info("Schema migration lock held by another instance — skipping migration on this startup");
+            return;
+        }
+        LOG.debug("Waiting {} for the migration lock to become visible to every instance's request cache",
+                LOCK_VISIBILITY_DELAY);
+        sleeper.accept(LOCK_VISIBILITY_DELAY.toMillis());
+        if (runPendingMigrations()) {
+            schemaVersionStore.releaseMigrationLock(instanceId);
+        } else {
+            LOG.error("Schema migration failed — leaving the migration lock held. This CalmHub instance "
+                    + "(and any others sharing this database) will refuse requests until an administrator "
+                    + "investigates and manually clears the migration lock.");
+        }
+    }
+
+    /**
+     * Runs every pending step in order. Returns {@code true} if the schema reached
+     * {@link #latestSchemaVersion} (including trivially, if there was nothing to do),
+     * {@code false} if a step threw and the run stopped early.
+     */
+    private boolean runPendingMigrations() {
+        int version = schemaVersionStore.getSchemaVersion();
+        while (version < latestSchemaVersion) {
+            SchemaMigrationStep step = stepsByFromVersion.get(version);
+            if (step == null) {
+                LOG.info("No applicable schema migration step for version {} -> {} — skipping", version, version + 1);
+            } else {
+                LOG.info("Running schema migration step for version {} -> {}", version, version + 1);
+                try {
+                    step.apply();
+                } catch (RuntimeException e) {
+                    LOG.error("Schema migration step for version {} -> {} failed — leaving schema version at {}",
+                            version, version + 1, version, e);
+                    return false;
+                }
+            }
+            version++;
+            schemaVersionStore.setSchemaVersion(version);
+        }
+        return true;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
@@ -34,20 +34,4 @@ public interface SchemaMigrationStep {
      * this step, so it will be retried next startup.
      */
     void apply();
-
-    /**
-     * Whether {@link SchemaMigrationRunner} should still run this step under
-     * {@code @QuarkusTest} (i.e. {@code LaunchMode.TEST}), where the runner otherwise skips
-     * everything — including its own lock/version-store calls, since most test classes don't
-     * back {@code SchemaVersionStore} with a real or fully-stubbed store.
-     *
-     * <p>Defaults to {@code false}. Only override to {@code true} if {@link #apply()} is
-     * safe to run unconditionally against whatever backend a {@code @QuarkusTest} happens to
-     * wire up — in particular, it must swallow its own failures rather than throwing, since a
-     * step run this way is invoked directly, outside the runner's normal try/catch around
-     * {@link #apply()}.</p>
-     */
-    default boolean runInTestMode() {
-        return false;
-    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
@@ -1,0 +1,37 @@
+package org.finos.calm.migration;
+
+/**
+ * A single unit of work that upgrades the active storage backend from one schema
+ * version to the next, run once by {@link SchemaMigrationRunner}.
+ *
+ * <p>Implementations should be idempotent where practical (safe to re-run if a
+ * previous attempt applied partially), since a failed step leaves the schema
+ * version unchanged and will be retried on the next application startup.</p>
+ *
+ * <p>Every implementation must be a CDI bean visible as this interface (no
+ * {@code @Typed} restriction to a narrower type) so {@link SchemaMigrationRunner}
+ * can discover it via {@code @All List<SchemaMigrationStep>}. A step gated by
+ * {@code @LookupIfProperty} (e.g. Mongo-only) simply doesn't exist as a bean when
+ * its condition doesn't hold, so it's naturally absent from that list — the
+ * runner treats a version with no registered step as "not applicable" and
+ * advances anyway.</p>
+ */
+public interface SchemaMigrationStep {
+
+    /**
+     * The schema version this step upgrades the database from. {@link SchemaMigrationRunner}
+     * runs this step when the current schema version equals this value, then advances the
+     * version to {@code fromVersion() + 1}.
+     *
+     * <p>Must be unique across all registered steps — two steps declaring the same
+     * {@code fromVersion()} is a fatal configuration error, detected at startup.</p>
+     */
+    int fromVersion();
+
+    /**
+     * Applies this step's migration/initialization logic. Throwing stops the
+     * migration run for this startup — the schema version is not advanced past
+     * this step, so it will be retried next startup.
+     */
+    void apply();
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/SchemaMigrationStep.java
@@ -34,4 +34,20 @@ public interface SchemaMigrationStep {
      * this step, so it will be retried next startup.
      */
     void apply();
+
+    /**
+     * Whether {@link SchemaMigrationRunner} should still run this step under
+     * {@code @QuarkusTest} (i.e. {@code LaunchMode.TEST}), where the runner otherwise skips
+     * everything — including its own lock/version-store calls, since most test classes don't
+     * back {@code SchemaVersionStore} with a real or fully-stubbed store.
+     *
+     * <p>Defaults to {@code false}. Only override to {@code true} if {@link #apply()} is
+     * safe to run unconditionally against whatever backend a {@code @QuarkusTest} happens to
+     * wire up — in particular, it must swallow its own failures rather than throwing, since a
+     * step run this way is invoked directly, outside the runner's normal try/catch around
+     * {@link #apply()}.</p>
+     */
+    default boolean runInTestMode() {
+        return false;
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -13,6 +13,8 @@ import org.finos.calm.store.mongo.MongoNamespaceStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Creates unique indexes on MongoDB collections at application startup to enforce data integrity
  * and prevent duplicate entries caused by concurrent POST requests.
@@ -63,7 +65,13 @@ import org.slf4j.LoggerFactory;
  * If index creation fails (e.g. MongoDB is unreachable or the user lacks permissions),
  * the exception is caught and logged as a warning. The application will continue to start
  * but will <em>not</em> have duplicate-prevention guarantees until the indexes are created
- * (manually or on the next successful startup).
+ * (manually or on the next successful startup). Because this step also runs under
+ * {@code @QuarkusTest} (see {@link #runInTestMode()}), every operation on {@link #database} is
+ * scoped to a short client-side operation timeout ({@link #OPERATION_TIMEOUT_SECONDS}) rather
+ * than the driver's 30-second default — otherwise, in a test environment with no real MongoDB
+ * available, a single {@code createIndex} call blocking for the full default would turn into
+ * many minutes added to application startup (one per collection whose index attempt is the
+ * first to touch an unreachable server).
  *
  * @see MongoNamespaceStore
  * @see MongoDomainStore
@@ -75,13 +83,15 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoIndexInitializationStep.class);
 
+    private static final int OPERATION_TIMEOUT_SECONDS = 3;
+
     private final MongoDatabase database;
 
     @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
     String databaseMode;
 
     public MongoIndexInitializationStep(MongoDatabase database) {
-        this.database = database;
+        this.database = database.withTimeout(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -71,16 +71,16 @@ import org.slf4j.LoggerFactory;
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
-public class MongoIndexInitializer implements SchemaMigrationStep {
+public class MongoIndexInitializationStep implements SchemaMigrationStep {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MongoIndexInitializer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MongoIndexInitializationStep.class);
 
     private final MongoDatabase database;
 
     @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
     String databaseMode;
 
-    public MongoIndexInitializer(MongoDatabase database) {
+    public MongoIndexInitializationStep(MongoDatabase database) {
         this.database = database;
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -90,6 +90,19 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
     }
 
     /**
+     * Runs in test mode too, matching this step's pre-migration-framework behaviour of
+     * creating indexes on every single application startup, {@code @QuarkusTest} included.
+     * Safe unconditionally: {@link #createUniqueIndexes()} and {@link #createAuditIndexes()}
+     * each catch their own failures rather than throwing (see their javadoc), so a
+     * {@code @QuarkusTest} with a mocked, unstubbed {@code MongoDatabase} just logs a warning
+     * instead of failing that test's startup.
+     */
+    @Override
+    public boolean runInTestMode() {
+        return true;
+    }
+
+    /**
      * Checks the configured database mode and creates unique indexes only when
      * running against MongoDB.
      */

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -13,8 +13,6 @@ import org.finos.calm.store.mongo.MongoNamespaceStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * Creates unique indexes on MongoDB collections at application startup to enforce data integrity
  * and prevent duplicate entries caused by concurrent POST requests.
@@ -62,16 +60,23 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  *
  * <h2>Failure behaviour</h2>
- * If index creation fails (e.g. MongoDB is unreachable or the user lacks permissions),
- * the exception is caught and logged as a warning. The application will continue to start
- * but will <em>not</em> have duplicate-prevention guarantees until the indexes are created
- * (manually or on the next successful startup). Because this step also runs under
- * {@code @QuarkusTest} (see {@link #runInTestMode()}), every operation on {@link #database} is
- * scoped to a short client-side operation timeout ({@link #OPERATION_TIMEOUT_SECONDS}) rather
- * than the driver's 30-second default — otherwise, in a test environment with no real MongoDB
- * available, a single {@code createIndex} call blocking for the full default would turn into
- * many minutes added to application startup (one per collection whose index attempt is the
- * first to touch an unreachable server).
+ * If index creation fails (e.g. MongoDB is unreachable, the operation times out, or the user
+ * lacks permissions), the exception is <em>not</em> caught here — it propagates out of
+ * {@link #apply()} to {@code SchemaMigrationRunner}, which is what actually decides what
+ * "failed" means for a migration step (see that class's javadoc): the schema version isn't
+ * advanced and the migration lock is left held, so this step is retried on the next startup
+ * instead of the migration being silently marked successful with indexes that were never
+ * created. Swallowing the exception here would mean that a single transient failure could
+ * permanently and silently disable duplicate-prevention for a deployment's entire lifetime,
+ * since {@code fromVersion() == 0} only ever runs once.
+ *
+ * <h2>Not run under {@code @QuarkusTest}</h2>
+ * This step does not run in test mode (see {@code SchemaMigrationRunner}'s javadoc on why
+ * {@code LaunchMode.TEST} can't be used to decide that here). The handful of real-MongoDB
+ * {@code -P integration} tests that need these indexes to exist (e.g. {@code MongoDomainIntegration}
+ * testing duplicate-key rejection) call {@link #createIndexes()} directly against their own
+ * TestContainers-provisioned database, before the Quarkus application under test even starts
+ * — see {@code src/integration-test/java/integration/EndToEndResource.java}.
  *
  * @see MongoNamespaceStore
  * @see MongoDomainStore
@@ -83,33 +88,18 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoIndexInitializationStep.class);
 
-    private static final int OPERATION_TIMEOUT_SECONDS = 3;
-
     private final MongoDatabase database;
 
     @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
     String databaseMode;
 
     public MongoIndexInitializationStep(MongoDatabase database) {
-        this.database = database.withTimeout(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        this.database = database;
     }
 
     @Override
     public int fromVersion() {
         return 0;
-    }
-
-    /**
-     * Runs in test mode too, matching this step's pre-migration-framework behaviour of
-     * creating indexes on every single application startup, {@code @QuarkusTest} included.
-     * Safe unconditionally: {@link #createUniqueIndexes()} and {@link #createAuditIndexes()}
-     * each catch their own failures rather than throwing (see their javadoc), so a
-     * {@code @QuarkusTest} with a mocked, unstubbed {@code MongoDatabase} just logs a warning
-     * instead of failing that test's startup.
-     */
-    @Override
-    public boolean runInTestMode() {
-        return true;
     }
 
     /**
@@ -122,6 +112,16 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
             LOG.info("Skipping MongoDB index creation (database mode: {})", databaseMode);
             return;
         }
+        createIndexes();
+    }
+
+    /**
+     * Creates every index this step manages, unconditionally — no {@code databaseMode} check.
+     * Public (unlike the two methods it delegates to) specifically so integration-test
+     * infrastructure with a known-real MongoDB container can call it directly, without needing
+     * to fake the CDI-injected {@link #databaseMode} field the way {@link #apply()} requires.
+     */
+    public void createIndexes() {
         createUniqueIndexes();
         createAuditIndexes();
     }
@@ -139,62 +139,60 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
      *   <li><b>Domain-scoped collection</b> (controls) — ensure exactly one document per
      *       domain, following the same nested-array pattern.</li>
      * </ol>
+     * Throws (rather than catching internally) on the first failure — see the class javadoc's
+     * "Failure behaviour" section for why.
      */
     private void createUniqueIndexes() {
         IndexOptions uniqueIndex = new IndexOptions().unique(true);
 
-        try {
-            // Top-level entity collections — prevent duplicate names/versions
-            database.getCollection("namespaces")
-                    .createIndex(new Document("name", 1), uniqueIndex);
-            LOG.info("Ensured unique index on namespaces.name");
+        // Top-level entity collections — prevent duplicate names/versions
+        database.getCollection("namespaces")
+                .createIndex(new Document("name", 1), uniqueIndex);
+        LOG.info("Ensured unique index on namespaces.name");
 
-            database.getCollection("domains")
-                    .createIndex(new Document("name", 1), uniqueIndex);
-            LOG.info("Ensured unique index on domains.name");
+        database.getCollection("domains")
+                .createIndex(new Document("name", 1), uniqueIndex);
+        LOG.info("Ensured unique index on domains.name");
 
-            database.getCollection("schemas")
-                    .createIndex(new Document("version", 1), uniqueIndex);
-            LOG.info("Ensured unique index on schemas.version");
+        database.getCollection("schemas")
+                .createIndex(new Document("version", 1), uniqueIndex);
+        LOG.info("Ensured unique index on schemas.version");
 
-            // Namespace-scoped collections — one document per namespace
-            for (String collection : new String[]{"architectures", "patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"}) {
-                database.getCollection(collection)
-                        .createIndex(new Document("namespace", 1), uniqueIndex);
-                LOG.info("Ensured unique index on {}.namespace", collection);
-            }
-
-            // Domain-scoped collection — one document per domain
-            database.getCollection("controls")
-                    .createIndex(new Document("domain", 1), uniqueIndex);
-            LOG.info("Ensured unique index on controls.domain");
-
-            // Resource mappings — unique (namespace, customId) and reverse lookup index
-            database.getCollection("resource_mappings")
-                    .createIndex(new Document("namespace", 1).append("customId", 1), uniqueIndex);
-            LOG.info("Ensured unique index on resource_mappings.(namespace, customId)");
-
-            database.getCollection("resource_mappings")
-                    .createIndex(new Document("namespace", 1).append("resourceType", 1).append("numericId", 1));
-            LOG.info("Ensured index on resource_mappings.(namespace, resourceType, numericId)");
-
-            // userAccess grants — partial unique indexes so identical concurrent grants dedupe.
-            // Two partials (not one compound index) because namespace-scoped and domain-scoped
-            // grant documents don't share a discriminating field.
-            database.getCollection("userAccess").createIndex(
-                    new Document("username", 1).append("namespace", 1).append("permission", 1),
-                    new IndexOptions().unique(true)
-                            .partialFilterExpression(new Document("namespace", new Document("$exists", true))));
-            LOG.info("Ensured unique partial index on userAccess.(username, namespace, permission)");
-
-            database.getCollection("userAccess").createIndex(
-                    new Document("username", 1).append("domain", 1).append("permission", 1),
-                    new IndexOptions().unique(true)
-                            .partialFilterExpression(new Document("domain", new Document("$exists", true))));
-            LOG.info("Ensured unique partial index on userAccess.(username, domain, permission)");
-        } catch (Exception e) {
-            LOG.warn("Failed to create MongoDB indexes — indexes may already exist or MongoDB is unavailable", e);
+        // Namespace-scoped collections — one document per namespace
+        for (String collection : new String[]{"architectures", "patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"}) {
+            database.getCollection(collection)
+                    .createIndex(new Document("namespace", 1), uniqueIndex);
+            LOG.info("Ensured unique index on {}.namespace", collection);
         }
+
+        // Domain-scoped collection — one document per domain
+        database.getCollection("controls")
+                .createIndex(new Document("domain", 1), uniqueIndex);
+        LOG.info("Ensured unique index on controls.domain");
+
+        // Resource mappings — unique (namespace, customId) and reverse lookup index
+        database.getCollection("resource_mappings")
+                .createIndex(new Document("namespace", 1).append("customId", 1), uniqueIndex);
+        LOG.info("Ensured unique index on resource_mappings.(namespace, customId)");
+
+        database.getCollection("resource_mappings")
+                .createIndex(new Document("namespace", 1).append("resourceType", 1).append("numericId", 1));
+        LOG.info("Ensured index on resource_mappings.(namespace, resourceType, numericId)");
+
+        // userAccess grants — partial unique indexes so identical concurrent grants dedupe.
+        // Two partials (not one compound index) because namespace-scoped and domain-scoped
+        // grant documents don't share a discriminating field.
+        database.getCollection("userAccess").createIndex(
+                new Document("username", 1).append("namespace", 1).append("permission", 1),
+                new IndexOptions().unique(true)
+                        .partialFilterExpression(new Document("namespace", new Document("$exists", true))));
+        LOG.info("Ensured unique partial index on userAccess.(username, namespace, permission)");
+
+        database.getCollection("userAccess").createIndex(
+                new Document("username", 1).append("domain", 1).append("permission", 1),
+                new IndexOptions().unique(true)
+                        .partialFilterExpression(new Document("domain", new Document("$exists", true))));
+        LOG.info("Ensured unique partial index on userAccess.(username, domain, permission)");
     }
 
     /**
@@ -204,28 +202,26 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
      * audit trail is append-only and every record is independent, so there is no
      * duplicate-prevention concern here. These indexes only support efficient lookups
      * for {@link org.finos.calm.store.AuditLogStore}'s internal {@code query()} method.
+     * Throws (rather than catching internally) on the first failure — see the class javadoc's
+     * "Failure behaviour" section for why.
      */
     private void createAuditIndexes() {
-        try {
-            database.getCollection("auditLogs")
-                    .createIndex(new Document("namespace", 1).append("entityType", 1)
-                            .append("entityId", 1).append("timestamp", -1));
-            LOG.info("Ensured index on auditLogs.(namespace, entityType, entityId, timestamp)");
+        database.getCollection("auditLogs")
+                .createIndex(new Document("namespace", 1).append("entityType", 1)
+                        .append("entityId", 1).append("timestamp", -1));
+        LOG.info("Ensured index on auditLogs.(namespace, entityType, entityId, timestamp)");
 
-            database.getCollection("auditLogs")
-                    .createIndex(new Document("domain", 1).append("entityType", 1)
-                            .append("entityId", 1).append("timestamp", -1));
-            LOG.info("Ensured index on auditLogs.(domain, entityType, entityId, timestamp)");
+        database.getCollection("auditLogs")
+                .createIndex(new Document("domain", 1).append("entityType", 1)
+                        .append("entityId", 1).append("timestamp", -1));
+        LOG.info("Ensured index on auditLogs.(domain, entityType, entityId, timestamp)");
 
-            database.getCollection("auditLogs")
-                    .createIndex(new Document("actor", 1).append("timestamp", -1));
-            LOG.info("Ensured index on auditLogs.(actor, timestamp)");
+        database.getCollection("auditLogs")
+                .createIndex(new Document("actor", 1).append("timestamp", -1));
+        LOG.info("Ensured index on auditLogs.(actor, timestamp)");
 
-            database.getCollection("auditLogs")
-                    .createIndex(new Document("timestamp", -1));
-            LOG.info("Ensured index on auditLogs.timestamp");
-        } catch (Exception e) {
-            LOG.warn("Failed to create MongoDB audit indexes — indexes may already exist or MongoDB is unavailable", e);
-        }
+        database.getCollection("auditLogs")
+                .createIndex(new Document("timestamp", -1));
+        LOG.info("Ensured index on auditLogs.timestamp");
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializer.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializer.java
@@ -1,13 +1,15 @@
-package org.finos.calm.store.mongo;
+package org.finos.calm.migration.steps;
 
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import io.quarkus.arc.lookup.LookupIfProperty;
-import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import org.bson.Document;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.mongo.MongoArchitectureStore;
+import org.finos.calm.store.mongo.MongoDomainStore;
+import org.finos.calm.store.mongo.MongoNamespaceStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,10 +25,10 @@ import org.slf4j.LoggerFactory;
  * (e.g. {@code NamespaceAlreadyExistsException}).
  *
  * <h2>Lifecycle</h2>
- * This bean observes the Quarkus {@link io.quarkus.runtime.StartupEvent}, so indexes are
- * created (or confirmed) exactly once during application bootstrap. MongoDB's
- * {@code createIndex} is idempotent — if the index already exists with the same definition,
- * the call is a no-op.
+ * This is a {@link SchemaMigrationStep}, run once by
+ * {@code org.finos.calm.migration.SchemaMigrationRunner} as part of the version 0 → 1
+ * schema migration. MongoDB's {@code createIndex} is idempotent — if the index already
+ * exists with the same definition, the call is a no-op.
  *
  * <h2>Conditional execution</h2>
  * Index creation only runs when {@code calm.database.mode} is {@code "mongo"} (the default).
@@ -69,7 +71,7 @@ import org.slf4j.LoggerFactory;
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
-public class MongoIndexInitializer {
+public class MongoIndexInitializer implements SchemaMigrationStep {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoIndexInitializer.class);
 
@@ -82,12 +84,17 @@ public class MongoIndexInitializer {
         this.database = database;
     }
 
+    @Override
+    public int fromVersion() {
+        return 0;
+    }
+
     /**
-     * Quarkus lifecycle callback — invoked once during application startup.
      * Checks the configured database mode and creates unique indexes only when
      * running against MongoDB.
      */
-    void onStart(@Observes StartupEvent ev) {
+    @Override
+    public void apply() {
         if (!"mongo".equals(databaseMode)) {
             LOG.info("Skipping MongoDB index creation (database mode: {})", databaseMode);
             return;

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NamespaceAccessBackfillStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NamespaceAccessBackfillStep.java
@@ -27,15 +27,15 @@ import java.util.List;
  * so it works for both MongoDB and Nitrite backends without duplication.
  */
 @ApplicationScoped
-public class NamespaceMigrationService implements SchemaMigrationStep {
+public class NamespaceAccessBackfillStep implements SchemaMigrationStep {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NamespaceMigrationService.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NamespaceAccessBackfillStep.class);
 
     private final NamespaceStore namespaceStore;
     private final UserAccessStore userAccessStore;
 
     @Inject
-    public NamespaceMigrationService(NamespaceStore namespaceStore, UserAccessStore userAccessStore) {
+    public NamespaceAccessBackfillStep(NamespaceStore namespaceStore, UserAccessStore userAccessStore) {
         this.namespaceStore = namespaceStore;
         this.userAccessStore = userAccessStore;
     }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NamespaceMigrationService.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NamespaceMigrationService.java
@@ -1,13 +1,11 @@
-package org.finos.calm.services;
+package org.finos.calm.migration.steps;
 
-import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
+import org.finos.calm.migration.SchemaMigrationStep;
 import org.finos.calm.store.NamespaceStore;
 import org.finos.calm.store.UserAccessStore;
 import org.slf4j.Logger;
@@ -20,15 +18,16 @@ import java.util.List;
  * ensuring existing namespaces remain publicly readable after the hierarchical
  * entitlement model is deployed.
  *
- * <p>Runs once at startup via {@link StartupEvent}. The operation is idempotent —
- * if a namespace already has <em>any</em> existing grant (wildcard or named-user),
- * it is skipped on the assumption that an administrator has intentionally configured
- * access for that namespace.
+ * <p>This is a {@link SchemaMigrationStep}, run once by
+ * {@code org.finos.calm.migration.SchemaMigrationRunner} as part of the version 1 → 2
+ * schema migration. The operation is idempotent — if a namespace already has
+ * <em>any</em> existing grant (wildcard or named-user), it is skipped on the assumption
+ * that an administrator has intentionally configured access for that namespace.
  * Uses the CDI-produced {@link NamespaceStore} and {@link UserAccessStore} interfaces
  * so it works for both MongoDB and Nitrite backends without duplication.
  */
 @ApplicationScoped
-public class NamespaceMigrationService {
+public class NamespaceMigrationService implements SchemaMigrationStep {
 
     private static final Logger LOG = LoggerFactory.getLogger(NamespaceMigrationService.class);
 
@@ -41,11 +40,13 @@ public class NamespaceMigrationService {
         this.userAccessStore = userAccessStore;
     }
 
-    void onStart(@Observes StartupEvent ev) {
-        if (LaunchMode.current() == LaunchMode.TEST) {
-            LOG.debug("Namespace migration skipped in test mode");
-            return;
-        }
+    @Override
+    public int fromVersion() {
+        return 1;
+    }
+
+    @Override
+    public void apply() {
         LOG.info("Running namespace migration: backfilling * read grants on existing namespaces");
         List<NamespaceInfo> namespaces = namespaceStore.getNamespaces();
         int backfilled = 0;

--- a/calm-hub/src/main/java/org/finos/calm/store/SchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/SchemaVersionStore.java
@@ -1,0 +1,64 @@
+package org.finos.calm.store;
+
+/**
+ * Tracks the schema/data-shape version currently applied to the active storage
+ * backend (Mongo or Nitrite), so {@code org.finos.calm.migration.SchemaMigrationRunner}
+ * can determine which outstanding changes still need to be applied.
+ *
+ * <p>Backed by the {@code calm} collection — distinct from the {@code schemas}
+ * collection, which holds user-facing CALM meta-schema releases and is
+ * unrelated to database schema versioning.</p>
+ *
+ * <p>Also provides a simple lock, held in the same collection, so that when
+ * multiple CalmHub instances start up concurrently against the same shared
+ * database (Mongo in particular), only one of them runs pending migration
+ * steps at a time.</p>
+ *
+ * <p><b>The lock never expires automatically.</b> A migration may legitimately
+ * run for a long time, or may fail partway and need investigation — in either
+ * case, guessing a timeout risks a second instance running the same migration
+ * concurrently with the first. Instead, a held lock is also used by
+ * {@code org.finos.calm.migration.SchemaMigrationInProgressFilter} to make
+ * every CalmHub instance (not just the one running the migration) refuse
+ * requests until the lock clears. If a migration fails, the lock is
+ * deliberately left held — an administrator must investigate and clear it
+ * manually (e.g. by unsetting the {@code holder} field on the
+ * {@code migrationLock} document) before the application resumes serving
+ * requests.</p>
+ */
+public interface SchemaVersionStore {
+
+    /**
+     * Returns the schema version currently applied to this database, or
+     * {@code 0} if no version has ever been recorded (a fresh database, or
+     * one that predates schema-version tracking).
+     */
+    int getSchemaVersion();
+
+    /**
+     * Records {@code version} as the schema version now applied to this
+     * database.
+     */
+    void setSchemaVersion(int version);
+
+    /**
+     * Attempts to acquire the schema-migration lock for {@code instanceId}.
+     * Succeeds only if the lock is currently unheld. Returns {@code false} if
+     * another instance already holds it — the lock never expires on its own.
+     */
+    boolean acquireMigrationLock(String instanceId);
+
+    /**
+     * Releases the schema-migration lock, but only if it is still held by
+     * {@code instanceId} — a no-op otherwise, so a delayed/late release can
+     * never clobber a lock a different instance has since acquired.
+     */
+    void releaseMigrationLock(String instanceId);
+
+    /**
+     * Returns {@code true} if the schema-migration lock is currently held by
+     * any instance — used to gate request-serving while a migration is in
+     * progress or has failed and is awaiting manual resolution.
+     */
+    boolean isMigrationLockHeld();
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -42,7 +42,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * conflict and {@link org.finos.calm.domain.exception.AdrRevisionExistsException} is thrown
  * instead of silently overwriting the other writer's revision.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -34,7 +34,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  *
  * <h2>Document model</h2>
  * The {@code architectures} collection has <em>one document per namespace</em>, enforced by a
- * unique index on the {@code namespace} field (created by {@link MongoIndexInitializer}).
+ * unique index on the {@code namespace} field (created by {@code MongoIndexInitializationStep}).
  * Each document contains an {@code architectures} array where individual architecture
  * entries are stored as sub-documents with a unique {@code architectureId}, versioned
  * content, and metadata.
@@ -53,7 +53,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * and {@code matchedCount == 0} signals a conflict, throwing
  * {@link ArchitectureVersionExistsException}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -39,7 +39,7 @@ import org.finos.calm.store.util.VersionKeySelector;
  *
  * <h2>Document model</h2>
  * The {@code controls} collection has <em>one document per domain</em>, enforced by a
- * unique index on the {@code domain} field (created by {@link MongoIndexInitializer}).
+ * unique index on the {@code domain} field (created by {@code MongoIndexInitializationStep}).
  * Each document contains a {@code controls} array of control sub-documents. Each control
  * in turn contains a {@code requirement} map (version → JSON) and a {@code configurations}
  * array of configuration sub-documents, each with its own versioned content.
@@ -61,7 +61,6 @@ import org.finos.calm.store.util.VersionKeySelector;
  * <p>This pattern ensures version writes are atomic and conflict-free without requiring
  * application-level locking.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoCoreSchemaStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoCoreSchemaStore.java
@@ -21,7 +21,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * MongoDB-backed implementation of {@link CoreSchemaStore}.
  *
  * <h2>Concurrency strategy — idempotent create</h2>
- * A unique index on {@code schemas.version} (created by {@link MongoIndexInitializer})
+ * A unique index on {@code schemas.version} (created by {@code MongoIndexInitializationStep})
  * prevents duplicate schema versions. Unlike the namespace and domain stores, this class
  * treats a {@code DUPLICATE_KEY} error as a <em>no-op</em> rather than an error:
  * if a schema version already exists, the insert is silently ignored. This makes
@@ -31,7 +31,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * <p>This is intentional because core schemas are typically loaded during application
  * bootstrap and may be re-applied on restart.
  *
- * @see MongoIndexInitializer
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDomainStore.java
@@ -23,11 +23,10 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  *
  * <h2>Concurrency strategy</h2>
  * Identical to {@link MongoNamespaceStore}: a unique index on {@code domains.name}
- * (created by {@link MongoIndexInitializer}) enforces uniqueness at the database level.
+ * (created by {@code MongoIndexInitializationStep}) enforces uniqueness at the database level.
  * Concurrent duplicate inserts are caught as {@link ErrorCategory#DUPLICATE_KEY} errors
  * and translated into {@link DomainAlreadyExistsException}.
  *
- * @see MongoIndexInitializer
  * @see org.finos.calm.store.nitrite.NitriteDomainStore NitriteDomainStore for the standalone
  *      ReentrantLock-based approach
  */

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -40,7 +40,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * {@code $exists: false} to prevent duplicate version creation under concurrency.
  * Unique flow IDs are generated atomically by {@link MongoCounterStore}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -35,7 +35,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * {@code $exists: false} to prevent duplicate version creation under concurrency.
  * Unique interface IDs are generated atomically by {@link MongoCounterStore}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
@@ -14,7 +14,6 @@ import org.bson.Document;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
-import org.finos.calm.migration.steps.MongoIndexInitializer;
 import org.finos.calm.store.NamespaceStore;
 
 import java.util.ArrayList;
@@ -25,7 +24,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * MongoDB-backed implementation of {@link NamespaceStore}.
  *
  * <h2>Concurrency strategy</h2>
- * A unique index on {@code namespaces.name} (created by {@link MongoIndexInitializer}) prevents
+ * A unique index on {@code namespaces.name} (created by {@code MongoIndexInitializationStep}) prevents
  * duplicate namespace names at the database level. When two concurrent requests try to create the
  * same namespace, the first {@code insertOne} succeeds and the second throws a
  * {@link MongoWriteException} with error category {@link ErrorCategory#DUPLICATE_KEY}.
@@ -36,7 +35,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * safe across multiple application instances (horizontal scaling), because the uniqueness
  * constraint is enforced by MongoDB itself.
  *
- * @see MongoIndexInitializer
  * @see org.finos.calm.store.nitrite.NitriteNamespaceStore NitriteNamespaceStore for the
  *      contrasting ReentrantLock-based approach used in standalone mode
  */

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoNamespaceStore.java
@@ -14,6 +14,7 @@ import org.bson.Document;
 import org.finos.calm.domain.exception.NamespaceAlreadyExistsException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.namespaces.NamespaceInfo;
+import org.finos.calm.migration.steps.MongoIndexInitializer;
 import org.finos.calm.store.NamespaceStore;
 
 import java.util.ArrayList;

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -41,7 +41,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * {@code $exists: false} to prevent duplicate version creation under concurrency.
  * Unique pattern IDs are generated atomically by {@link MongoCounterStore}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
@@ -14,6 +14,7 @@ import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.DuplicateMappingException;
 import org.finos.calm.domain.exception.MappingNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.migration.steps.MongoIndexInitializer;
 import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
@@ -14,7 +14,6 @@ import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.DuplicateMappingException;
 import org.finos.calm.domain.exception.MappingNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.migration.steps.MongoIndexInitializer;
 import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +36,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * {@code (namespace, customId)} throws a {@link MongoWriteException} with
  * {@link ErrorCategory#DUPLICATE_KEY}, which is translated to {@link DuplicateMappingException}.
  *
- * @see MongoIndexInitializer
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
@@ -1,0 +1,98 @@
+package org.finos.calm.store.mongo;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.finos.calm.store.SchemaVersionStore;
+
+import java.util.Date;
+
+/**
+ * MongoDB-backed implementation of {@link SchemaVersionStore}.
+ *
+ * <p>Stores two documents, each identified by a fixed {@code _id}, in the
+ * {@code calm} collection: {@code schemaVersion} (the version marker) and
+ * {@code migrationLock} (the cross-instance lock). Neither document exists
+ * until first written — {@link #getSchemaVersion()} treats an absent
+ * document as version {@code 0}.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+@Typed(MongoSchemaVersionStore.class)
+public class MongoSchemaVersionStore implements SchemaVersionStore {
+
+    private static final String VERSION_DOCUMENT_ID = "schemaVersion";
+    private static final String VERSION_FIELD = "version";
+
+    private static final String LOCK_DOCUMENT_ID = "migrationLock";
+    private static final String HOLDER_FIELD = "holder";
+    private static final String ACQUIRED_AT_FIELD = "acquiredAt";
+
+    private final MongoCollection<Document> calmCollection;
+
+    public MongoSchemaVersionStore(MongoDatabase database) {
+        this.calmCollection = database.getCollection("calm");
+    }
+
+    @Override
+    public int getSchemaVersion() {
+        Document doc = calmCollection.find(Filters.eq("_id", VERSION_DOCUMENT_ID)).first();
+        return doc == null ? 0 : doc.getInteger(VERSION_FIELD, 0);
+    }
+
+    @Override
+    public void setSchemaVersion(int version) {
+        calmCollection.updateOne(
+                Filters.eq("_id", VERSION_DOCUMENT_ID),
+                Updates.set(VERSION_FIELD, version),
+                new UpdateOptions().upsert(true));
+    }
+
+    @Override
+    public boolean acquireMigrationLock(String instanceId) {
+        // acquiredAt is diagnostic only (so a human investigating a stuck lock can see how
+        // long it's been held) — it plays no part in acquisition, which never expires on its own.
+        Bson filter = Filters.and(Filters.eq("_id", LOCK_DOCUMENT_ID), Filters.exists(HOLDER_FIELD, false));
+        Bson update = Updates.combine(
+                Updates.set(HOLDER_FIELD, instanceId),
+                Updates.set(ACQUIRED_AT_FIELD, new Date()));
+        UpdateOptions options = new UpdateOptions().upsert(true);
+        try {
+            return tryAcquire(filter, update, options);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            // Lost the race to create the lock document — it exists now, retry the conditional update once.
+            return tryAcquire(filter, update, options);
+        }
+    }
+
+    private boolean tryAcquire(Bson filter, Bson update, UpdateOptions options) {
+        UpdateResult result = calmCollection.updateOne(filter, update, options);
+        return result.getModifiedCount() > 0 || result.getUpsertedId() != null;
+    }
+
+    @Override
+    public void releaseMigrationLock(String instanceId) {
+        calmCollection.updateOne(
+                Filters.and(Filters.eq("_id", LOCK_DOCUMENT_ID), Filters.eq(HOLDER_FIELD, instanceId)),
+                Updates.unset(HOLDER_FIELD));
+    }
+
+    @Override
+    public boolean isMigrationLockHeld() {
+        Document doc = calmCollection.find(Filters.eq("_id", LOCK_DOCUMENT_ID)).first();
+        return doc != null && doc.get(HOLDER_FIELD) != null;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
@@ -74,7 +74,19 @@ public class MongoSchemaVersionStore implements SchemaVersionStore {
                 throw e;
             }
             // Lost the race to create the lock document — it exists now, retry the conditional update once.
-            return tryAcquire(filter, update, options);
+            // Unlike a plain upsert-and-push, our filter has an anti-condition (holder must be absent), so
+            // if the winner already set holder, this retry's filter won't match either: the upsert path
+            // tries to insert a duplicate _id again and would throw a second time. That second collision
+            // unambiguously means someone else holds the lock now, so we report "not acquired" instead of
+            // letting the exception propagate.
+            try {
+                return tryAcquire(filter, update, options);
+            } catch (MongoWriteException retryException) {
+                if (retryException.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                    throw retryException;
+                }
+                return false;
+            }
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
@@ -16,6 +16,7 @@ import org.bson.conversions.Bson;
 import org.finos.calm.store.SchemaVersionStore;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 /**
  * MongoDB-backed implementation of {@link SchemaVersionStore}.
@@ -25,6 +26,16 @@ import java.util.Date;
  * {@code migrationLock} (the cross-instance lock). Neither document exists
  * until first written — {@link #getSchemaVersion()} treats an absent
  * document as version {@code 0}.</p>
+ *
+ * <p>{@link #isMigrationLockHeld()} runs on (effectively) every request via
+ * {@code SchemaMigrationInProgressFilter}, which fails open — allows the
+ * request through — if the store call throws. The MongoDB driver's default
+ * {@code serverSelectionTimeoutMS} is 30 seconds, so without a tighter bound
+ * a Mongo outage would still stall every request for up to 30 seconds before
+ * degrading gracefully. All operations on {@link #calmCollection} are scoped
+ * to a short client-side operation timeout instead — bounding the entire
+ * operation, including server selection, not just query execution — so an
+ * outage degrades in {@link #OPERATION_TIMEOUT_SECONDS} seconds.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
@@ -38,10 +49,12 @@ public class MongoSchemaVersionStore implements SchemaVersionStore {
     private static final String HOLDER_FIELD = "holder";
     private static final String ACQUIRED_AT_FIELD = "acquiredAt";
 
+    private static final int OPERATION_TIMEOUT_SECONDS = 3;
+
     private final MongoCollection<Document> calmCollection;
 
     public MongoSchemaVersionStore(MongoDatabase database) {
-        this.calmCollection = database.getCollection("calm");
+        this.calmCollection = database.getCollection("calm").withTimeout(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSchemaVersionStore.java
@@ -62,7 +62,15 @@ public class MongoSchemaVersionStore implements SchemaVersionStore {
     public boolean acquireMigrationLock(String instanceId) {
         // acquiredAt is diagnostic only (so a human investigating a stuck lock can see how
         // long it's been held) — it plays no part in acquisition, which never expires on its own.
-        Bson filter = Filters.and(Filters.eq("_id", LOCK_DOCUMENT_ID), Filters.exists(HOLDER_FIELD, false));
+        //
+        // holder absent OR explicitly null both count as "unlocked" — matching isMigrationLockHeld's
+        // check — so a human manually recovering a stuck lock with `$set: {holder: null}` instead of
+        // `$unset` doesn't leave the lock permanently unacquirable (the $exists:false-only filter this
+        // used to have would never match a present-but-null holder, so acquisition would keep colliding
+        // on the document's _id and always fail, even though isMigrationLockHeld() correctly reported
+        // "not held").
+        Bson filter = Filters.and(Filters.eq("_id", LOCK_DOCUMENT_ID),
+                Filters.or(Filters.exists(HOLDER_FIELD, false), Filters.eq(HOLDER_FIELD, null)));
         Bson update = Updates.combine(
                 Updates.set(HOLDER_FIELD, instanceId),
                 Updates.set(ACQUIRED_AT_FIELD, new Date()));
@@ -99,7 +107,7 @@ public class MongoSchemaVersionStore implements SchemaVersionStore {
     public void releaseMigrationLock(String instanceId) {
         calmCollection.updateOne(
                 Filters.and(Filters.eq("_id", LOCK_DOCUMENT_ID), Filters.eq(HOLDER_FIELD, instanceId)),
-                Updates.unset(HOLDER_FIELD));
+                Updates.combine(Updates.unset(HOLDER_FIELD), Updates.unset(ACQUIRED_AT_FIELD)));
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -36,7 +36,6 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * {@code $exists: false} to prevent duplicate version creation under concurrency.
  * Unique standard IDs are generated atomically by {@link MongoCounterStore}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -38,7 +38,6 @@ import java.util.Set;
  * {@code $elemMatch} / {@code $exists: false} to prevent duplicate version creation under
  * concurrency. Unique timeline IDs are generated atomically by {@link MongoCounterStore}.
  *
- * @see MongoIndexInitializer
  * @see MongoCounterStore
  */
 @ApplicationScoped

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSchemaVersionStore.java
@@ -1,0 +1,144 @@
+package org.finos.calm.store.nitrite;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.store.SchemaVersionStore;
+
+import java.time.Instant;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.dizitart.no2.filters.FluentFilter.where;
+
+/**
+ * NitriteDB-backed implementation of {@link SchemaVersionStore}, used in
+ * standalone mode.
+ *
+ * <p>Stores two documents, each identified by a fixed {@code documentId}
+ * field value, in the {@code calm} collection: {@code schemaVersion} (the
+ * version marker) and {@code migrationLock} (the cross-instance lock).
+ * Neither document exists until first written — {@link #getSchemaVersion()}
+ * treats an absent document as version {@code 0}. A {@link ReentrantLock}
+ * guards each find-then-write, consistent with {@link NitriteCounterStore}'s
+ * pattern for single-document collections in this embedded, in-process
+ * store — the lock document itself is mostly a formality here, since
+ * NitriteDB's underlying MVStore file lock already prevents a second process
+ * from opening the same database for writing.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+@Typed(NitriteSchemaVersionStore.class)
+public class NitriteSchemaVersionStore implements SchemaVersionStore {
+
+    private static final String COLLECTION_NAME = "calm";
+    private static final String DOCUMENT_ID_FIELD = "documentId";
+    private static final String VERSION_DOCUMENT_ID = "schemaVersion";
+    private static final String VERSION_FIELD = "version";
+
+    private static final String LOCK_DOCUMENT_ID = "migrationLock";
+    private static final String HOLDER_FIELD = "holder";
+    private static final String ACQUIRED_AT_FIELD = "acquiredAt";
+
+    private final Lock lock = new ReentrantLock();
+    private final NitriteCollection calmCollection;
+
+    @Inject
+    public NitriteSchemaVersionStore(@StandaloneQualifier Nitrite db) {
+        this.calmCollection = db.getCollection(COLLECTION_NAME);
+    }
+
+    @Override
+    public int getSchemaVersion() {
+        lock.lock();
+        try {
+            Document doc = findDocument(VERSION_DOCUMENT_ID);
+            if (doc == null) {
+                return 0;
+            }
+            Integer version = doc.get(VERSION_FIELD, Integer.class);
+            return version == null ? 0 : version;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void setSchemaVersion(int version) {
+        lock.lock();
+        try {
+            Document doc = findDocument(VERSION_DOCUMENT_ID);
+            if (doc == null) {
+                calmCollection.insert(Document.createDocument()
+                        .put(DOCUMENT_ID_FIELD, VERSION_DOCUMENT_ID)
+                        .put(VERSION_FIELD, version));
+            } else {
+                doc.put(VERSION_FIELD, version);
+                calmCollection.update(doc);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean acquireMigrationLock(String instanceId) {
+        lock.lock();
+        try {
+            Document doc = findDocument(LOCK_DOCUMENT_ID);
+            if (doc != null) {
+                String holder = doc.get(HOLDER_FIELD, String.class);
+                if (holder != null) {
+                    return false;
+                }
+                doc.put(HOLDER_FIELD, instanceId);
+                doc.put(ACQUIRED_AT_FIELD, Instant.now().toEpochMilli());
+                calmCollection.update(doc);
+            } else {
+                calmCollection.insert(Document.createDocument()
+                        .put(DOCUMENT_ID_FIELD, LOCK_DOCUMENT_ID)
+                        .put(HOLDER_FIELD, instanceId)
+                        .put(ACQUIRED_AT_FIELD, Instant.now().toEpochMilli()));
+            }
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void releaseMigrationLock(String instanceId) {
+        lock.lock();
+        try {
+            Document doc = findDocument(LOCK_DOCUMENT_ID);
+            if (doc != null && instanceId.equals(doc.get(HOLDER_FIELD, String.class))) {
+                doc.put(HOLDER_FIELD, null);
+                calmCollection.update(doc);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isMigrationLockHeld() {
+        lock.lock();
+        try {
+            Document doc = findDocument(LOCK_DOCUMENT_ID);
+            return doc != null && doc.get(HOLDER_FIELD, String.class) != null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private Document findDocument(String documentId) {
+        Filter filter = where(DOCUMENT_ID_FIELD).eq(documentId);
+        return calmCollection.find(filter).firstOrNull();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSchemaVersionStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSchemaVersionStore.java
@@ -119,6 +119,7 @@ public class NitriteSchemaVersionStore implements SchemaVersionStore {
             Document doc = findDocument(LOCK_DOCUMENT_ID);
             if (doc != null && instanceId.equals(doc.get(HOLDER_FIELD, String.class))) {
                 doc.put(HOLDER_FIELD, null);
+                doc.put(ACQUIRED_AT_FIELD, null);
                 calmCollection.update(doc);
             }
         } finally {

--- a/calm-hub/src/main/java/org/finos/calm/store/producer/SchemaVersionStoreProducer.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/producer/SchemaVersionStoreProducer.java
@@ -1,0 +1,43 @@
+package org.finos.calm.store.producer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.store.SchemaVersionStore;
+import org.finos.calm.store.mongo.MongoSchemaVersionStore;
+import org.finos.calm.store.nitrite.NitriteSchemaVersionStore;
+
+/**
+ * Producer for {@link SchemaVersionStore} implementations.
+ * This class provides either the MongoDB or NitriteDB implementation based on configuration.
+ */
+@ApplicationScoped
+public class SchemaVersionStoreProducer {
+
+    @Inject
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    @Inject
+    Instance<MongoSchemaVersionStore> mongoSchemaVersionStore;
+
+    @Inject
+    Instance<NitriteSchemaVersionStore> standaloneSchemaVersionStore;
+
+    /**
+     * Produces the appropriate SchemaVersionStore implementation based on the configured database mode.
+     *
+     * @return the SchemaVersionStore implementation
+     */
+    @Produces
+    @ApplicationScoped
+    public SchemaVersionStore produceSchemaVersionStore() {
+        if ("standalone".equals(databaseMode)) {
+            return standaloneSchemaVersionStore.get();
+        } else {
+            return mongoSchemaVersionStore.get();
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertPush.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertPush.java
@@ -16,7 +16,7 @@ import org.bson.conversions.Bson;
  * <h2>Why this exists</h2>
  * The upsert-insert that creates the very first entity in a brand-new namespace/domain can
  * race with a concurrent request doing the same thing: the unique index on the namespace/domain
- * field (see {@code MongoIndexInitializer}) lets exactly one of them insert, and the loser gets
+ * field (see {@code MongoIndexInitializationStep}) lets exactly one of them insert, and the loser gets
  * a {@link MongoWriteException} with {@link ErrorCategory#DUPLICATE_KEY} instead of a matched
  * document to push into. Retrying the same push once the document exists resolves this safely
  * with no data loss, instead of surfacing a spurious 500.

--- a/calm-hub/src/test/java/org/finos/calm/config/NitriteDBConfigTest.java
+++ b/calm-hub/src/test/java/org/finos/calm/config/NitriteDBConfigTest.java
@@ -74,6 +74,7 @@ public class NitriteDBConfigTest {
         assertTrue(db.hasCollection("schemas"), "schemas collection should exist");
         assertTrue(db.hasCollection("counters"), "counters collection should exist");
         assertTrue(db.hasCollection("decorators"), "decorators collection should exist");
+        assertTrue(db.hasCollection("calm"), "calm collection should exist");
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
@@ -72,7 +72,7 @@ class TestSchemaMigrationInProgressFilterShould {
         when(schemaVersionStore.isMigrationLockHeld()).thenReturn(true);
 
         cachingFilter.filter(requestContext);
-        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() - 1);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toNanos() - 1);
         cachingFilter.filter(requestContext);
 
         verify(schemaVersionStore, times(1)).isMigrationLockHeld();
@@ -85,7 +85,7 @@ class TestSchemaMigrationInProgressFilterShould {
         when(schemaVersionStore.isMigrationLockHeld()).thenReturn(false);
 
         cachingFilter.filter(requestContext);
-        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() + 1);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toNanos() + 1);
         cachingFilter.filter(requestContext);
 
         verify(schemaVersionStore, times(2)).isMigrationLockHeld();
@@ -99,7 +99,7 @@ class TestSchemaMigrationInProgressFilterShould {
         cachingFilter.filter(requestContext);
 
         when(schemaVersionStore.isMigrationLockHeld()).thenReturn(true);
-        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() - 1);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toNanos() - 1);
         cachingFilter.filter(requestContext);
 
         verify(requestContext, never()).abortWith(any());

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
@@ -104,4 +104,28 @@ class TestSchemaMigrationInProgressFilterShould {
 
         verify(requestContext, never()).abortWith(any());
     }
+
+    @Test
+    void allow_the_request_when_the_store_fails_instead_of_letting_the_exception_escape() {
+        when(schemaVersionStore.isMigrationLockHeld()).thenThrow(new RuntimeException("Mongo unavailable"));
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    void not_cache_a_store_failure_so_the_next_request_retries() {
+        AtomicLong now = new AtomicLong(1_000_000L);
+        SchemaMigrationInProgressFilter cachingFilter = new SchemaMigrationInProgressFilter(schemaVersionStore, now::get);
+        when(schemaVersionStore.isMigrationLockHeld())
+                .thenThrow(new RuntimeException("Mongo unavailable"))
+                .thenReturn(true);
+
+        cachingFilter.filter(requestContext);
+        now.addAndGet(1);
+        cachingFilter.filter(requestContext);
+
+        verify(schemaVersionStore, times(2)).isMigrationLockHeld();
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationInProgressFilterShould.java
@@ -1,0 +1,107 @@
+package org.finos.calm.migration;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.finos.calm.store.SchemaVersionStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class TestSchemaMigrationInProgressFilterShould {
+
+    @Mock
+    SchemaVersionStore schemaVersionStore;
+
+    @Mock
+    ContainerRequestContext requestContext;
+
+    @Mock
+    UriInfo uriInfo;
+
+    private SchemaMigrationInProgressFilter filter;
+
+    @BeforeEach
+    void setup() {
+        filter = new SchemaMigrationInProgressFilter(schemaVersionStore);
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("calm/namespaces");
+        when(requestContext.getMethod()).thenReturn("GET");
+    }
+
+    @Test
+    void reject_the_request_with_503_when_the_migration_lock_is_held() {
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(true);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(captor.capture());
+        assertEquals(503, captor.getValue().getStatus());
+    }
+
+    @Test
+    void allow_the_request_when_the_migration_lock_is_not_held() {
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(false);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    void not_recheck_the_store_for_a_second_request_within_the_cache_ttl() {
+        AtomicLong now = new AtomicLong(1_000_000L);
+        SchemaMigrationInProgressFilter cachingFilter = new SchemaMigrationInProgressFilter(schemaVersionStore, now::get);
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(true);
+
+        cachingFilter.filter(requestContext);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() - 1);
+        cachingFilter.filter(requestContext);
+
+        verify(schemaVersionStore, times(1)).isMigrationLockHeld();
+    }
+
+    @Test
+    void recheck_the_store_once_the_cache_ttl_has_elapsed() {
+        AtomicLong now = new AtomicLong(1_000_000L);
+        SchemaMigrationInProgressFilter cachingFilter = new SchemaMigrationInProgressFilter(schemaVersionStore, now::get);
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(false);
+
+        cachingFilter.filter(requestContext);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() + 1);
+        cachingFilter.filter(requestContext);
+
+        verify(schemaVersionStore, times(2)).isMigrationLockHeld();
+    }
+
+    @Test
+    void keep_serving_a_stale_cached_result_until_the_ttl_elapses_even_if_the_store_changes() {
+        AtomicLong now = new AtomicLong(1_000_000L);
+        SchemaMigrationInProgressFilter cachingFilter = new SchemaMigrationInProgressFilter(schemaVersionStore, now::get);
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(false);
+        cachingFilter.filter(requestContext);
+
+        when(schemaVersionStore.isMigrationLockHeld()).thenReturn(true);
+        now.addAndGet(SchemaMigrationInProgressFilter.CACHE_TTL.toMillis() - 1);
+        cachingFilter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
@@ -170,33 +170,6 @@ class TestSchemaMigrationRunnerShould {
     }
 
     @Test
-    void only_run_steps_that_opt_into_test_mode() {
-        when(mongoIndexInitializer.runInTestMode()).thenReturn(true);
-        when(namespaceMigrationService.runInTestMode()).thenReturn(false);
-        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
-
-        runner.runTestModeSteps();
-
-        verify(mongoIndexInitializer).apply();
-        verify(namespaceMigrationService, never()).apply();
-        verify(schemaVersionStore, never()).acquireMigrationLock(anyString());
-        verify(schemaVersionStore, never()).getSchemaVersion();
-        verify(schemaVersionStore, never()).setSchemaVersion(anyInt());
-    }
-
-    @Test
-    void isolate_a_test_mode_step_failure_from_other_test_mode_steps() {
-        when(mongoIndexInitializer.runInTestMode()).thenReturn(true);
-        when(namespaceMigrationService.runInTestMode()).thenReturn(true);
-        doThrow(new RuntimeException("boom")).when(mongoIndexInitializer).apply();
-        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
-
-        runner.runTestModeSteps();
-
-        verify(namespaceMigrationService).apply();
-    }
-
-    @Test
     void not_let_an_unexpected_store_failure_escape_onStart_or_release_the_lock() {
         when(schemaVersionStore.getSchemaVersion()).thenThrow(new RuntimeException("Mongo unavailable"));
         SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
@@ -1,7 +1,7 @@
 package org.finos.calm.migration;
 
-import org.finos.calm.migration.steps.MongoIndexInitializer;
-import org.finos.calm.migration.steps.NamespaceMigrationService;
+import org.finos.calm.migration.steps.MongoIndexInitializationStep;
+import org.finos.calm.migration.steps.NamespaceAccessBackfillStep;
 import org.finos.calm.store.SchemaVersionStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,10 +37,10 @@ class TestSchemaMigrationRunnerShould {
     SchemaVersionStore schemaVersionStore;
 
     @Mock
-    MongoIndexInitializer mongoIndexInitializer;
+    MongoIndexInitializationStep mongoIndexInitializer;
 
     @Mock
-    NamespaceMigrationService namespaceMigrationService;
+    NamespaceAccessBackfillStep namespaceMigrationService;
 
     // A no-op sleeper so tests exercising onStart() don't pay the real lock-visibility delay.
     private static final LongConsumer NO_OP_SLEEPER = millis -> { };

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
@@ -170,6 +170,43 @@ class TestSchemaMigrationRunnerShould {
     }
 
     @Test
+    void only_run_steps_that_opt_into_test_mode() {
+        when(mongoIndexInitializer.runInTestMode()).thenReturn(true);
+        when(namespaceMigrationService.runInTestMode()).thenReturn(false);
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.runTestModeSteps();
+
+        verify(mongoIndexInitializer).apply();
+        verify(namespaceMigrationService, never()).apply();
+        verify(schemaVersionStore, never()).acquireMigrationLock(anyString());
+        verify(schemaVersionStore, never()).getSchemaVersion();
+        verify(schemaVersionStore, never()).setSchemaVersion(anyInt());
+    }
+
+    @Test
+    void isolate_a_test_mode_step_failure_from_other_test_mode_steps() {
+        when(mongoIndexInitializer.runInTestMode()).thenReturn(true);
+        when(namespaceMigrationService.runInTestMode()).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(mongoIndexInitializer).apply();
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.runTestModeSteps();
+
+        verify(namespaceMigrationService).apply();
+    }
+
+    @Test
+    void not_let_an_unexpected_store_failure_escape_onStart_or_release_the_lock() {
+        when(schemaVersionStore.getSchemaVersion()).thenThrow(new RuntimeException("Mongo unavailable"));
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(schemaVersionStore, never()).releaseMigrationLock(anyString());
+    }
+
+    @Test
     void fail_fast_at_construction_when_two_steps_declare_the_same_from_version() {
         when(namespaceMigrationService.fromVersion()).thenReturn(0);
 

--- a/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/TestSchemaMigrationRunnerShould.java
@@ -1,0 +1,182 @@
+package org.finos.calm.migration;
+
+import org.finos.calm.migration.steps.MongoIndexInitializer;
+import org.finos.calm.migration.steps.NamespaceMigrationService;
+import org.finos.calm.store.SchemaVersionStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.LongConsumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class TestSchemaMigrationRunnerShould {
+
+    @Mock
+    SchemaVersionStore schemaVersionStore;
+
+    @Mock
+    MongoIndexInitializer mongoIndexInitializer;
+
+    @Mock
+    NamespaceMigrationService namespaceMigrationService;
+
+    // A no-op sleeper so tests exercising onStart() don't pay the real lock-visibility delay.
+    private static final LongConsumer NO_OP_SLEEPER = millis -> { };
+
+    @BeforeEach
+    void setup() {
+        when(schemaVersionStore.acquireMigrationLock(anyString())).thenReturn(true);
+        when(mongoIndexInitializer.fromVersion()).thenReturn(0);
+        when(namespaceMigrationService.fromVersion()).thenReturn(1);
+    }
+
+    private SchemaMigrationRunner newRunner(List<SchemaMigrationStep> steps) {
+        return new SchemaMigrationRunner(schemaVersionStore, steps, NO_OP_SLEEPER);
+    }
+
+    @Test
+    void run_both_steps_in_order_and_reach_the_latest_version_from_zero() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        InOrder inOrder = inOrder(mongoIndexInitializer, namespaceMigrationService, schemaVersionStore);
+        inOrder.verify(mongoIndexInitializer).apply();
+        inOrder.verify(schemaVersionStore).setSchemaVersion(1);
+        inOrder.verify(namespaceMigrationService).apply();
+        inOrder.verify(schemaVersionStore).setSchemaVersion(2);
+        verify(schemaVersionStore).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void skip_the_mongo_index_step_but_still_advance_when_not_registered() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        SchemaMigrationRunner runner = newRunner(List.of(namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(mongoIndexInitializer, never()).apply();
+        verify(schemaVersionStore).setSchemaVersion(1);
+        verify(namespaceMigrationService).apply();
+        verify(schemaVersionStore).setSchemaVersion(2);
+        verify(schemaVersionStore).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void only_run_the_namespace_step_when_starting_from_version_one() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(1);
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(mongoIndexInitializer, never()).apply();
+        verify(namespaceMigrationService).apply();
+        verify(schemaVersionStore).setSchemaVersion(2);
+        verify(schemaVersionStore, never()).setSchemaVersion(1);
+        verify(schemaVersionStore).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void skip_lock_acquisition_entirely_when_already_at_the_latest_version() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(2);
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(mongoIndexInitializer, never()).apply();
+        verify(namespaceMigrationService, never()).apply();
+        verify(schemaVersionStore, never()).setSchemaVersion(anyInt());
+        verify(schemaVersionStore, never()).acquireMigrationLock(anyString());
+        verify(schemaVersionStore, never()).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void skip_migration_entirely_when_the_lock_cannot_be_acquired() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        when(schemaVersionStore.acquireMigrationLock(anyString())).thenReturn(false);
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(schemaVersionStore, never()).setSchemaVersion(anyInt());
+        verify(schemaVersionStore, never()).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void leave_the_lock_held_when_the_first_step_fails() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        doThrow(new RuntimeException("boom")).when(mongoIndexInitializer).apply();
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(schemaVersionStore, never()).setSchemaVersion(anyInt());
+        verify(namespaceMigrationService, never()).apply();
+        verify(schemaVersionStore, never()).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void advance_past_a_successful_step_but_leave_the_lock_held_when_a_later_step_fails() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        doThrow(new RuntimeException("boom")).when(namespaceMigrationService).apply();
+        SchemaMigrationRunner runner = newRunner(List.of(mongoIndexInitializer, namespaceMigrationService));
+
+        runner.onStart(null);
+
+        verify(schemaVersionStore).setSchemaVersion(1);
+        verify(schemaVersionStore, never()).setSchemaVersion(2);
+        verify(schemaVersionStore, never()).releaseMigrationLock(anyString());
+    }
+
+    @Test
+    void wait_longer_than_the_filter_cache_ttl_after_acquiring_the_lock_before_running_steps() {
+        when(schemaVersionStore.getSchemaVersion()).thenReturn(0);
+        StringBuilder callOrder = new StringBuilder();
+        LongConsumer recordingSleeper = millis -> callOrder.append("sleep(").append(millis).append(");");
+        doAnswer(invocation -> {
+            callOrder.append("apply();");
+            return null;
+        }).when(mongoIndexInitializer).apply();
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(schemaVersionStore,
+                List.of(mongoIndexInitializer, namespaceMigrationService), recordingSleeper);
+
+        runner.onStart(null);
+
+        long expectedMillis = SchemaMigrationInProgressFilter.CACHE_TTL.plus(Duration.ofSeconds(1)).toMillis();
+        assertThat(callOrder.toString(), is("sleep(" + expectedMillis + ");apply();"));
+    }
+
+    @Test
+    void fail_fast_at_construction_when_two_steps_declare_the_same_from_version() {
+        when(namespaceMigrationService.fromVersion()).thenReturn(0);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new SchemaMigrationRunner(schemaVersionStore,
+                        List.of(mongoIndexInitializer, namespaceMigrationService)));
+
+        assertThat(exception.getMessage(), containsString("Duplicate SchemaMigrationStep"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
@@ -17,13 +17,13 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class TestMongoIndexInitializerShould {
+class TestMongoIndexInitializationStepShould {
 
     private interface DocumentMongoCollection extends MongoCollection<Document> {}
 
     @Test
     void report_zero_as_its_from_version() {
-        MongoIndexInitializer initializer = new MongoIndexInitializer(mock(MongoDatabase.class));
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class));
 
         assertThat(initializer.fromVersion(), is(0));
     }
@@ -31,7 +31,7 @@ class TestMongoIndexInitializerShould {
     @Test
     void skip_index_creation_when_database_mode_is_not_mongo() throws Exception {
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
-        MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "nitrite");
 
         initializer.apply();
@@ -47,7 +47,7 @@ class TestMongoIndexInitializerShould {
         when(mockCollection.createIndex(any(Document.class), any(IndexOptions.class))).thenReturn("idx");
         when(mockCollection.createIndex(any(Document.class))).thenReturn("idx");
 
-        MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "mongo");
 
         initializer.apply();
@@ -76,7 +76,7 @@ class TestMongoIndexInitializerShould {
     void handle_exception_during_index_creation_gracefully() throws Exception {
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         when(mockDatabase.getCollection(anyString())).thenThrow(new RuntimeException("MongoDB unavailable"));
-        MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "mongo");
 
         initializer.apply();
@@ -84,8 +84,8 @@ class TestMongoIndexInitializerShould {
         verify(mockDatabase).getCollection("namespaces");
     }
 
-    private void setDatabaseMode(MongoIndexInitializer initializer, String mode) throws Exception {
-        Field field = MongoIndexInitializer.class.getDeclaredField("databaseMode");
+    private void setDatabaseMode(MongoIndexInitializationStep initializer, String mode) throws Exception {
+        Field field = MongoIndexInitializationStep.class.getDeclaredField("databaseMode");
         field.setAccessible(true);
         field.set(initializer, mode);
     }

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
@@ -29,6 +29,13 @@ class TestMongoIndexInitializationStepShould {
     }
 
     @Test
+    void run_in_test_mode() {
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class));
+
+        assertThat(initializer.runInTestMode(), is(true));
+    }
+
+    @Test
     void skip_index_creation_when_database_mode_is_not_mongo() throws Exception {
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -24,43 +23,25 @@ class TestMongoIndexInitializationStepShould {
 
     @Test
     void report_zero_as_its_from_version() {
-        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF));
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class));
 
         assertThat(initializer.fromVersion(), is(0));
     }
 
     @Test
-    void run_in_test_mode() {
-        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF));
-
-        assertThat(initializer.runInTestMode(), is(true));
-    }
-
-    @Test
-    void scope_every_operation_to_a_short_client_side_timeout() {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
-
-        new MongoIndexInitializationStep(mockDatabase);
-
-        verify(mockDatabase).withTimeout(3, TimeUnit.SECONDS);
-    }
-
-    @Test
     void skip_index_creation_when_database_mode_is_not_mongo() throws Exception {
-        // Not verifyNoInteractions: the constructor always calls withTimeout(...) regardless
-        // of mode, so the assertion here is specifically "no index-related calls happen".
-        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "nitrite");
 
         initializer.apply();
 
-        verify(mockDatabase, never()).getCollection(anyString());
+        verifyNoInteractions(mockDatabase);
     }
 
     @Test
     void create_all_unique_indexes_when_database_mode_is_mongo() throws Exception {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoCollection<Document> mockCollection = mock(DocumentMongoCollection.class);
         when(mockDatabase.getCollection(anyString())).thenReturn(mockCollection);
         when(mockCollection.createIndex(any(Document.class), any(IndexOptions.class))).thenReturn("idx");
@@ -92,15 +73,41 @@ class TestMongoIndexInitializationStepShould {
     }
 
     @Test
-    void handle_exception_during_index_creation_gracefully() throws Exception {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
-        when(mockDatabase.getCollection(anyString())).thenThrow(new RuntimeException("MongoDB unavailable"));
+    void propagate_index_creation_failures_instead_of_swallowing_them() throws Exception {
+        // A swallowed failure here would let SchemaMigrationRunner mark the version-0-to-1
+        // migration successful with indexes that were never actually created — and since this
+        // step only ever runs once, that gap would be permanent and silent. Letting the
+        // exception propagate is what makes the runner retry this step on the next startup
+        // instead.
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        RuntimeException unavailable = new RuntimeException("MongoDB unavailable");
+        when(mockDatabase.getCollection(anyString())).thenThrow(unavailable);
         MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "mongo");
 
-        initializer.apply();
+        RuntimeException thrown = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, initializer::apply);
+
+        assertThat(thrown, is(unavailable));
+        verify(mockDatabase).getCollection("namespaces");
+    }
+
+    @Test
+    void create_indexes_directly_without_needing_the_database_mode_configured() {
+        // createIndexes() is the entry point integration-test infrastructure (EndToEndResource)
+        // calls directly against a real, known-Mongo container — it must not depend on the
+        // CDI-injected databaseMode field, which is never set outside a running application.
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        MongoCollection<Document> mockCollection = mock(DocumentMongoCollection.class);
+        when(mockDatabase.getCollection(anyString())).thenReturn(mockCollection);
+        when(mockCollection.createIndex(any(Document.class), any(IndexOptions.class))).thenReturn("idx");
+        when(mockCollection.createIndex(any(Document.class))).thenReturn("idx");
+
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
+
+        initializer.createIndexes();
 
         verify(mockDatabase).getCollection("namespaces");
+        verify(mockDatabase, times(4)).getCollection("auditLogs");
     }
 
     private void setDatabaseMode(MongoIndexInitializationStep initializer, String mode) throws Exception {

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializationStepShould.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -23,32 +24,43 @@ class TestMongoIndexInitializationStepShould {
 
     @Test
     void report_zero_as_its_from_version() {
-        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class));
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF));
 
         assertThat(initializer.fromVersion(), is(0));
     }
 
     @Test
     void run_in_test_mode() {
-        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class));
+        MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF));
 
         assertThat(initializer.runInTestMode(), is(true));
     }
 
     @Test
+    void scope_every_operation_to_a_short_client_side_timeout() {
+        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
+
+        new MongoIndexInitializationStep(mockDatabase);
+
+        verify(mockDatabase).withTimeout(3, TimeUnit.SECONDS);
+    }
+
+    @Test
     void skip_index_creation_when_database_mode_is_not_mongo() throws Exception {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        // Not verifyNoInteractions: the constructor always calls withTimeout(...) regardless
+        // of mode, so the assertion here is specifically "no index-related calls happen".
+        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
         MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "nitrite");
 
         initializer.apply();
 
-        verifyNoInteractions(mockDatabase);
+        verify(mockDatabase, never()).getCollection(anyString());
     }
 
     @Test
     void create_all_unique_indexes_when_database_mode_is_mongo() throws Exception {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
         MongoCollection<Document> mockCollection = mock(DocumentMongoCollection.class);
         when(mockDatabase.getCollection(anyString())).thenReturn(mockCollection);
         when(mockCollection.createIndex(any(Document.class), any(IndexOptions.class))).thenReturn("idx");
@@ -81,7 +93,7 @@ class TestMongoIndexInitializationStepShould {
 
     @Test
     void handle_exception_during_index_creation_gracefully() throws Exception {
-        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class, org.mockito.Answers.RETURNS_SELF);
         when(mockDatabase.getCollection(anyString())).thenThrow(new RuntimeException("MongoDB unavailable"));
         MongoIndexInitializationStep initializer = new MongoIndexInitializationStep(mockDatabase);
         setDatabaseMode(initializer, "mongo");

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoIndexInitializerShould.java
@@ -1,9 +1,8 @@
-package org.finos.calm.store.mongo;
+package org.finos.calm.migration.steps;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
-import io.quarkus.runtime.StartupEvent;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -21,12 +22,19 @@ class TestMongoIndexInitializerShould {
     private interface DocumentMongoCollection extends MongoCollection<Document> {}
 
     @Test
+    void report_zero_as_its_from_version() {
+        MongoIndexInitializer initializer = new MongoIndexInitializer(mock(MongoDatabase.class));
+
+        assertThat(initializer.fromVersion(), is(0));
+    }
+
+    @Test
     void skip_index_creation_when_database_mode_is_not_mongo() throws Exception {
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
         setDatabaseMode(initializer, "nitrite");
 
-        initializer.onStart(mock(StartupEvent.class));
+        initializer.apply();
 
         verifyNoInteractions(mockDatabase);
     }
@@ -42,7 +50,7 @@ class TestMongoIndexInitializerShould {
         MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
         setDatabaseMode(initializer, "mongo");
 
-        initializer.onStart(mock(StartupEvent.class));
+        initializer.apply();
 
         // Top-level collections: namespaces, domains, schemas
         verify(mockDatabase).getCollection("namespaces");
@@ -71,7 +79,7 @@ class TestMongoIndexInitializerShould {
         MongoIndexInitializer initializer = new MongoIndexInitializer(mockDatabase);
         setDatabaseMode(initializer, "mongo");
 
-        initializer.onStart(mock(StartupEvent.class));
+        initializer.apply();
 
         verify(mockDatabase).getCollection("namespaces");
     }

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
@@ -42,11 +42,6 @@ class TestNamespaceAccessBackfillStepShould {
         assertThat(service.fromVersion(), is(1));
     }
 
-    @Test
-    void not_run_in_test_mode() {
-        assertThat(service.runInTestMode(), is(false));
-    }
-
     // --- backfillIfNeeded unit tests ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
@@ -42,6 +42,11 @@ class TestNamespaceAccessBackfillStepShould {
         assertThat(service.fromVersion(), is(1));
     }
 
+    @Test
+    void not_run_in_test_mode() {
+        assertThat(service.runInTestMode(), is(false));
+    }
+
     // --- backfillIfNeeded unit tests ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceAccessBackfillStepShould.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class TestNamespaceMigrationServiceShould {
+class TestNamespaceAccessBackfillStepShould {
 
     @Mock
     NamespaceStore mockNamespaceStore;
@@ -30,11 +30,11 @@ class TestNamespaceMigrationServiceShould {
     @Mock
     UserAccessStore mockUserAccessStore;
 
-    NamespaceMigrationService service;
+    NamespaceAccessBackfillStep service;
 
     @BeforeEach
     void setUp() {
-        service = new NamespaceMigrationService(mockNamespaceStore, mockUserAccessStore);
+        service = new NamespaceAccessBackfillStep(mockNamespaceStore, mockUserAccessStore);
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceMigrationServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNamespaceMigrationServiceShould.java
@@ -1,4 +1,4 @@
-package org.finos.calm.services;
+package org.finos.calm.migration.steps;
 
 import org.finos.calm.domain.UserAccess;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
@@ -35,6 +35,11 @@ class TestNamespaceMigrationServiceShould {
     @BeforeEach
     void setUp() {
         service = new NamespaceMigrationService(mockNamespaceStore, mockUserAccessStore);
+    }
+
+    @Test
+    void report_one_as_its_from_version() {
+        assertThat(service.fromVersion(), is(1));
     }
 
     // --- backfillIfNeeded unit tests ---
@@ -111,7 +116,7 @@ class TestNamespaceMigrationServiceShould {
         assertFalse(result);
     }
 
-    // --- onStart integration of backfillIfNeeded ---
+    // --- apply() integration of backfillIfNeeded ---
 
     @Test
     void backfills_multiple_namespaces_on_startup() throws Exception {
@@ -122,7 +127,7 @@ class TestNamespaceMigrationServiceShould {
         when(mockUserAccessStore.getUserAccessForNamespace(any()))
                 .thenReturn(List.of());
 
-        service.onStart(null);
+        service.apply();
 
         verify(mockUserAccessStore, times(2)).createUserAccessForNamespace(any());
     }
@@ -133,7 +138,7 @@ class TestNamespaceMigrationServiceShould {
         when(mockNamespaceStore.getNamespaces()).thenReturn(List.of(new NamespaceInfo("org", "")));
         when(mockUserAccessStore.getUserAccessForNamespace("org")).thenReturn(List.of(existing));
 
-        service.onStart(null);
+        service.apply();
 
         verify(mockUserAccessStore, never()).createUserAccessForNamespace(any());
     }
@@ -146,8 +151,8 @@ class TestNamespaceMigrationServiceShould {
                 .thenReturn(List.of())
                 .thenReturn(List.of(new UserAccess("*", UserAccess.Permission.read, "org")));
 
-        service.onStart(null);
-        service.onStart(null);
+        service.apply();
+        service.apply();
 
         // Grant inserted exactly once across both runs
         verify(mockUserAccessStore, times(1)).createUserAccessForNamespace(any());

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
@@ -118,6 +118,38 @@ class TestMongoSchemaVersionStoreShould {
     }
 
     @Test
+    void return_false_instead_of_throwing_when_the_retry_also_collides_on_duplicate_key() {
+        // Both attempts race a concurrent instance that keeps winning: the retry's filter
+        // (holder must be absent) no longer matches once a holder is set, so its own upsert
+        // attempts another insert with the same _id and collides again.
+        MongoWriteException duplicateKey = new MongoWriteException(
+                new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of());
+        MongoWriteException duplicateKeyOnRetry = new MongoWriteException(
+                new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of());
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class)))
+                .thenThrow(duplicateKey)
+                .thenThrow(duplicateKeyOnRetry);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(false));
+    }
+
+    @Test
+    void rethrow_a_non_duplicate_key_write_exception_from_the_retry() {
+        MongoWriteException duplicateKey = new MongoWriteException(
+                new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of());
+        MongoWriteException otherOnRetry = new MongoWriteException(
+                new WriteError(2, "some other error", new BsonDocument()), new ServerAddress(), List.of());
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class)))
+                .thenThrow(duplicateKey)
+                .thenThrow(otherOnRetry);
+
+        org.junit.jupiter.api.Assertions.assertThrows(MongoWriteException.class,
+                () -> store.acquireMigrationLock("instance-a"));
+    }
+
+    @Test
     void rethrow_non_duplicate_key_write_exceptions_when_acquiring_the_lock() {
         MongoWriteException other = new MongoWriteException(
                 new WriteError(2, "some other error", new BsonDocument()), new ServerAddress(), List.of());

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
@@ -103,6 +103,32 @@ class TestMongoSchemaVersionStoreShould {
     }
 
     @Test
+    void build_a_filter_that_treats_an_absent_or_a_null_holder_as_unlocked() {
+        // A human recovering a stuck lock might run `$set: {holder: null}` instead of `$unset` —
+        // acquisition must still succeed against a present-but-null holder, not just an absent one,
+        // or the lock becomes permanently unacquirable despite isMigrationLockHeld() correctly
+        // reporting it as not held.
+        UpdateResult result = mock(UpdateResult.class);
+        when(result.getModifiedCount()).thenReturn(1L);
+        when(result.getUpsertedId()).thenReturn(null);
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class))).thenReturn(result);
+
+        store.acquireMigrationLock("instance-a");
+
+        verify(calmCollection).updateOne(
+                ArgumentMatchers.<Bson>argThat(filter -> {
+                    BsonDocument and = filter.toBsonDocument().getArray("$and").get(1).asDocument();
+                    return and.containsKey("$or")
+                            && and.getArray("$or").stream()
+                                    .anyMatch(clause -> clause.asDocument().containsKey("holder")
+                                            && clause.asDocument().get("holder").isNull());
+                }),
+                ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class));
+    }
+
+    @Test
     void retry_once_after_losing_the_race_to_create_the_lock_document() {
         MongoWriteException duplicateKey = new MongoWriteException(
                 new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of());
@@ -169,7 +195,10 @@ class TestMongoSchemaVersionStoreShould {
                     BsonDocument and = filter.toBsonDocument().getArray("$and").get(1).asDocument();
                     return "instance-a".equals(and.getString("holder").getValue());
                 }),
-                ArgumentMatchers.<Bson>argThat(update -> update.toBsonDocument().getDocument("$unset").containsKey("holder")));
+                ArgumentMatchers.<Bson>argThat(update -> {
+                    BsonDocument unset = update.toBsonDocument().getDocument("$unset");
+                    return unset.containsKey("holder") && unset.containsKey("acquiredAt");
+                }));
     }
 
     @Test
@@ -186,6 +215,15 @@ class TestMongoSchemaVersionStoreShould {
         DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
         when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
         when(findIterable.first()).thenReturn(new Document("_id", "migrationLock"));
+
+        assertThat(store.isMigrationLockHeld(), is(false));
+    }
+
+    @Test
+    void report_the_lock_as_not_held_when_the_holder_field_is_explicitly_null() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(new Document("_id", "migrationLock").append("holder", null));
 
         assertThat(store.isMigrationLockHeld(), is(false));
     }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
@@ -1,0 +1,169 @@
+package org.finos.calm.store.mongo;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.UpdateResult;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class TestMongoSchemaVersionStoreShould {
+
+    @InjectMock
+    MongoDatabase mongoDatabase;
+
+    private MongoCollection<Document> calmCollection;
+    private MongoSchemaVersionStore store;
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    @BeforeEach
+    void setup() {
+        calmCollection = Mockito.mock(DocumentMongoCollection.class);
+        when(mongoDatabase.getCollection("calm")).thenReturn(calmCollection);
+        store = new MongoSchemaVersionStore(mongoDatabase);
+    }
+
+    @Test
+    void return_zero_when_no_schema_version_document_exists() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(null);
+
+        assertThat(store.getSchemaVersion(), is(0));
+    }
+
+    @Test
+    void return_the_stored_version_when_a_schema_version_document_exists() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(new Document("_id", "schemaVersion").append("version", 3));
+
+        assertThat(store.getSchemaVersion(), is(3));
+    }
+
+    @Test
+    void upsert_the_schema_version_document_on_set() {
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class))).thenReturn(mock(UpdateResult.class));
+
+        store.setSchemaVersion(2);
+
+        verify(calmCollection).updateOne(
+                ArgumentMatchers.<Bson>argThat(filter -> filter.toBsonDocument().get("_id").asString().getValue().equals("schemaVersion")),
+                ArgumentMatchers.<Bson>argThat(update -> update.toBsonDocument().getDocument("$set").getInt32("version").getValue() == 2),
+                ArgumentMatchers.argThat(UpdateOptions::isUpsert));
+    }
+
+    @Test
+    void acquire_the_lock_when_no_lock_document_exists() {
+        UpdateResult result = mock(UpdateResult.class);
+        when(result.getModifiedCount()).thenReturn(0L);
+        when(result.getUpsertedId()).thenReturn(new BsonString("upserted"));
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class))).thenReturn(result);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(true));
+    }
+
+    @Test
+    void not_acquire_the_lock_when_another_instance_already_holds_it() {
+        UpdateResult result = mock(UpdateResult.class);
+        when(result.getModifiedCount()).thenReturn(0L);
+        when(result.getUpsertedId()).thenReturn(null);
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class))).thenReturn(result);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(false));
+    }
+
+    @Test
+    void retry_once_after_losing_the_race_to_create_the_lock_document() {
+        MongoWriteException duplicateKey = new MongoWriteException(
+                new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of());
+        UpdateResult retryResult = mock(UpdateResult.class);
+        when(retryResult.getModifiedCount()).thenReturn(0L);
+        when(retryResult.getUpsertedId()).thenReturn(null);
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class)))
+                .thenThrow(duplicateKey)
+                .thenReturn(retryResult);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(false));
+    }
+
+    @Test
+    void rethrow_non_duplicate_key_write_exceptions_when_acquiring_the_lock() {
+        MongoWriteException other = new MongoWriteException(
+                new WriteError(2, "some other error", new BsonDocument()), new ServerAddress(), List.of());
+        when(calmCollection.updateOne(ArgumentMatchers.any(Bson.class), ArgumentMatchers.any(Bson.class),
+                ArgumentMatchers.any(UpdateOptions.class))).thenThrow(other);
+
+        org.junit.jupiter.api.Assertions.assertThrows(MongoWriteException.class,
+                () -> store.acquireMigrationLock("instance-a"));
+    }
+
+    @Test
+    void release_the_lock_conditioned_on_the_given_instance_being_the_holder() {
+        store.releaseMigrationLock("instance-a");
+
+        verify(calmCollection).updateOne(
+                ArgumentMatchers.<Bson>argThat(filter -> {
+                    BsonDocument and = filter.toBsonDocument().getArray("$and").get(1).asDocument();
+                    return "instance-a".equals(and.getString("holder").getValue());
+                }),
+                ArgumentMatchers.<Bson>argThat(update -> update.toBsonDocument().getDocument("$unset").containsKey("holder")));
+    }
+
+    @Test
+    void report_the_lock_as_not_held_when_no_lock_document_exists() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(null);
+
+        assertThat(store.isMigrationLockHeld(), is(false));
+    }
+
+    @Test
+    void report_the_lock_as_not_held_when_the_lock_document_has_no_holder() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(new Document("_id", "migrationLock"));
+
+        assertThat(store.isMigrationLockHeld(), is(false));
+    }
+
+    @Test
+    void report_the_lock_as_held_when_the_lock_document_has_a_holder() {
+        DocumentFindIterable findIterable = mock(DocumentFindIterable.class);
+        when(calmCollection.find(ArgumentMatchers.any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(new Document("_id", "migrationLock").append("holder", "instance-a"));
+
+        assertThat(store.isMigrationLockHeld(), is(true));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSchemaVersionStoreShould.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -33,6 +34,7 @@ class TestMongoSchemaVersionStoreShould {
     @InjectMock
     MongoDatabase mongoDatabase;
 
+    private MongoCollection<Document> rawCollection;
     private MongoCollection<Document> calmCollection;
     private MongoSchemaVersionStore store;
 
@@ -44,9 +46,16 @@ class TestMongoSchemaVersionStoreShould {
 
     @BeforeEach
     void setup() {
+        rawCollection = Mockito.mock(DocumentMongoCollection.class);
         calmCollection = Mockito.mock(DocumentMongoCollection.class);
-        when(mongoDatabase.getCollection("calm")).thenReturn(calmCollection);
+        when(mongoDatabase.getCollection("calm")).thenReturn(rawCollection);
+        when(rawCollection.withTimeout(3, TimeUnit.SECONDS)).thenReturn(calmCollection);
         store = new MongoSchemaVersionStore(mongoDatabase);
+    }
+
+    @Test
+    void scope_every_operation_to_a_short_client_side_timeout() {
+        verify(rawCollection).withTimeout(3, TimeUnit.SECONDS);
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSchemaVersionStoreShould.java
@@ -1,0 +1,197 @@
+package org.finos.calm.store.nitrite;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestNitriteSchemaVersionStoreShould {
+
+    @Mock
+    private Nitrite mockDb;
+
+    @Mock
+    private NitriteCollection mockCollection;
+
+    @Mock
+    private DocumentCursor mockCursor;
+
+    private NitriteSchemaVersionStore store;
+
+    @BeforeEach
+    void setup() {
+        when(mockDb.getCollection("calm")).thenReturn(mockCollection);
+        store = new NitriteSchemaVersionStore(mockDb);
+    }
+
+    @Test
+    void return_zero_when_no_schema_version_document_exists() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        assertThat(store.getSchemaVersion(), is(0));
+    }
+
+    @Test
+    void return_zero_when_the_schema_version_document_has_no_version_field() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("version", Integer.class)).thenReturn(null);
+
+        assertThat(store.getSchemaVersion(), is(0));
+    }
+
+    @Test
+    void return_the_stored_version_when_a_schema_version_document_exists() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("version", Integer.class)).thenReturn(4);
+
+        assertThat(store.getSchemaVersion(), is(4));
+    }
+
+    @Test
+    void insert_a_new_document_when_setting_the_version_and_none_exists() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        store.setSchemaVersion(1);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(mockCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("documentId", String.class), is("schemaVersion"));
+        assertThat(captor.getValue().get("version", Integer.class), is(1));
+    }
+
+    @Test
+    void update_the_existing_document_when_setting_the_version_and_one_exists() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+
+        store.setSchemaVersion(5);
+
+        verify(doc).put("version", 5);
+        verify(mockCollection).update(doc);
+    }
+
+    @Test
+    void acquire_the_lock_when_no_lock_document_exists() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(true));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(mockCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("documentId", String.class), is("migrationLock"));
+        assertThat(captor.getValue().get("holder", String.class), is("instance-a"));
+    }
+
+    @Test
+    void acquire_the_lock_when_the_lock_document_exists_but_has_no_holder() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn(null);
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(true));
+
+        verify(doc).put("holder", "instance-a");
+        verify(mockCollection).update(doc);
+    }
+
+    @Test
+    void not_acquire_the_lock_when_another_instance_already_holds_it() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn("instance-other");
+
+        assertThat(store.acquireMigrationLock("instance-a"), is(false));
+
+        verify(mockCollection, never()).update(any(Document.class));
+        verify(mockCollection, never()).insert(any(Document.class));
+    }
+
+    @Test
+    void release_the_lock_when_held_by_the_given_instance() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn("instance-a");
+
+        store.releaseMigrationLock("instance-a");
+
+        verify(doc).put("holder", null);
+        verify(mockCollection).update(doc);
+    }
+
+    @Test
+    void not_release_the_lock_when_held_by_a_different_instance() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn("instance-other");
+
+        store.releaseMigrationLock("instance-a");
+
+        verify(mockCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void not_release_the_lock_when_no_lock_document_exists() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        store.releaseMigrationLock("instance-a");
+
+        verify(mockCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void report_the_lock_as_not_held_when_no_lock_document_exists() {
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(null);
+
+        assertThat(store.isMigrationLockHeld(), is(false));
+    }
+
+    @Test
+    void report_the_lock_as_not_held_when_the_lock_document_has_no_holder() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn(null);
+
+        assertThat(store.isMigrationLockHeld(), is(false));
+    }
+
+    @Test
+    void report_the_lock_as_held_when_the_lock_document_has_a_holder() {
+        Document doc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(doc);
+        when(doc.get("holder", String.class)).thenReturn("instance-a");
+
+        assertThat(store.isMigrationLockHeld(), is(true));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSchemaVersionStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSchemaVersionStoreShould.java
@@ -142,6 +142,7 @@ class TestNitriteSchemaVersionStoreShould {
         store.releaseMigrationLock("instance-a");
 
         verify(doc).put("holder", null);
+        verify(doc).put("acquiredAt", null);
         verify(mockCollection).update(doc);
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/producer/TestSchemaVersionStoreProducerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/producer/TestSchemaVersionStoreProducerShould.java
@@ -1,0 +1,73 @@
+package org.finos.calm.store.producer;
+
+import jakarta.enterprise.inject.Instance;
+import org.finos.calm.store.SchemaVersionStore;
+import org.finos.calm.store.mongo.MongoSchemaVersionStore;
+import org.finos.calm.store.nitrite.NitriteSchemaVersionStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class TestSchemaVersionStoreProducerShould {
+
+    @Mock
+    MongoSchemaVersionStore mongoSchemaVersionStore;
+
+    @Mock
+    Instance<MongoSchemaVersionStore> mongoSchemaVersionStoreInstance;
+
+    @Mock
+    NitriteSchemaVersionStore nitriteSchemaVersionStore;
+
+    @Mock
+    Instance<NitriteSchemaVersionStore> nitriteSchemaVersionStoreInstance;
+
+    private SchemaVersionStoreProducer producer;
+
+    @BeforeEach
+    void setup() {
+        producer = new SchemaVersionStoreProducer();
+        when(mongoSchemaVersionStoreInstance.get()).thenReturn(mongoSchemaVersionStore);
+        producer.mongoSchemaVersionStore = mongoSchemaVersionStoreInstance;
+        when(nitriteSchemaVersionStoreInstance.get()).thenReturn(nitriteSchemaVersionStore);
+        producer.standaloneSchemaVersionStore = nitriteSchemaVersionStoreInstance;
+    }
+
+    @Test
+    void return_mongo_schema_version_store_when_database_mode_is_mongo() {
+        producer.databaseMode = "mongo";
+
+        SchemaVersionStore result = producer.produceSchemaVersionStore();
+
+        assertThat(result, is(sameInstance(mongoSchemaVersionStore)));
+    }
+
+    @Test
+    void return_nitrite_schema_version_store_when_database_mode_is_standalone() {
+        producer.databaseMode = "standalone";
+
+        SchemaVersionStore result = producer.produceSchemaVersionStore();
+
+        assertThat(result, is(sameInstance(nitriteSchemaVersionStore)));
+    }
+
+    @Test
+    void return_mongo_schema_version_store_when_database_mode_is_not_recognized() {
+        producer.databaseMode = "unknown";
+
+        SchemaVersionStore result = producer.produceSchemaVersionStore();
+
+        assertThat(result, is(sameInstance(mongoSchemaVersionStore)));
+    }
+}


### PR DESCRIPTION
## Description

A spike on the pathway to #2884, based on a brief discussion with @jpgough-ms.

Adds a `calm` collection (Mongo + Nitrite) that tracks the schema/data version applied to the active storage backend — a precursor to the larger storage redesign discussed in #2884, so future migrations have a version marker to gate on.

`SchemaMigrationRunner` drives startup migrations: it reads the current version from `SchemaVersionStore` and runs pending `SchemaMigrationStep` implementations one version at a time. Steps (currently `MongoIndexInitializationStep` and `NamespaceAccessBackfillStep`) are autowired via CDI's `@All List<SchemaMigrationStep>` and indexed by each step's declared `fromVersion()` — adding a future step requires no changes to the runner itself, and two steps declaring the same `fromVersion()` is a fatal, fail-fast configuration error detected both at build time and run time. Deliberate design choice by @markscott-ms .

Since multiple CalmHub instances can start concurrently against the same shared database, `SchemaVersionStore` also holds a `migrationLock` document guarding the run. The lock has **no automatic timeout** — a migration that fails or runs long requires manual operator resolution rather than risking a second instance racing in on a guessed timeout. Deliberate design choice by @markscott-ms.

`SchemaMigrationInProgressFilter` makes every instance reject requests with 503 while the lock is held (the check is cached briefly to avoid a DB round-trip per request, with the runner deliberately waiting slightly longer than that cache window after acquiring the lock before running any real migration step, so every instance's cache is guaranteed to reflect the lock first). Again, deliberate design choice by @markscott-ms . I intend a subsequent PR that will surface the 503 on CALMHub UI in a nice way.

This went through two rounds of `/code-review`, which found and fixed several real issues: a Mongo lock retry that could throw uncaught on a second concurrent-startup race instead of correctly reporting the lock as unacquired; store exceptions escaping `onStart` and aborting Quarkus startup entirely, contradicting the intended graceful-degradation behaviour; a test-mode skip that silently disabled Mongo index creation even under real-MongoDB integration tests, breaking duplicate-key-detection assertions (confirmed and fixed via an empirical before/after TestContainers run); a wall-clock cache-TTL check vulnerable to clock adjustments; and a filter that could 500 instead of failing open on a transient store error.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)