### PR TITLE
feat(calm-hub-ui): show a Keep CALM modal on 503 responses

### DIFF
--- a/calm-hub-ui/src/AuthModalError.tsx
+++ b/calm-hub-ui/src/AuthModalError.tsx
@@ -51,7 +51,7 @@ export function AuthErrorModal() {
                 </div>
             </div>
             <form method="dialog" className="modal-backdrop">
-                <button onClick={handleClose}>close</button>
+                <button type="button" onClick={handleClose}>close</button>
             </form>
         </dialog>
     );

--- a/calm-hub-ui/src/MigrationModalError.test.tsx
+++ b/calm-hub-ui/src/MigrationModalError.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MigrationErrorModal } from './MigrationModalError.js';
+import type { MigrationErrorMessage } from './service/utils/migration-store.js';
+
+const { mockSetMigrationError } = vi.hoisted(() => ({
+    mockSetMigrationError: vi.fn(),
+}));
+
+vi.mock('./service/utils/migration-store.js', () => ({
+    migrationStore: { setMigrationError: mockSetMigrationError },
+}));
+
+let mockMigrationError: MigrationErrorMessage = null;
+vi.mock('./service/utils/use-migration-store.js', () => ({
+    useMigrationError: () => mockMigrationError,
+}));
+
+describe('MigrationErrorModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMigrationError = null;
+    });
+
+    it('renders nothing when there is no migration error', () => {
+        const { container } = render(<MigrationErrorModal />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows the Keep CALM title and the backend-provided message', () => {
+        mockMigrationError = 'CalmHub is applying a schema migration and cannot serve requests right now.';
+        render(<MigrationErrorModal />);
+        expect(screen.getByText('Keep CALM')).toBeInTheDocument();
+        expect(
+            screen.getByText('CalmHub is applying a schema migration and cannot serve requests right now.')
+        ).toBeInTheDocument();
+    });
+
+    it('calls setMigrationError(null) when Close is clicked', () => {
+        mockMigrationError = 'migrating';
+        render(<MigrationErrorModal />);
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        expect(mockSetMigrationError).toHaveBeenCalledWith(null);
+    });
+});

--- a/calm-hub-ui/src/MigrationModalError.tsx
+++ b/calm-hub-ui/src/MigrationModalError.tsx
@@ -26,7 +26,7 @@ export function MigrationErrorModal() {
                 </div>
             </div>
             <form method="dialog" className="modal-backdrop">
-                <button onClick={handleClose}>close</button>
+                <button type="button" onClick={handleClose}>close</button>
             </form>
         </dialog>
     );

--- a/calm-hub-ui/src/MigrationModalError.tsx
+++ b/calm-hub-ui/src/MigrationModalError.tsx
@@ -1,0 +1,33 @@
+import { IoConstructOutline } from 'react-icons/io5';
+import { migrationStore } from './service/utils/migration-store.js';
+import { useMigrationError } from './service/utils/use-migration-store.js';
+
+export function MigrationErrorModal() {
+    const message = useMigrationError();
+
+    if (!message) {
+        return null;
+    }
+
+    const handleClose = () => migrationStore.setMigrationError(null);
+
+    return (
+        <dialog className="modal modal-open" open>
+            <div className="modal-box">
+                <div className="flex items-center gap-3 mb-1">
+                    <IoConstructOutline className="text-2xl shrink-0 text-warning" aria-hidden />
+                    <h3 className="font-bold text-lg">Keep CALM</h3>
+                </div>
+                <p className="py-3 text-base-content/70">{message}</p>
+                <div className="modal-action">
+                    <button className="btn btn-primary" onClick={handleClose}>
+                        Close
+                    </button>
+                </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+                <button onClick={handleClose}>close</button>
+            </form>
+        </dialog>
+    );
+}

--- a/calm-hub-ui/src/index.tsx
+++ b/calm-hub-ui/src/index.tsx
@@ -6,6 +6,7 @@ import { isAuthServiceEnabled } from './authService.js';
 import App from './App.js';
 import { LogoutButton } from './components/logout-button/LogoutButton.js';
 import { AuthErrorModal } from './AuthModalError.js';
+import { MigrationErrorModal } from './MigrationModalError.js';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
@@ -22,5 +23,6 @@ root.render(
             <App />
         )}
         <AuthErrorModal />
+        <MigrationErrorModal />
     </React.StrictMode>
 );

--- a/calm-hub-ui/src/service/utils/api-client.test.ts
+++ b/calm-hub-ui/src/service/utils/api-client.test.ts
@@ -12,6 +12,13 @@ vi.mock('./auth-store.js', () => ({
     },
 }));
 
+const mockSetMigrationError = vi.fn();
+vi.mock('./migration-store.js', () => ({
+    migrationStore: {
+        setMigrationError: mockSetMigrationError,
+    },
+}));
+
 describe('apiClient interceptor', () => {
     let mock: AxiosMockAdapter;
 
@@ -57,5 +64,31 @@ describe('apiClient interceptor', () => {
         const res = await apiClient.get('/test');
         expect(res.data).toEqual({ ok: true });
         expect(mockSetAuthError).not.toHaveBeenCalled();
+    });
+
+    it('calls setMigrationError with the backend-provided message on 503', async () => {
+        const { apiClient } = await import('./api-client.js');
+        mock.onGet('/test').reply(503, 'CalmHub is applying a schema migration and cannot serve requests right now.');
+
+        await expect(apiClient.get('/test')).rejects.toThrow();
+        expect(mockSetMigrationError).toHaveBeenCalledWith(
+            'CalmHub is applying a schema migration and cannot serve requests right now.'
+        );
+    });
+
+    it('falls back to a default message on 503 when the body is not usable text', async () => {
+        const { apiClient } = await import('./api-client.js');
+        mock.onGet('/test').reply(503, { unexpected: 'shape' });
+
+        await expect(apiClient.get('/test')).rejects.toThrow();
+        expect(mockSetMigrationError).toHaveBeenCalledWith('CalmHub is temporarily unavailable. Please try again shortly.');
+    });
+
+    it('does not call setMigrationError for other errors', async () => {
+        const { apiClient } = await import('./api-client.js');
+        mock.onGet('/test').reply(500);
+
+        await expect(apiClient.get('/test')).rejects.toThrow();
+        expect(mockSetMigrationError).not.toHaveBeenCalled();
     });
 });

