### PR TITLE
chore(deps): patch npm security vulnerability in @hono/node-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11487,12 +11487,12 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
             "license": "MIT",
             "dependencies": {
-                "@hono/node-server": "^1.19.9",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,18 +317,6 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "calm-guard/node_modules/@mermaid-js/layout-elk": {
-            "version": "0.1.9",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "d3": "^7.9.0",
-                "elkjs": "^0.9.3"
-            },
-            "peerDependencies": {
-                "mermaid": "^11.0.2"
-            }
-        },
         "calm-guard/node_modules/agent-base": {
             "version": "7.1.4",
             "dev": true,
@@ -362,11 +350,6 @@
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
-        },
-        "calm-guard/node_modules/elkjs": {
-            "version": "0.9.3",
-            "extraneous": true,
-            "license": "EPL-2.0"
         },
         "calm-guard/node_modules/entities": {
             "version": "8.0.0",
@@ -8783,12 +8766,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.17",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-            "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -17405,16 +17388,6 @@
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
             "license": "Apache-2.0"
-        },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.23",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-            "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
         },
         "node_modules/@swc/html": {
             "version": "1.15.46",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "overrides": {
         "@babel/plugin-transform-modules-systemjs": "^7.29.4",
         "@docusaurus/plugin-content-docs": "3.10.1",
+        "@hono/node-server": "^2.0.5",
         "@types/node": "^26",
         "axios": "^1.15.2",
         "brace-expansion@^1.0.0": "^1.1.16",


### PR DESCRIPTION
## Description
Patches the one fixable open Dependabot security alert on the npm root workspace lockfile.

| Advisory | Package | Severity | From → To | Method |
|---|---|---|---|---|
| GHSA-frvp-7c67-39w9 | `@hono/node-server` | Medium | 1.19.17 → 2.0.12 | Centralised: root `package.json` `overrides` |

`@hono/node-server` is pulled in transitively via `@modelcontextprotocol/sdk` (declared by `calm-studio/packages/mcp-server`, range `^1.27.1`). The initially-resolved sdk version (1.29.0) only declared `@hono/node-server: ^1.19.9`, which would have forced hono outside the sdk's declared range — flagged in review by Copilot and @markscott-ms. Fixed by also bumping the resolved sdk to `1.30.0` (still within `^1.27.1`), which explicitly documents support for `^1.19.9 || ^2.0.5`, so the pairing is genuinely intentional upstream, not a forced mismatch. `@hono/node-server` has zero dependencies of its own, and the MCP server's full test suite (`@calmstudio/mcp`, 80 tests) passes unchanged.

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Dependencies

## Commit Message Format ✅
Commit follows conventional commits: `chore(deps): patch npm security vulnerability in @hono/node-server`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Ran from a clean `npm ci` on this branch:
- `npm run build` — all workspaces build clean
- `npm run lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- `npm test` — all workspaces pass (including `@calmstudio/mcp`'s 80 tests, the package that consumes the bumped dependency)

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

## Not addressed
- **GHSA-mh99-v99m-4gvg (`brace-expansion` ≤5.0.7, high)** — the vulnerable instance is bundled inside `npm@11.18.0` (`bundleDependencies: true`), pinned via the existing `@semantic-release/npm` → `npm` override used only for the release pipeline. A bundled dependency inside a published tarball cannot be reached by an `overrides` entry; the top-level/eslint-toolchain instances of `brace-expansion` are already patched via the existing `brace-expansion@^1.0.0`/`@^5.0.0` overrides. The only newer `npm` release is `12.0.1`, a major bump to the release-automation toolchain that's out of scope for a security-only PR. `npm audit` confirms `fixAvailable: false` for this advisory.
- **GHSA-qwww-vcr4-c8h2 (`react-router` ≥7.12.0 <8.3.0, high)** — resolved via `react-router-dom@7.18.1`, a direct dependency of `calm-hub-ui` (`^7.12.0`). `react-router-dom@7.18.1` hard-pins `react-router` to the exact version `7.18.1` (no range). `react-router@8.x` was published 2026-07-22 and no `react-router-dom` release depending on it exists yet, so there is no in-range patched version to override to. The only alternative — downgrading below the vulnerable range to `react-router-dom@7.11.0` — falls below calm-hub-ui's own declared floor and would be a regression, not a fix. The advisory is specific to React Router's RSC (React Server Components) mode; calm-hub-ui is a client-rendered SPA and does not use RSC mode, which limits real-world exposure while this is pending upstream.
