### PR TITLE
docs(calm-hub): ADRs for versioned artifact storage redesign (#2884)

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -594,6 +594,10 @@ trail in this iteration — read it via direct DB access or ops tooling.
 - `src/main/resources/application-secure.properties` - Secure (OIDC/Keycloak) profile config
 - `src/main/resources/application-proxy-auth.properties` - Proxy-auth profile config (proxy-injected `Remote-User` header)
 - `PERMISSIONS.md` - Per-namespace permission model reference
+- `decisions/` - Architecture Decision Records for calm-hub's own backend
+  design (not the CALM ADR resource type). See `decisions/README.md` for
+  the format; check each ADR's `Status` field before assuming it describes
+  current behaviour rather than a proposed/pending design.
 
 ## Dependencies on Other Packages
 

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -65,10 +65,10 @@ done in-memory after loading the full array.
 ### Scope
 
 - **In scope**: Mongo store code (`store/mongo/`), Nitrite store code
-  (`store/nitrite/`), database initialization/seed scripts
-  (`MongoIndexInitializationStep`, `nitrite/init-nitrite.sh`,
-  `nitrite/seed-readonly.sh`), and a migration pathway for existing
-  production data in both backends.
+  (`store/nitrite/`), the `mongo/init-mongo.js` seed script (it hand-writes
+  documents in the storage shape, so it has to change with it), new
+  `SchemaMigrationStep`s, and a migration pathway for existing production
+  data in both backends.
 - **Out of scope**: the domain interfaces (`ArchitectureStore` etc. stay
   unchanged — REST/service layers untouched). Controls and Decorators are
   deliberately deferred, not addressed by this ADR — see
@@ -76,6 +76,13 @@ done in-memory after loading the full array.
   of scope for an unrelated reason: the `domains` collection isn't a
   versioned artefact at all, just a grouping mechanism, so it doesn't have
   the growth problem this ADR addresses.
+- **Also out of scope, for reasons worth stating** so nobody re-adds them:
+  the Nitrite seed scripts (`nitrite/init-nitrite.sh`,
+  `nitrite/seed-readonly.sh`) seed exclusively over the REST API against a
+  writable instance, so they follow the storage shape automatically and need
+  no changes (see *Migration and rollback*); and
+  `MongoIndexInitializationStep` cannot be touched at all, because a
+  committed migration step is immutable (same section).
 
 ### Shape: two collections per artefact type, one document per version
 
@@ -267,11 +274,23 @@ discriminator**:
   `{namespace: 1, <type>Id: 1, version: 1}` on `<type>Versions`, before
   fanning out the data. Dropping must tolerate the index already being
   absent, to preserve the idempotency `SchemaMigrationStep` asks for.
-- Read-only pre-seeded Nitrite images (`build-readonly-image.sh`,
-  `seed-readonly.sh`) bake the `.db` file at image-build time — the seed
-  scripts themselves need updating to produce the new shape directly, not
-  just a runtime migration path (there's no "runtime" for a read-only image
-  opened with `readOnly(true)`).
+- Read-only pre-seeded Nitrite images bake the `.db` file at image-build
+  time, and a database opened with `readOnly(true)` genuinely has no runtime
+  migration path. **Despite that, the seed scripts need no changes.**
+  `seed-readonly.sh` boots the real application in standalone *writable*
+  mode and then runs `init-nitrite.sh`, which populates it purely over
+  HTTP — there are no direct `.db` or database writes in either script. The
+  seeders therefore emit whatever shape the store layer writes at that
+  commit, with no knowledge of document shape and nothing to keep in step.
+  This also means there's no ordering constraint against the rest of the
+  migration: a partially-migrated codebase bakes an image consistent with
+  the code that will read it.
+- What *does* need checking for read-only images: the baked `.db` must
+  record the latest schema version, so that at runtime
+  `SchemaMigrationRunner` sees `version == latest` and skips acquiring the
+  migration lock rather than attempting a write against a read-only
+  database. The runner's javadoc states it already handles this case —
+  worth verifying against a built image, not designing for.
 - **Rollback story: database backup, not an additive/non-destructive
   migration with a burn-in period.** CalmHub is pre-1.0 — no public
   stability guarantee is broken by a migration that isn't reversible

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -1,4 +1,4 @@
-# ADR 0001: Versioned artifact storage redesign
+# ADR 0001: Versioned artefact storage redesign
 
 **Status**: Proposed — not yet implemented. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -205,15 +205,21 @@ The full architecture JSON now lives in `content`; the header no longer
 holds a `versions` field at all once migration has run.
 
 **Why reuse the existing collection name instead of `architectureHeaders`
-etc.**: it turns the migration into "add one new collection, then shrink
-the existing documents in place" (extract each `versions` entry into
-`architectureVersions`, then `$unset` the `versions` field from the
-`architectures` doc) rather than "create two new collections, backfill
-both, drop the old one" — smaller, lower-risk migration, and every existing
-index/ops reference to the collection name stays valid throughout. Accepted
-tradeoff: `architectures` no longer holds full content post-migration, just
-headers — mildly misleading to anyone running a raw
+etc.**: only one new collection has to be introduced (`architectureVersions`)
+rather than two, and every existing index/ops reference to `architectures`
+stays valid throughout — no cutover to a differently-named collection.
+Accepted tradeoff: `architectures` no longer holds full content
+post-migration, just headers — mildly misleading to anyone running a raw
 `db.architectures.findOne()` without knowing about this ADR.
+
+Note this is **not** an in-place shrink of each existing document. The
+old-shape document is one per *namespace* holding an **array** of
+architectures, each with its own embedded `versions` map — so the migration
+is a genuine **1 → N fan-out**: one namespace document becomes N header
+documents (one per architecture) plus M version documents, and the original
+namespace document is replaced rather than edited down. Reusing the
+collection name is about avoiding a second new collection and keeping the
+name stable, not about making the rewrite smaller.
 
 **Why per-type collections instead of a single shared
 `versionedArtifactHeaders`/`versionedArtifacts` pair with a `resourceType`
