### PR TITLE
docs: embed live CALM architecture diagram via @finos/calm-docusaurus-plugin

### DIFF
--- a/docs/docs/working-with-calm/architectures/calm-platform.calm.json
+++ b/docs/docs/working-with-calm/architectures/calm-platform.calm.json
@@ -1,0 +1,145 @@
+{
+    "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+    "nodes": [
+        {
+            "unique-id": "calm-user",
+            "node-type": "actor",
+            "name": "CALM User",
+            "description": "User working with CALM architectures through various tools and interfaces"
+        },
+        {
+            "unique-id": "calm-cli",
+            "node-type": "service",
+            "name": "CALM CLI",
+            "description": "Command-line interface for CALM operations including validation, generation, visualization, and documentation",
+            "development-language": "TypeScript"
+        },
+        {
+            "unique-id": "calm-hub",
+            "node-type": "service",
+            "name": "CALM Hub API",
+            "description": "Central registry and API service for CALM architectures, patterns, and standards built with Quarkus",
+            "development-language": "Java",
+            "interfaces": [
+                {
+                    "unique-id": "calm-hub-rest-api",
+                    "type": "api"
+                }
+            ]
+        },
+        {
+            "unique-id": "calm-hub-ui",
+            "node-type": "system",
+            "name": "CALM Hub UI",
+            "description": "React-based web interface for browsing and managing CALM architectures, patterns, and standards",
+            "development-language": "TypeScript"
+        },
+        {
+            "unique-id": "mongodb",
+            "node-type": "database",
+            "name": "MongoDB",
+            "description": "Document database for storing CALM architectures, patterns, and standards in CALM Hub",
+            "interfaces": [
+                {
+                    "unique-id": "mongodb-port",
+                    "type": "port-interface",
+                    "port": 27017
+                }
+            ]
+        },
+        {
+            "unique-id": "calm-hub-system",
+            "node-type": "system",
+            "name": "CALM Hub System",
+            "description": "Complete CALM Hub system including API backend, web UI, and database"
+        }
+    ],
+    "relationships": [
+        {
+            "unique-id": "user-interacts-with-ui",
+            "description": "CALM user interacts with CALM Hub UI through web browser",
+            "relationship-type": {
+                "interacts": {
+                    "actor": "calm-user",
+                    "nodes": [
+                        "calm-hub-ui"
+                    ]
+                }
+            }
+        },
+        {
+            "unique-id": "user-interacts-with-cli",
+            "description": "CALM user interacts with CALM CLI through command line",
+            "relationship-type": {
+                "interacts": {
+                    "actor": "calm-user",
+                    "nodes": [
+                        "calm-cli"
+                    ]
+                }
+            }
+        },
+        {
+            "unique-id": "cli-to-hub",
+            "description": "CLI interacts with CALM Hub API REST endpoint for publishing and retrieving architectures",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-cli"
+                    },
+                    "destination": {
+                        "node": "calm-hub",
+                        "interface": "calm-hub-rest-api"
+                    }
+                }
+            },
+            "protocol": "HTTPS"
+        },
+        {
+            "unique-id": "hub-to-db",
+            "description": "CALM Hub API stores and retrieves data from MongoDB",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub"
+                    },
+                    "destination": {
+                        "node": "mongodb",
+                        "interface": "mongodb-port"
+                    }
+                }
+            },
+            "protocol": "TCP"
+        },
+        {
+            "unique-id": "hub-ui-to-hub",
+            "description": "CALM Hub UI interacts with CALM Hub API via REST endpoint",
+            "relationship-type": {
+                "connects": {
+                    "source": {
+                        "node": "calm-hub-ui"
+                    },
+                    "destination": {
+                        "node": "calm-hub",
+                        "interface": "calm-hub-rest-api"
+                    }
+                }
+            },
+            "protocol": "HTTPS"
+        },
+        {
+            "unique-id": "hub-system-composition",
+            "description": "CALM Hub System is composed of API backend, web UI, and database",
+            "relationship-type": {
+                "composed-of": {
+                    "container": "calm-hub-system",
+                    "nodes": [
+                        "calm-hub",
+                        "calm-hub-ui",
+                        "mongodb"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/docs/docs/working-with-calm/architectures/calm-platform.calm.json
+++ b/docs/docs/working-with-calm/architectures/calm-platform.calm.json
@@ -89,7 +89,7 @@
                     },
                     "destination": {
                         "node": "calm-hub",
-                        "interface": "calm-hub-rest-api"
+                        "interfaces": ["calm-hub-rest-api"]
                     }
                 }
             },
@@ -105,7 +105,7 @@
                     },
                     "destination": {
                         "node": "mongodb",
-                        "interface": "mongodb-port"
+                        "interfaces": ["mongodb-port"]
                     }
                 }
             },
@@ -121,7 +121,7 @@
                     },
                     "destination": {
                         "node": "calm-hub",
-                        "interface": "calm-hub-rest-api"
+                        "interfaces": ["calm-hub-rest-api"]
                     }
                 }
             },

--- a/docs/docs/working-with-calm/visualizing-architectures.mdx
+++ b/docs/docs/working-with-calm/visualizing-architectures.mdx
@@ -1,7 +1,7 @@
 ---
 id: visualizing-architectures
 title: Visualizing Architectures in Docs
