### PR TITLE
feat(calm-suite): render composed-of and deployed-in as nested containers

### DIFF
--- a/calm-studio/packages/docusaurus-plugin/README.md
+++ b/calm-studio/packages/docusaurus-plugin/README.md
@@ -64,6 +64,7 @@ import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
 | `data` | `object` | — | Inline CALM architecture. Client-rendered only. |
 | `theme` | `'light' \| 'dark'` | follows `html[data-theme]` | Force a theme. |
 | `flow` | `string` | — | Flow `unique-id` to highlight (applied after hydration). |
+| `containers` | `'nested' \| 'edges'` | `'nested'` | How `composed-of`/`deployed-in` render: nested boxes or dashed arrows. Non-default values apply after hydration (build-time SVG uses the default). |
 | `interactive` | `boolean` | `true` | `false` keeps the static SVG and skips the client-side JavaScript entirely. |
 
 ## Error behavior

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.ssr.test.tsx
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.ssr.test.tsx
@@ -46,4 +46,11 @@ describe('CalmDiagram SSR', () => {
     expect(html).toContain('calm-diagram-error');
     expect(html).toContain('no architecture provided');
   });
+
+  it('passes containers prop through to the custom element markup contract', () => {
+    // SSR renders static SVG regardless; the containers prop must be accepted
+    // by the component type and not break SSR output.
+    const html = renderToString(<CalmDiagram __bundle={bundle} containers="edges" />);
+    expect(html).toContain('calm-diagram-static-light');
+  });
 });

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/index.tsx
@@ -20,7 +20,7 @@ function isRemoteUrl(value: string | undefined): value is string {
  * in for zoom/pan/tooltips/flow animation, unless interactive={false}.
  */
 export function CalmDiagram(props: CalmDiagramProps): React.ReactElement | null {
-  const { src, data, theme, flow, interactive = true, __bundle } = props;
+  const { src, data, theme, flow, containers, interactive = true, __bundle } = props;
   const [upgraded, setUpgraded] = useState(false);
   const [domTheme, setDomTheme] = useState<'light' | 'dark'>('light');
 
@@ -80,6 +80,7 @@ export function CalmDiagram(props: CalmDiagramProps): React.ReactElement | null 
           src={remote ? src : undefined}
           theme={effectiveTheme}
           flow={flow || undefined}
+          containers={containers === 'edges' ? 'edges' : undefined}
         />
       </div>
     );

--- a/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/theme/CalmDiagram/types.ts
@@ -19,6 +19,8 @@ export interface CalmDiagramProps {
   theme?: 'light' | 'dark';
   /** Flow unique-id to highlight (applied after hydration). */
   flow?: string;
+  /** Containment rendering: nested boxes (default) or legacy dashed edges. Non-default values apply client-side. */
+  containers?: 'nested' | 'edges';
   /** Set false to keep the static SVG and skip loading the interactive web component. */
   interactive?: boolean;
   /** Injected by the remark plugin — do not set manually. */
@@ -33,6 +35,7 @@ declare module 'react' {
         data?: string;
         theme?: string;
         flow?: string;
+        containers?: string;
       };
     }
   }

--- a/calm-studio/packages/web-component/src/CalmDiagram.svelte
+++ b/calm-studio/packages/web-component/src/CalmDiagram.svelte
@@ -7,6 +7,7 @@
       data: { type: 'String', attribute: 'data' },
       theme: { type: 'String', attribute: 'theme', reflect: true },
       flow: { type: 'String', attribute: 'flow' },
+      containers: { type: 'String', attribute: 'containers' },
     },
   }}
 />
@@ -20,7 +21,8 @@
     data = '',
     theme = 'light' as 'light' | 'dark',
     flow = '',
-  }: { src?: string; data?: string; theme?: 'light' | 'dark'; flow?: string } = $props();
+    containers = 'nested' as 'nested' | 'edges',
+  }: { src?: string; data?: string; theme?: 'light' | 'dark'; flow?: string; containers?: 'nested' | 'edges' } = $props();
 
   let svgContent = $state('');
   let error = $state('');
@@ -44,6 +46,7 @@
     const currentData = data;
     const currentTheme = theme;
     const currentFlow = flow;
