### PR TITLE
docs: add Flows page to Core Concepts

### DIFF
--- a/docs/docs/core-concepts/decorators.md
+++ b/docs/docs/core-concepts/decorators.md
@@ -1,7 +1,7 @@
 ---
 id: decorators
 title: Decorators
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Decorators

--- a/docs/docs/core-concepts/flows.md
+++ b/docs/docs/core-concepts/flows.md
@@ -1,7 +1,7 @@
 ---
 id: flows
 title: Flows
-sidebar_position: 3
+sidebar_position: 6
 ---
 
 # Flows in CALM

--- a/docs/docs/core-concepts/flows.md
+++ b/docs/docs/core-concepts/flows.md
@@ -1,0 +1,119 @@
+---
+id: flows
+title: Flows
+sidebar_position: 3
+---
+
+# Flows in CALM
+
+Flows in CALM describe business processes as they move through your technical architecture. Where nodes and relationships capture what the architecture is, a flow captures how a business capability is realised by traversing those relationships in a defined order. This connects business intent to the concrete components and connections that implement it.
+
+## What is a Flow?
+
+A flow is an ordered sequence of transitions, each of which references an existing relationship in the architecture. By walking the transitions in sequence, a flow traces a single business process, for example a customer placing an order, or an admin checking stock levels, across the nodes and relationships that carry it.
+
+Because transitions reference relationships by `unique-id` rather than redefining connections, flows stay in sync with the architecture: they reuse the same relationships that already exist between nodes.
+
+### Why Use Flows?
+
+Flows serve several purposes:
+
+- Business-to-technical traceability: Show how a business capability maps onto real components and connections.
+- Impact analysis: Answer questions like "which services participate in my order flow?"
+- Documentation: Generate sequence diagrams that describe a process step by step.
+- Compliance: Attach control requirements to a specific process rather than to the whole architecture.
+
+## Key Properties of Flows
+
+A flow has the following properties:
+
+- `unique-id`: A mandatory identifier that uniquely defines the flow within the architecture.
+- `name`: A mandatory, human-readable name for the business process.
+- `description`: A mandatory description of the flow's purpose.
+- `transitions`: A mandatory, ordered array of at least one transition (see below).
+- `requirement-url`: Optional link to a detailed requirement document.
+- `controls`: Optional controls that apply to the flow, such as audit or logging requirements.
+- `metadata`: Optional additional information attached to the flow.
+
+### Transitions: The Steps of a Flow
+
+Each transition describes one step of the process and has the following properties:
+
+- `relationship-unique-id`: A mandatory reference to the `unique-id` of a relationship in the architecture that this step uses.
+- `sequence-number`: A mandatory integer indicating the order of this step within the flow (1, 2, 3…).
+- `description`: A mandatory functional summary of what happens in this step.
+- `direction`: Optional. Either `source-to-destination` (default) or `destination-to-source`, indicating which way the interaction travels along the referenced relationship.
+
+The same relationship can appear more than once in a flow with different directions, which is how request-and-response patterns are modelled.
+
+## Example of a Flow Definition
+
+Flows are defined in a top-level `flows` array in an architecture document, alongside `nodes` and `relationships`:
+
+```json
+{
+  "flows": [
+    {
+      "unique-id": "order-processing-flow",
+      "name": "Customer Order Processing",
+      "description": "End-to-end flow from a customer placing an order to payment confirmation.",
+      "transitions": [
+        {
+          "relationship-unique-id": "customer-to-gateway",
+          "sequence-number": 1,
+          "description": "Customer submits order via the web interface",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "gateway-to-order-service",
+          "sequence-number": 2,
+          "description": "API Gateway routes the order to the Order Service",
+          "direction": "source-to-destination"
+        },
+        {
+          "relationship-unique-id": "order-service-to-payment-service",
+          "sequence-number": 3,
+          "description": "Order Service initiates payment processing",
+          "direction": "source-to-destination"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Modelling Request and Response
+
+To model a response travelling back along the same connection, reuse the relationship with the opposite direction:
+
+```json
+{ "relationship-unique-id": "svc-to-db", "sequence-number": 3, "description": "Query current stock levels", "direction": "source-to-destination" },
+{ "relationship-unique-id": "svc-to-db", "sequence-number": 4, "description": "Return stock data", "direction": "destination-to-source" }
+```
+
+## Using Flows Effectively
+
+- Trace complete business capabilities: Use a flow to capture an end-to-end process rather than a single interaction.
+- Reference real relationships: Each transition must point at a relationship that already exists in the architecture, keeping business and technical views consistent.
+- Sequence carefully: `sequence-number` defines the order steps are rendered and reasoned about, including in sequence diagrams.
+- Attach controls where they belong: Use flow-level `controls` to express requirements that apply to the process as a whole, such as audit logging.
+
+## Visualising Flows
+
+Flows appear in the CALM Model Elements view in the VS Code extension. Selecting a flow renders a sequence diagram showing its transitions in order, making it easy to communicate how a process moves through the architecture.
+
+## Validating Flows
+
+Flows are validated as part of an architecture document. Use the `validate` command:
+
+```bash
+calm validate -a path/to/architecture.json
+```
+
+Validation checks that each flow has a `unique-id`, `name`, `description`, and at least one transition, and that every transition has a `relationship-unique-id`, `sequence-number`, and `description`.
+
+## Related
+
+- [Relationships](relationships): The connections that transitions reference.
+- [Controls](controls): How to attach requirements, which can also be applied at the flow level.
+- Tutorial: [Model Business Flows](../tutorials/intermediate/09-business-flows) walks through building flows step by step.

--- a/docs/docs/core-concepts/index.md
+++ b/docs/docs/core-concepts/index.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Core Concepts
 
-Welcome to the Core Concepts section of CALM. This section provides a comprehensive understanding of the primary components that make up CALM, including nodes, interfaces, relationships, and metadata. By mastering these concepts, you can effectively define and manage your software architecture using CALM.
+Welcome to the Core Concepts section of CALM. This section provides a comprehensive understanding of the primary components that make up CALM, including nodes, interfaces, relationships, flows, and metadata. By mastering these concepts, you can effectively define and manage your software architecture using CALM.
 
 Explore each concept below:
 
@@ -15,6 +15,7 @@ Explore each concept below:
 - [Interfaces](interfaces): Understand how nodes expose interaction points.
 - [Controls](controls): Understand how to apply domain controls to your architecture.
 - [Standards](standards): Learn how to extend CALM components with organizational requirements.
+- [Flows](flows): Trace business processes through the relationships in your architecture.
 - [Timelines](timelines): Track how your architecture evolves over time through significant moments.
 - [Decorators](decorators): Attach supplementary information like deployments, security context, and business metadata to architecture elements.
 - [Metadata](metadata): Learn how to enrich your architecture with additional information.

--- a/docs/docs/core-concepts/metadata.md
+++ b/docs/docs/core-concepts/metadata.md
@@ -1,7 +1,7 @@
 ---
 id: metadata
 title: Metadata
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Metadata in CALM
@@ -46,4 +46,3 @@ Metadata allows you to enrich your architecture model with any additional contex
 - **Drive Automation**: Use metadata to trigger specific behaviors in downstream tools, such as alerting on non-compliant components.
 - **Custom Reporting**: Generate reports or visualizations that include metadata fields to provide additional insights.
 - **Enhance Validation**: Include metadata in validation processes to check for compliance or completeness.
-

--- a/docs/docs/core-concepts/patterns.md
+++ b/docs/docs/core-concepts/patterns.md
@@ -1,7 +1,7 @@
 ---
 id: patterns
 title: Patterns
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Patterns in CALM

--- a/docs/docs/core-concepts/timelines.md
+++ b/docs/docs/core-concepts/timelines.md
@@ -1,7 +1,7 @@
 ---
 id: timelines
 title: Timelines
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Timelines in CALM
@@ -215,4 +215,3 @@ In addition to schema validation, CALM applies custom validation rules:
 - **Future Moment Dates**: Moments after the current moment should not have `valid-from` dates (they represent planned future states)
 - **Chronological Order**: Moments with `valid-from` dates should be in chronological order
 - **Date Format**: All dates must be valid ISO dates (YYYY-MM-DD)
-

--- a/docs/docs/core-concepts/widgets.md
+++ b/docs/docs/core-concepts/widgets.md
@@ -1,7 +1,7 @@
 ---
 id: widgets
 title: Widgets
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Widgets in CALM

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -36,6 +36,7 @@ const sidebars = {
         'core-concepts/interfaces',
         'core-concepts/controls',
         'core-concepts/standards',
+        'core-concepts/flows',
         'core-concepts/timelines',
         'core-concepts/decorators',
         'core-concepts/metadata',

--- a/docs/src/pages/reference/index.js
+++ b/docs/src/pages/reference/index.js
@@ -10,6 +10,7 @@ const CONCEPTS = [
     {to: '/core-concepts/interfaces', title: 'Interfaces', desc: 'How nodes expose interaction points.'},
     {to: '/core-concepts/controls', title: 'Controls', desc: 'Apply domain controls to your architecture.'},
     {to: '/core-concepts/standards', title: 'Standards', desc: 'Extend CALM components with organizational requirements.'},
+    {to: '/core-concepts/flows', title: 'Flows', desc: 'Trace business processes through the relationships in your architecture.'},
     {to: '/core-concepts/timelines', title: 'Timelines', desc: 'Track how your architecture evolves over time.'},
     {to: '/core-concepts/decorators', title: 'Decorators', desc: 'Attach deployment, security and business metadata.'},
     {to: '/core-concepts/metadata', title: 'Metadata', desc: 'Enrich your architecture with additional information.'},


### PR DESCRIPTION
## Description

Adds the missing Flows page to the Core Concepts documentation and wires it into the Core Concepts sidebar and index as identified by a consumer of CALM. 

Flows are a first-class, released CALM concept: `flow.json` ships in every schema release, and the `flows` array is part of `core.json`. Flows are already covered in the learning path via the intermediate tutorial [Model Business Flows](https://calm.finos.org/tutorials/intermediate/09-business-flows). However, following the recent documentation redesign, the Core Concepts reference section has a page for every first-class concept except flows (nodes, relationships, interfaces, controls, standards, timelines, decorators, metadata, patterns, widgets). This PR closes that gap so the reference docs are consistent with the schema and the tutorials.

### Scope: current released schema only
This PR documents flows **as they exist in the released schema today** (inline `flow` objects with architecture-linked `transitions`). It deliberately does **not** pre-empt the two open design discussions about where flows are heading:

- [#1875 — Support flow-first modelling before logical architecture](https://github.com/finos/calm-schema/issues/19) (the `bdd` / flow-first proposal: abstract, actor-based transitions decoupled from the architecture). This is still under debate.
- [#1876 — Allow flows array to be a reference to a document referencing a flow](https://github.com/finos/calm-schema/issues/20) (`flow-url` external references). Roadmap: Next.

Whether/how those land is a separate schema decision. This page documents current behaviour and can be extended when either proposal ships.

### What this PR does
- Adds `docs/docs/core-concepts/flows.md`, describing flows, transitions, `direction` (including request/response modelling), flow-level controls, visualisation, and validation, consistent with `flow.json` and the existing Core Concepts page style.
- Inserts `core-concepts/flows` into the Core Concepts sidebar (after Standards).
- Adds a Flows entry to the Core Concepts index page and to the `/reference` landing page.

### What this PR does not do
- No schema, CLI, or tooling changes — flows already exist end to end; this is documentation only.
- No opinion imposed on flow authoring workflow or external references (#1875 / finos/calm-schema#20 remain open).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] Documentation (`docs/`)

## Commit Message Format ✅
`docs: add missing Flows page to Core Concepts`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

<!-- Verify locally from docs/ with a Docusaurus build to confirm the Flows page renders and the sidebar/cross links resolve. -->

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