@@ -239,9 +245,28 @@ discriminator**:
   mechanism (`SchemaVersionStore` + `SchemaMigrationRunner` +
   `SchemaMigrationStep`, both backends, with a distributed lock) — what's
   needed is a `SchemaMigrationStep` implementation that does the
-  old-shape → new-shape fan-out: read every old-shape namespace document,
-  write it out as version documents + a header doc, verify no version data
-  lost/reordered.
+  old-shape → new-shape fan-out: read every old-shape namespace document
+  and, for each entry in its resource array, write one header document plus
+  one version document per entry in that resource's `versions` map, then
+  verify no version data was lost or reordered.
+- **A new step per resource type, never an edit to an existing one.** A
+  committed `SchemaMigrationStep` is immutable: `SchemaMigrationRunner`
+  records the schema version in `SchemaVersionStore` and runs each step
+  once, so a deployment already past version N never re-runs step N.
+  Editing a shipped step would therefore change behaviour only on *fresh*
+  deployments, silently diverging them from existing ones with nothing to
+  catch it.
+- **Each new step must also transition its collection's indexes.**
+  `MongoIndexInitializationStep` created a unique index on `namespace`
+  *alone* for every entity collection — that enforces exactly one document
+  per namespace, which is the old shape and directly contradicts the header
+  collection's one-document-per-`(namespace, resourceId)`. Since that step
+  is immutable (above), each per-type migration step drops the old
+  `{namespace: 1}` unique index on its own collection and creates
+  `{namespace: 1, <type>Id: 1}` on the header collection and
+  `{namespace: 1, <type>Id: 1, version: 1}` on `<type>Versions`, before
+  fanning out the data. Dropping must tolerate the index already being
+  absent, to preserve the idempotency `SchemaMigrationStep` asks for.
 - Read-only pre-seeded Nitrite images (`build-readonly-image.sh`,
   `seed-readonly.sh`) bake the `.db` file at image-build time — the seed
   scripts themselves need updating to produce the new shape directly, not

