### PR TITLE
fix: resolve open CodeQL code scanning alerts (75-79)

### DIFF
--- a/.github/workflows/release-parent.yml
+++ b/.github/workflows/release-parent.yml
@@ -1,5 +1,8 @@
 name: "Release Parent POM to Maven Central"
 
+permissions:
+    contents: read
+
 on:
     workflow_dispatch:
 

--- a/calm-studio/packages/docusaurus-plugin/src/prerender.ts
+++ b/calm-studio/packages/docusaurus-plugin/src/prerender.ts
@@ -9,9 +9,21 @@ export interface CalmSvgBundle {
   size: { width: number; height: number };
 }
 
-const SVG_SIZE_RE = /<svg[^>]*\bwidth="(\d+(?:\.\d+)?)"[^>]*\bheight="(\d+(?:\.\d+)?)"/;
+const SVG_WIDTH_RE = /\bwidth="(\d+(?:\.\d+)?)"/;
+const SVG_HEIGHT_RE = /\bheight="(\d+(?:\.\d+)?)"/;
 
 const FALLBACK_SIZE = { width: 800, height: 480 };
+
+/** Read width/height from the SVG root's open tag, or null if either is absent. */
+function extractSvgSize(svg: string): { width: number; height: number } | null {
+  const open = svg.indexOf('<svg');
+  if (open === -1) return null;
+  const close = svg.indexOf('>', open);
+  const tag = svg.slice(open, close === -1 ? undefined : close);
+  const width = SVG_WIDTH_RE.exec(tag);
+  const height = SVG_HEIGHT_RE.exec(tag);
+  return width && height ? { width: Number(width[1]), height: Number(height[1]) } : null;
+}
 
 /**
  * Render a CALM architecture to light + dark SVG strings at build time,
@@ -22,9 +34,6 @@ export async function prerenderCalmSvg(architecture: unknown): Promise<CalmSvgBu
     renderELKDiagram(architecture, { theme: 'light' }),
     renderELKDiagram(architecture, { theme: 'dark' }),
   ]);
-  const match = SVG_SIZE_RE.exec(light);
-  const size = match
-    ? { width: Number(match[1]), height: Number(match[2]) }
-    : FALLBACK_SIZE;
+  const size = extractSvgSize(light) ?? FALLBACK_SIZE;
   return { svg: { light, dark }, size };
 }

--- a/calm-studio/packages/web-component/src/render/containment.test.ts
+++ b/calm-studio/packages/web-component/src/render/containment.test.ts
@@ -23,6 +23,15 @@ function connects(uid: string, source: string, destination: string): CalmRelatio
 
 const KNOWN = new Set(['sys', 'svc-a', 'svc-b', 'cluster', 'db']);
 
+/** data-bounds value from the open tag carrying data-container-id="<id>", or null. */
+function containerBounds(svg: string, id: string): string | null {
+  const at = svg.indexOf(`data-container-id="${id}"`);
+  if (at === -1) return null;
+  const end = svg.indexOf('>', at);
+  const m = /data-bounds="([\d.,-]+)"/.exec(svg.slice(at, end === -1 ? undefined : end));
+  return m?.[1] ?? null;
+}
+
 describe('isNestedContainment', () => {
   it('true for nested composed-of and deployed-in', () => {
     expect(isNestedContainment(composedOf('r', 'sys', ['svc-a']))).toBe(true);
@@ -174,10 +183,9 @@ describe('renderELKDiagram nested containers (integration)', () => {
 
   it('positions member nodes inside the container bounds', async () => {
     const svg = await renderELKDiagram(nestedArch, { theme: 'light' });
-    const container = /data-container-id="sys"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
-    expect(container).not.toBeNull();
-    const boundsRaw = (container as RegExpExecArray)[1] as string;
-    const [cx, cy, cw, ch] = boundsRaw.split(',').map(Number) as [number, number, number, number];
+    const boundsRaw = containerBounds(svg, 'sys');
+    expect(boundsRaw).not.toBeNull();
+    const [cx, cy, cw, ch] = (boundsRaw as string).split(',').map(Number) as [number, number, number, number];
     // Each member node's x/y (from its <rect>) must fall inside the container bounds.
     for (const member of ['svc-a', 'svc-b']) {
       const m = new RegExp(`data-node-id="${member}"[\\s\\S]{0,200}?<rect x="([\\d.]+)" y="([\\d.]+)"`).exec(svg);
@@ -263,12 +271,12 @@ describe('renderELKDiagram nested containers (integration)', () => {
       ],
     };
     const svg = await renderELKDiagram(arch, { theme: 'light', direction: 'RIGHT' });
-    const outer = /data-container-id="cluster"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
-    const inner = /data-container-id="sys"[^>]*data-bounds="([\d.,-]+)"/.exec(svg);
+    const outer = containerBounds(svg, 'cluster');
+    const inner = containerBounds(svg, 'sys');
     expect(outer).not.toBeNull();
     expect(inner).not.toBeNull();
-    const [ox, oy, ow, oh] = (outer as RegExpExecArray)[1]!.split(',').map(Number) as [number, number, number, number];
-    const [ix, iy, iw, ih] = (inner as RegExpExecArray)[1]!.split(',').map(Number) as [number, number, number, number];
+    const [ox, oy, ow, oh] = (outer as string).split(',').map(Number) as [number, number, number, number];
+    const [ix, iy, iw, ih] = (inner as string).split(',').map(Number) as [number, number, number, number];
     expect(ix).toBeGreaterThanOrEqual(ox);
     expect(iy).toBeGreaterThanOrEqual(oy);
     expect(ix + iw).toBeLessThanOrEqual(ox + ow);


### PR DESCRIPTION
## Description

Resolves all five open CodeQL code scanning alerts on `main`:

| Alert | Rule | File | Fix |
|---|---|---|---|
| [#75](https://github.com/finos/architecture-as-code/security/code-scanning/75) | `actions/missing-workflow-permissions` (medium) | `.github/workflows/release-parent.yml` | Add top-level `permissions: contents: read` — the workflow only checks out and deploys via Sonatype/GPG secrets, never writes with `GITHUB_TOKEN`. It was the only workflow in the repo without a permissions block. |
| [#76](https://github.com/finos/architecture-as-code/security/code-scanning/76) | `js/polynomial-redos` (high) | `calm-studio/packages/docusaurus-plugin/src/prerender.ts` | Replace the ambiguous `<svg[^>]*width=...[^>]*height=...` regex with an `extractSvgSize` helper: indexOf-bounded slice of the `<svg>` open tag + two unambiguous attribute regexes. |
| [#77](https://github.com/finos/architecture-as-code/security/code-scanning/77) | `js/polynomial-redos` (high) | `calm-studio/packages/web-component/src/render/containment.test.ts` | Replace the three `data-container-id="…"[^>]*data-bounds="…"` regexes with a shared `containerBounds` helper using the same indexOf-bounded pattern. |
| [#78](https://github.com/finos/architecture-as-code/security/code-scanning/78) | `js/polynomial-redos` (high) | same file | same helper |
| [#79](https://github.com/finos/architecture-as-code/security/code-scanning/79) | `js/polynomial-redos` (high) | same file | same helper |

In each flagged regex a `[^>]*` run preceded a literal it could also consume, giving polynomial backtracking. The replacements keep the same semantics (both attributes must sit inside the same element open tag, with the existing fallback/null behavior on no match) and eliminate the flagged expressions entirely rather than guarding them.

**Local CodeQL verification:** reproduced all five findings pre-fix and confirmed zero results at the flagged locations post-fix, with no new findings in the touched files, using CodeQL CLI 2.26.2 (the version CI runs) against `codeql/javascript-queries` `Performance/PolynomialReDoS.ql` and `codeql/actions-queries` `Security/CWE-275/MissingActionsPermissions.ql`.

No dismissals: all five alerts were fixed, none dismissed. The three test-file alerts were fixed rather than dismissed as "used in tests" since the fix is trivial and removes a pattern that could be copied into production code.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CI/CD
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies

Also affects `calm-suite/calm-studio` (docusaurus-plugin + web-component packages — no checkbox exists for it).

## Commit Message Format ✅

- `ci: add least-privilege permissions to release-parent workflow`
- `fix(calm-suite): eliminate polynomial-ReDoS regexes flagged by CodeQL`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Ran in an isolated worktree: `@finos/calm-docusaurus-plugin` lint + typecheck + tests (22 passed, covering the rewritten size extraction via `prerender.test.ts`) and `@calmstudio/diagram` tests (53 passed, including the rewritten containment assertions). No new tests added — existing coverage already exercises both rewritten paths.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
