### PR TITLE
docs: live CALM diagrams in learn tutorials (2-page demo)

### DIFF
--- a/docs/docs/tutorials/beginner/07-complete-architecture.md
+++ b/docs/docs/tutorials/beginner/07-complete-architecture.md
@@ -4,6 +4,9 @@ title: "Build a Complete Architecture"
 sidebar_position: 7
 ---
 
+import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
+
+
 # Build a Complete E-Commerce Microservice Architecture
 
 🟢 **Difficulty:** Beginner | ⏱️ **Time:** 45-60 minutes
@@ -549,6 +552,14 @@ calm validate -a architectures/ecommerce-platform.json
 ```
 You should see no errors and no warnings.
 :::
+
+## See What You Built
+
+This is the architecture you have been building through this tutorial, rendered live from the same kind of `.calm.json` file you just wrote. It is generated at build time from [`ecommerce-platform.calm.json`](./architectures/ecommerce-platform.calm.json) — zoom, pan, and click nodes for details. Notice the platform boundary drawn as a box: that is the `composed-of` relationship, rendered as real containment.
+
+<CalmDiagram src="./architectures/ecommerce-platform.calm.json" />
+
+If your file validates, it will render exactly like this. A broken file fails the site build — architecture diagrams in docs can never silently drift from the model.
 
 ## Resources
 

--- a/docs/docs/tutorials/beginner/architectures/ecommerce-platform.calm.json
+++ b/docs/docs/tutorials/beginner/architectures/ecommerce-platform.calm.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+  "metadata": {
+    "owner": "platform-team@example.com",
+    "version": "1.0.0",
+    "created": "2026-01-09",
+    "description": "E-commerce order processing platform",
+    "tags": [
+      "ecommerce",
+      "microservices",
+      "orders"
+    ],
+    "status": "production"
+  },
+  "nodes": [
+    {
+      "unique-id": "customer",
+      "node-type": "actor",
+      "name": "Customer",
+      "description": "End user who browses products and places orders"
+    },
+    {
+      "unique-id": "admin",
+      "node-type": "actor",
+      "name": "Admin",
+      "description": "Administrator who manages inventory and monitors orders"
+    },
+    {
+      "unique-id": "api-gateway",
+      "node-type": "service",
+      "name": "API Gateway",
+      "description": "Public entry point for all client requests, handles routing and authentication",
+      "interfaces": [
+        {
+          "unique-id": "gateway-https",
+          "protocol": "HTTPS",
+          "host": "api.ecommerce.example.com",
+          "port": 443
+        }
+      ],
+      "metadata": {
+        "tech-owner": "platform-team@example.com",
+        "repository": "https://github.com/example/api-gateway",
+        "deployment-type": "kubernetes",
+        "sla-tier": "tier-1"
+      }
+    },
+    {
+      "unique-id": "order-service",
+      "node-type": "service",
+      "name": "Order Service",
+      "description": "Manages order lifecycle from creation to fulfillment",
+      "interfaces": [
+        {
+          "unique-id": "order-api",
+          "protocol": "HTTPS",
+          "port": 8080
+        }
+      ],
+      "metadata": {
+        "tech-owner": "orders-team@example.com",
+        "repository": "https://github.com/example/order-service",
+        "deployment-type": "kubernetes"
+      }
+    },
+    {
+      "unique-id": "inventory-service",
+      "node-type": "service",
+      "name": "Inventory Service",
+      "description": "Tracks product stock levels and availability",
+      "interfaces": [
+        {
+          "unique-id": "inventory-api",
+          "protocol": "HTTPS",
+          "port": 8081
+        }
+      ],
+      "metadata": {
+        "tech-owner": "inventory-team@example.com",
+        "repository": "https://github.com/example/inventory-service",
+        "deployment-type": "kubernetes"
+      }
+    },
+    {
+      "unique-id": "payment-service",
+      "node-type": "service",
+      "name": "Payment Service",
+      "description": "Processes payment transactions securely",
+      "interfaces": [
+        {
+          "unique-id": "payment-api",
+          "protocol": "HTTPS",
+          "port": 8082
+        }
+      ],
+      "metadata": {
+        "tech-owner": "payments-team@example.com",
+        "repository": "https://github.com/example/payment-service",
+        "deployment-type": "kubernetes",
+        "pci-compliant": true
+      }
+    },
+    {
+      "unique-id": "order-database",
+      "node-type": "database",
+      "name": "Order Database",
+      "description": "PostgreSQL database storing order records and history",
+      "interfaces": [
+        {
+          "unique-id": "order-db-jdbc",
+          "protocol": "JDBC",
+          "port": 5432
+        }
+      ],
+      "metadata": {
+        "database-type": "PostgreSQL",
+        "version": "15",
+        "backup-frequency": "daily"
+      }
+    },
+    {
+      "unique-id": "inventory-database",
+      "node-type": "database",
+      "name": "Inventory Database",
+      "description": "PostgreSQL database storing product inventory levels",
+      "interfaces": [
+        {
+          "unique-id": "inventory-db-jdbc",
+          "protocol": "JDBC",
+          "port": 5433
+        }
+      ],
+      "metadata": {
+        "database-type": "PostgreSQL",
+        "version": "15",
+        "backup-frequency": "daily"
+      }
+    },
+    {
+      "unique-id": "ecommerce-platform",
+      "node-type": "system",
+      "name": "E-Commerce Platform",
+      "description": "Complete e-commerce order processing system"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "customer-to-gateway",
+      "description": "Customer accesses the platform through the API Gateway",
+      "relationship-type": {
+        "interacts": {
+          "actor": "customer",
+          "nodes": [
+            "api-gateway"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "admin-to-gateway",
+      "description": "Admin accesses the platform through the API Gateway",
+      "relationship-type": {
+        "interacts": {
+          "actor": "admin",
+          "nodes": [
+            "api-gateway"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "gateway-to-orders",
+      "description": "API Gateway routes order requests to Order Service",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "api-gateway",
+            "interfaces": [
+              "gateway-https"
+            ]
+          },
+          "destination": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "100ms",
+        "protocol": "REST"
+      }
+    },
+    {
+      "unique-id": "gateway-to-inventory",
+      "description": "API Gateway routes inventory requests to Inventory Service",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "api-gateway",
+            "interfaces": [
+              "gateway-https"
+            ]
+          },
+          "destination": {
+            "node": "inventory-service",
+            "interfaces": [
+              "inventory-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "100ms",
+        "protocol": "REST"
+      }
+    },
+    {
+      "unique-id": "orders-to-database",
+      "description": "Order Service persists order data to the database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          },
+          "destination": {
+            "node": "order-database",
+            "interfaces": [
+              "order-db-jdbc"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "connection-pool-size": 20
+      }
+    },
+    {
+      "unique-id": "orders-to-payment",
+      "description": "Order Service calls Payment Service to process payments",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          },
+          "destination": {
+            "node": "payment-service",
+            "interfaces": [
+              "payment-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "500ms",
+        "retry-policy": "exponential-backoff"
+      }
+    },
+    {
+      "unique-id": "inventory-to-database",
+      "description": "Inventory Service persists stock data to the database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "inventory-service",
+            "interfaces": [
+              "inventory-api"
+            ]
+          },
+          "destination": {
+            "node": "inventory-database",
+            "interfaces": [
+              "inventory-db-jdbc"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "connection-pool-size": 20
+      }
+    },
+    {
+      "unique-id": "platform-composition",
+      "description": "E-Commerce Platform contains all services and databases",
+      "relationship-type": {
+        "composed-of": {
+          "container": "ecommerce-platform",
+          "nodes": [
+            "api-gateway",
+            "order-service",
+            "inventory-service",
+            "payment-service",
+            "order-database",
+            "inventory-database"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/docs/tutorials/intermediate/09-business-flows.md
+++ b/docs/docs/tutorials/intermediate/09-business-flows.md
@@ -4,6 +4,9 @@ title: "Model Business Flows"
 sidebar_position: 3
 ---
 
+import { CalmDiagram } from '@finos/calm-docusaurus-plugin'
+
+
 # Model Business Flows
 
 🟡 **Difficulty:** Intermediate | ⏱️ **Time:** 30-45 minutes
@@ -162,6 +165,14 @@ The same relationship can appear multiple times in a flow with different directi
 - Impact analysis ("which services are in my order flow?")
 - Generating sequence diagrams for documentation
 - Attaching compliance controls to a specific process
+
+## See the Flow Live
+
+Here is the order-processing flow you just modelled, animated over the e-commerce architecture. The moving dots trace each transition in sequence — including the reverse `destination-to-source` transition for the payment confirmation. Nodes and connections outside the flow are dimmed.
+
+<CalmDiagram src="./architectures/ecommerce-platform-with-flow.calm.json" flow="order-processing-flow" />
+
+The diagram is rendered from [`ecommerce-platform-with-flow.calm.json`](./architectures/ecommerce-platform-with-flow.calm.json), the same architecture from the beginner track with the `flows` array added exactly as described above.
 
 ## Resources
 

--- a/docs/docs/tutorials/intermediate/09-business-flows.md
+++ b/docs/docs/tutorials/intermediate/09-business-flows.md
@@ -166,13 +166,17 @@ The same relationship can appear multiple times in a flow with different directi
 - Generating sequence diagrams for documentation
 - Attaching compliance controls to a specific process
 
-## See the Flow Live
+## See the Flows Live
 
-Here is the order-processing flow you just modelled, animated over the e-commerce architecture. The moving dots trace each transition in sequence — including the reverse `destination-to-source` transition for the payment confirmation. Nodes and connections outside the flow are dimmed.
+Here is the order-processing flow you modelled in step 2, animated over the e-commerce architecture — three transitions, in sequence, with everything outside the flow dimmed:
 
 <CalmDiagram src="./architectures/ecommerce-platform-with-flow.calm.json" flow="order-processing-flow" />
 
-The diagram is rendered from [`ecommerce-platform-with-flow.calm.json`](./architectures/ecommerce-platform-with-flow.calm.json), the same architecture from the beginner track with the `flows` array added exactly as described above.
+And here is the inventory stock check from step 4 — watch the dots on the inventory-service connections travel **both ways**: steps 4 and 5 reuse the same relationships with `destination-to-source`, exactly the request-response pattern this tutorial teaches:
+
+<CalmDiagram src="./architectures/ecommerce-platform-with-flow.calm.json" flow="inventory-check-flow" />
+
+Both diagrams render from [`ecommerce-platform-with-flow.calm.json`](./architectures/ecommerce-platform-with-flow.calm.json), the beginner-track architecture with the two flows added exactly as described above.
 
 ## Resources
 

--- a/docs/docs/tutorials/intermediate/architectures/ecommerce-platform-with-flow.calm.json
+++ b/docs/docs/tutorials/intermediate/architectures/ecommerce-platform-with-flow.calm.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
+  "metadata": {
+    "owner": "platform-team@example.com",
+    "version": "1.0.0",
+    "created": "2026-01-09",
+    "description": "E-commerce order processing platform",
+    "tags": [
+      "ecommerce",
+      "microservices",
+      "orders"
+    ],
+    "status": "production"
+  },
+  "nodes": [
+    {
+      "unique-id": "customer",
+      "node-type": "actor",
+      "name": "Customer",
+      "description": "End user who browses products and places orders"
+    },
+    {
+      "unique-id": "admin",
+      "node-type": "actor",
+      "name": "Admin",
+      "description": "Administrator who manages inventory and monitors orders"
+    },
+    {
+      "unique-id": "api-gateway",
+      "node-type": "service",
+      "name": "API Gateway",
+      "description": "Public entry point for all client requests, handles routing and authentication",
+      "interfaces": [
+        {
+          "unique-id": "gateway-https",
+          "protocol": "HTTPS",
+          "host": "api.ecommerce.example.com",
+          "port": 443
+        }
+      ],
+      "metadata": {
+        "tech-owner": "platform-team@example.com",
+        "repository": "https://github.com/example/api-gateway",
+        "deployment-type": "kubernetes",
+        "sla-tier": "tier-1"
+      }
+    },
+    {
+      "unique-id": "order-service",
+      "node-type": "service",
+      "name": "Order Service",
+      "description": "Manages order lifecycle from creation to fulfillment",
+      "interfaces": [
+        {
+          "unique-id": "order-api",
+          "protocol": "HTTPS",
+          "port": 8080
+        }
+      ],
+      "metadata": {
+        "tech-owner": "orders-team@example.com",
+        "repository": "https://github.com/example/order-service",
+        "deployment-type": "kubernetes"
+      }
+    },
+    {
+      "unique-id": "inventory-service",
+      "node-type": "service",
+      "name": "Inventory Service",
+      "description": "Tracks product stock levels and availability",
+      "interfaces": [
+        {
+          "unique-id": "inventory-api",
+          "protocol": "HTTPS",
+          "port": 8081
+        }
+      ],
+      "metadata": {
+        "tech-owner": "inventory-team@example.com",
+        "repository": "https://github.com/example/inventory-service",
+        "deployment-type": "kubernetes"
+      }
+    },
+    {
+      "unique-id": "payment-service",
+      "node-type": "service",
+      "name": "Payment Service",
+      "description": "Processes payment transactions securely",
+      "interfaces": [
+        {
+          "unique-id": "payment-api",
+          "protocol": "HTTPS",
+          "port": 8082
+        }
+      ],
+      "metadata": {
+        "tech-owner": "payments-team@example.com",
+        "repository": "https://github.com/example/payment-service",
+        "deployment-type": "kubernetes",
+        "pci-compliant": true
+      }
+    },
+    {
+      "unique-id": "order-database",
+      "node-type": "database",
+      "name": "Order Database",
+      "description": "PostgreSQL database storing order records and history",
+      "interfaces": [
+        {
+          "unique-id": "order-db-jdbc",
+          "protocol": "JDBC",
+          "port": 5432
+        }
+      ],
+      "metadata": {
+        "database-type": "PostgreSQL",
+        "version": "15",
+        "backup-frequency": "daily"
+      }
+    },
+    {
+      "unique-id": "inventory-database",
+      "node-type": "database",
+      "name": "Inventory Database",
+      "description": "PostgreSQL database storing product inventory levels",
+      "interfaces": [
+        {
+          "unique-id": "inventory-db-jdbc",
+          "protocol": "JDBC",
+          "port": 5433
+        }
+      ],
+      "metadata": {
+        "database-type": "PostgreSQL",
+        "version": "15",
+        "backup-frequency": "daily"
+      }
+    },
+    {
+      "unique-id": "ecommerce-platform",
+      "node-type": "system",
+      "name": "E-Commerce Platform",
+      "description": "Complete e-commerce order processing system"
+    }
+  ],
+  "relationships": [
+    {
+      "unique-id": "customer-to-gateway",
+      "description": "Customer accesses the platform through the API Gateway",
+      "relationship-type": {
+        "interacts": {
+          "actor": "customer",
+          "nodes": [
+            "api-gateway"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "admin-to-gateway",
+      "description": "Admin accesses the platform through the API Gateway",
+      "relationship-type": {
+        "interacts": {
+          "actor": "admin",
+          "nodes": [
+            "api-gateway"
+          ]
+        }
+      }
+    },
+    {
+      "unique-id": "gateway-to-orders",
+      "description": "API Gateway routes order requests to Order Service",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "api-gateway",
+            "interfaces": [
+              "gateway-https"
+            ]
+          },
+          "destination": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "100ms",
+        "protocol": "REST"
+      }
+    },
+    {
+      "unique-id": "gateway-to-inventory",
+      "description": "API Gateway routes inventory requests to Inventory Service",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "api-gateway",
+            "interfaces": [
+              "gateway-https"
+            ]
+          },
+          "destination": {
+            "node": "inventory-service",
+            "interfaces": [
+              "inventory-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "100ms",
+        "protocol": "REST"
+      }
+    },
+    {
+      "unique-id": "orders-to-database",
+      "description": "Order Service persists order data to the database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          },
+          "destination": {
+            "node": "order-database",
+            "interfaces": [
+              "order-db-jdbc"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "connection-pool-size": 20
+      }
+    },
+    {
+      "unique-id": "orders-to-payment",
+      "description": "Order Service calls Payment Service to process payments",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "order-service",
+            "interfaces": [
+              "order-api"
+            ]
+          },
+          "destination": {
+            "node": "payment-service",
+            "interfaces": [
+              "payment-api"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "latency-sla": "500ms",
+        "retry-policy": "exponential-backoff"
+      }
+    },
+    {
+      "unique-id": "inventory-to-database",
+      "description": "Inventory Service persists stock data to the database",
+      "relationship-type": {
+        "connects": {
+          "source": {
+            "node": "inventory-service",
+            "interfaces": [
+              "inventory-api"
+            ]
+          },
+          "destination": {
+            "node": "inventory-database",
+            "interfaces": [
+              "inventory-db-jdbc"
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "connection-pool-size": 20
+      }
+    },
+    {
+      "unique-id": "platform-composition",
+      "description": "E-Commerce Platform contains all services and databases",
+      "relationship-type": {
+        "composed-of": {
+          "container": "ecommerce-platform",
+          "nodes": [
+            "api-gateway",
+            "order-service",
+            "inventory-service",
+            "payment-service",
+            "order-database",
+            "inventory-database"
+          ]
+        }
+      }
+    }
+  ],
+  "flows": [
+    {
+      "unique-id": "order-processing-flow",
+      "name": "Customer Order Processing",
+      "description": "End-to-end flow from customer placing an order to payment confirmation",
+      "transitions": [
+        {
+          "relationship-unique-id": "customer-to-gateway",
+          "sequence-number": 1,
+          "description": "Customer submits order via web interface",
+          "summary": "Customer submits order via web interface",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "gateway-to-orders",
+          "sequence-number": 2,
+          "description": "Gateway routes the order to the order service",
+          "summary": "Gateway routes the order to the order service",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "orders-to-payment",
+          "sequence-number": 3,
+          "description": "Order service requests payment authorisation",
+          "summary": "Order service requests payment authorisation",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "orders-to-payment",
+          "sequence-number": 4,
+          "description": "Payment service returns confirmation",
+          "summary": "Payment service returns confirmation",
+          "direction": "destination-to-source"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/docs/tutorials/intermediate/architectures/ecommerce-platform-with-flow.calm.json
+++ b/docs/docs/tutorials/intermediate/architectures/ecommerce-platform-with-flow.calm.json
@@ -320,22 +320,57 @@
         {
           "relationship-unique-id": "gateway-to-orders",
           "sequence-number": 2,
-          "description": "Gateway routes the order to the order service",
-          "summary": "Gateway routes the order to the order service",
+          "description": "API Gateway routes order to Order Service",
+          "summary": "API Gateway routes order to Order Service",
           "direction": "source-to-destination"
         },
         {
           "relationship-unique-id": "orders-to-payment",
           "sequence-number": 3,
-          "description": "Order service requests payment authorisation",
-          "summary": "Order service requests payment authorisation",
+          "description": "Order Service initiates payment processing",
+          "summary": "Order Service initiates payment processing",
+          "direction": "source-to-destination"
+        }
+      ]
+    },
+    {
+      "unique-id": "inventory-check-flow",
+      "name": "Inventory Stock Check",
+      "description": "Admin checks and updates inventory stock levels",
+      "transitions": [
+        {
+          "relationship-unique-id": "admin-to-gateway",
+          "sequence-number": 1,
+          "description": "Admin requests inventory status",
+          "summary": "Admin requests inventory status",
           "direction": "source-to-destination"
         },
         {
-          "relationship-unique-id": "orders-to-payment",
+          "relationship-unique-id": "gateway-to-inventory",
+          "sequence-number": 2,
+          "description": "Route to inventory service",
+          "summary": "Route to inventory service",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "inventory-to-database",
+          "sequence-number": 3,
+          "description": "Query current stock levels",
+          "summary": "Query current stock levels",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "inventory-to-database",
           "sequence-number": 4,
-          "description": "Payment service returns confirmation",
-          "summary": "Payment service returns confirmation",
+          "description": "Return stock data",
+          "summary": "Return stock data",
+          "direction": "destination-to-source"
+        },
+        {
+          "relationship-unique-id": "gateway-to-inventory",
+          "sequence-number": 5,
+          "description": "Return inventory report",
+          "summary": "Return inventory report",
           "direction": "destination-to-source"
         }
       ]


### PR DESCRIPTION
## Description

Part of #2928 (PoC tracking issue — accept/extend or discard is decided there).

**Draft — a 2-page demo for feedback before doing the full learn track.**

The learn tutorials teach people to build CALM architectures step by step, but the learner never *sees* what they built — they paste JSON and read "validation succeeded with 4 nodes". This demo adds live diagrams (via `@finos/calm-docusaurus-plugin`, merged in #2854/#2909) to two pages:

- **Beginner → Build a Complete Architecture**: the finished e-commerce architecture renders at the end of the page, with the `composed-of` platform boundary drawn as a nested container (#2900). What you built is what you see.
- **Intermediate → Model Business Flows**: the order-processing flow the learner just modelled animates over the architecture — including the reverse `destination-to-source` transition for payment confirmation, with non-flow elements dimmed.

Both diagrams are generated at build time from committed `.calm.json` files (extracted from the tutorials' own JSON), so a broken tutorial architecture now **fails the site build** — tutorials cannot silently rot.

If this direction is agreed, the follow-up for the full track would use a single-source pattern: one `.calm.json` per tutorial step feeding **both** the code block (via `raw-loader`) and the diagram, so the fenced JSON and the rendered picture can never drift. Not implemented here to keep the demo dependency-free.

One renderer follow-up found while building this: the flow overlay reads a transition `summary` field, but the flow schema defines `description` — the demo files carry both; a small fix to the web component will follow so schema-only files work.

## Type of Change

- [x] 📚 Documentation update

## Affected Components

- [x] Docs (`docs/`)

## Testing

- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Evidence: `npm run build --workspace docs` green on current `main`; both pages emit the pre-rendered SVG in their built HTML; the flows page hydrates to the animated overlay in the browser.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable) — docs-only; the site build is the test
- [x] My changes follow the project's coding standards