--- a/calm-hub/decisions/0001-versioned-artifact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artifact-storage.md
@@ -1,0 +1,287 @@
+# ADR 0001: Versioned artifact storage redesign
+
+**Status**: Proposed — not yet implemented. Tracked in
+[#2884](https://github.com/finos/architecture-as-code/issues/2884).
+
+## Context
+
+Every Mongo store in `calm-hub` (`store/mongo/`) uses a **one document per
+namespace (or per domain for Control)** shape: a single Mongo document holds
+an array of entities, and each entity carries a `versions` map containing
+the **full raw content of every version ever written**. Nothing is ever
+deleted (CalmHub is append-only). MongoDB enforces a hard **16MB limit per
+BSON document**, inclusive of all nested arrays/sub-documents. At ~40KB per
+realistic architecture JSON, a single namespace can hit that ceiling after
+roughly **400 version-writes total** across every resource of that type in
+the namespace — plausible for any actively-used, long-lived, shared
+namespace.
+
+NitriteDB (standalone/embedded mode) has the identical document shape and
+the identical unbounded-growth problem, just without Mongo's specific
+16MB/BSON ceiling (different storage engine — H2 MVStore, file-backed, not
+in-memory; see `NitriteDBConfig.java`). Every Nitrite read/write does a full
+in-memory read-modify-write of the entire namespace document, under a
+store-instance-wide `ReentrantReadWriteLock` (not per-namespace) — so as
+documents grow, lock hold times grow and contention increases across *all*
+namespaces for that store, not just the busy one. No hard byte-count wall,
+but real memory/perf degradation risk, especially in memory-constrained
+embedded deployments (e.g. the pre-seeded read-only Docker images).
+
+### Current shape (as-is)
+
+All 8 Mongo stores (`store/mongo/`) and their Nitrite equivalents
+(`store/nitrite/`) share this pattern:
+
+| Store | Collection | Entity fields | Version map field |
+|---|---|---|---|
+| Architecture | `architectures` | `architectureId`, `name`, `description`, `versions` | `versions` |
+| Pattern | `patterns` | `patternId`, `name`, `description`, `versions` | `versions` |
+| ADR | `adrs` | `adrId`, `revisions` | `revisions` |
+| Flow | `flows` | `flowId`, `name`, `description`, `versions` | `versions` |
+| Interface | `interfaces` | `interfaceId`, `name`, `description`, `versions` | `versions` |
+| Standard | `standards` | `standardId`, `name`, `description`, `versions` | `versions` |
+| Timeline | `timelines` | `timelineId`, `name`, `description`, `versions` | `versions` |
+| Control | `controls` (per **domain**) | `controlId`, `requirement` (versions), `configurations[]` (nested, own `versions`) | `requirement` + nested `configurations[].versions` |
+
+Version keys are dash-encoded (`"1-0-0"` instead of `"1.0.0"`) because Mongo
+field names can't contain `.`. `MongoControlStore` is the structural
+outlier — genuinely double-nested arrays, uses `arrayFilters` with
+`$[ctrl]`/`$[cfg]` placeholders to reach two levels deep.
+
+Not in this table: **Decorator** (`decorators` collection). It's a 9th
+non-domain, non-control resource type, but it's not versioned —
+`updateDecorator` overwrites in place, no `versions` map, no version
+history. It doesn't have the unbounded-growth problem this ADR addresses.
+
+No shared base class across the 8 stores in either backend — each
+duplicates read/write/version logic independently. Only shared code today:
+`MongoUpsertPush` (push+upsert-with-duplicate-retry) and
+`MongoResourceSlice` (`$slice`-projection pagination, only used by
+Architecture/Pattern). Nitrite has no `$slice` equivalent; pagination is
+done in-memory after loading the full array.
+
+## Decision
+
+### Scope
+
+- **In scope**: Mongo store code (`store/mongo/`), Nitrite store code
+  (`store/nitrite/`), database initialization/seed scripts
+  (`MongoIndexInitializationStep`, `nitrite/init-nitrite.sh`,
+  `nitrite/seed-readonly.sh`), and a migration pathway for existing
+  production data in both backends.
+- **Out of scope**: the domain interfaces (`ArchitectureStore` etc. stay
+  unchanged — REST/service layers untouched). Controls and Decorators are
+  deliberately deferred, not addressed by this ADR — see
+  [ADR 0004](0004-defer-control-and-decorator-storage.md). Domains are out
+  of scope for an unrelated reason: the `domains` collection isn't a
+  versioned artefact at all, just a grouping mechanism, so it doesn't have
+  the growth problem this ADR addresses.
+
+### Shape: two collections per artefact type, one document per version
+
+Move from **one-document-per-namespace** to **one-document-per-version**,
+generalized across the 7 versioned types (Control excluded).
+
+- **Header collection reuses the existing collection name**
+  (`architectures`, `patterns`, etc.); a new sibling `<type>Versions`
+  collection is added (`architectureVersions`, `patternVersions`, etc.) —
+  14 collections total.
+  - Header collection: one document per `(namespace, resourceId)`, holding
+    `name`/`description` (plus `versionCount` and `metadata` — see below).
+    This is what lets a resource exist with zero versions — the header doc
+    *is* the "this resource exists" record, independent of whether any
+    version documents have been written.
+  - Version collection: one document per `(namespace, resourceId,
+    version)` tuple, holding that version's `content` (plus `metadata` —
+    see below).
+  - **No `latestVersion` field on the header.** Checked against actual
+    usage: `NamespaceResourceSummary` (the summary API type) only exposes
+    `name`/`description`/`id`/`versionCount`, never a latest-version
+    pointer or its content. A cached pointer would be one more place for
+    staleness bugs with no current consumer. If something later needs
+    "latest version's content," resolve it by querying the version
+    collection sorted by version key — same comparison
+    `VersionKeySelector.latestVersionKey()` already does in-memory today,
+    applied to stored documents instead of a loaded map.
+  - **`versionCount` *is* denormalized on the header** (revised from an
+    earlier draft of this ADR, which rejected caching it — see below).
+    `NamespaceResourceSummary.versionCount` is read by `calm-hub-ui`'s
+    `ItemCard.tsx` on every namespace listing page view; reads of this
+    field vastly outnumber writes (creating a version is rare relative to
+    browsing a namespace), so the classic counter-cache tradeoff favours
+    paying a small write-side cost to avoid computing it on every read. It
+    is maintained via an atomic `$inc` on the header document as part of
+    the version-creation write path — see
+    [ADR 0003](0003-shared-version-store-helper.md) for the mechanism.
+  - Consequence: creating a version is no longer one atomic document
+    write — it's two: the version document insert, then an atomic `$inc`
+    on the header's `versionCount`. If a crash lands between the two, the
+    header can undercount by one until corrected. Accepted risk: the
+    window is two sequential writes within the same request, the blast
+    radius is a display number off by one (not data loss or corrupted
+    content), and it doesn't compound across requests. Not justified by
+    "we can restore from backup" — that's the *migration* rollback story
+    below, an unrelated one-time event, not a standing excuse for ongoing
+    drift. Stronger guarantees (a Mongo transaction wrapping both writes)
+    would require a replica-set deployment — `local-dev/docker-compose.yml`
+    and `deploy/docker-compose.yml` both run Mongo standalone today, so
+    this isn't available without a deployment topology change, and wasn't
+    judged worth that cost for a version-count badge.
+  - **Both the header and version documents get a `metadata` field** — an
+    open, schema-free object, empty by default. Not driven by a concrete
+    requirement in this ADR; added because this redesign is what makes it
+    cheap to add and expensive to retrofit later. Motivated by
+    [#2856](https://github.com/finos/architecture-as-code/issues/2856)
+    ("Allow archiving of documents in CalmHub"), specifically
+    [this comment](https://github.com/finos/architecture-as-code/issues/2856#issuecomment-5050999800),
+    which proposes archiving as a `metadata` property (e.g. `{"status":
+    "ARCHIVED"}`) set via `PATCH
+    .../versions/{version}/metadata` with an
+    `application/merge-patch+json` (RFC 7396) body, extensible later to
+    other per-version or per-resource metadata (e.g. asset inventory IDs)
+    without needing first-class CalmHub support for each one. Under the
+    *old* shape, a targeted merge-patch to one version's metadata would
+    mean updating one key inside a map nested inside an array inside a
+    namespace-wide document — under this ADR's shape, it's a `$set` on one
+    small, independently-addressable document. Note from the issue thread
+    itself: while scoping #2856, its author (Mark) found this exact
+    16MB/growth problem (#2884) and flagged it as a blocker to build #2856
+    on top of — this ADR is that prerequisite work. Deliberately not
+    designing the archiving feature itself here (that's #2856's own scope,
+    a separate future ADR) — just reserving the field so it doesn't
+    require another migration when that work starts.
+
+#### Example: an architecture with 2 versions
+
+**Before** (current shape — one `architectures` document per namespace,
+this architecture as one array entry with an embedded `versions` map,
+dash-encoded keys):
+
+```jsonc
+// architectures collection — one document per namespace
+{
+  "namespace": "finos",
+  "architectures": [
+    {
+      "architectureId": 1,
+      "name": "Sample Architecture",
+      "description": "...",
+      "versions": {
+        "1-0-0": { ... },   // full architecture content for v1.0.0
+        "1-1-0": { ... }    // full architecture content for v1.1.0
+      }
+    }
+    // ...other architectures in this namespace
+  ]
+}
+```
+
+**After** (this ADR's shape — a header document in `architectures`,
+holding identity, the denormalized `versionCount`, and an open `metadata`
+object, plus one document per version in the new `architectureVersions`
+collection, using the dot-separated version field from
+[ADR 0002](0002-version-key-encoding.md) and each carrying its own
+`metadata`):
+
+```jsonc
+// architectures collection — now one document per resource (the header)
+{
+  "namespace": "finos",
+  "architectureId": 1,
+  "name": "Sample Architecture",
+  "description": "...",
+  "versionCount": 2,
+  "metadata": {}
+}
+```
+
+```jsonc
+// architectureVersions collection — one document per version
+{ "namespace": "finos", "architectureId": 1, "version": "1.0.0", "content": { ... }, "metadata": {} }
+{ "namespace": "finos", "architectureId": 1, "version": "1.1.0", "content": { ... }, "metadata": { "status": "ARCHIVED" } }
+```
+
+The full architecture JSON now lives in `content`; the header no longer
+holds a `versions` field at all once migration has run.
+
+**Why reuse the existing collection name instead of `architectureHeaders`
+etc.**: it turns the migration into "add one new collection, then shrink
+the existing documents in place" (extract each `versions` entry into
+`architectureVersions`, then `$unset` the `versions` field from the
+`architectures` doc) rather than "create two new collections, backfill
+both, drop the old one" — smaller, lower-risk migration, and every existing
+index/ops reference to the collection name stays valid throughout. Accepted
+tradeoff: `architectures` no longer holds full content post-migration, just
+headers — mildly misleading to anyone running a raw
+`db.architectures.findOne()` without knowing about this ADR.
+
+**Why per-type collections instead of a single shared
+`versionedArtifactHeaders`/`versionedArtifacts` pair with a `resourceType`
+discriminator**:
+- Matches the existing convention — each resource type already has its own
+  collection today — so no surprise for anyone querying collections
+  directly or for adjacent tooling.
+- Smaller blast radius: a bug in one type's write path can't corrupt
+  another type's data, since they're physically separate collections.
+- Independent migration/rollback per type, matching the incremental
+  migration approach below.
+- Code reuse still happens via a shared helper (see
+  [ADR 0003](0003-shared-version-store-helper.md)), not shared storage —
+  same pattern as the existing `MongoUpsertPush`/`MongoResourceSlice`
+  static helpers.
+- Minor bonus, not the deciding factor: `resourceType` doesn't need to be a
+  field in every document or a leading key in every compound index — it's
+  implicit in which collection you're querying.
+
+### Migration and rollback
+
+- Migration runs once per deployment via the existing gating/once-only
+  mechanism (`SchemaVersionStore` + `SchemaMigrationRunner` +
+  `SchemaMigrationStep`, both backends, with a distributed lock) — what's
+  needed is a `SchemaMigrationStep` implementation that does the
+  old-shape → new-shape fan-out: read every old-shape namespace document,
+  write it out as version documents + a header doc, verify no version data
+  lost/reordered.
+- Read-only pre-seeded Nitrite images (`build-readonly-image.sh`,
+  `seed-readonly.sh`) bake the `.db` file at image-build time — the seed
+  scripts themselves need updating to produce the new shape directly, not
+  just a runtime migration path (there's no "runtime" for a read-only image
+  opened with `readOnly(true)`).
+- **Rollback story: database backup, not an additive/non-destructive
+  migration with a burn-in period.** CalmHub is pre-1.0 — no public
+  stability guarantee is broken by a migration that isn't reversible
+  in-place, so the extra design/implementation cost of dual-write or
+  delayed-delete isn't justified. If the new shape has a bug
+  post-migration, restore from backup rather than rolling the schema back.
+
+## Consequences
+
+- Removes the 16MB risk entirely for Mongo (each document is bounded by a
+  single version's size, not accumulated history) and removes the
+  full-document read-modify-write cost for Nitrite.
+- All 8 `TestMongo<X>StoreShould` + 8 `TestNitrite<X>StoreShould` unit test
+  classes need rewriting for the new document shape. Integration tests
+  (`Mongo<X>Integration.java`) need updating plus a new migration-specific
+  integration test. JaCoCo's 90%-per-class gate applies to new
+  migration/helper code as usual.
+- Need a real "approaching/exceeding 16MB" regression test — currently zero
+  tests reference document size limits anywhere in the codebase. The only
+  suite hitting a real Mongo instance today is
+  `MongoConcurrencyIntegration.java` (via `../mvnw -P integration verify`,
+  TestContainers) — natural home for this, since mocked unit tests can only
+  simulate `MongoWriteException`, not trigger Mongo's real enforcement.
+
+### Open questions (not yet decided)
+
+- ~~Keep dash-encoded version keys as a document field, or make version a
+  proper indexed field now that it's not a map key?~~ Resolved: see
+  [ADR 0002](0002-version-key-encoding.md) — dot-separated, dash-encoding
+  dropped entirely.
+- ~~Need a new shared helper (parallel to `MongoUpsertPush`) since there's
+  no base class to override.~~ Resolved: see
+  [ADR 0003](0003-shared-version-store-helper.md).
+- ~~`MongoControlStore`'s double-nesting doesn't fit this shape as cleanly
+  (domain → control → configuration → version, one extra level) — needs
+  bespoke design.~~ Deferred, not resolved: see
+  [ADR 0004](0004-defer-control-and-decorator-storage.md) — deliberately
+  not designed yet, revisit after ADR 0001–0003 ship.

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -1,0 +1,51 @@
+# ADR 0002: Version field encoding — dots, not dashes
+
+**Status**: Proposed — not yet implemented. Depends on
+[ADR 0001](0001-versioned-artifact-storage.md).
+
+## Context
+
+In the current (pre-redesign) shape, each versioned entity document embeds
+a `versions` map keyed by version string, e.g.
+`versions: { "1-0-0": { ...content } }`. Mongo field names cannot contain
+`.`, so every store dash-encodes the version before using it as a map key
+and reverses the encoding on read — e.g. `MongoStandardStore`,
+`MongoInterfaceStore`, and `MongoControlStore` all call
+`version.replace('.', '-')` on write and the inverse on read.
+
+The REST API's canonical external representation is dot-separated
+(`"1.0.0"`); `ResourceValidationConstants.VERSION_REGEX` already accepts
+both `.` and `-` as separators (`^(0|[1-9][0-9]*)[-.]?...`), so callers can
+technically pass either today, but dashes only exist internally because of
+the Mongo map-key constraint — they are not a deliberate domain choice.
+
+ADR 0001 moves `version` from being a map *key* to being a document
+*field value* (one document per `(namespace, resourceId, version)` tuple in
+the new `<type>Versions` collections). The "no `.` in Mongo field names"
+constraint that motivated dash-encoding no longer applies once version is a
+field value rather than a key name.
+
+## Decision
+
+Store the `version` field using the **dot-separated canonical form**
+(`"1.0.0"`), matching the API's external representation. Delete the
+`replace('.', '-')` / `replace('-', '.')` round-trip entirely — it becomes
+dead code once no store uses version as a map key.
+
+## Consequences
+
+- Removes a whole class of conversion bugs (forgetting one direction of the
+  replace, or double-converting) across all 7 versioned stores.
+- Simplifies every store: no encode-on-write/decode-on-read step, and the
+  field value handed to Mongo queries is the same string the API received.
+- The version-comparison logic in `VersionKeySelector.latestVersionKey()`
+  (currently splitting on `"-"`) needs to split on `"."` instead, or be
+  made separator-agnostic if any transitional dash-encoded data must still
+  be read (see migration note below).
+- **Migration cost**: the `SchemaMigrationStep` that fans out old
+  documents into new version documents (ADR 0001) must convert each dash
+  key to dot form during the fan-out (`"1-0-0".replace('-', '.')`) —
+  trivial, one-time, contained entirely within that migration step. No
+  ongoing dual-format handling is needed once migration has run, since
+  CalmHub's rollback story (ADR 0001) is backup-based rather than
+  additive/dual-write.

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -38,14 +38,36 @@ dead code once no store uses version as a map key.
   replace, or double-converting) across all 7 versioned stores.
 - Simplifies every store: no encode-on-write/decode-on-read step, and the
   field value handed to Mongo queries is the same string the API received.
-- The version-comparison logic in `VersionKeySelector.latestVersionKey()`
-  (currently splitting on `"-"`) needs to split on `"."` instead, or be
-  made separator-agnostic if any transitional dash-encoded data must still
-  be read (see migration note below).
+- **`VersionKeySelector` needs no change at all** — neither a switch to
+  `"."` nor a separator-agnostic rewrite, both of which an earlier draft of
+  this ADR called for. Its two methods turn out to have completely disjoint
+  callers:
+  - `latestVersionKey()` — the only separator-sensitive part (it splits on
+    `"-"`) — is called **only** by `MongoControlStore` and
+    `NitriteControlStore`. Control deliberately keeps the old shape and its
+    dash-encoded keys (see
+    [ADR 0004](0004-defer-control-and-decorator-storage.md)), so this method
+    must be **left alone**: "fixing" it to split on `"."` would break the
+    one thing still using it. It retires with Control, whenever that's
+    redesigned.
+  - `versionCount()` is called by the migrating types
+    (Architecture/Pattern/Flow/Standard, both backends) and **never parses
+    separators** — it is just `keys.size()`. Those call sites disappear as
+    each type migrates, because `versionCount` becomes a stored field on the
+    header (ADR 0001). Once Control is the only caller left of the class,
+    `versionCount()` has none and can be deleted.
+  - Ordering versions in the new shape is therefore **new code alongside**,
+    not a modification or a fork of this class — nothing that parses `"-"`
+    is used by a migrating type, and nothing a migrating type uses cares
+    about the separator.
 - **Migration cost**: the `SchemaMigrationStep` that fans out old
   documents into new version documents (ADR 0001) must convert each dash
   key to dot form during the fan-out (`"1-0-0".replace('-', '.')`) —
-  trivial, one-time, contained entirely within that migration step. No
-  ongoing dual-format handling is needed once migration has run, since
-  CalmHub's rollback story (ADR 0001) is backup-based rather than
-  additive/dual-write.
+  trivial, one-time, contained entirely within that migration step.
+- Dash-encoded keys do **not** disappear from the database entirely — the
+  `controls` collection keeps them for as long as Control keeps the old
+  shape (ADR 0004). What this ADR removes is any *shared* code path having
+  to handle both formats: dot-separated keys live in the new
+  `<type>Versions` collections read by the new helper, dash-encoded keys
+  live in `controls` read by `MongoControlStore`/`NitriteControlStore`, and
+  the two never meet.

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -1,7 +1,7 @@
 # ADR 0002: Version field encoding — dots, not dashes
 
 **Status**: Proposed — not yet implemented. Depends on
-[ADR 0001](0001-versioned-artifact-storage.md).
+[ADR 0001](0001-versioned-artefact-storage.md).
 
 ## Context
 

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -84,13 +84,38 @@ shape but would be wrong under the new one).
 
 ### Nitrite
 
-Same two-collection shape and the same operation set. Whether the existing
-store-instance-wide `ReentrantReadWriteLock` (currently coarse: one lock
-per store, not per-namespace or per-resource) can be narrowed under the new
-shape is a real question — smaller, more numerous documents plausibly
-reduce lock hold times and contention — but it's a performance question,
-not a correctness one, and isn't resolved by this ADR. Left as a follow-up
-to revisit if profiling after implementation shows it matters.
+Same two-collection shape and the same operation set, but **uniqueness
+cannot be delegated to the database the way the Mongo helper delegates it
+to a unique index**. CalmHub creates no Nitrite indexes at all — checked
+across `store/nitrite/` and `config/`, there is not a single `createIndex`
+call, and `MongoIndexInitializationStep`'s javadoc says so outright: *"In
+standalone/Nitrite mode the indexes are irrelevant — Nitrite stores use
+`ReentrantLock` for concurrency control instead."*
+
+So `NitriteVersionDocumentStore` must perform its own
+check-then-write for duplicate rejection (does this
+`(namespace, resourceId, version)` already exist?) **inside** the store's
+existing write lock. That is genuinely safe here rather than a
+check-then-act race, because Nitrite is single-process embedded and the
+lock serialises every write to the store — unlike Mongo, where concurrent
+application instances share one database and only a DB-level constraint can
+arbitrate.
+
+The practical consequence is that the two helpers are not symmetric:
+`createVersion` on the Mongo side can insert optimistically and translate a
+`DUPLICATE_KEY` error, while the Nitrite side must look first. Both present
+the same result to callers.
+
+Whether the existing store-instance-wide `ReentrantReadWriteLock`
+(currently coarse: one lock per store, not per-namespace or per-resource)
+can be narrowed under the new shape is a separate, still-open question —
+smaller, more numerous documents plausibly reduce lock hold times and
+contention — but it's a performance question, not a correctness one, and
+isn't resolved by this ADR. Note that narrowing it would interact with the
+check-then-write above: any narrower lock must still serialise writes to
+the same `(namespace, resourceId, version)`, or uniqueness stops holding.
+Left as a follow-up to revisit if profiling after implementation shows it
+matters.
 
 ## Consequences
 

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -7,13 +7,9 @@
 ## Context
 
 ADR 0001 gives each of the 7 versioned types a header collection (reusing
-the existing collection name) plus a new `<type>Versions` collection. Per
-ADR 0001's "no shared base class" convention (each of the 8 existing stores
-duplicates read/write/version logic independently today), the new shape
-needs equivalent code reuse via a shared *helper*, not shared storage or
-inheritance — the same pattern as the existing `MongoUpsertPush`
-(push+upsert-with-duplicate-retry) and `MongoResourceSlice` (`$slice`
-pagination) static helpers.
+the existing collection name) plus a new `<type>Versions` collection. Each
+of the 8 existing stores hand-rolls its own read/write/version logic, so the
+new shape needs somewhere for that logic to live once.
 
 Looked at the current implementation in detail —
 `MongoArchitectureStore`/`NitriteArchitectureStore` plus both existing
