### PR TITLE
fix(templates): remove dead 'meeting' label from meeting issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -2,7 +2,6 @@
 name: 🤝 Architecture as Code Meeting Agenda
 about: To track Architecture as Code meeting agenda and attendance
 type: Meeting
-labels: meeting
 ---
 
 ## Date

--- a/.github/ISSUE_TEMPLATE/Office_Hours.md
+++ b/.github/ISSUE_TEMPLATE/Office_Hours.md
@@ -2,7 +2,7 @@
 name: 🏢 Architecture as Code Office Hours
 about: Track Office Hours meetings
 type: Meeting
-labels: meeting, office-hours
+labels: office-hours
 ---
 
 ## Date


### PR DESCRIPTION
## Description
Both meeting-style issue templates declare a `labels: meeting` (and `Office_Hours.md` also `office-hours`) in their frontmatter, but no `meeting` label exists in this repo — it's silently dropped on every issue created from these templates (verified against #2521, #2393, #2851). `office-hours` is a real label and does apply correctly. Both templates already set the GitHub Issue Type to `Meeting`, which is what past meeting/office-hours issues actually carry — so the dead label reference was pure noise.

This drops the non-functional `meeting` label from both templates, keeping the working `office-hours` label on `Office_Hours.md`.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

Neither box above covers repo-root `.github/ISSUE_TEMPLATE/` config — that's the actual affected area.

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

Config-only change (issue template frontmatter) — no code path to unit test. Verified via `gh api repos/finos/architecture-as-code/labels` that `meeting` doesn't exist, and confirmed real meeting/office-hours issues (#2521, #2393, #2851) already carry the `Meeting` issue type but never the `meeting` label.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