--- a/calm-hub-ui/src/service/utils/api-client.ts
+++ b/calm-hub-ui/src/service/utils/api-client.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 import { authStore } from './auth-store.js';
+import { migrationStore } from './migration-store.js';
+
+const DEFAULT_MIGRATION_MESSAGE = 'CalmHub is temporarily unavailable. Please try again shortly.';
 
 export const apiClient = axios.create();
 
@@ -12,6 +15,12 @@ apiClient.interceptors.response.use(
             authStore.setAuthError(status);
         }
 
-        return Promise.reject(error);         
+        if (status === 503) {
+            const body = error.response?.data;
+            const message = typeof body === 'string' && body.trim().length > 0 ? body : DEFAULT_MIGRATION_MESSAGE;
+            migrationStore.setMigrationError(message);
+        }
+
+        return Promise.reject(error);
     }
 );

--- a/calm-hub-ui/src/service/utils/migration-store.test.ts
+++ b/calm-hub-ui/src/service/utils/migration-store.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MigrationStore } from './migration-store.js';
+
+describe('MigrationStore', () => {
+    let store: MigrationStore;
+
+    beforeEach(() => {
+        store = new MigrationStore();
+    });
+
+    it('starts with message null', () => {
+        expect(store.getMigrationError()).toBeNull();
+    });
+
+    it('setMigrationError updates the stored message', () => {
+        store.setMigrationError('CalmHub is applying a schema migration.');
+        expect(store.getMigrationError()).toBe('CalmHub is applying a schema migration.');
+
+        store.setMigrationError(null);
+        expect(store.getMigrationError()).toBeNull();
+    });
+
+    it('notifies subscribed listeners when the message changes', () => {
+        const received: (string | null)[] = [];
+        store.subscribe((m) => received.push(m));
+
+        store.setMigrationError('migrating');
+        store.setMigrationError(null);
+
+        expect(received).toEqual(['migrating', null]);
+    });
+
+    it('supports multiple listeners', () => {
+        const a: (string | null)[] = [];
+        const b: (string | null)[] = [];
+        store.subscribe((m) => a.push(m));
+        store.subscribe((m) => b.push(m));
+
+        store.setMigrationError('migrating');
+
+        expect(a).toEqual(['migrating']);
+        expect(b).toEqual(['migrating']);
+    });
+
+    it('unsubscribes when the returned function is called', () => {
+        const received: (string | null)[] = [];
+        const unsub = store.subscribe((m) => received.push(m));
+
+        store.setMigrationError('migrating');
+        unsub();
+        store.setMigrationError(null);
+
+        expect(received).toEqual(['migrating']);
+    });
+});

--- a/calm-hub-ui/src/service/utils/migration-store.ts
+++ b/calm-hub-ui/src/service/utils/migration-store.ts
@@ -1,0 +1,25 @@
+export type MigrationErrorMessage = string | null;
+type Listener = (message: MigrationErrorMessage) => void;
+
+export class MigrationStore {
+    private message: MigrationErrorMessage = null;
+    private listeners = new Set<Listener>();
+
+    setMigrationError(message: MigrationErrorMessage) {
+        this.message = message;
+        this.listeners.forEach((l) => l(message));
+    }
+
+    getMigrationError(): MigrationErrorMessage {
+        return this.message;
+    }
+
+    subscribe(listener: Listener) {
+        this.listeners.add(listener);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+}
+
+export const migrationStore = new MigrationStore();

--- a/calm-hub-ui/src/service/utils/use-migration-store.ts
+++ b/calm-hub-ui/src/service/utils/use-migration-store.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+import { migrationStore, MigrationErrorMessage } from './migration-store.js';
+
+export function useMigrationError(): MigrationErrorMessage {
+    const [message, setMessage] = useState<MigrationErrorMessage>(migrationStore.getMigrationError());
+    useEffect(() => {
+        return migrationStore.subscribe(setMessage);
+    }, []);
+    return message;
+}


### PR DESCRIPTION
## Description

Adds a global 503 handler to the shared `apiClient` axios interceptor (already used by every service in the app), so any request rejected while CalmHub is temporarily unavailable — e.g. applying a schema migration, per #2884's `SchemaMigrationInProgressFilter` — surfaces the backend's message to the user instead of failing silently or with a raw error.

Follows the existing `AuthErrorModal`/`auth-store` pattern already in this codebase: a small pub-sub `MigrationStore` holds the current message, a hook subscribes to it, and `MigrationErrorModal` renders it — titled **"Keep CALM"** — when present. Falls back to a generic message if the response body isn't usable text.

This is independent of the backend PR that introduces the 503 (#2897) — it just handles whatever message a 503 response body contains, so it works standalone.

It can be merged before or after #2897.

<img width="624" height="339" alt="image" src="https://github.com/user-attachments/assets/6b56870d-91a2-44ce-a7c1-93ea92d0c1d9" />

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)