@@ -24,10 +20,10 @@ exists), and force-write a version (upsert regardless).
 
 ## Decision
 
-Two helper classes, mirroring the existing per-backend split (no shared
-base class across backends): `MongoVersionDocumentStore` and a Nitrite
-counterpart. Each exposes the primitive operations every store needs
-against its `(header collection, version collection)` pair:
+Two helper classes that each store **composes**, one per backend:
+`MongoVersionDocumentStore` and `NitriteVersionDocumentStore`. Each exposes
+the primitive operations every store needs against its
+`(header collection, version collection)` pair:
 
 - `headerExists(namespace, resourceId) -> boolean`
 - `createHeader(namespace, resourceId, name, description)`
@@ -38,6 +34,33 @@ against its `(header collection, version collection)` pair:
 - `getVersion(namespace, resourceId, version) -> content or not-found`
 - `listVersions(namespace, resourceId) -> List<String>`
 - `listSummariesPaged(namespace, page) -> List<NamespaceResourceSummary>`
+
+### Why composition rather than a shared base class
+
+Not simply because the codebase has no base class today — it doesn't, but
+what it has instead is duplication, which is no argument for anything. The
+reason is that a base class can't actually express what these stores have
+in common:
+
+- **Every store implements a different interface, with differently-named
+  methods and different checked exception types.**
+  `ArchitectureStore.getArchitectureVersions` throws
+  `ArchitectureNotFoundException`; `PatternStore.getPatternVersions` throws
+  `PatternNotFoundException`. A shared superclass method can't declare the
+  right exception per subclass without generic exception parameters plus a
+  per-type exception factory to construct them — more machinery than the
+  one-line delegation it would replace, and it still wouldn't unify the
+  method names the interfaces demand.
+- **Two backends mean two hierarchies.** Mongo and Nitrite share no storage
+  API, so a base class helps within a backend at best, and the
+  cross-backend duplication (the part actually worth removing) stays.
+- **The stores are CDI beans** selected by `@LookupIfProperty` and narrowed
+  with `@Typed`. Keeping them plain implementors of their interface, each
+  holding a helper, avoids entangling that wiring with an inheritance chain.
+
+Composition also keeps the seam honest: the helper knows about documents and
+collections, the store knows about domain objects and exceptions, and
+neither leaks into the other.
 
 ### Two of the three existing shared helpers retire
 

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -1,7 +1,7 @@
 # ADR 0003: Shared header/version store helper
 
 **Status**: Proposed — not yet implemented. Depends on
