### PR TITLE
docs(calm-hub): point test-config comments at the %test. block

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -593,6 +593,15 @@ trail in this iteration — read it via direct DB access or ops tooling.
 - `src/main/resources/application-no-auth.properties` - No-auth profile (local testing only, no IdP)
 - `src/main/resources/application-secure.properties` - Secure (OIDC/Keycloak) profile config
 - `src/main/resources/application-proxy-auth.properties` - Proxy-auth profile config (proxy-injected `Remote-User` header)
+
+**Do not add a second `application.properties` under `src/test/resources`.** One
+used to exist and, depending on the machine, either it or the main file won
+wholesale rather than merging per-property — so tests silently lost either the
+audit-disable settings (writing to whatever MongoDB the developer had running) or
+the auth and security-header settings (7 failures that passed in isolation). All
+test-only configuration lives in the `%test.` block of
+`src/main/resources/application.properties`; add new test settings there.
+
 - `PERMISSIONS.md` - Per-namespace permission model reference
 - `decisions/` - Architecture Decision Records for calm-hub's own backend
   design (not the CALM ADR resource type). See `decisions/README.md` for

--- a/calm-hub/src/integration-test/java/integration/IntegrationTestProfile.java
+++ b/calm-hub/src/integration-test/java/integration/IntegrationTestProfile.java
@@ -26,10 +26,11 @@ public class IntegrationTestProfile implements QuarkusTestProfile {
         // Enable the PUT/upsert paths so the MCP updateArchitecture tool and the
         // equivalent REST PUT endpoint can be exercised by the integration suite.
         //
-        // calm.audit.* re-enables audit logging, which src/test/resources/application.properties
-        // disables for the general unit-test suite (to avoid every mutating-endpoint
-        // resource test depending on live Mongo). Integration tests run against a real,
-        // controlled Mongo container and deliberately need this on — see
+        // calm.audit.* re-enables audit logging, which the %test. block in
+        // src/main/resources/application.properties disables for the general unit-test
+        // suite (to avoid every mutating-endpoint resource test depending on live Mongo).
+        // Integration tests run against a real, controlled Mongo container and
+        // deliberately need this on — see
         // MongoAuditLogIntegration/MongoAuditLogDeniedIntegration.
         return Map.of(
                 "allow.put.operations", "true",

--- a/calm-hub/src/integration-test/java/integration/IntegrationTestSecureProfile.java
+++ b/calm-hub/src/integration-test/java/integration/IntegrationTestSecureProfile.java
@@ -28,9 +28,10 @@ public class IntegrationTestSecureProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         // override the following secure profile's properties to start the application container with http
         //
-        // calm.audit.* re-enables audit logging, which src/test/resources/application.properties
-        // disables for the general unit-test suite — see IntegrationTestProfile for why, and
-        // MongoAuditLogDeniedIntegration for the test that needs this on here.
+        // calm.audit.* re-enables audit logging, which the %test. block in
+        // src/main/resources/application.properties disables for the general unit-test
+        // suite — see IntegrationTestProfile for why, and MongoAuditLogDeniedIntegration
+        // for the test that needs this on here.
         return Map.of(
                 "quarkus.profile", "secure",
                 "quarkus.http.ssl-port", "0",


### PR DESCRIPTION
## Description

Follow-up to #2910, taking up @rocketstack-matt's non-blocking nit on that PR:

> `IntegrationTestProfile.java:29` and `IntegrationTestSecureProfile.java:31` both have comments referencing `src/test/resources/application.properties`, which this PR deletes. Worth a follow-up to point them at the `%test.` block in `src/main/resources/application.properties` instead.

Both profiles override `calm.audit.*` back to `true`, and each explains why by referring to the file that turns audit *off* for the unit-test suite. #2910 deleted that file, so the explanation pointed at nothing. Now repointed at the `%test.` block that actually holds those settings. Comments only — no behaviour change, and the integration-test sources still compile under `-P integration`.

I swept the rest of the repo for other references rather than fixing only the two named. The only other mention is the line in `src/main/resources/application.properties` that says the test settings live there *"rather than in `src/test/resources/application.properties`"* — that one describes a path deliberately not taken, so it stays. `calm-hub/AGENTS.md` and `docs/docs/calm-hub/developer-guide.md` both list the config files and neither had ever mentioned the deleted one, so no change was needed there.

### One addition beyond the nit

A note in `calm-hub/AGENTS.md` not to reintroduce a second `application.properties` under `src/test/resources`. Nothing in the build prevents someone adding one back, and the resulting failure is unpleasant to diagnose: the two files don't merge per-property — one wins wholesale, and which one depends on the machine. So it presents as flaky tests that pass in isolation, and the symptom differs by direction (either audit writes escape into whatever MongoDB the developer has running, or auth and the security-header filter go missing and 7 tests fail). Happy to drop this hunk if you'd rather keep the PR to the comment fix.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- [x] Conventional commit format (`docs(calm-hub): ...`)

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Comments and markdown only. Verified `../mvnw -P integration test-compile` succeeds, since the two edited files live in `src/integration-test/java` and are not compiled by a normal build.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