-sidebar_position: 99
+sidebar_position: 9
 ---
 
 import { CalmDiagram } from '@finos/calm-docusaurus-plugin'

--- a/docs/docs/working-with-calm/visualizing-architectures.mdx
+++ b/docs/docs/working-with-calm/visualizing-architectures.mdx
@@ -1,0 +1,37 @@
+---
+id: visualizing-architectures
+title: Visualizing Architectures in Docs
+sidebar_position: 99
+---
+
+import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
+
+# Visualizing Architectures in Docs
+
+CALM architectures can be embedded directly in Docusaurus pages — the same
+way you would embed a Mermaid diagram, but driven by your real,
+validatable architecture file instead of a hand-drawn sketch.
+
+The diagram below renders `calm-platform.calm.json`, the CALM
+self-description of the CALM platform itself. It is generated at build
+time as a static SVG (works without JavaScript, indexed by search
+engines) and upgrades in the browser to an interactive view — scroll to
+zoom, drag to pan, click nodes for details.
+
+<CalmDiagram src="./architectures/calm-platform.calm.json" />
+
+## Usage
+
+```mdx
+import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
+
+<CalmDiagram src="./architectures/my-system.calm.json" />
+```
+
+| Prop | Default | Description |
+| --- | --- | --- |
+| `src` | — | Relative path to a `.calm.json` file, or an `https://` URL (fetched client-side). |
+| `data` | — | Inline architecture object (client-rendered). |
+| `theme` | follows site theme | Force `light` or `dark`. |
+| `flow` | — | Flow `unique-id` to highlight after hydration. |
+| `interactive` | `true` | Set `false` to keep the static SVG only. |

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,6 +6,7 @@
 
 import {themes as prismThemes} from 'prism-react-renderer';
 import remarkSectionCallouts from './src/plugins/remark-section-callouts.js';
+import calmRemark from '@finos/calm-docusaurus-plugin/remark';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -66,7 +67,7 @@ const config = {
                     // Runs before Docusaurus' own heading/TOC plugins so the
                     // headings it replaces with callouts never reach the page
                     // TOC. Deliberately not applied to the 'talks' plugin.
-                    beforeDefaultRemarkPlugins: [remarkSectionCallouts],
+                    beforeDefaultRemarkPlugins: [remarkSectionCallouts, calmRemark],
                 },
                 blog: false,
                 theme: {
@@ -75,6 +76,8 @@ const config = {
             }),
         ],
     ],
+
+    plugins: ['@finos/calm-docusaurus-plugin'],
 
     themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
         "dependency-check": "dependency-check --project 'calm-docs' --scan . --out ./dependency-check-report --format ALL --suppression ../.github/node-cve-ignore-list.xml"
     },
     "dependencies": {
+        "@finos/calm-docusaurus-plugin": "*",
         "@docusaurus/core": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
         "@docusaurus/react-loadable": "6.0.0",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -65,6 +65,7 @@ const sidebars = {
         'working-with-calm/cli',
         'working-with-calm/validation-server',
         'working-with-calm/voice-mode',
+        'working-with-calm/visualizing-architectures',
       ],
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,6 +1138,7 @@
                 "@docusaurus/core": "3.10.1",
                 "@docusaurus/preset-classic": "3.10.1",
                 "@docusaurus/react-loadable": "6.0.0",
+                "@finos/calm-docusaurus-plugin": "*",
                 "@mdx-js/react": "^3.1.0",
                 "clsx": "^2.1.1",
                 "prism-react-renderer": "^2.4.1",


### PR DESCRIPTION
## Description

The docs site now dogfoods **`@finos/calm-docusaurus-plugin`** (merged in #2854): a new **Visualizing Architectures in Docs** page under *Working with CALM* embeds `calm-platform.calm.json` — the CALM platform's own self-description — as a live diagram:

```mdx
import { CalmDiagram } from '@finos/calm-docusaurus-plugin'

<CalmDiagram src="./architectures/calm-platform.calm.json" />
```

The diagram is pre-rendered to static SVG at build time (light + dark, follows the site theme, works without JavaScript, SEO-indexable) and upgrades in the browser to the interactive web component (zoom, pan, click-for-details). The page also documents the props and the fail-the-build error contract for broken `.calm.json` files.

Wiring: plugin entry in `docusaurus.config.js`, its remark transform registered **alongside** the redesign's `remarkSectionCallouts` (callouts first, per its ordering comment), one sidebar entry, and the docs workspace dependency.

Notes for reviewers:
- `package-lock.json`: +1 line for the docs dependency; the other hunks remove stale `"extraneous": true` ghost entries that `main`'s lockfile carried (benign npm cleanup).
- Full docs build verified green on the redesigned site with the SVG baked into the emitted HTML.

Closes #2853.

## Type of Change

- [x] 📚 Documentation update

## Affected Components

- [x] Docs (`docs/`)

## Testing

- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Evidence: `npm run build --workspace docs` succeeds on current `main`; built HTML for the new page contains both theme variants of the pre-rendered SVG; plugin + renderer suites green upstream (#2854).

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable) — docs-only change; E2E proof is the site build
- [x] My changes follow the project's coding standards