-[ADR 0001](0001-versioned-artifact-storage.md) and
+[ADR 0001](0001-versioned-artefact-storage.md) and
 [ADR 0002](0002-version-key-encoding.md).
 
 ## Context

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -1,0 +1,107 @@
+# ADR 0003: Shared header/version store helper
+
+**Status**: Proposed — not yet implemented. Depends on
+[ADR 0001](0001-versioned-artifact-storage.md) and
+[ADR 0002](0002-version-key-encoding.md).
+
+## Context
+
+ADR 0001 gives each of the 7 versioned types a header collection (reusing
+the existing collection name) plus a new `<type>Versions` collection. Per
+ADR 0001's "no shared base class" convention (each of the 8 existing stores
+duplicates read/write/version logic independently today), the new shape
+needs equivalent code reuse via a shared *helper*, not shared storage or
+inheritance — the same pattern as the existing `MongoUpsertPush`
+(push+upsert-with-duplicate-retry) and `MongoResourceSlice` (`$slice`
+pagination) static helpers.
+
+Looked at the current implementation in detail —
+`MongoArchitectureStore`/`NitriteArchitectureStore` plus both existing
+helpers — to ground the new helper's operations in what each store
+actually needs to do today: list summaries (paged), create the entity,
+list versions, get one version's content, create a version (reject if
+exists), and force-write a version (upsert regardless).
+
+## Decision
+
+Two helper classes, mirroring the existing per-backend split (no shared
+base class across backends): `MongoVersionDocumentStore` and a Nitrite
+counterpart. Each exposes the primitive operations every store needs
+against its `(header collection, version collection)` pair:
+
+- `headerExists(namespace, resourceId) -> boolean`
+- `createHeader(namespace, resourceId, name, description)`
+- `createVersion(namespace, resourceId, version, content)` — throws if the
+  version already exists
+- `upsertVersion(namespace, resourceId, version, content)` — force-write,
+  used by the update-in-place path
+- `getVersion(namespace, resourceId, version) -> content or not-found`
+- `listVersions(namespace, resourceId) -> List<String>`
+- `listSummariesPaged(namespace, page) -> List<NamespaceResourceSummary>`
+
+### Two of the three existing shared helpers retire
+
+- **`MongoUpsertPush`'s retry-on-duplicate-key logic becomes
+  unnecessary.** It exists because the old shape upserts into a shared
+  per-namespace array document, which can race between two concurrent
+  first-writes to a brand-new namespace. In the new shape, `resourceId`
+  comes from the atomic counter (`MongoCounterStore`) before the header
+  insert happens — there's no genuine race to retry, just a plain
+  `insertOne` backed by a unique index on `(namespace, resourceId)`.
+- **`MongoResourceSlice`'s `$slice` projection becomes unnecessary too.**
+  It exists to page into an array field on one shared document. Headers
+  are now one document per resource, so `listSummariesPaged` is ordinary
+  `skip()`/`limit()` on the header collection.
+- Both helpers stay in place for `MongoControlStore`, which keeps the old
+  shape (ADR 0001 excludes Control from this redesign).
+- `VersionKeySelector` (version-count/latest-version comparison) is
+  unaffected — `versionCount` is now a stored field (see below), not
+  computed from a loaded map, so its `versionCount()` method's callers
+  move into this helper's `createVersion`; `latestVersionKey()` is
+  unused by the helper (ADR 0001 decided against a `latestVersion` field)
+  but is left in place for any caller that still needs it against a
+  loaded version list.
+
+### `createVersion` maintains the header's `versionCount`
+
+Per ADR 0001's revised decision, `versionCount` is denormalized on the
+header (not computed via aggregation). `createVersion` therefore performs
+two writes: insert the version document, then an atomic `$inc` on the
+header's `versionCount`. See ADR 0001's *Decision* section for the accepted
+drift risk if a crash lands between the two.
+
+### Existence checking must use the header, not the version list
+
+A header can legitimately have zero versions (that's the point of
+splitting header from version — see ADR 0001). So `listVersions` returning
+an empty list is **not** evidence the resource doesn't exist — callers that
+need to distinguish "exists with 0 versions" from "doesn't exist" must call
+`headerExists` explicitly, not infer non-existence from an empty version
+list the way `getArchitectureVersions` does today (its `ArchitectureDoc ==
+null` check conflates "namespace has no matching architecture array entry"
+with "architecture not found," which happened to be safe under the old
+shape but would be wrong under the new one).
+
+### Nitrite
+
+Same two-collection shape and the same operation set. Whether the existing
+store-instance-wide `ReentrantReadWriteLock` (currently coarse: one lock
+per store, not per-namespace or per-resource) can be narrowed under the new
+shape is a real question — smaller, more numerous documents plausibly
+reduce lock hold times and contention — but it's a performance question,
+not a correctness one, and isn't resolved by this ADR. Left as a follow-up
+to revisit if profiling after implementation shows it matters.
+
+## Consequences
+
+- Each of the 7 stores' Mongo/Nitrite implementations shrinks to calling
+  the shared helper plus type-specific glue (constructing the right
+  `Document`/domain object, translating exceptions), replacing the
+  duplicated read/write/version logic every store currently hand-rolls.
+- `MongoControlStore` is unaffected — out of scope per ADR 0001, still
+  uses `MongoUpsertPush`/`MongoResourceSlice` directly.
+- Test impact: as already noted in ADR 0001, all 8
+  `TestMongo<X>StoreShould`/`TestNitrite<X>StoreShould` classes need
+  rewriting; the shared helpers themselves need their own dedicated test
+  classes (`TestMongoVersionDocumentStoreShould` etc.), consistent with how
+  `MongoUpsertPush`/`MongoResourceSlice` are tested today.