+    const currentContainers = containers;
 
     void (async () => {
       error = '';
@@ -66,7 +69,7 @@
           return;
         }
 
-        svgContent = await renderELKDiagram(arch, { theme: currentTheme, flow: currentFlow || undefined });
+        svgContent = await renderELKDiagram(arch, { theme: currentTheme, flow: currentFlow || undefined, containers: currentContainers });
       } catch (err) {
         error = err instanceof Error ? err.message : String(err);
       } finally {

--- a/calm-studio/packages/web-component/src/render/containment.test.ts
+++ b/calm-studio/packages/web-component/src/render/containment.test.ts
@@ -178,12 +178,7 @@ describe('renderELKDiagram nested containers (integration)', () => {
     expect(container).not.toBeNull();
     const boundsRaw = (container as RegExpExecArray)[1] as string;
     const [cx, cy, cw, ch] = boundsRaw.split(',').map(Number) as [number, number, number, number];
-    // Each member node's x/y must fall inside the container bounds.
-    // NOTE FOR IMPLEMENTER: before finalizing this regex, inspect what
-    // renderNodeSvg actually emits (grep the node group markup for 'svc-a' in a
-    // console.log of the svg) — it may use a translate() transform OR x/y attrs
-    // on the group's <rect>. Adapt ONLY the coordinate-extraction regex to the
-    // real markup; keep these numeric containment assertions exactly as written.
+    // Each member node's x/y (from its <rect>) must fall inside the container bounds.
     for (const member of ['svc-a', 'svc-b']) {
       const m = new RegExp(`data-node-id="${member}"[\\s\\S]{0,200}?<rect x="([\\d.]+)" y="([\\d.]+)"`).exec(svg);
       expect(m).not.toBeNull();
@@ -202,6 +197,19 @@ describe('renderELKDiagram nested containers (integration)', () => {
     // composed-of fan-out (2 members) + connects = 3 polylines
     const polylines = (svg.match(/<polyline/g) ?? []).length;
     expect(polylines).toBe(3);
+  });
+
+  it('an unrecognized containers value falls back to nested (never a silent drop)', async () => {
+    // The 'nested' | 'edges' union is not enforced at the DOM-attribute
+    // boundary, so a typo'd attribute must not make containment vanish.
+    const svg = await renderELKDiagram(nestedArch, {
+      theme: 'light',
+      containers: 'banana' as unknown as 'nested',
+    });
+    expect(svg).toContain('data-container-id="sys"');
+    // connects edge still present; no silent drop of the containment relationship
+    const polylines = (svg.match(/<polyline/g) ?? []).length;
+    expect(polylines).toBe(1);
   });
 
   it('doubly-claimed node: one box plus one fallback arrow', async () => {

--- a/calm-studio/packages/web-component/src/render/containment.test.ts
+++ b/calm-studio/packages/web-component/src/render/containment.test.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { planContainment, isNestedContainment, emptyContainmentPlan } from './containment.js';
+import type { CalmRelationship } from '@calmstudio/calm-core';
+
+function composedOf(uid: string, container: string, nodes: string[]): CalmRelationship {
+  return { 'unique-id': uid, 'relationship-type': { 'composed-of': { container, nodes } } };
+}
+function deployedIn(uid: string, container: string, nodes: string[]): CalmRelationship {
+  return { 'unique-id': uid, 'relationship-type': { 'deployed-in': { container, nodes } } };
+}
+function connects(uid: string, source: string, destination: string): CalmRelationship {
+  return {
+    'unique-id': uid,
+    'relationship-type': { connects: { source: { node: source }, destination: { node: destination } } },
+  };
+}
+
+const KNOWN = new Set(['sys', 'svc-a', 'svc-b', 'cluster', 'db']);
+
+describe('isNestedContainment', () => {
+  it('true for nested composed-of and deployed-in', () => {
+    expect(isNestedContainment(composedOf('r', 'sys', ['svc-a']))).toBe(true);
+    expect(isNestedContainment(deployedIn('r', 'cluster', ['svc-a']))).toBe(true);
+  });
+  it('false for connects, options, and legacy flat', () => {
+    expect(isNestedContainment(connects('r', 'svc-a', 'db'))).toBe(false);
+    const flat = {
+      'unique-id': 'r-flat',
+      'relationship-type': 'composed-of',
+      source: 'sys',
+      destination: 'svc-a',
+    } as unknown as CalmRelationship;
+    expect(isNestedContainment(flat)).toBe(false);
+  });
+});
+
+describe('planContainment', () => {
+  it('nests a basic composed-of and consumes the relationship', () => {
+    const plan = planContainment([composedOf('r1', 'sys', ['svc-a', 'svc-b'])], KNOWN);
+    expect(plan.childrenOf.get('sys')).toEqual(['svc-a', 'svc-b']);
+    expect(plan.parentOf.get('svc-a')).toBe('sys');
+    expect(plan.fallbackEdges).toEqual([]);
+    expect(plan.consumedRelationshipIds.has('r1')).toBe(true);
+  });
+
+  it('supports nesting inside nesting (cluster ⊃ sys ⊃ svc-a)', () => {
+    const plan = planContainment(
+      [composedOf('r1', 'sys', ['svc-a']), deployedIn('r2', 'cluster', ['sys'])],
+      KNOWN
+    );
+    expect(plan.parentOf.get('svc-a')).toBe('sys');
+    expect(plan.parentOf.get('sys')).toBe('cluster');
+  });
+
+  it('double claim: first wins, second becomes a fallback edge with fan-out id rules', () => {
+    const plan = planContainment(
+      [composedOf('r1', 'sys', ['svc-a']), deployedIn('r2', 'cluster', ['svc-a'])],
+      KNOWN
+    );
+    expect(plan.parentOf.get('svc-a')).toBe('sys');
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r2', relationshipId: 'r2', source: 'cluster', target: 'svc-a', variant: 'deployed-in' },
+    ]);
+    expect(plan.consumedRelationshipIds.has('r2')).toBe(false);
+  });
+
+  it('partial fallback uses __N suffixes when a relationship yields 2+ fallback edges', () => {
+    const plan = planContainment(
+      [
+        composedOf('r1', 'sys', ['svc-a', 'svc-b']),
+        deployedIn('r2', 'cluster', ['svc-a', 'svc-b', 'db']),
+      ],
+      KNOWN
+    );
+    // svc-a and svc-b already claimed by r1; db nests under cluster
+    expect(plan.parentOf.get('db')).toBe('cluster');
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r2__0', relationshipId: 'r2', source: 'cluster', target: 'svc-a', variant: 'deployed-in' },
+      { id: 'r2__1', relationshipId: 'r2', source: 'cluster', target: 'svc-b', variant: 'deployed-in' },
+    ]);
+  });
+
+  it('cycle: second claim that would create a cycle falls back to an edge', () => {
+    const plan = planContainment(
+      [composedOf('r1', 'sys', ['svc-a']), composedOf('r2', 'svc-a', ['sys'])],
+      KNOWN
+    );
+    expect(plan.parentOf.get('svc-a')).toBe('sys');
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r2', relationshipId: 'r2', source: 'svc-a', target: 'sys', variant: 'composed-of' },
+    ]);
+  });
+
+  it('self-claim falls back to an edge', () => {
+    const plan = planContainment([composedOf('r1', 'sys', ['sys', 'svc-a'])], KNOWN);
+    expect(plan.parentOf.get('svc-a')).toBe('sys');
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r1', relationshipId: 'r1', source: 'sys', target: 'sys', variant: 'composed-of' },
+    ]);
+  });
+
+  it('unknown member id falls back to an edge (renderer would drop it, but identity is preserved)', () => {
+    const plan = planContainment([composedOf('r1', 'sys', ['ghost'])], KNOWN);
+    expect(plan.childrenOf.size).toBe(0);
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r1', relationshipId: 'r1', source: 'sys', target: 'ghost', variant: 'composed-of' },
+    ]);
+  });
+
+  it('unknown container id: all claims fall back', () => {
+    const plan = planContainment([composedOf('r1', 'ghost', ['svc-a'])], KNOWN);
+    expect(plan.childrenOf.size).toBe(0);
+    expect(plan.fallbackEdges).toEqual([
+      { id: 'r1', relationshipId: 'r1', source: 'ghost', target: 'svc-a', variant: 'composed-of' },
+    ]);
+  });
+
+  it('ignores connects and legacy flat relationships entirely', () => {
+    const flat = {
+      'unique-id': 'r-flat',
+      'relationship-type': 'composed-of',
+      source: 'sys',
+      destination: 'svc-a',
+    } as unknown as CalmRelationship;
+    const plan = planContainment([connects('rc', 'svc-a', 'db'), flat], KNOWN);
+    expect(plan.childrenOf.size).toBe(0);
+    expect(plan.fallbackEdges).toEqual([]);
+    expect(plan.consumedRelationshipIds.size).toBe(0);
+  });
+
+  it('emptyContainmentPlan returns an inert plan', () => {
+    const plan = emptyContainmentPlan();
+    expect(plan.childrenOf.size).toBe(0);
+    expect(plan.parentOf.size).toBe(0);
+    expect(plan.fallbackEdges).toEqual([]);
+    expect(plan.consumedRelationshipIds.size).toBe(0);
+  });
+});

--- a/calm-studio/packages/web-component/src/render/containment.test.ts
+++ b/calm-studio/packages/web-component/src/render/containment.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect } from 'vitest';
 import { planContainment, isNestedContainment, emptyContainmentPlan } from './containment.js';
 import type { CalmRelationship } from '@calmstudio/calm-core';
+import { renderELKDiagram } from './elkRender.js';
+import type { CalmArchitecture } from '@calmstudio/calm-core';
 
 function composedOf(uid: string, container: string, nodes: string[]): CalmRelationship {
   return { 'unique-id': uid, 'relationship-type': { 'composed-of': { container, nodes } } };
@@ -138,5 +140,105 @@ describe('planContainment', () => {
     expect(plan.parentOf.size).toBe(0);
     expect(plan.fallbackEdges).toEqual([]);
     expect(plan.consumedRelationshipIds.size).toBe(0);
+  });
+});
+
+const nestedArch: CalmArchitecture = {
+  nodes: [
+    { 'unique-id': 'sys', 'node-type': 'system', name: 'Trading System', description: 'The system' },
+    { 'unique-id': 'svc-a', 'node-type': 'service', name: 'Service A', description: 'A' },
+    { 'unique-id': 'svc-b', 'node-type': 'service', name: 'Service B', description: 'B' },
+    { 'unique-id': 'db', 'node-type': 'database', name: 'Main DB', description: 'DB' },
+  ],
+  relationships: [
+    {
+      'unique-id': 'sys-contains',
+      'relationship-type': { 'composed-of': { container: 'sys', nodes: ['svc-a', 'svc-b'] } },
+    },
+    {
+      'unique-id': 'a-to-db',
+      'relationship-type': { connects: { source: { node: 'svc-a' }, destination: { node: 'db' } } },
+    },
+  ],
+};
+
+describe('renderELKDiagram nested containers (integration)', () => {
+  it('renders a container box with data attrs and NO containment arrow (default nested)', async () => {
+    const svg = await renderELKDiagram(nestedArch, { theme: 'light' });
+    expect(svg).toContain('data-container-id="sys"');
+    expect(svg).toContain('Trading System');
+    // Containment fully consumed: only the connects edge remains
+    const polylines = (svg.match(/<polyline/g) ?? []).length;
+    expect(polylines).toBe(1);
+  });
+
+  it('positions member nodes inside the container bounds', async () => {
+    const svg = await renderELKDiagram(nestedArch, { theme: 'light' });
+    const container = /data-container-id="sys"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
+    expect(container).not.toBeNull();
+    const boundsRaw = (container as RegExpExecArray)[1] as string;
+    const [cx, cy, cw, ch] = boundsRaw.split(',').map(Number) as [number, number, number, number];
+    // Each member node's x/y must fall inside the container bounds.
+    // NOTE FOR IMPLEMENTER: before finalizing this regex, inspect what
+    // renderNodeSvg actually emits (grep the node group markup for 'svc-a' in a
+    // console.log of the svg) — it may use a translate() transform OR x/y attrs
+    // on the group's <rect>. Adapt ONLY the coordinate-extraction regex to the
+    // real markup; keep these numeric containment assertions exactly as written.
+    for (const member of ['svc-a', 'svc-b']) {
+      const m = new RegExp(`data-node-id="${member}"[\\s\\S]{0,200}?<rect x="([\\d.]+)" y="([\\d.]+)"`).exec(svg);
+      expect(m).not.toBeNull();
+      const mx = Number((m as RegExpExecArray)[1]);
+      const my = Number((m as RegExpExecArray)[2]);
+      expect(mx).toBeGreaterThanOrEqual(cx);
+      expect(my).toBeGreaterThanOrEqual(cy);
+      expect(mx).toBeLessThanOrEqual(cx + cw);
+      expect(my).toBeLessThanOrEqual(cy + ch);
+    }
+  });
+
+  it("containers: 'edges' reproduces the arrow behavior with no container box", async () => {
+    const svg = await renderELKDiagram(nestedArch, { theme: 'light', containers: 'edges' });
+    expect(svg).not.toContain('data-container-id');
+    // composed-of fan-out (2 members) + connects = 3 polylines
+    const polylines = (svg.match(/<polyline/g) ?? []).length;
+    expect(polylines).toBe(3);
+  });
+
+  it('doubly-claimed node: one box plus one fallback arrow', async () => {
+    const arch: CalmArchitecture = {
+      nodes: [
+        { 'unique-id': 'sys', 'node-type': 'system', name: 'Sys', description: 's' },
+        { 'unique-id': 'cluster', 'node-type': 'network', name: 'Cluster', description: 'c' },
+        { 'unique-id': 'svc-a', 'node-type': 'service', name: 'Service A', description: 'a' },
+      ],
+      relationships: [
+        { 'unique-id': 'r1', 'relationship-type': { 'composed-of': { container: 'sys', nodes: ['svc-a'] } } },
+        { 'unique-id': 'r2', 'relationship-type': { 'deployed-in': { container: 'cluster', nodes: ['svc-a'] } } },
+      ],
+    };
+    const svg = await renderELKDiagram(arch, { theme: 'light' });
+    expect(svg).toContain('data-container-id="sys"');
+    // cluster keeps no members -> renders as a normal leaf node, with the fallback edge to svc-a
+    const polylines = (svg.match(/<polyline/g) ?? []).length;
+    expect(polylines).toBe(1);
+  });
+
+  it('flow referencing a consumed containment relationship renders no dot and does not crash', async () => {
+    const arch: CalmArchitecture = {
+      ...nestedArch,
+      flows: [
+        {
+          'unique-id': 'f1',
+          name: 'F',
+          description: 'd',
+          transitions: [
+            { 'relationship-unique-id': 'sys-contains', 'sequence-number': 1, summary: 's', direction: 'source-to-destination' },
+          ],
+        },
+      ],
+    };
+    const svg = await renderELKDiagram(arch, { theme: 'light', flow: 'f1' });
+    expect((svg.match(/<animateMotion/g) ?? []).length).toBe(0);
+    expect(svg).toContain('data-container-id="sys"');
   });
 });

