### PR TITLE
feat(calm-hub): header/version document store helpers (#2884, phase 1)

### DIFF
--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -1,6 +1,7 @@
 # ADR 0001: Versioned artefact storage redesign
 
-**Status**: Proposed — not yet implemented. Tracked in
+**Status**: Accepted — not yet implemented. No store uses this shape yet, so
+this describes the target design rather than current behaviour. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).
 
 ## Context

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -1,6 +1,7 @@
 # ADR 0002: Version field encoding — dots, not dashes
 
-**Status**: Proposed — not yet implemented. Depends on
+**Status**: Accepted — not yet implemented. Stored versions are still
+dash-encoded everywhere today. Depends on
 [ADR 0001](0001-versioned-artefact-storage.md).
 
 ## Context

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -30,8 +30,13 @@ the primitive operations every store needs against its
 
 - `headerExists(namespace, resourceId) -> boolean`
 - `createHeader(namespace, resourceId, name, description)`
-- `createVersion(namespace, resourceId, version, content)` — throws if the
-  version already exists
+- `createVersion(namespace, resourceId, version, content) -> boolean` —
+  never overwrites; returns `false` if the version already exists rather
+  than throwing. The helper has no way to construct the right exception:
+  each store's interface declares its own type
+  (`ArchitectureVersionExistsException`, `PatternVersionExistsException`,
+  and so on), so choosing the domain meaning of "already there" stays with
+  the caller. Genuine write failures still throw `StorageWriteException`.
 - `upsertVersion(namespace, resourceId, version, content)` — force-write,
   used by the update-in-place path
 - `getVersion(namespace, resourceId, version) -> content or not-found`
@@ -95,6 +100,17 @@ header (not computed via aggregation). `createVersion` therefore performs
 two writes: insert the version document, then an atomic `$inc` on the
 header's `versionCount`. See ADR 0001's *Decision* section for the accepted
 drift risk if a crash lands between the two.
+
+The count write is **best-effort, and never fails the version write**. It
+runs only after the version document is durably stored, so a failure there
+— whether the header is missing or the write itself errors — is logged at
+`WARN` and swallowed rather than propagated. Propagating it would report
+failure for a version that was in fact written, and a caller retrying that
+"failure" would then be told the version already exists: strictly worse
+than the understated count ADR 0001 already accepts, since that costs a
+display number off by one rather than a wrong answer. `upsertVersion`
+maintains the count on the same terms, incrementing only when it actually
+inserted.
 
 ### Existence checking must use the header, not the version list
 

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -1,6 +1,9 @@
 # ADR 0003: Shared header/version store helper
 
-**Status**: Proposed — not yet implemented. Depends on
+**Status**: Accepted — partially implemented. The helpers themselves exist
+(`MongoVersionDocumentStore`, `NitriteVersionDocumentStore`,
+`SemanticVersionOrder`), but no store calls them yet, so nothing in running
+CALM Hub uses this design. Depends on
 [ADR 0001](0001-versioned-artefact-storage.md) and
 [ADR 0002](0002-version-key-encoding.md).
 

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -7,14 +7,17 @@ about *their own* architectures via the API.
 
 Format: lightweight MADR-style — Status, Context, Decision, Consequences.
 `Status` is one of `Proposed`, `Accepted`, `Implemented`, `Superseded by
-ADR-000N`. A `Proposed` ADR records a decision that's been made about the
-target design before implementation starts — it is not a description of
-current behaviour; check the `Status` field before assuming what's written
-here is how the code works today.
+ADR-000N`.
+
+**Only `Implemented` means the code works this way today.** `Proposed` and
+`Accepted` both describe a target design: `Proposed` is still up for debate,
+`Accepted` has been agreed but may not be built yet. Check the `Status` line —
+it also carries a note on how much of the ADR has actually landed — before
+assuming anything here reflects current behaviour.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Proposed |
-| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Proposed |
-| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Proposed |
+| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Accepted |
+| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Accepted |
+| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Accepted |
 | [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted |

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -1,6 +1,7 @@
 package org.finos.calm.store.util;
 
 import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
@@ -164,16 +165,20 @@ public class MongoVersionDocumentStore {
         Bson update = Updates.combine(
                 Updates.set(CONTENT_FIELD, content),
                 Updates.setOnInsert(METADATA_FIELD, new Document()));
+        boolean inserted;
         try {
             UpdateResult result = versionCollection.updateOne(
                     versionFilter(namespace, resourceId, version), update, new UpdateOptions().upsert(true));
-            if (result.getUpsertedId() != null) {
-                incrementVersionCount(namespace, resourceId);
-            }
+            inserted = result.getUpsertedId() != null;
         } catch (MongoWriteException e) {
             LOG.error("Failed to write version [namespace={}, {}={}, version={}]",
                     namespace, idField, resourceId, version, e);
             throw MongoWriteFailures.toStorageWriteException(e);
+        }
+        // Outside the try, matching createVersion: the count is best-effort follow-up
+        // work once the version is stored, not part of the write being translated above.
+        if (inserted) {
+            incrementVersionCount(namespace, resourceId);
         }
     }
 
@@ -236,16 +241,32 @@ public class MongoVersionDocumentStore {
 
     /**
      * Keeps the header's denormalised {@code versionCount} in step with the version
-     * collection. A miss means the header is gone while its versions aren't — a real
-     * inconsistency worth surfacing, but not worth failing an otherwise-successful
-     * write over, since the version content is already safely stored.
+     * collection. Best-effort by design: it is always called <em>after</em> the version
+     * document is durably stored, so neither a miss nor a failed write is worth failing
+     * the caller's write over.
+     *
+     * <p>A miss means the header is gone while its versions aren't — a real inconsistency
+     * worth surfacing. A driver failure means the count write itself didn't land. Both
+     * leave the same footprint ADR 0001 already accepts for a crash between the two
+     * writes: the count is understated until corrected, which is a display number off by
+     * one rather than lost or corrupted content.</p>
+     *
+     * <p>Deliberately swallows {@link MongoException} rather than translating it like the
+     * version writes do. Propagating it — classified or not — would report failure for a
+     * version that <em>was</em> written, and a caller retrying that "failure" would then
+     * be told the version already exists.</p>
      */
     private void incrementVersionCount(String namespace, int resourceId) {
-        UpdateResult result = headerCollection.updateOne(
-                headerFilter(namespace, resourceId), Updates.inc(VERSION_COUNT_FIELD, 1));
-        if (result.getMatchedCount() == 0) {
-            LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
-                    + "versionCount for this resource is now understated", namespace, idField, resourceId);
+        try {
+            UpdateResult result = headerCollection.updateOne(
+                    headerFilter(namespace, resourceId), Updates.inc(VERSION_COUNT_FIELD, 1));
+            if (result.getMatchedCount() == 0) {
+                LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
+                        + "versionCount for this resource is now understated", namespace, idField, resourceId);
+            }
+        } catch (MongoException e) {
+            LOG.warn("Failed to increment versionCount after writing a version [namespace={}, {}={}] — "
+                    + "versionCount for this resource is now understated", namespace, idField, resourceId, e);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -1,0 +1,261 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared MongoDB access for the header/version document shape: one <em>header</em>
+ * document per {@code (namespace, resourceId)} recording that a resource exists, and
+ * one <em>version</em> document per {@code (namespace, resourceId, version)} holding
+ * that version's content.
+ *
+ * <p>Replaces the "one document per namespace, holding an array of resources, each
+ * with an embedded map of every version's content" shape, which grew without bound
+ * and risked MongoDB's hard 16MB per-document limit. See
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}.</p>
+ *
+ * <h2>Not a base class</h2>
+ * Each resource type's store composes one of these rather than extending it,
+ * matching the codebase's existing static-helper convention ({@link MongoUpsertPush},
+ * {@code MongoResourceSlice}). The type-specific parts — the id field name, the
+ * label used when a stored {@code name} is missing — are constructor arguments, so
+ * one instance serves exactly one resource type.
+ *
+ * <h2>Existence is the header's job</h2>
+ * A header may legitimately have zero version documents, so an empty
+ * {@link #listVersions} is <em>not</em> evidence the resource doesn't exist. Callers
+ * that need to tell "exists, no versions yet" from "doesn't exist" must ask
+ * {@link #headerExists}.
+ *
+ * <h2>Concurrency</h2>
+ * Uniqueness is enforced by the database, not by check-then-write here: the unique
+ * index on {@code (namespace, resourceId, version)} makes a losing concurrent
+ * writer fail with {@code DUPLICATE_KEY}, which {@link #createVersion} reports as
+ * {@code false}. Those indexes are created by the per-type schema migration step,
+ * not by this class.
+ */
+public class MongoVersionDocumentStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoVersionDocumentStore.class);
+
+    static final String NAMESPACE_FIELD = "namespace";
+    static final String VERSION_FIELD = "version";
+    static final String CONTENT_FIELD = "content";
+    static final String NAME_FIELD = "name";
+    static final String DESCRIPTION_FIELD = "description";
+    static final String VERSION_COUNT_FIELD = "versionCount";
+    static final String METADATA_FIELD = "metadata";
+
+    private final MongoCollection<Document> headerCollection;
+    private final MongoCollection<Document> versionCollection;
+    private final String idField;
+    private final String resourceLabel;
+
+    /**
+     * @param headerCollection  the existing per-type collection, now holding headers
+     *                          (e.g. {@code architectures})
+     * @param versionCollection the new sibling version collection
+     *                          (e.g. {@code architectureVersions})
+     * @param idField           the type's numeric id field (e.g. {@code architectureId})
+     * @param resourceLabel     human-readable type name, used only to synthesise a
+     *                          display name when a header has none (e.g. {@code Architecture})
+     */
+    public MongoVersionDocumentStore(MongoCollection<Document> headerCollection,
+                                     MongoCollection<Document> versionCollection,
+                                     String idField,
+                                     String resourceLabel) {
+        this.headerCollection = headerCollection;
+        this.versionCollection = versionCollection;
+        this.idField = idField;
+        this.resourceLabel = resourceLabel;
+    }
+
+    /**
+     * @return {@code true} if the resource exists, regardless of how many versions
+     * (including none) have been written for it.
+     */
+    public boolean headerExists(String namespace, int resourceId) {
+        return headerCollection.find(headerFilter(namespace, resourceId))
+                .projection(Projections.include("_id"))
+                .first() != null;
+    }
+
+    /**
+     * Inserts the header that makes a resource exist, with a zero version count and
+     * empty metadata.
+     *
+     * <p>A plain insert with no duplicate-key retry: unlike the old shape — where
+     * concurrent first-writes to a new namespace raced to create the shared namespace
+     * document (see {@link MongoUpsertPush}) — {@code resourceId} comes from the
+     * atomic counter before this is called, so there is no race to lose.</p>
+     */
+    public void createHeader(String namespace, int resourceId, String name, String description) {
+        Document header = new Document(NAMESPACE_FIELD, namespace)
+                .append(idField, resourceId)
+                .append(NAME_FIELD, name)
+                .append(DESCRIPTION_FIELD, description)
+                .append(VERSION_COUNT_FIELD, 0)
+                .append(METADATA_FIELD, new Document());
+        try {
+            headerCollection.insertOne(header);
+        } catch (MongoWriteException e) {
+            LOG.error("Failed to create header [namespace={}, {}={}]", namespace, idField, resourceId, e);
+            throw MongoWriteFailures.toStorageWriteException(e);
+        }
+    }
+
+    /**
+     * Writes a version that must not already exist.
+     *
+     * @return {@code false} if that version is already present — the caller decides
+     * which domain exception that means. Never overwrites.
+     */
+    public boolean createVersion(String namespace, int resourceId, String version, Document content) {
+        Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
+                .append(idField, resourceId)
+                .append(VERSION_FIELD, version)
+                .append(CONTENT_FIELD, content)
+                .append(METADATA_FIELD, new Document());
+        try {
+            versionCollection.insertOne(versionDocument);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+                return false;
+            }
+            // Log identifying fields only — the content can be megabytes.
+            LOG.error("Failed to create version [namespace={}, {}={}, version={}]",
+                    namespace, idField, resourceId, version, e);
+            throw MongoWriteFailures.toStorageWriteException(e);
+        }
+        incrementVersionCount(namespace, resourceId);
+        return true;
+    }
+
+    /**
+     * Writes a version whether or not it already exists, for the update-in-place path.
+     *
+     * <p>Updates {@code content} only, deliberately leaving any {@code metadata} on an
+     * existing version document untouched — overwriting the whole document would
+     * silently discard per-version metadata (the field reserved for document archiving).
+     * Metadata is initialised to empty only when this call is the one that inserts.</p>
+     *
+     * <p>Because this path can <em>create</em> a version rather than only overwrite one,
+     * it increments the header's {@code versionCount} when — and only when — it actually
+     * inserted; otherwise the count would drift permanently low.</p>
+     */
+    public void upsertVersion(String namespace, int resourceId, String version, Document content) {
+        Bson update = Updates.combine(
+                Updates.set(CONTENT_FIELD, content),
+                Updates.setOnInsert(METADATA_FIELD, new Document()));
+        try {
+            UpdateResult result = versionCollection.updateOne(
+                    versionFilter(namespace, resourceId, version), update, new UpdateOptions().upsert(true));
+            if (result.getUpsertedId() != null) {
+                incrementVersionCount(namespace, resourceId);
+            }
+        } catch (MongoWriteException e) {
+            LOG.error("Failed to write version [namespace={}, {}={}, version={}]",
+                    namespace, idField, resourceId, version, e);
+            throw MongoWriteFailures.toStorageWriteException(e);
+        }
+    }
+
+    /**
+     * @return the stored content for one version, or {@code null} if that version
+     * (or the resource) doesn't exist.
+     */
+    public Document getVersion(String namespace, int resourceId, String version) {
+        Document versionDocument = versionCollection.find(versionFilter(namespace, resourceId, version)).first();
+        return versionDocument == null ? null : versionDocument.get(CONTENT_FIELD, Document.class);
+    }
+
+    /**
+     * @return every version of one resource, ordered by {@link SemanticVersionOrder}.
+     * Empty means "no versions written" — <em>not</em> "no such resource"; ask
+     * {@link #headerExists} to tell those apart. Sorted in memory rather than by the
+     * database because semantic ordering isn't expressible as a Mongo sort, which is
+     * safe given the version count per resource is small.
+     */
+    public List<String> listVersions(String namespace, int resourceId) {
+        List<String> versions = new ArrayList<>();
+        versionCollection.find(headerFilter(namespace, resourceId))
+                .projection(Projections.include(VERSION_FIELD))
+                .forEach(document -> versions.add(document.getString(VERSION_FIELD)));
+        versions.sort(SemanticVersionOrder.ASCENDING);
+        return versions;
+    }
+
+    /**
+     * Lists resource summaries for a namespace, applying the paging window at the
+     * database with {@code skip}/{@code limit}.
+     *
+     * <p>No {@code $slice} projection is involved: that existed to page into an array
+     * field inside a single shared document, and headers are now one document per
+     * resource. Sorted by id so the window is stable — an unsorted Mongo query has no
+     * defined order, which would make paging return overlapping or missing rows.</p>
+     */
+    public List<NamespaceResourceSummary> listSummariesPaged(String namespace, PageRequest page) {
+        FindIterable<Document> headers = headerCollection.find(Filters.eq(NAMESPACE_FIELD, namespace))
+                .sort(Sorts.ascending(idField));
+        if (page.isPaged()) {
+            headers = headers.skip(page.normalizedOffset()).limit(page.limit());
+        }
+        List<NamespaceResourceSummary> summaries = new ArrayList<>();
+        headers.forEach(header -> summaries.add(toSummary(header)));
+        return summaries;
+    }
+
+    private NamespaceResourceSummary toSummary(Document header) {
+        Integer resourceId = header.getInteger(idField);
+        String name = header.getString(NAME_FIELD);
+        String description = header.getString(DESCRIPTION_FIELD);
+        Integer versionCount = header.getInteger(VERSION_COUNT_FIELD);
+        return new NamespaceResourceSummary(
+                name == null ? resourceLabel + " " + resourceId : name,
+                description == null ? "" : description,
+                resourceId,
+                versionCount == null ? 0 : versionCount);
+    }
+
+    /**
+     * Keeps the header's denormalised {@code versionCount} in step with the version
+     * collection. A miss means the header is gone while its versions aren't — a real
+     * inconsistency worth surfacing, but not worth failing an otherwise-successful
+     * write over, since the version content is already safely stored.
+     */
+    private void incrementVersionCount(String namespace, int resourceId) {
+        UpdateResult result = headerCollection.updateOne(
+                headerFilter(namespace, resourceId), Updates.inc(VERSION_COUNT_FIELD, 1));
+        if (result.getMatchedCount() == 0) {
+            LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
+                    + "versionCount for this resource is now understated", namespace, idField, resourceId);
+        }
+    }
+
+    private Bson headerFilter(String namespace, int resourceId) {
+        return Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(idField, resourceId));
+    }
+
+    private Bson versionFilter(String namespace, int resourceId, String version) {
+        return Filters.and(Filters.eq(NAMESPACE_FIELD, namespace),
+                Filters.eq(idField, resourceId),
+                Filters.eq(VERSION_FIELD, version));
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -2,6 +2,7 @@ package org.finos.calm.store.util;
 
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
@@ -235,21 +236,30 @@ public class NitriteVersionDocumentStore {
 
     /**
      * Keeps the header's denormalised {@code versionCount} in step with the version
-     * collection. Always called with the write lock already held. A missing header
-     * means the header is gone while its versions aren't — worth surfacing, but not
-     * worth failing an otherwise-successful write over.
+     * collection. Always called with the write lock already held, and always
+     * <em>after</em> the version document is stored.
+     *
+     * <p>Best-effort by design, matching {@code MongoVersionDocumentStore}: neither a
+     * missing header nor a failure of the count write itself is worth failing an
+     * otherwise-successful write over, since the version content is already stored.
+     * Both leave the count understated until corrected — the drift ADR 0001 accepts.</p>
      */
     private void incrementVersionCount(String namespace, int resourceId) {
-        Filter filter = headerFilter(namespace, resourceId);
-        Document header = headerCollection.find(filter).firstOrNull();
-        if (header == null) {
-            LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
-                    + "versionCount for this resource is now understated", namespace, idField, resourceId);
-            return;
+        try {
+            Filter filter = headerFilter(namespace, resourceId);
+            Document header = headerCollection.find(filter).firstOrNull();
+            if (header == null) {
+                LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
+                        + "versionCount for this resource is now understated", namespace, idField, resourceId);
+                return;
+            }
+            Integer current = header.get(VERSION_COUNT_FIELD, Integer.class);
+            header.put(VERSION_COUNT_FIELD, (current == null ? 0 : current) + 1);
+            headerCollection.update(filter, header);
+        } catch (NitriteException e) {
+            LOG.warn("Failed to increment versionCount after writing a version [namespace={}, {}={}] — "
+                    + "versionCount for this resource is now understated", namespace, idField, resourceId, e);
         }
-        Integer current = header.get(VERSION_COUNT_FIELD, Integer.class);
-        header.put(VERSION_COUNT_FIELD, (current == null ? 0 : current) + 1);
-        headerCollection.update(filter, header);
     }
 
     private Filter headerFilter(String namespace, int resourceId) {

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -1,0 +1,264 @@
+package org.finos.calm.store.util;
+
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.dizitart.no2.filters.FluentFilter.where;
+
+/**
+ * NitriteDB counterpart to {@link MongoVersionDocumentStore}: one <em>header</em>
+ * document per {@code (namespace, resourceId)}, one <em>version</em> document per
+ * {@code (namespace, resourceId, version)}. See
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}.
+ *
+ * <h2>Why this isn't a mirror image of the Mongo helper</h2>
+ * Two deliberate differences, both forced by the backend rather than chosen:
+ * <ul>
+ *   <li><b>Uniqueness is enforced here, not by the database.</b> CalmHub creates no
+ *       Nitrite indexes at all, so there is no unique constraint to make a duplicate
+ *       write fail. {@link #createVersion} therefore checks before writing, holding
+ *       the write lock across both — which is genuinely safe, rather than a
+ *       check-then-act race, because Nitrite is a single-process embedded store and
+ *       this lock serialises every write through it. The Mongo helper can instead
+ *       write optimistically and translate a {@code DUPLICATE_KEY} error, because
+ *       there a shared database arbitrates between separate application instances.</li>
+ *   <li><b>Content is stored as a JSON string</b>, not a parsed document, matching
+ *       what the existing Nitrite stores already do.</li>
+ * </ul>
+ *
+ * <h2>Locking</h2>
+ * A single store-wide {@link ReentrantReadWriteLock}, matching the existing Nitrite
+ * stores. Narrowing it is a possible optimisation but not a correctness fix — note
+ * that any narrower lock must still serialise writes to the same
+ * {@code (namespace, resourceId, version)}, or the uniqueness guarantee above stops
+ * holding.
+ */
+public class NitriteVersionDocumentStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NitriteVersionDocumentStore.class);
+
+    static final String NAMESPACE_FIELD = "namespace";
+    static final String VERSION_FIELD = "version";
+    static final String CONTENT_FIELD = "content";
+    static final String NAME_FIELD = "name";
+    static final String DESCRIPTION_FIELD = "description";
+    static final String VERSION_COUNT_FIELD = "versionCount";
+    static final String METADATA_FIELD = "metadata";
+
+    private final NitriteCollection headerCollection;
+    private final NitriteCollection versionCollection;
+    private final String idField;
+    private final String resourceLabel;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /**
+     * @param headerCollection  the existing per-type collection, now holding headers
+     * @param versionCollection the new sibling version collection
+     * @param idField           the type's numeric id field (e.g. {@code architectureId})
+     * @param resourceLabel     human-readable type name, used only to synthesise a
+     *                          display name when a header has none
+     */
+    public NitriteVersionDocumentStore(NitriteCollection headerCollection,
+                                       NitriteCollection versionCollection,
+                                       String idField,
+                                       String resourceLabel) {
+        this.headerCollection = headerCollection;
+        this.versionCollection = versionCollection;
+        this.idField = idField;
+        this.resourceLabel = resourceLabel;
+    }
+
+    /**
+     * @return {@code true} if the resource exists, regardless of how many versions
+     * (including none) have been written for it.
+     */
+    public boolean headerExists(String namespace, int resourceId) {
+        lock.readLock().lock();
+        try {
+            return headerCollection.find(headerFilter(namespace, resourceId)).firstOrNull() != null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /** Inserts the header that makes a resource exist, with a zero version count. */
+    public void createHeader(String namespace, int resourceId, String name, String description) {
+        lock.writeLock().lock();
+        try {
+            headerCollection.insert(Document.createDocument()
+                    .put(NAMESPACE_FIELD, namespace)
+                    .put(idField, resourceId)
+                    .put(NAME_FIELD, name)
+                    .put(DESCRIPTION_FIELD, description)
+                    .put(VERSION_COUNT_FIELD, 0)
+                    .put(METADATA_FIELD, Document.createDocument()));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Writes a version that must not already exist.
+     *
+     * <p>The existence check and the insert both happen under the write lock, so no
+     * concurrent caller can slip between them — see the class javadoc on why that
+     * substitutes for a database constraint here.</p>
+     *
+     * @return {@code false} if that version is already present. Never overwrites.
+     */
+    public boolean createVersion(String namespace, int resourceId, String version, String content) {
+        lock.writeLock().lock();
+        try {
+            if (versionCollection.find(versionFilter(namespace, resourceId, version)).firstOrNull() != null) {
+                return false;
+            }
+            versionCollection.insert(Document.createDocument()
+                    .put(NAMESPACE_FIELD, namespace)
+                    .put(idField, resourceId)
+                    .put(VERSION_FIELD, version)
+                    .put(CONTENT_FIELD, content)
+                    .put(METADATA_FIELD, Document.createDocument()));
+            incrementVersionCount(namespace, resourceId);
+            return true;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Writes a version whether or not it already exists, for the update-in-place path.
+     *
+     * <p>Replaces {@code content} on an existing version document while leaving its
+     * {@code metadata} intact — overwriting wholesale would silently discard
+     * per-version metadata. When no such version exists this inserts one, and only
+     * then increments the header's {@code versionCount}, since this path can create
+     * as well as overwrite.</p>
+     */
+    public void upsertVersion(String namespace, int resourceId, String version, String content) {
+        lock.writeLock().lock();
+        try {
+            Filter filter = versionFilter(namespace, resourceId, version);
+            Document existing = versionCollection.find(filter).firstOrNull();
+            if (existing == null) {
+                versionCollection.insert(Document.createDocument()
+                        .put(NAMESPACE_FIELD, namespace)
+                        .put(idField, resourceId)
+                        .put(VERSION_FIELD, version)
+                        .put(CONTENT_FIELD, content)
+                        .put(METADATA_FIELD, Document.createDocument()));
+                incrementVersionCount(namespace, resourceId);
+                return;
+            }
+            existing.put(CONTENT_FIELD, content);
+            versionCollection.update(filter, existing);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * @return the stored content for one version, or {@code null} if that version
+     * (or the resource) doesn't exist.
+     */
+    public String getVersion(String namespace, int resourceId, String version) {
+        lock.readLock().lock();
+        try {
+            Document versionDocument = versionCollection.find(versionFilter(namespace, resourceId, version)).firstOrNull();
+            return versionDocument == null ? null : versionDocument.get(CONTENT_FIELD, String.class);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * @return every version of one resource, ordered by {@link SemanticVersionOrder}.
+     * Empty means "no versions written" — <em>not</em> "no such resource"; ask
+     * {@link #headerExists} to tell those apart.
+     */
+    public List<String> listVersions(String namespace, int resourceId) {
+        lock.readLock().lock();
+        try {
+            List<String> versions = new ArrayList<>();
+            for (Document versionDocument : versionCollection.find(headerFilter(namespace, resourceId))) {
+                versions.add(versionDocument.get(VERSION_FIELD, String.class));
+            }
+            versions.sort(SemanticVersionOrder.ASCENDING);
+            return versions;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Lists resource summaries for a namespace.
+     *
+     * <p>Nitrite has no server-side paging equivalent, so the window is applied in
+     * memory after materialising and sorting the namespace's headers — the same
+     * approach the existing Nitrite stores take. Sorted by id so the window is
+     * stable across calls.</p>
+     */
+    public List<NamespaceResourceSummary> listSummariesPaged(String namespace, PageRequest page) {
+        lock.readLock().lock();
+        try {
+            List<NamespaceResourceSummary> summaries = new ArrayList<>();
+            for (Document header : headerCollection.find(where(NAMESPACE_FIELD).eq(namespace))) {
+                summaries.add(toSummary(header));
+            }
+            summaries.sort((left, right) -> Integer.compare(left.getId(), right.getId()));
+            return page.apply(summaries);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private NamespaceResourceSummary toSummary(Document header) {
+        Integer resourceId = header.get(idField, Integer.class);
+        String name = header.get(NAME_FIELD, String.class);
+        String description = header.get(DESCRIPTION_FIELD, String.class);
+        Integer versionCount = header.get(VERSION_COUNT_FIELD, Integer.class);
+        return new NamespaceResourceSummary(
+                name == null ? resourceLabel + " " + resourceId : name,
+                description == null ? "" : description,
+                resourceId,
+                versionCount == null ? 0 : versionCount);
+    }
+
+    /**
+     * Keeps the header's denormalised {@code versionCount} in step with the version
+     * collection. Always called with the write lock already held. A missing header
+     * means the header is gone while its versions aren't — worth surfacing, but not
+     * worth failing an otherwise-successful write over.
+     */
+    private void incrementVersionCount(String namespace, int resourceId) {
+        Filter filter = headerFilter(namespace, resourceId);
+        Document header = headerCollection.find(filter).firstOrNull();
+        if (header == null) {
+            LOG.warn("Wrote a version with no matching header to count it [namespace={}, {}={}] — "
+                    + "versionCount for this resource is now understated", namespace, idField, resourceId);
+            return;
+        }
+        Integer current = header.get(VERSION_COUNT_FIELD, Integer.class);
+        header.put(VERSION_COUNT_FIELD, (current == null ? 0 : current) + 1);
+        headerCollection.update(filter, header);
+    }
+
+    private Filter headerFilter(String namespace, int resourceId) {
+        return Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(idField).eq(resourceId));
+    }
+
+    private Filter versionFilter(String namespace, int resourceId, String version) {
+        return Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                where(idField).eq(resourceId),
+                where(VERSION_FIELD).eq(version));
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/SemanticVersionOrder.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/SemanticVersionOrder.java
@@ -1,10 +1,11 @@
 package org.finos.calm.store.util;
 
+import org.finos.calm.domain.Semver;
+
 import java.util.Comparator;
 
 /**
- * Orders dot-separated version strings ({@code "1.0.0"}) numerically by
- * major, then minor, then patch.
+ * Orders version strings numerically by major, then minor, then patch.
  *
  * <h2>Why not a plain string sort</h2>
  * Lexicographic ordering puts {@code "1.10.0"} before {@code "1.9.0"}, which is
@@ -13,24 +14,32 @@ import java.util.Comparator;
  * impose one — this is it.
  *
  * <h2>Why this is not {@link VersionKeySelector}</h2>
- * {@code VersionKeySelector.latestVersionKey} parses the <em>dash</em>-encoded
- * keys ({@code "1-0-0"}) used by the pre-redesign document shape, where the
- * version was a Mongo field name and therefore couldn't contain {@code '.'}.
- * Its only remaining callers are the Control stores, which deliberately keep
- * that shape, so it must keep parsing dashes. This class is the dot-separated
- * equivalent for the new shape — deliberately separate, so neither has to
- * handle both formats. See {@code calm-hub/decisions/0002-version-key-encoding.md}.
+ * {@code VersionKeySelector.latestVersionKey} exists to pick a single winner out
+ * of the dash-encoded {@code versions} <em>map</em> used by the pre-redesign
+ * document shape. Its only remaining callers are the Control stores, which
+ * deliberately keep that shape, so it is left alone. This class is the ordering
+ * for the new one-document-per-version shape, where version is a field value.
+ * See {@code calm-hub/decisions/0002-version-key-encoding.md}.
+ *
+ * <h2>Separators</h2>
+ * Parsing is delegated to {@link Semver#tryParse}, so both the canonical
+ * dot-separated form and the dash-encoded form order identically. ADR 0002 has
+ * the new {@code <type>Versions} collections storing dots only, so dashes should
+ * never reach here — but {@code VERSION_REGEX} accepts either from the API, and a
+ * comparator silently demoting {@code "1-10-0"} to {@code 0.0.0} would be a
+ * confusing way to find that out. Accepting both costs nothing and keeps this
+ * consistent with every other version comparison in the codebase, all of which
+ * already go through {@code Semver}.
  *
  * <h2>Malformed input</h2>
- * A version that isn't three numeric segments sorts as {@code 0.0.0} rather than
- * throwing, matching {@link VersionKeySelector}'s existing leniency — stored data
- * predating validation shouldn't make a listing endpoint fail. Ties (including
- * between two malformed values) fall back to a plain string comparison so the
- * order is always total and therefore stable.
+ * A version that isn't three numeric segments — including {@code null} — sorts as
+ * {@code 0.0.0} rather than throwing: stored data predating validation shouldn't
+ * make a listing endpoint fail, and {@code listVersions} reads the version field
+ * straight out of a document, so an absent field arrives here as {@code null}.
+ * Ties (including between two malformed values) fall back to a plain string
+ * comparison so the order is always total and therefore stable.
  */
 public final class SemanticVersionOrder {
-
-    private static final int SEGMENTS = 3;
 
     /** Ascending: {@code 1.0.0}, {@code 1.9.0}, {@code 1.10.0}, {@code 2.0.0}. */
     public static final Comparator<String> ASCENDING = SemanticVersionOrder::compare;
@@ -39,37 +48,22 @@ public final class SemanticVersionOrder {
     }
 
     private static int compare(String left, String right) {
-        int[] leftParts = parse(left);
-        int[] rightParts = parse(right);
-        for (int i = 0; i < SEGMENTS; i++) {
-            int comparison = Integer.compare(leftParts[i], rightParts[i]);
-            if (comparison != 0) {
-                return comparison;
-            }
+        String leftVersion = orEmpty(left);
+        String rightVersion = orEmpty(right);
+        int comparison = Semver.tryParse(leftVersion).compareTo(Semver.tryParse(rightVersion));
+        if (comparison != 0) {
+            return comparison;
         }
         // Total-order tiebreak so equal-ranking values (e.g. two unparseable
         // strings, both 0.0.0) still sort deterministically.
-        return left.compareTo(right);
+        return leftVersion.compareTo(rightVersion);
     }
 
     /**
-     * Splits a version into its three numeric segments. Compares segment by segment
-     * rather than packing them into a single integer, so a large major/minor/patch
-     * can't overflow into the neighbouring segment's range.
+     * Maps {@code null} onto a value {@link Semver#tryParse} treats as malformed, so a
+     * missing version field sorts with the other unparseable values instead of throwing.
      */
-    private static int[] parse(String version) {
-        int[] parts = new int[SEGMENTS];
-        String[] segments = version.split("\\.");
-        if (segments.length != SEGMENTS) {
-            return parts;
-        }
-        for (int i = 0; i < SEGMENTS; i++) {
-            try {
-                parts[i] = Integer.parseInt(segments[i]);
-            } catch (NumberFormatException e) {
-                return new int[SEGMENTS];
-            }
-        }
-        return parts;
+    private static String orEmpty(String version) {
+        return version == null ? "" : version;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/SemanticVersionOrder.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/SemanticVersionOrder.java
@@ -1,0 +1,75 @@
+package org.finos.calm.store.util;
+
+import java.util.Comparator;
+
+/**
+ * Orders dot-separated version strings ({@code "1.0.0"}) numerically by
+ * major, then minor, then patch.
+ *
+ * <h2>Why not a plain string sort</h2>
+ * Lexicographic ordering puts {@code "1.10.0"} before {@code "1.9.0"}, which is
+ * wrong for every consumer of a version list. A Mongo {@code find} without an
+ * explicit sort has no defined order at all, so the version-document stores must
+ * impose one — this is it.
+ *
+ * <h2>Why this is not {@link VersionKeySelector}</h2>
+ * {@code VersionKeySelector.latestVersionKey} parses the <em>dash</em>-encoded
+ * keys ({@code "1-0-0"}) used by the pre-redesign document shape, where the
+ * version was a Mongo field name and therefore couldn't contain {@code '.'}.
+ * Its only remaining callers are the Control stores, which deliberately keep
+ * that shape, so it must keep parsing dashes. This class is the dot-separated
+ * equivalent for the new shape — deliberately separate, so neither has to
+ * handle both formats. See {@code calm-hub/decisions/0002-version-key-encoding.md}.
+ *
+ * <h2>Malformed input</h2>
+ * A version that isn't three numeric segments sorts as {@code 0.0.0} rather than
+ * throwing, matching {@link VersionKeySelector}'s existing leniency — stored data
+ * predating validation shouldn't make a listing endpoint fail. Ties (including
+ * between two malformed values) fall back to a plain string comparison so the
+ * order is always total and therefore stable.
+ */
+public final class SemanticVersionOrder {
+
+    private static final int SEGMENTS = 3;
+
+    /** Ascending: {@code 1.0.0}, {@code 1.9.0}, {@code 1.10.0}, {@code 2.0.0}. */
+    public static final Comparator<String> ASCENDING = SemanticVersionOrder::compare;
+
+    private SemanticVersionOrder() {
+    }
+
+    private static int compare(String left, String right) {
+        int[] leftParts = parse(left);
+        int[] rightParts = parse(right);
+        for (int i = 0; i < SEGMENTS; i++) {
+            int comparison = Integer.compare(leftParts[i], rightParts[i]);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        // Total-order tiebreak so equal-ranking values (e.g. two unparseable
+        // strings, both 0.0.0) still sort deterministically.
+        return left.compareTo(right);
+    }
+
+    /**
+     * Splits a version into its three numeric segments. Compares segment by segment
+     * rather than packing them into a single integer, so a large major/minor/patch
+     * can't overflow into the neighbouring segment's range.
+     */
+    private static int[] parse(String version) {
+        int[] parts = new int[SEGMENTS];
+        String[] segments = version.split("\\.");
+        if (segments.length != SEGMENTS) {
+            return parts;
+        }
+        for (int i = 0; i < SEGMENTS; i++) {
+            try {
+                parts[i] = Integer.parseInt(segments[i]);
+            } catch (NumberFormatException e) {
+                return new int[SEGMENTS];
+            }
+        }
+        return parts;
+    }
+}

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -61,9 +61,23 @@ quarkus.mongodb.database = calmSchemas
 %test.quarkus.test.continuous-testing=enabled
 %test.quarkus.test.flat-class-path=true
 
-# Align Quarkus coverage output with jacoco-maven-plugin
-%test.quarkus.jacoco.data-file=target/jacoco.exec
-%test.quarkus.jacoco.reuse-data-file=true
+# Align Quarkus coverage output with jacoco-maven-plugin.
+#
+# Deliberately NOT %test.-prefixed, unlike everything around them. Both are
+# build-time-fixed properties, read during augmentation. Tests that declare their
+# own profile name via QuarkusTestProfile.getConfigProfile() (secure,
+# integration-test, and the other custom profiles) augment under that name, where
+# a %test. prefix does not apply — the properties then fix to null/false, and
+# Quarkus diverts coverage to target/jacoco-quarkus.exec with the warning
+# "quarkus.jacoco.data-file is set to 'target/jacoco.exec' but it is build time
+# fixed to 'null'". Every @QuarkusTest-covered class then reports 0% and the
+# jacoco check fails ~40 classes. Whether it bites depends on test ordering, so
+# it surfaces as an unrelated change "breaking coverage".
+#
+# Leave these unprefixed: the jacoco extension is test-scoped, so they are inert
+# in a real deployment.
+quarkus.jacoco.data-file=target/jacoco.exec
+quarkus.jacoco.reuse-data-file=true
 
 # Database configuration for tests
 %test.quarkus.mongodb.database=test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -1,5 +1,6 @@
 package org.finos.calm.store.util;
 
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteError;
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -195,6 +197,29 @@ class TestMongoVersionDocumentStoreShould {
         assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()), is(true));
     }
 
+    @Test
+    void still_succeed_when_the_count_update_itself_fails_after_creating_a_version() {
+        // The version document is durably stored by the time the count is touched. Failing
+        // here would report failure for a write that succeeded, and a caller retrying that
+        // "failure" would then be told the version already exists. ADR 0001 accepts an
+        // understated count as the cost.
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(writeError(10107, "not master"));
+
+        assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()), is(true));
+        verify(versionCollection).insertOne(any(Document.class));
+    }
+
+    @Test
+    void still_succeed_when_the_count_update_fails_with_a_non_write_driver_error() {
+        // Not every driver failure is a MongoWriteException — a timeout or socket error
+        // reaching the header collection must be tolerated the same way.
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(new MongoTimeoutException("timed out selecting a server"));
+
+        assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()), is(true));
+    }
+
     // --- upsertVersion ---
 
     @Test
@@ -206,6 +231,18 @@ class TestMongoVersionDocumentStoreShould {
         store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document());
 
         verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void still_succeed_when_the_count_update_fails_after_an_upsert_inserts() {
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(acknowledged(0, new BsonObjectId(new ObjectId())));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(writeError(10107, "not master"));
+
+        // Same reasoning as createVersion: the version is stored, so the count is
+        // follow-up work and must not turn a successful write into a failure.
+        assertDoesNotThrow(() -> store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -1,0 +1,310 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonDocument;
+import org.bson.BsonObjectId;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+import org.finos.calm.domain.exception.StorageWriteException;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoVersionDocumentStoreShould {
+
+    private static final String NAMESPACE = "finos";
+    private static final int RESOURCE_ID = 42;
+    private static final String ID_FIELD = "architectureId";
+    private static final String LABEL = "Architecture";
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoVersionDocumentStore store;
+
+    @BeforeEach
+    void setup() {
+        headerCollection = mock(DocumentMongoCollection.class);
+        versionCollection = mock(DocumentMongoCollection.class);
+        store = new MongoVersionDocumentStore(headerCollection, versionCollection, ID_FIELD, LABEL);
+    }
+
+    /** A find(...) chain that yields the given documents when iterated, and the first on first(). */
+    private FindIterable<Document> stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+        return iterable;
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static Document header(Integer id, String name, String description, Integer versionCount) {
+        Document header = new Document(ID_FIELD, id);
+        if (name != null) header.append("name", name);
+        if (description != null) header.append("description", description);
+        if (versionCount != null) header.append("versionCount", versionCount);
+        return header;
+    }
+
+    /**
+     * A real {@link UpdateResult} rather than a mock — building one inside a
+     * {@code when(...)} argument would nest stubbing and fail.
+     */
+    private static UpdateResult acknowledged(int matched, BsonObjectId upsertedId) {
+        return UpdateResult.acknowledged(matched, (long) matched, upsertedId);
+    }
+
+    // --- headerExists ---
+
+    @Test
+    void report_a_resource_exists_when_its_header_is_present() {
+        stubFind(headerCollection, List.of(new Document("_id", new ObjectId())));
+
+        assertThat(store.headerExists(NAMESPACE, RESOURCE_ID), is(true));
+    }
+
+    @Test
+    void report_a_resource_does_not_exist_when_no_header_is_present() {
+        stubFind(headerCollection, List.of());
+
+        assertThat(store.headerExists(NAMESPACE, RESOURCE_ID), is(false));
+    }
+
+    // --- createHeader ---
+
+    @Test
+    void create_a_header_with_a_zero_version_count_and_empty_metadata() {
+        store.createHeader(NAMESPACE, RESOURCE_ID, "My Architecture", "A description");
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(captor.capture());
+        Document inserted = captor.getValue();
+        assertThat(inserted.getString("namespace"), is(NAMESPACE));
+        assertThat(inserted.getInteger(ID_FIELD), is(RESOURCE_ID));
+        assertThat(inserted.getString("name"), is("My Architecture"));
+        assertThat(inserted.getString("description"), is("A description"));
+        assertThat(inserted.getInteger("versionCount"), is(0));
+        assertThat(inserted.get("metadata", Document.class), is(new Document()));
+    }
+
+    @Test
+    void translate_a_write_failure_when_creating_a_header() {
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(headerCollection).insertOne(any(Document.class));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createHeader(NAMESPACE, RESOURCE_ID, "name", "description"));
+    }
+
+    // --- createVersion ---
+
+    @Test
+    void create_a_version_and_increment_the_header_count() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        boolean created = store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document("nodes", List.of()));
+
+        assertThat(created, is(true));
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(captor.capture());
+        Document inserted = captor.getValue();
+        assertThat(inserted.getString("version"), is("1.0.0"));
+        assertThat(inserted.get("content", Document.class), is(new Document("nodes", List.of())));
+        assertThat(inserted.get("metadata", Document.class), is(new Document()));
+        verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void report_a_version_already_exists_rather_than_overwriting_it() {
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        boolean created = store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document());
+
+        assertThat(created, is(false));
+        // The count must not move when nothing was written.
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void translate_a_non_duplicate_write_failure_when_creating_a_version() {
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()));
+    }
+
+    @Test
+    void warn_but_still_succeed_when_a_version_has_no_header_to_count_it() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(0, null));
+
+        // The version content is already stored, so an orphaned count is not worth failing over.
+        assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()), is(true));
+    }
+
+    // --- upsertVersion ---
+
+    @Test
+    void increment_the_version_count_when_an_upsert_inserts_a_new_version() {
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(acknowledged(0, new BsonObjectId(new ObjectId())));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document());
+
+        verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void not_increment_the_version_count_when_an_upsert_replaces_an_existing_version() {
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(acknowledged(1, null));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document());
+
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void translate_a_write_failure_when_upserting_a_version() {
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10334, "object to insert too large"));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()));
+    }
+
+    // --- getVersion ---
+
+    @Test
+    void return_the_content_of_a_stored_version() {
+        Document content = new Document("title", "My Architecture");
+        stubFind(versionCollection, List.of(new Document("version", "1.0.0").append("content", content)));
+
+        assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "1.0.0"), is(content));
+    }
+
+    @Test
+    void return_null_when_a_version_is_not_stored() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "9.9.9"), is(nullValue()));
+    }
+
+    // --- listVersions ---
+
+    @Test
+    void list_versions_in_semantic_order_rather_than_stored_order() {
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void return_no_versions_for_a_resource_that_has_none() {
+        stubFind(versionCollection, List.of());
+
+        // Empty means "no versions", never "no such resource" — that's headerExists' job.
+        assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), is(empty()));
+    }
+
+    // --- listSummariesPaged ---
+
+    @Test
+    void list_summaries_for_a_namespace() {
+        stubFind(headerCollection, List.of(
+                header(1, "First", "First description", 2),
+                header(2, "Second", "Second description", 0)));
+
+        List<NamespaceResourceSummary> summaries = store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED);
+
+        assertThat(summaries, contains(
+                new NamespaceResourceSummary("First", "First description", 1, 2),
+                new NamespaceResourceSummary("Second", "Second description", 2, 0)));
+    }
+
+    @Test
+    void push_the_paging_window_down_to_the_database() {
+        FindIterable<Document> iterable = stubFind(headerCollection, List.of(header(2, "Second", "d", 1)));
+
+        store.listSummariesPaged(NAMESPACE, new PageRequest(1, 1));
+
+        verify(iterable).skip(1);
+        verify(iterable).limit(1);
+    }
+
+    @Test
+    void not_apply_a_paging_window_when_unpaged() {
+        FindIterable<Document> iterable = stubFind(headerCollection, List.of(header(1, "First", "d", 1)));
+
+        store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED);
+
+        verify(iterable, never()).skip(anyInt());
+        verify(iterable, never()).limit(anyInt());
+    }
+
+    @Test
+    void fall_back_to_a_generated_name_and_blank_description_when_a_header_has_neither() {
+        // Headers migrated from the old shape can lack both, which must not produce nulls.
+        stubFind(headerCollection, List.of(header(7, null, null, null)));
+
+        assertThat(store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED),
+                contains(new NamespaceResourceSummary("Architecture 7", "", 7, 0)));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -1,0 +1,268 @@
+package org.finos.calm.store.util;
+
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteVersionDocumentStoreShould {
+
+    private static final String NAMESPACE = "finos";
+    private static final int RESOURCE_ID = 42;
+    private static final String ID_FIELD = "architectureId";
+    private static final String LABEL = "Architecture";
+    private static final String CONTENT = "{\"title\":\"My Architecture\"}";
+
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteVersionDocumentStore store;
+
+    @BeforeEach
+    void setup() {
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+        store = new NitriteVersionDocumentStore(headerCollection, versionCollection, ID_FIELD, LABEL);
+    }
+
+    /** Stubs find(...) to return a cursor over the given documents. */
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
+    }
+
+    private static Document header(Integer id, String name, String description, Integer versionCount) {
+        Document header = Document.createDocument().put(ID_FIELD, id);
+        if (name != null) header.put("name", name);
+        if (description != null) header.put("description", description);
+        if (versionCount != null) header.put("versionCount", versionCount);
+        return header;
+    }
+
+    private static Document versionDocument(String version) {
+        return Document.createDocument().put("version", version);
+    }
+
+    // --- headerExists ---
+
+    @Test
+    void report_a_resource_exists_when_its_header_is_present() {
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+
+        assertThat(store.headerExists(NAMESPACE, RESOURCE_ID), is(true));
+    }
+
+    @Test
+    void report_a_resource_does_not_exist_when_no_header_is_present() {
+        stubFind(headerCollection, List.of());
+
+        assertThat(store.headerExists(NAMESPACE, RESOURCE_ID), is(false));
+    }
+
+    // --- createHeader ---
+
+    @Test
+    void create_a_header_with_a_zero_version_count_and_empty_metadata() {
+        store.createHeader(NAMESPACE, RESOURCE_ID, "My Architecture", "A description");
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(captor.capture());
+        Document inserted = captor.getValue();
+        assertThat(inserted.get("namespace", String.class), is(NAMESPACE));
+        assertThat(inserted.get(ID_FIELD, Integer.class), is(RESOURCE_ID));
+        assertThat(inserted.get("name", String.class), is("My Architecture"));
+        assertThat(inserted.get("description", String.class), is("A description"));
+        assertThat(inserted.get("versionCount", Integer.class), is(0));
+        assertThat(inserted.get("metadata", Document.class), is(Document.createDocument()));
+    }
+
+    // --- createVersion ---
+
+    @Test
+    void create_a_version_and_increment_the_header_count() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+
+        boolean created = store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT);
+
+        assertThat(created, is(true));
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("version", String.class), is("1.0.0"));
+        assertThat(captor.getValue().get("content", String.class), is(CONTENT));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(2));
+    }
+
+    @Test
+    void report_a_version_already_exists_rather_than_overwriting_it() {
+        // Nitrite has no unique index to reject this, so the check happens here — see the
+        // class javadoc on why holding the write lock across check-then-insert is safe.
+        stubFind(versionCollection, List.of(versionDocument("1.0.0")));
+
+        boolean created = store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT);
+
+        assertThat(created, is(false));
+        verify(versionCollection, never()).insert(any(Document.class));
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    void treat_a_missing_version_count_as_zero_when_incrementing() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", null)));
+
+        store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("versionCount", Integer.class), is(1));
+    }
+
+    @Test
+    void warn_but_still_succeed_when_a_version_has_no_header_to_count_it() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of());
+
+        // The version content is already stored, so an orphaned count is not worth failing over.
+        assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT), is(true));
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- upsertVersion ---
+
+    @Test
+    void insert_and_increment_when_upserting_a_version_that_does_not_exist() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "2.0.0", CONTENT);
+
+        verify(versionCollection).insert(any(Document.class));
+        verify(headerCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    void replace_content_but_preserve_metadata_when_upserting_an_existing_version() {
+        Document existing = Document.createDocument()
+                .put("version", "1.0.0")
+                .put("content", "{\"old\":true}")
+                .put("metadata", Document.createDocument().put("status", "ARCHIVED"));
+        stubFind(versionCollection, List.of(existing));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).update(any(Filter.class), captor.capture());
+        Document written = captor.getValue();
+        assertThat(written.get("content", String.class), is(CONTENT));
+        // Overwriting wholesale would silently discard an archived marker.
+        assertThat(written.get("metadata", Document.class).get("status", String.class), is("ARCHIVED"));
+        verify(versionCollection, never()).insert(any(Document.class));
+    }
+
+    @Test
+    void not_increment_the_version_count_when_an_upsert_replaces_an_existing_version() {
+        stubFind(versionCollection, List.of(versionDocument("1.0.0")));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT);
+
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- getVersion ---
+
+    @Test
+    void return_the_content_of_a_stored_version() {
+        stubFind(versionCollection, List.of(versionDocument("1.0.0").put("content", CONTENT)));
+
+        assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "1.0.0"), is(CONTENT));
+    }
+
+    @Test
+    void return_null_when_a_version_is_not_stored() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "9.9.9"), is(nullValue()));
+    }
+
+    // --- listVersions ---
+
+    @Test
+    void list_versions_in_semantic_order_rather_than_stored_order() {
+        stubFind(versionCollection, List.of(
+                versionDocument("1.10.0"), versionDocument("1.9.0"), versionDocument("1.0.0")));
+
+        assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void return_no_versions_for_a_resource_that_has_none() {
+        stubFind(versionCollection, List.of());
+
+        // Empty means "no versions", never "no such resource" — that's headerExists' job.
+        assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), is(empty()));
+    }
+
+    // --- listSummariesPaged ---
+
+    @Test
+    void list_summaries_for_a_namespace_ordered_by_id() {
+        stubFind(headerCollection, List.of(
+                header(2, "Second", "Second description", 0),
+                header(1, "First", "First description", 2)));
+
+        assertThat(store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED), contains(
+                new NamespaceResourceSummary("First", "First description", 1, 2),
+                new NamespaceResourceSummary("Second", "Second description", 2, 0)));
+    }
+
+    @Test
+    void apply_the_paging_window_in_memory() {
+        // Nitrite has no server-side skip/limit, so the window is applied after materialising.
+        stubFind(headerCollection, List.of(
+                header(1, "First", "d", 1),
+                header(2, "Second", "d", 1),
+                header(3, "Third", "d", 1)));
+
+        assertThat(store.listSummariesPaged(NAMESPACE, new PageRequest(1, 1)),
+                contains(new NamespaceResourceSummary("Second", "d", 2, 1)));
+    }
+
+    @Test
+    void fall_back_to_a_generated_name_and_blank_description_when_a_header_has_neither() {
+        // Headers migrated from the old shape can lack both, which must not produce nulls.
+        stubFind(headerCollection, List.of(header(7, null, null, null)));
+
+        assertThat(store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED),
+                contains(new NamespaceResourceSummary("Architecture 7", "", 7, 0)));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -3,6 +3,7 @@ package org.finos.calm.store.util;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
@@ -155,6 +156,19 @@ class TestNitriteVersionDocumentStoreShould {
         // The version content is already stored, so an orphaned count is not worth failing over.
         assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT), is(true));
         verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    void still_succeed_when_the_count_update_itself_fails_after_creating_a_version() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+        when(headerCollection.update(any(Filter.class), any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
+
+        // Matches the Mongo helper: the version is stored, so a failed count write must
+        // not report failure for a write that succeeded (ADR 0003).
+        assertThat(store.createVersion(NAMESPACE, RESOURCE_ID, "1.0.0", CONTENT), is(true));
+        verify(versionCollection).insert(any(Document.class));
     }
 
     // --- upsertVersion ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestSemanticVersionOrderShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestSemanticVersionOrderShould.java
@@ -3,6 +3,7 @@ package org.finos.calm.store.util;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,8 +12,10 @@ import static org.hamcrest.Matchers.is;
 
 class TestSemanticVersionOrderShould {
 
+    // Arrays.asList rather than List.of: the latter rejects null elements, and a null
+    // version is one of the malformed inputs this comparator has to survive.
     private static List<String> sorted(String... versions) {
-        List<String> sorted = new ArrayList<>(List.of(versions));
+        List<String> sorted = new ArrayList<>(Arrays.asList(versions));
         sorted.sort(SemanticVersionOrder.ASCENDING);
         return sorted;
     }
@@ -42,6 +45,23 @@ class TestSemanticVersionOrderShould {
         // would let a big patch number overflow into the minor version's range.
         assertThat(sorted("1.1.0", "1.0.999999"),
                 contains("1.0.999999", "1.1.0"));
+    }
+
+    @Test
+    void order_dash_encoded_versions_numerically_too() {
+        // VERSION_REGEX accepts dashes from the API, so they can reach a store even though
+        // ADR 0002 has the new collections storing dots. Treating "1-10-0" as malformed
+        // would silently sort it below every real version.
+        assertThat(sorted("1-10-0", "1-9-0", "1-2-0"),
+                contains("1-2-0", "1-9-0", "1-10-0"));
+    }
+
+    @Test
+    void rank_the_two_separators_as_the_same_version() {
+        // Same version, two spellings: they must rank equally rather than one being
+        // demoted to 0.0.0. Only the string tiebreak then separates them.
+        assertThat(sorted("1.0.0", "2-0-0", "1-0-0", "2.0.0"),
+                contains("1-0-0", "1.0.0", "2-0-0", "2.0.0"));
     }
 
     @Test
@@ -80,5 +100,18 @@ class TestSemanticVersionOrderShould {
     @Test
     void treat_identical_versions_as_equal() {
         assertThat(SemanticVersionOrder.ASCENDING.compare("1.2.3", "1.2.3"), is(0));
+    }
+
+    @Test
+    void sort_a_null_version_first_rather_than_throwing() {
+        // listVersions reads the version field straight out of a stored document, so a
+        // document missing that field arrives here as null. One malformed row must not
+        // fail the whole listing.
+        assertThat(sorted("1.0.0", null), contains(null, "1.0.0"));
+    }
+
+    @Test
+    void treat_two_null_versions_as_equal() {
+        assertThat(SemanticVersionOrder.ASCENDING.compare(null, null), is(0));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestSemanticVersionOrderShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestSemanticVersionOrderShould.java
@@ -1,0 +1,84 @@
+package org.finos.calm.store.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+class TestSemanticVersionOrderShould {
+
+    private static List<String> sorted(String... versions) {
+        List<String> sorted = new ArrayList<>(List.of(versions));
+        sorted.sort(SemanticVersionOrder.ASCENDING);
+        return sorted;
+    }
+
+    @Test
+    void order_by_major_then_minor_then_patch() {
+        assertThat(sorted("2.0.0", "1.1.0", "1.0.1", "1.0.0"),
+                contains("1.0.0", "1.0.1", "1.1.0", "2.0.0"));
+    }
+
+    @Test
+    void order_numerically_rather_than_lexicographically() {
+        // The whole reason this class exists: a plain string sort puts 1.10.0 before 1.9.0.
+        assertThat(sorted("1.10.0", "1.9.0", "1.2.0"),
+                contains("1.2.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void order_double_digit_major_versions_numerically() {
+        assertThat(sorted("10.0.0", "9.0.0", "2.0.0"),
+                contains("2.0.0", "9.0.0", "10.0.0"));
+    }
+
+    @Test
+    void not_let_a_large_patch_outrank_a_higher_minor() {
+        // Guards the segment-by-segment comparison: packing segments into one integer
+        // would let a big patch number overflow into the minor version's range.
+        assertThat(sorted("1.1.0", "1.0.999999"),
+                contains("1.0.999999", "1.1.0"));
+    }
+
+    @Test
+    void sort_unparseable_versions_first_rather_than_throwing() {
+        assertThat(sorted("1.0.0", "not-a-version"),
+                contains("not-a-version", "1.0.0"));
+    }
+
+    @Test
+    void sort_versions_with_the_wrong_segment_count_first_rather_than_throwing() {
+        assertThat(sorted("1.0.0", "1.0", "1.0.0.0"),
+                contains("1.0", "1.0.0.0", "1.0.0"));
+    }
+
+    @Test
+    void sort_a_non_numeric_segment_first_rather_than_throwing() {
+        // Distinct from the wrong-segment-count case: this has exactly three segments, so
+        // it gets as far as parsing them and has to survive the parse failing.
+        assertThat(sorted("1.0.0", "1.x.0"), contains("1.x.0", "1.0.0"));
+    }
+
+    @Test
+    void ignore_earlier_segments_of_a_version_whose_later_segment_is_non_numeric() {
+        // A partially-parsed version must not rank on its valid leading segments — 9.0.x
+        // would otherwise outrank every real 1.x.y release.
+        assertThat(sorted("1.0.0", "9.0.x"), contains("9.0.x", "1.0.0"));
+    }
+
+    @Test
+    void order_equal_ranking_values_deterministically() {
+        // Two unparseable values both rank as 0.0.0 — the string tiebreak keeps the
+        // overall order total, so sorting is stable rather than arbitrary.
+        assertThat(sorted("zzz", "aaa"), contains("aaa", "zzz"));
+    }
+
+    @Test
+    void treat_identical_versions_as_equal() {
+        assertThat(SemanticVersionOrder.ASCENDING.compare("1.2.3", "1.2.3"), is(0));
+    }
+}


### PR DESCRIPTION
## Description

**This PR does not affect any existing class.** It adds three new classes and their tests, and nothing in `src/main` references them yet — every existing store still uses the current document shape, unchanged. It is deliberately mergeable on its own with zero behavioural change.

Phase 1 of the storage redesign in #2884: the shared access layer for the new document shape, where a resource becomes one *header* document per `(namespace, id)` plus one *version* document per `(namespace, id, version)` — replacing the single per-namespace document whose embedded version map grows without bound toward MongoDB's hard 16MB limit. Each resource type moves onto these helpers one at a time in later phases.

The ADRs describing this design merged in #2907 and now live in [`calm-hub/decisions/`](https://github.com/finos/architecture-as-code/tree/main/calm-hub/decisions). This branch has been rebased onto them.

It also **marks ADRs 0001–0003 as `Accepted`** now that they have merged and are no longer under discussion. `Accepted` is not `Implemented`, and none of this is built yet, so each `Status` line records how much has actually landed — nothing for 0001 and 0002, and for 0003 the helpers in this PR with no store calling them. The README's “this is not current behaviour” warning was keyed to `Proposed`, which no longer applies to any ADR here even though the warning still does, so it has been generalised.

### What's added

| Class | Notes |
|---|---|
| `MongoVersionDocumentStore` | Delegates uniqueness to the unique index, translating `DUPLICATE_KEY` into "already exists" |
| `NitriteVersionDocumentStore` | Cannot do that — CalmHub creates no Nitrite indexes, so it checks before writing while holding the write lock. Sound because Nitrite is single-process embedded. The asymmetry is deliberate and recorded in ADR 0003 |
| `SemanticVersionOrder` | Gives `listVersions` a defined order — an unsorted Mongo query has none, and a lexicographic sort puts `1.10.0` before `1.9.0`. A thin comparator over the existing `Semver` record, kept separate from `VersionKeySelector`, which must keep parsing dash-encoded map keys for the Control stores (ADR 0002) |

### Two details worth a reviewer's eye

- **`upsertVersion` sets `content` alone rather than replacing the document**, so per-version `metadata` survives an update. Replacing wholesale would silently discard the archived marker that field is reserved for (#2856).
- **It increments the header's `versionCount` only when it actually inserted.** The update path can create a version that never existed (`verifyArchitectureExists` checks the *architecture*, not the *version*), so a blind increment — or none — would drift the count. That underlying create-on-PUT behaviour is pre-existing and preserved here rather than quietly changed; it may deserve its own discussion, as it's reachable only when `allow.put.operations` is enabled, which is **off by default**.

### Review feedback addressed

Copilot raised three points on `SemanticVersionOrder`, all valid, all fixed in `fix(calm-hub): make version ordering null- and separator-tolerant`. The fix went slightly wider than the comments: the class had been re-implementing parsing that the existing `Semver` record already does, so it now delegates to `Semver.tryParse` rather than carrying a second, less tolerant parser.

- **`null` threw an NPE**, contradicting the class's own documented contract that malformed input sorts as `0.0.0` rather than failing. Reachable in practice — `listVersions` reads the version field straight off a stored document, so a document missing that field arrives as `null`.
- **Dash-encoded versions were demoted to `0.0.0`.** ADR 0002 has the new collections storing dots only, so this shouldn't arise, but `VERSION_REGEX` accepts either form from the API and a silent mis-sort is a poor way to discover otherwise.
- **Tests now cover both**, including an assertion that `1.0.0` and `1-0-0` rank equally, so a future change dropping normalization fails here too.

One related issue is **deliberately not fixed here**, and is logged for the phase that wires these helpers to callers: in the old shape `version.replace('.', '-')` on write made `1.0.0` and `1-0-0` converge on one map key. In the new shape the version is a field value, so writing it verbatim would produce *two documents for the same logical version*. That needs canonicalization on write — a comparator cannot deduplicate. It is not yet reachable, because this PR adds no callers.

### One unrelated fix, needed to keep this branch green

`fix(calm-hub): stop profile-prefixing the build-time jacoco properties` is a follow-up to #2910, not part of the storage redesign. It is here because without it this branch fails the coverage gate.

#2910 moved every test setting under `%test.` in the main `application.properties`. That is right for runtime properties but wrong for `quarkus.jacoco.data-file` and `quarkus.jacoco.reuse-data-file`, which are **build-time-fixed** and read during augmentation. Tests that declare their own profile name via `getConfigProfile()` — `secure`, `integration-test`, and the other custom profiles — augment under that name, where `%test.` does not apply. The properties then fix to `null`/`false`, Quarkus diverts coverage to `target/jacoco-quarkus.exec`, and every `@QuarkusTest`-covered class reports 0%:

```
quarkus.jacoco.data-file is set to 'target/jacoco.exec'
  but it is build time fixed to 'null'
```

That fails the jacoco check on ~40 classes while every test still passes. Whether it bites depends on test ordering, which is why `main` passes today and why adding only new test classes elsewhere was enough to trigger it — `main` is latently exposed, not broken. Verified by controlled comparison: plain `upstream/main` clean twice, this branch failing identically twice, and this branch clean before the rebase.

Unprefixed, they apply under every profile. The jacoco extension is test-scoped, so they are inert in a real deployment. The comment block above them explains why they must not be tidied back under `%test.`.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- [x] Conventional commit format (`feat(calm-hub): ...`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

50 unit tests across the three classes. Rebased onto current `main`. Unit suite green at 2435 tests and the integration suite at 498, both with JaCoCo's 90%-per-class gate passing and zero violations. All three new classes are at 100% line **and** branch coverage, including the new best-effort-count paths.