--- a/calm-hub/decisions/0004-defer-control-and-decorator-storage.md
+++ b/calm-hub/decisions/0004-defer-control-and-decorator-storage.md
@@ -1,0 +1,55 @@
+# ADR 0004: Defer Control and Decorator storage redesign
+
+**Status**: Accepted. This is a decision to *not* decide yet — it needs no
+code changes of its own.
+
+## Context
+
+`MongoControlStore` doesn't fit the header/version split cleanly: it's
+double-nested (domain → control → configuration → version, one extra level
+versus the other 7 types), using `arrayFilters` with `$[ctrl]`/`$[cfg]`
+placeholders to reach two levels deep. ADR 0001 already excluded it,
+flagging that it "needs bespoke design, not a straight copy of the other
+7."
+
+`DecoratorStore` isn't versioned at all — `updateDecorator` overwrites in
+place, no `versions` map, no history — so it doesn't share the unbounded
+per-document growth problem ([#2884](https://github.com/finos/architecture-as-code/issues/2884))
+that motivates this whole redesign in the first place.
+
+Both were already out of scope for ADR 0001. This ADR makes that exclusion
+an explicit, deliberate sequencing decision rather than a silent gap.
+
+## Decision
+
+Defer designing a storage approach for Controls and Decorators. Implement
+[ADR 0001](0001-versioned-artifact-storage.md),
+[ADR 0002](0002-version-key-encoding.md), and
+[ADR 0003](0003-shared-version-store-helper.md) first — the 7-type
+versioned redesign, version-key encoding, and shared helper — and only
+return to Controls/Decorators once that work has shipped.
+
+Rationale:
+
+- Controls' double-nesting is a genuinely different shape problem. Solving
+  it in parallel with the 7-type redesign risks coupling two unrelated
+  migrations together, growing the blast radius and review surface of the
+  higher-priority, already-scoped work.
+- Decorators have no urgency here — they don't have the growth problem this
+  effort exists to solve.
+- Real implementation experience from ADR 0001–0003 (in particular,
+  whatever the shared helper in ADR 0003 turns out to look like once built)
+  should inform Controls' bespoke design more usefully than speculating
+  about it now, before any of the groundwork exists.
+
+## Consequences
+
+- `MongoControlStore` and `NitriteControlStore` are untouched by ADR
+  0001–0003's implementation; `MongoControlStore` keeps using
+  `MongoUpsertPush`/`MongoResourceSlice` directly (per ADR 0003).
+- `DecoratorStore`/`MongoDecoratorStore`/`NitriteDecoratorStore` are
+  untouched — still overwrite in place, no version history.
+- A future ADR (0005 or later) will need to actually design Controls' and
+  Decorators' storage when this work resumes. This ADR is a placeholder
+  marking that intent, not a design — do not treat its existence as
+  evidence a design decision has been made.

--- a/calm-hub/decisions/0004-defer-control-and-decorator-storage.md
+++ b/calm-hub/decisions/0004-defer-control-and-decorator-storage.md
@@ -23,7 +23,7 @@ an explicit, deliberate sequencing decision rather than a silent gap.
 ## Decision
 
 Defer designing a storage approach for Controls and Decorators. Implement
-[ADR 0001](0001-versioned-artifact-storage.md),
+[ADR 0001](0001-versioned-artefact-storage.md),
 [ADR 0002](0002-version-key-encoding.md), and
 [ADR 0003](0003-shared-version-store-helper.md) first — the 7-type
 versioned redesign, version-key encoding, and shared helper — and only

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -14,7 +14,7 @@ here is how the code works today.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-versioned-artifact-storage.md) | Versioned artifact storage redesign | Proposed |
+| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Proposed |
 | [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Proposed |
 | [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Proposed |
 | [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted |

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records
+
+This directory holds ADRs for `calm-hub` — decisions about how the backend
+itself is built, not to be confused with the CALM **ADR resource type**
+(`org.finos.calm.store.AdrStore` etc.), which lets *users* record decisions
+about *their own* architectures via the API.
+
+Format: lightweight MADR-style — Status, Context, Decision, Consequences.
+`Status` is one of `Proposed`, `Accepted`, `Implemented`, `Superseded by
+ADR-000N`. A `Proposed` ADR records a decision that's been made about the
+target design before implementation starts — it is not a description of
+current behaviour; check the `Status` field before assuming what's written
+here is how the code works today.
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-versioned-artifact-storage.md) | Versioned artifact storage redesign | Proposed |
+| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Proposed |
+| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Proposed |
+| [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted |


### PR DESCRIPTION
## Description
Adds `calm-hub/decisions/` — an Architecture Decision Records directory for calm-hub's own backend design (distinct from the CALM ADR *resource type*) — with four ADRs addressing #2884 (documents can hit Mongo's 16MB BSON limit as version history grows, in both the Mongo and Nitrite backends):

- **[ADR 0001](calm-hub/decisions/0001-versioned-artifact-storage.md)** — move from one-document-per-namespace to one-document-per-version, split into a header collection (existence, `name`/`description`, denormalized `versionCount`, and an open `metadata` field) and a version collection, reusing existing collection names to keep the migration additive rather than a full cutover.
- **[ADR 0002](calm-hub/decisions/0002-version-key-encoding.md)** — drop dash-encoded version keys (`"1-0-0"`) now that version is a document field value rather than a Mongo map key, which is what forced the encoding in the first place.
- **[ADR 0003](calm-hub/decisions/0003-shared-version-store-helper.md)** — a shared Mongo/Nitrite helper for the new shape, and why two of the three existing shared helpers (`MongoUpsertPush`, `MongoResourceSlice`) retire once documents are no longer arrays-in-a-shared-doc.
- **[ADR 0004](calm-hub/decisions/0004-defer-control-and-decorator-storage.md)** — a deliberate decision to *not* design Control's (double-nested) or Decorator's (unversioned) storage yet; revisit after 0001-0003 ship.

This is docs-only — no code changes. Opening as a **draft** to get early feedback before implementation starts, especially on the collection/document shape and the migration approach, from folks who've worked in this area or discussed related storage/archiving concerns: @rocketstack-matt @jpgough-ms @LeighF @willosborne @jimthompson5802.

Worth flagging: ADR 0001 reserves a `metadata` field on both collections specifically to support #2856 (document archiving) — while scoping that issue, @markscott-ms found this same 16MB/growth problem and flagged #2884 as a blocker for it, so this work is a prerequisite for #2856 as well as being useful on its own.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- [x] Commit uses conventional commit format (`docs(calm-hub): ...`)

## Testing
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass
N/A — documentation only, no code changes in this PR.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards