### PR TITLE
refactor(calm-hub-ui): migrate store hooks to useSyncExternalStore

### DIFF
--- a/calm-hub-ui/src/service/utils/use-auth-store.test.ts
+++ b/calm-hub-ui/src/service/utils/use-auth-store.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useAuthError } from './use-auth-store.js';
 import { authStore } from './auth-store.js';
 
@@ -25,14 +25,16 @@ describe('useAuthError', () => {
         expect(result.current).toBe(403);
     });
 
-    it('stops updating after unmount', () => {
-        const { result, unmount } = renderHook(() => useAuthError());
+    it('unsubscribes from the store on unmount', () => {
+        const unsubscribe = vi.fn();
+        const subscribeSpy = vi.spyOn(authStore, 'subscribe').mockReturnValue(unsubscribe);
+
+        const { unmount } = renderHook(() => useAuthError());
+        expect(unsubscribe).not.toHaveBeenCalled();
+
         unmount();
 
-        act(() => {
-            authStore.setAuthError(401);
-        });
-
-        expect(result.current).toBeNull();
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        subscribeSpy.mockRestore();
     });
 });

--- a/calm-hub-ui/src/service/utils/use-auth-store.test.ts
+++ b/calm-hub-ui/src/service/utils/use-auth-store.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAuthError } from './use-auth-store.js';
+import { authStore } from './auth-store.js';
+
+describe('useAuthError', () => {
+    beforeEach(() => {
+        authStore.setAuthError(null);
+    });
+
+    it('returns the current store status on initial render', () => {
+        authStore.setAuthError(401);
+        const { result } = renderHook(() => useAuthError());
+        expect(result.current).toBe(401);
+    });
+
+    it('updates when the store emits a new status', () => {
+        const { result } = renderHook(() => useAuthError());
+        expect(result.current).toBeNull();
+
+        act(() => {
+            authStore.setAuthError(403);
+        });
+
+        expect(result.current).toBe(403);
+    });
+
+    it('stops updating after unmount', () => {
+        const { result, unmount } = renderHook(() => useAuthError());
+        unmount();
+
+        act(() => {
+            authStore.setAuthError(401);
+        });
+
+        expect(result.current).toBeNull();
+    });
+});

--- a/calm-hub-ui/src/service/utils/use-auth-store.ts
+++ b/calm-hub-ui/src/service/utils/use-auth-store.ts
@@ -1,9 +1,14 @@
 import { useSyncExternalStore } from 'react';
 import { authStore, AuthErrorStatus } from './auth-store.js';
 
+function subscribeToAuthStore(onStoreChange: () => void): () => void {
+    return authStore.subscribe(() => onStoreChange());
+}
+
+function getAuthErrorSnapshot(): AuthErrorStatus {
+    return authStore.getAuthError();
+}
+
 export function useAuthError(): AuthErrorStatus {
-    return useSyncExternalStore(
-        (onStoreChange) => authStore.subscribe(() => onStoreChange()),
-        () => authStore.getAuthError()
-    );
+    return useSyncExternalStore(subscribeToAuthStore, getAuthErrorSnapshot);
 }

--- a/calm-hub-ui/src/service/utils/use-auth-store.ts
+++ b/calm-hub-ui/src/service/utils/use-auth-store.ts
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { authStore, AuthErrorStatus } from './auth-store.js';
 
 export function useAuthError(): AuthErrorStatus {
-    const [status, setStatus] = useState<AuthErrorStatus>(authStore.getAuthError());
-    useEffect(() => {
-        return authStore.subscribe(setStatus);
-    }, []);
-    return status;
+    return useSyncExternalStore(
+        (onStoreChange) => authStore.subscribe(() => onStoreChange()),
+        () => authStore.getAuthError()
+    );
 }

--- a/calm-hub-ui/src/service/utils/use-migration-store.test.ts
+++ b/calm-hub-ui/src/service/utils/use-migration-store.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useMigrationError } from './use-migration-store.js';
 import { migrationStore } from './migration-store.js';
 
@@ -25,14 +25,16 @@ describe('useMigrationError', () => {
         expect(result.current).toBe('migrating');
     });
 
-    it('stops updating after unmount', () => {
-        const { result, unmount } = renderHook(() => useMigrationError());
+    it('unsubscribes from the store on unmount', () => {
+        const unsubscribe = vi.fn();
+        const subscribeSpy = vi.spyOn(migrationStore, 'subscribe').mockReturnValue(unsubscribe);
+
+        const { unmount } = renderHook(() => useMigrationError());
+        expect(unsubscribe).not.toHaveBeenCalled();
+
         unmount();
 
-        act(() => {
-            migrationStore.setMigrationError('migrating');
-        });
-
-        expect(result.current).toBeNull();
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        subscribeSpy.mockRestore();
     });
 });

--- a/calm-hub-ui/src/service/utils/use-migration-store.test.ts
+++ b/calm-hub-ui/src/service/utils/use-migration-store.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMigrationError } from './use-migration-store.js';
+import { migrationStore } from './migration-store.js';
+
+describe('useMigrationError', () => {
+    beforeEach(() => {
+        migrationStore.setMigrationError(null);
+    });
+
+    it('returns the current store message on initial render', () => {
+        migrationStore.setMigrationError('migrating');
+        const { result } = renderHook(() => useMigrationError());
+        expect(result.current).toBe('migrating');
+    });
+
+    it('updates when the store emits a new message', () => {
+        const { result } = renderHook(() => useMigrationError());
+        expect(result.current).toBeNull();
+
+        act(() => {
+            migrationStore.setMigrationError('migrating');
+        });
+
+        expect(result.current).toBe('migrating');
+    });
+
+    it('stops updating after unmount', () => {
+        const { result, unmount } = renderHook(() => useMigrationError());
+        unmount();
+
+        act(() => {
+            migrationStore.setMigrationError('migrating');
+        });
+
+        expect(result.current).toBeNull();
+    });
+});

--- a/calm-hub-ui/src/service/utils/use-migration-store.ts
+++ b/calm-hub-ui/src/service/utils/use-migration-store.ts
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { migrationStore, MigrationErrorMessage } from './migration-store.js';
 
 export function useMigrationError(): MigrationErrorMessage {
-    const [message, setMessage] = useState<MigrationErrorMessage>(migrationStore.getMigrationError());
-    useEffect(() => {
-        return migrationStore.subscribe(setMessage);
-    }, []);
-    return message;
+    return useSyncExternalStore(
+        (onStoreChange) => migrationStore.subscribe(() => onStoreChange()),
+        () => migrationStore.getMigrationError()
+    );
 }

--- a/calm-hub-ui/src/service/utils/use-migration-store.ts
+++ b/calm-hub-ui/src/service/utils/use-migration-store.ts
@@ -1,9 +1,14 @@
 import { useSyncExternalStore } from 'react';
 import { migrationStore, MigrationErrorMessage } from './migration-store.js';
 
+function subscribeToMigrationStore(onStoreChange: () => void): () => void {
+    return migrationStore.subscribe(() => onStoreChange());
+}
+
+function getMigrationErrorSnapshot(): MigrationErrorMessage {
+    return migrationStore.getMigrationError();
+}
+
 export function useMigrationError(): MigrationErrorMessage {
-    return useSyncExternalStore(
-        (onStoreChange) => migrationStore.subscribe(() => onStoreChange()),
-        () => migrationStore.getMigrationError()
-    );
+    return useSyncExternalStore(subscribeToMigrationStore, getMigrationErrorSnapshot);
 }


### PR DESCRIPTION
## Description

Follow-up to #2899, implementing a non-blocking review comment from @rocketstack-matt.

`useState` + `useEffect` for external-store subscriptions can miss an update that arrives between the initial render's snapshot and the effect establishing the subscription, under React 18 concurrent rendering. [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) is what React exposes specifically to close that gap.

The reviewer noted the concern applied codebase-wide rather than being specific to the new hook, since `use-migration-store.ts` was modelled on the pre-existing `use-auth-store.ts`. This PR migrates both.

Also adds direct unit tests for both hooks (via `renderHook`) — previously they were only ever exercised indirectly through the modal component tests, which mock the hook away entirely.

## Type of Change
- [x] ♻️ Refactoring (no functional changes)

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)