### PR TITLE
fix(calm-hub): repoint workshop decorator and ADR links at architecture 2

### DIFF
--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -6288,7 +6288,7 @@ if (db.adrs.countDocuments() === 0) {
                                 rationale: 'A dedicated load balancer provides health checking and automatic failover which are critical for ensuring availability during peak conference registration periods.',
                             },
                             links: [
-                                { rel: 'Conference Signup Architecture', href: '/calm/namespaces/workshop/architectures/1/versions/1-0-0' },
+                                { rel: 'Conference Signup Architecture', href: '/calm/namespaces/workshop/architectures/2/versions/1-0-0' },
                             ],
                         },
                     },
@@ -6416,7 +6416,7 @@ if (db.decorators.countDocuments() === 0) {
                         "unique-id": "workshop-conference-deployment",
                         "type": "deployment",
                         "target": [
-                            "/calm/namespaces/workshop/architectures/1/versions/1-0-0"
+                            "/calm/namespaces/workshop/architectures/2/versions/1-0-0"
                         ],
                         "target-type": [
                             "architecture"
@@ -6441,7 +6441,7 @@ if (db.decorators.countDocuments() === 0) {
                         "unique-id": "workshop-conference-monitoring",
                         "type": "observability",
                         "target": [
-                            "/calm/namespaces/workshop/architectures/1/versions/1-0-0"
+                            "/calm/namespaces/workshop/architectures/2/versions/1-0-0"
                         ],
                         "target-type": [
                             "architecture"


### PR DESCRIPTION
## Description

Follow-up to #2914 (refs #2913). That PR renumbered the seeded `architectureId`s to be globally unique — correctly, and it updated `resource_mappings` to match — but three references to the workshop Conference Signup Architecture were left pointing at its old id of `1`. It is now `2`.

The stale references in `calm-hub/mongo/init-mongo.js`:

| Location | Field |
|---|---|
| Workshop ADR | `links[].href` — *"Conference Signup Architecture"* |
| Workshop deployment decorator | `target[]` |
| Workshop observability decorator | `target[]` |

Architecture lookups are namespace-scoped, so these do not silently resolve to something else — `id 1` belongs to the `finos` namespace, and `workshop` has no architecture `1`, so the seeded links and decorator targets point at nothing.

Three characters changed, `1` → `2`, in the seed data only.

### Scope check

- **Nitrite seed is unaffected** — `init-nitrite.sh` builds the equivalent paths from a computed `$id` variable rather than a literal, so it was always correct.
- **No test or smoke assertion is pinned to the old value.** A repo-wide sweep for `workshop/architectures/N` turns up only: decorator store/tool unit tests, which build their own in-test fixtures and never read the seed; one illustrative `@ToolArg` description string in `DecoratorTools`; and an unrelated conferences fixture. `smoke-test.sh` asserts on namespaces and names, not ids.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- [x] Conventional commit format (`fix(calm-hub): ...`)

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified by inspection of the seed data against the post-#2914 `architectureId` assignments (`finos`=1, `workshop`=2, `finos.traderx`=3, `ai-governance-v2`=4, `qcon`=5, `finos.fluxnova`=6–11) and the `resource_mappings` entries, which already use `2` for `conference-signup-architecture`. No unit tests added: this is seed data with no assertions covering these links.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