--- a/calm-studio/packages/web-component/src/render/containment.test.ts
+++ b/calm-studio/packages/web-component/src/render/containment.test.ts
@@ -105,7 +105,7 @@ describe('planContainment', () => {
     ]);
   });
 
-  it('unknown member id falls back to an edge (renderer would drop it, but identity is preserved)', () => {
+  it('unknown member id falls back to an edge (a dangling ref later fails the render loudly)', () => {
     const plan = planContainment([composedOf('r1', 'sys', ['ghost'])], KNOWN);
     expect(plan.childrenOf.size).toBe(0);
     expect(plan.fallbackEdges).toEqual([
@@ -240,5 +240,47 @@ describe('renderELKDiagram nested containers (integration)', () => {
     const svg = await renderELKDiagram(arch, { theme: 'light', flow: 'f1' });
     expect((svg.match(/<animateMotion/g) ?? []).length).toBe(0);
     expect(svg).toContain('data-container-id="sys"');
+  });
+
+  it('renders 3-level nesting with each box inside its parent bounds', async () => {
+    const arch: CalmArchitecture = {
+      nodes: [
+        { 'unique-id': 'cluster', 'node-type': 'network', name: 'Cluster', description: 'c' },
+        { 'unique-id': 'sys', 'node-type': 'system', name: 'Sys', description: 's' },
+        { 'unique-id': 'svc', 'node-type': 'service', name: 'Svc', description: 'v' },
+      ],
+      relationships: [
+        { 'unique-id': 'r1', 'relationship-type': { 'composed-of': { container: 'sys', nodes: ['svc'] } } },
+        { 'unique-id': 'r2', 'relationship-type': { 'deployed-in': { container: 'cluster', nodes: ['sys'] } } },
+      ],
+    };
+    const svg = await renderELKDiagram(arch, { theme: 'light', direction: 'RIGHT' });
+    const outer = /data-container-id="cluster"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
+    const inner = /data-container-id="sys"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
+    expect(outer).not.toBeNull();
+    expect(inner).not.toBeNull();
+    const [ox, oy, ow, oh] = (outer as RegExpExecArray)[1]!.split(',').map(Number) as [number, number, number, number];
+    const [ix, iy, iw, ih] = (inner as RegExpExecArray)[1]!.split(',').map(Number) as [number, number, number, number];
+    expect(ix).toBeGreaterThanOrEqual(ox);
+    expect(iy).toBeGreaterThanOrEqual(oy);
+    expect(ix + iw).toBeLessThanOrEqual(ox + ow);
+    expect(iy + ih).toBeLessThanOrEqual(oy + oh);
+  });
+
+  it('a container can be a connects endpoint (edge terminates at the box)', async () => {
+    const arch: CalmArchitecture = {
+      nodes: [
+        { 'unique-id': 'sys', 'node-type': 'system', name: 'Sys', description: 's' },
+        { 'unique-id': 'svc', 'node-type': 'service', name: 'Svc', description: 'v' },
+        { 'unique-id': 'db', 'node-type': 'database', name: 'DB', description: 'd' },
+      ],
+      relationships: [
+        { 'unique-id': 'r1', 'relationship-type': { 'composed-of': { container: 'sys', nodes: ['svc'] } } },
+        { 'unique-id': 'r2', 'relationship-type': { connects: { source: { node: 'sys' }, destination: { node: 'db' } } } },
+      ],
+    };
+    const svg = await renderELKDiagram(arch, { theme: 'light' });
+    expect(svg).toContain('data-container-id="sys"');
+    expect((svg.match(/<polyline/g) ?? []).length).toBe(1);
   });
 });

--- a/calm-studio/packages/web-component/src/render/containment.ts
+++ b/calm-studio/packages/web-component/src/render/containment.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2024 CalmStudio contributors - see NOTICE file
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getContainerAndNodes,
+  getRelationshipVariant,
+  type CalmRelationship,
+} from '@calmstudio/calm-core';
+import { isFlatRelationship, type DiagramEdge } from './relationshipEdges.js';
+
+/**
+ * The result of resolving containment relationships into a render forest.
+ * Satisfiable claims become parent/child nesting; everything else becomes
+ * a deterministic fallback edge (rendered dashed, exactly like the
+ * pre-nesting behavior).
+ */
+export interface ContainmentPlan {
+  /** containerId -> member node ids (only satisfiable claims, document order) */
+  childrenOf: Map<string, string[]>;
+  /** nodeId -> containerId (inverse of childrenOf) */
+  parentOf: Map<string, string>;
+  /** Unsatisfiable claims, as dashed edges with fan-out id rules */
+  fallbackEdges: DiagramEdge[];
+  /** Containment relationships fully represented by nesting (no edges at all) */
+  consumedRelationshipIds: Set<string>;
+}
+
+export function emptyContainmentPlan(): ContainmentPlan {
+  return {
+    childrenOf: new Map(),
+    parentOf: new Map(),
+    fallbackEdges: [],
+    consumedRelationshipIds: new Set(),
+  };
+}
+
+/** True for canonical nested composed-of / deployed-in relationships only. */
+export function isNestedContainment(rel: CalmRelationship): boolean {
+  if (isFlatRelationship(rel)) return false;
+  const variant = getRelationshipVariant(rel['relationship-type']);
+  return variant === 'composed-of' || variant === 'deployed-in';
+}
+
+/** Walk parentOf upward from `start`; true if `target` is an ancestor of `start`. */
+function hasAncestor(parentOf: Map<string, string>, start: string, target: string): boolean {
+  let current: string | undefined = parentOf.get(start);
+  while (current !== undefined) {
+    if (current === target) return true;
+    current = parentOf.get(current);
+  }
+  return false;
+}
+
+/**
+ * Resolve containment claims in document order. A claim container⊃member is
+ * satisfiable iff: both ids exist, member is not already claimed, member is
+ * not the container itself, and nesting would not create a cycle (the
+ * container is not itself a descendant of the member). Unsatisfiable claims
+ * fall back to edges; a relationship with zero fallbacks is fully consumed.
+ */
+export function planContainment(
+  relationships: CalmRelationship[],
+  knownNodeIds: Set<string>
+): ContainmentPlan {
+  const plan = emptyContainmentPlan();
+
+  for (const rel of relationships) {
+    if (!isNestedContainment(rel)) continue;
+    const uid = rel['unique-id'];
+    const variant = getRelationshipVariant(rel['relationship-type']);
+    const containerAndNodes = getContainerAndNodes(rel);
+    if (!containerAndNodes || !containerAndNodes.container) continue;
+    const { container } = containerAndNodes;
+    const members = (containerAndNodes.nodes ?? []).filter(
+      (n): n is string => typeof n === 'string' && n.length > 0
+    );
+    if (members.length === 0) continue;
+
+    const rejected: string[] = [];
+    for (const member of members) {
+      const satisfiable =
+        knownNodeIds.has(container) &&
+        knownNodeIds.has(member) &&
+        member !== container &&
+        !plan.parentOf.has(member) &&
+        !hasAncestor(plan.parentOf, container, member);
+      if (satisfiable) {
+        const siblings = plan.childrenOf.get(container) ?? [];
+        siblings.push(member);
+        plan.childrenOf.set(container, siblings);
+        plan.parentOf.set(member, container);
+      } else {
+        rejected.push(member);
+      }
+    }
+
+    if (rejected.length === 0) {
+      plan.consumedRelationshipIds.add(uid);
+    } else if (rejected.length === 1) {
+      plan.fallbackEdges.push({
+        id: uid,
+        relationshipId: uid,
+        source: container,
+        target: rejected[0] as string,
+        variant,
+      });
+    } else {
+      rejected.forEach((target, index) => {
+        plan.fallbackEdges.push({
+          id: `${uid}__${index}`,
+          relationshipId: uid,
+          source: container,
+          target,
+          variant,
+        });
+      });
+    }
+  }
+
+  return plan;
+}

--- a/calm-studio/packages/web-component/src/render/containment.ts
+++ b/calm-studio/packages/web-component/src/render/containment.ts
@@ -22,7 +22,7 @@ export interface ContainmentPlan {
   parentOf: Map<string, string>;
   /** Unsatisfiable claims, as dashed edges with fan-out id rules */
   fallbackEdges: DiagramEdge[];
-  /** Containment relationships fully represented by nesting (no edges at all) */
+  /** Containment relationships fully represented by nesting (no edges at all). Informational: the renderer filters containment relationships via isNestedContainment (a partially-fallen-back relationship must not fan out either), so it does not read this set; it exists for consumers that need to know which relationships are fully expressed by nesting. */
   consumedRelationshipIds: Set<string>;
 }
 

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -85,7 +85,12 @@ export async function renderELKDiagram(
   }
 
   const knownNodeIds = new Set(nodes.map((n) => n['unique-id']));
-  const plan = containers === 'nested'
+  // The 'nested' | 'edges' union is not enforced at the DOM-attribute boundary
+  // (the custom element passes attributes through as strings), so normalize
+  // once: anything that is not exactly 'edges' renders nested. Both the plan
+  // and the edge filter below must agree, or containment silently vanishes.
+  const containersMode: 'nested' | 'edges' = containers === 'edges' ? 'edges' : 'nested';
+  const plan = containersMode === 'nested'
     ? planContainment(relationships, knownNodeIds)
     : emptyContainmentPlan();
 
@@ -94,7 +99,7 @@ export async function renderELKDiagram(
   // must not also expand into fan-out edges.
   const diagramEdges: DiagramEdge[] = [
     ...relationships
-      .filter((r) => containers === 'edges' || !isNestedContainment(r))
+      .filter((r) => containersMode === 'edges' || !isNestedContainment(r))
       .flatMap((r) => relationshipToEdges(r)),
     ...plan.fallbackEdges,
   ];

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -7,10 +7,11 @@ import ELKImport from 'elkjs/lib/elk.bundled.js';
 const ELK = (ELKImport as unknown as { default?: new () => { layout: (graph: unknown) => Promise<unknown> } }).default ?? ELKImport as unknown as new () => { layout: (graph: unknown) => Promise<unknown> };
 
 import type { CalmArchitecture } from '@calmstudio/calm-core';
-import { renderNodeSvg } from './nodeRenderer.js';
+import { renderNodeSvg, renderContainerSvg } from './nodeRenderer.js';
 import { renderEdgeSvg, renderEdgeMarkers } from './edgeRenderer.js';
 import { renderFlowOverlay, applyFlowDimming, getFlowNodeIds, type EdgeLayout } from './flowOverlay.js';
 import { relationshipToEdges, type DiagramEdge } from './relationshipEdges.js';
+import { planContainment, emptyContainmentPlan, isNestedContainment } from './containment.js';
 
 // ---------------------------------------------------------------------------
 // ELK type helpers
@@ -23,6 +24,7 @@ type ElkChild = {
   width?: number;
   height?: number;
   labels?: Array<{ text: string }>;
+  children?: ElkChild[];
 };
 
 type ElkEdgeSection = {
@@ -44,6 +46,7 @@ export interface RenderOptions {
   theme?: 'light' | 'dark';
   direction?: 'DOWN' | 'RIGHT';
   flow?: string;
+  containers?: 'nested' | 'edges';
 }
 
 // ---------------------------------------------------------------------------
@@ -62,7 +65,7 @@ export async function renderELKDiagram(
   arch: CalmArchitecture,
   options: RenderOptions = {}
 ): Promise<string> {
-  const { theme = 'light', direction = 'DOWN', flow: flowId } = options;
+  const { theme = 'light', direction = 'DOWN', flow: flowId, containers = 'nested' } = options;
 
   // CALM's meta-schema requires no top-level properties, so `nodes` and
   // `relationships` may both be absent on a valid architecture document.
@@ -81,12 +84,53 @@ export async function renderELKDiagram(
     );
   }
 
-  // Expand relationships (nested or legacy flat) into renderable edges
-  const diagramEdges: DiagramEdge[] = relationships.flatMap((r) => relationshipToEdges(r));
+  const knownNodeIds = new Set(nodes.map((n) => n['unique-id']));
+  const plan = containers === 'nested'
+    ? planContainment(relationships, knownNodeIds)
+    : emptyContainmentPlan();
+
+  // Expand relationships into renderable edges. In nested mode, containment
+  // relationships are represented by the plan (nesting + fallback edges) and
+  // must not also expand into fan-out edges.
+  const diagramEdges: DiagramEdge[] = [
+    ...relationships
+      .filter((r) => containers === 'edges' || !isNestedContainment(r))
+      .flatMap((r) => relationshipToEdges(r)),
+    ...plan.fallbackEdges,
+  ];
 
   // Build ELK graph
   const NODE_WIDTH = 180;
   const NODE_HEIGHT = 70;
+
+  interface ElkNodeInput {
+    id: string;
+    width?: number;
+    height?: number;
+    labels: Array<{ text: string }>;
+    layoutOptions?: Record<string, string>;
+    children?: ElkNodeInput[];
+  }
+
+  const nodeNameMap = new Map(nodes.map((n) => [n['unique-id'], n.name] as const));
+
+  function buildElkNode(id: string): ElkNodeInput {
+    const members = plan.childrenOf.get(id);
+    const label = { text: nodeNameMap.get(id) ?? id };
+    if (members && members.length > 0) {
+      return {
+        id,
+        labels: [label],
+        layoutOptions: { 'elk.padding': '[top=44.0,left=16.0,bottom=16.0,right=16.0]' },
+        children: members.map(buildElkNode),
+      };
+    }
+    return { id, width: NODE_WIDTH, height: NODE_HEIGHT, labels: [label] };
+  }
+
+  const topLevelIds = nodes
+    .map((n) => n['unique-id'])
+    .filter((id) => !plan.parentOf.has(id));
 
   const graph = {
     id: 'root',
@@ -95,13 +139,10 @@ export async function renderELKDiagram(
       'elk.direction': direction,
       'elk.layered.spacing.nodeNodeBetweenLayers': '80',
       'elk.spacing.nodeNode': '60',
+      'org.eclipse.elk.json.edgeCoords': 'ROOT',
+      'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
     },
-    children: nodes.map((n) => ({
-      id: n['unique-id'],
-      width: NODE_WIDTH,
-      height: NODE_HEIGHT,
-      labels: [{ text: n.name }],
-    })),
+    children: topLevelIds.map(buildElkNode),
     edges: diagramEdges.map((e) => ({
       id: e.id,
       sources: [e.source],
@@ -127,16 +168,44 @@ export async function renderELKDiagram(
     relIdByRenderId.set(e.id, e.relationshipId);
   }
 
-  // Compute canvas dimensions
+  // Flatten the (possibly hierarchical) ELK layout into absolute-position
+  // placed nodes, recursively accumulating parent offsets.
+  interface PlacedNode {
+    id: string;
+    x: number; // absolute
+    y: number; // absolute
+    width: number;
+    height: number;
+    label: string;
+    depth: number;
+    isContainer: boolean;
+  }
+
+  const placed: PlacedNode[] = [];
+  function placeNodes(children: ElkChild[] | undefined, offsetX: number, offsetY: number, depth: number): void {
+    for (const child of children ?? []) {
+      const x = (child.x ?? 0) + offsetX;
+      const y = (child.y ?? 0) + offsetY;
+      placed.push({
+        id: child.id,
+        x,
+        y,
+        width: child.width ?? NODE_WIDTH,
+        height: child.height ?? NODE_HEIGHT,
+        label: child.labels?.[0]?.text ?? child.id,
+        depth,
+        isContainer: (plan.childrenOf.get(child.id)?.length ?? 0) > 0,
+      });
+      placeNodes(child.children, x, y, depth + 1);
+    }
+  }
+  placeNodes(layouted.children, 0, 0, 0);
+
+  // Compute canvas dimensions from top-level placed nodes
   const PADDING = 40;
-  const svgWidth = Math.max(
-    400,
-    ...(layouted.children ?? []).map((c) => (c.x ?? 0) + (c.width ?? NODE_WIDTH) + PADDING)
-  );
-  const svgHeight = Math.max(
-    200,
-    ...(layouted.children ?? []).map((c) => (c.y ?? 0) + (c.height ?? NODE_HEIGHT) + PADDING)
-  );
+  const topLevelPlaced = placed.filter((p) => p.depth === 0);
+  const svgWidth = Math.max(400, ...topLevelPlaced.map((p) => p.x + p.width + PADDING));
+  const svgHeight = Math.max(200, ...topLevelPlaced.map((p) => p.y + p.height + PADDING));
 
   const bgColor = theme === 'dark' ? '#1e1e1e' : 'transparent';
 
@@ -173,6 +242,26 @@ export async function renderELKDiagram(
   // Edge layouts grouped by source relationship id, so the flow overlay can
   // animate every render edge a fanned-out relationship expands into.
   const edgeLayoutsByRelationship = new Map<string, EdgeLayout[]>();
+
+  // Draw container boxes first, outermost (lowest depth) first, so children paint on top
+  for (const p of placed.filter((n) => n.isContainer).sort((a, b) => a.depth - b.depth)) {
+    const nodeType = nodeTypeMap.get(p.id) ?? 'system';
+    const description = nodeDescMap.get(p.id) ?? '';
+    const nodeOpacity =
+      activeFlow && activeFlowNodeIds.size > 0 && !activeFlowNodeIds.has(p.id) ? '0.3' : '1';
+    const containerSvg = renderContainerSvg({
+      id: p.id,
+      x: p.x,
+      y: p.y,
+      width: p.width,
+      height: p.height,
+      name: p.label,
+      nodeType,
+      description,
+      theme,
+    });
+    parts.push(nodeOpacity !== '1' ? `<g opacity="${nodeOpacity}">${containerSvg}</g>` : containerSvg);
+  }
 
   // Draw edges first (behind nodes)
   for (const edge of layouted.edges ?? []) {
@@ -216,29 +305,24 @@ export async function renderELKDiagram(
     }
   }
 
-  // Draw nodes
-  for (const child of layouted.children ?? []) {
-    const x = child.x ?? 0;
-    const y = child.y ?? 0;
-    const w = child.width ?? NODE_WIDTH;
-    const h = child.height ?? NODE_HEIGHT;
-    const nodeType = nodeTypeMap.get(child.id) ?? 'system';
-    const description = nodeDescMap.get(child.id) ?? '';
-    const label = child.labels?.[0]?.text ?? child.id;
+  // Draw leaf nodes on top of containers and edges
+  for (const p of placed.filter((n) => !n.isContainer)) {
+    const nodeType = nodeTypeMap.get(p.id) ?? 'system';
+    const description = nodeDescMap.get(p.id) ?? '';
 
     // Dim nodes not connected to the active flow
     const nodeOpacity =
-      activeFlow && activeFlowNodeIds.size > 0 && !activeFlowNodeIds.has(child.id)
+      activeFlow && activeFlowNodeIds.size > 0 && !activeFlowNodeIds.has(p.id)
         ? '0.3'
         : '1';
 
     const nodeSvg = renderNodeSvg({
-      id: child.id,
-      x,
-      y,
-      width: w,
-      height: h,
-      name: label,
+      id: p.id,
+      x: p.x,
+      y: p.y,
+      width: p.width,
+      height: p.height,
+      name: p.label,
       nodeType,
       description,
     });

--- a/calm-studio/packages/web-component/src/render/elkRender.ts
+++ b/calm-studio/packages/web-component/src/render/elkRender.ts
@@ -139,7 +139,10 @@ export async function renderELKDiagram(
       'elk.direction': direction,
       'elk.layered.spacing.nodeNodeBetweenLayers': '80',
       'elk.spacing.nodeNode': '60',
+      // edgeCoords ROOT: edge sections arrive root-relative, so the edge-drawing
+      // loop needs no offset math (node coords stay parent-relative — see placeNodes).
       'org.eclipse.elk.json.edgeCoords': 'ROOT',
+      // INCLUDE_CHILDREN: lets the layered algorithm route edges across hierarchy levels.
       'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
     },
     children: topLevelIds.map(buildElkNode),
@@ -263,7 +266,7 @@ export async function renderELKDiagram(
     parts.push(nodeOpacity !== '1' ? `<g opacity="${nodeOpacity}">${containerSvg}</g>` : containerSvg);
   }
 
-  // Draw edges first (behind nodes)
+  // Draw edges above container boxes, below leaf nodes
   for (const edge of layouted.edges ?? []) {
     for (const section of edge.sections ?? []) {
       const points: Array<{ x: number; y: number }> = [];

--- a/calm-studio/packages/web-component/src/render/nodeRenderer.ts
+++ b/calm-studio/packages/web-component/src/render/nodeRenderer.ts
@@ -143,3 +143,44 @@ export function renderNodeSvg(node: RenderNodeInput): string {
   parts.push(`</g>`);
   return parts.join('\n');
 }
+
+export interface RenderContainerInput {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  name: string;
+  nodeType: string;
+  description: string;
+  theme: 'light' | 'dark';
+}
+
+/** Convert a #rrggbb hex color to an rgba() string with the given alpha. */
+function hexToRgba(hex: string, alpha: number): string {
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) return `rgba(127,127,127,${alpha})`;
+  const [, r, g, b] = m;
+  return `rgba(${parseInt(r as string, 16)},${parseInt(g as string, 16)},${parseInt(b as string, 16)},${alpha})`;
+}
+
+/**
+ * Render a container box (composed-of / deployed-in) with its member nodes
+ * drawn separately on top. Label strip pinned top-left; data attributes match
+ * leaf nodes so click-tooltips keep working (data-container-id marks it as a
+ * container for tests and styling).
+ */
+export function renderContainerSvg(input: RenderContainerInput): string {
+  const { id, x, y, width, height, name, nodeType, description, theme } = input;
+  const style = getNodeStyle(nodeType);
+  const fill = theme === 'dark' ? 'rgba(255,255,255,0.03)' : hexToRgba(style.fill, 0.06);
+  const labelColor = theme === 'dark' ? '#e5e5e5' : '#333';
+  const bounds = `${x},${y},${width},${height}`;
+  return [
+    `<g class="calm-container" data-container-id="${escapeXml(id)}" data-node-id="${escapeXml(id)}" data-description="${escapeXml(description)}" data-bounds="${bounds}">`,
+    `  <rect x="${x}" y="${y}" width="${width}" height="${height}" rx="10" fill="${fill}" stroke="${style.fill}" stroke-width="1.5"/>`,
+    `  <text x="${x + 12}" y="${y + 20}" font-family="sans-serif" font-size="13" font-weight="bold" fill="${labelColor}">${escapeXml(name)}</text>`,
+    `  <text x="${x + 12}" y="${y + 34}" font-family="sans-serif" font-size="10" fill="${labelColor}" opacity="0.7">${escapeXml(nodeType)}</text>`,
+    `</g>`,
+  ].join('\n');
+}

--- a/calm-studio/packages/web-component/src/render/relationshipEdges.ts
+++ b/calm-studio/packages/web-component/src/render/relationshipEdges.ts
@@ -26,7 +26,7 @@ export interface DiagramEdge {
 }
 
 /** True when `rel` uses the legacy flat CalmStudio shape (never valid CALM). */
-function isFlatRelationship(
+export function isFlatRelationship(
   rel: CalmRelationship
 ): rel is CalmRelationship & { source: string; destination: string } {
   const raw = rel as unknown as Record<string, unknown>;

--- a/calm-studio/packages/web-component/src/types.ts
+++ b/calm-studio/packages/web-component/src/types.ts
@@ -7,4 +7,5 @@ export interface CalmDiagramProps {
   data?: string;
   theme?: 'light' | 'dark';
   flow?: string;
+  containers?: 'nested' | 'edges';
 }


### PR DESCRIPTION
## Description

`composed-of` and `deployed-in` relationships in `@calmstudio/diagram` now render as **nested container boxes** (elkjs hierarchical layout) instead of dashed arrows — the Mermaid-subgraph-style visual raised at office hours (#2851), where it was noted Mermaid's static render handles nested containers and basic layouts well. Follow-up to #2854 (announced there before opening), part of the W2 visualization workstream in #2857.

How it works:
- A pure **containment planner** resolves containment claims into a parent/child forest: first claim wins (document order), cycle-safe, self/unknown-id-safe. Every unsatisfiable claim falls back to the previous dashed-edge rendering, so no information is silently dropped.
- The ELK graph nests member nodes inside container nodes (`elk.hierarchyHandling: INCLUDE_CHILDREN`, root-relative edge coordinates), and containers draw as translucent rounded boxes (node-type-colored border, name + type label) with members laid out inside. Containers keep the same `data-` attributes as leaf nodes, so click-tooltips keep working; flows referencing a nested containment relationship simply have no edge to animate (member nodes still highlight).
- **Opt-out:** `containers: 'nested' | 'edges'` on `renderELKDiagram`, the `<calm-diagram>` element, and the React `<CalmDiagram>` — `'edges'` reproduces the previous output exactly (verified by differential layout probe). Default is `'nested'`.

Notes for reviewers:
- Default-behavior change for the web component (boxes instead of arrows); the opt-out plus 0.x versioning is the mitigation. Happy to flip the default if preferred.
- A CALM document referencing a nonexistent node id in a relationship fails the render loudly (ELK error) — pre-existing behavior, consistent with the fail-the-build error contract of the docs plugin.
- One benign typecheck-fixture complaint added (`summary` property on a flow-transition test fixture) matching the pre-existing convention in `flowOverlay.test.ts`; the package's 17 pre-existing typecheck errors on `main` are untouched.
- Before/after renders of `calm/architecture/calm-1.json` attached below.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components

- [x] CALM Studio (`calm-studio/`) — `packages/web-component` (renderer), `packages/docusaurus-plugin` (prop pass-through + README)

## Testing

- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Evidence: `@calmstudio/diagram` 52/52 (14 new: planner unit suite incl. double-claim/cycle/self/unknown-id cases, integration: container bounds containment, 3-level nesting, container-as-edge-endpoint, edges-mode parity, flow-over-containment), `@finos/calm-docusaurus-plugin` 22/22, lint 0 errors — all re-verified after rebasing onto post-#2854 `main` with a fresh `npm ci`.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary (plugin README props table)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
