### PR TITLE
feat(calm-hub): versioned artefact storage redesign — Architecture (#2884)

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -602,6 +602,16 @@ the auth and security-header settings (7 failures that passed in isolation). All
 test-only configuration lives in the `%test.` block of
 `src/main/resources/application.properties`; add new test settings there.
 
+**When you add a `SchemaMigrationStep`, update `mongo/init-mongo.js` in the same change.**
+That script seeds a fresh database directly in the current storage shape and pins
+`LATEST_SCHEMA_VERSION`, so `SchemaMigrationRunner` skips every step on first startup.
+Two consequences: the seed data must already be in the shape your new step produces, and
+because step 0 is skipped along with the rest, the script creates the whole index
+inventory itself — a duplicate of `MongoIndexInitializationStep` that has to be kept in
+step. Miss the version bump and the seeded stack runs migrations it does not need; miss
+the index list and duplicate-prevention silently disappears. See
+[ADR 0001](decisions/0001-versioned-artefact-storage.md).
+
 - `PERMISSIONS.md` - Per-namespace permission model reference
 - `decisions/` - Architecture Decision Records for calm-hub's own backend
   design (not the CALM ADR resource type). See `decisions/README.md` for

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -70,10 +70,46 @@ done in-memory after loading the full array.
 ### Scope
 
 - **In scope**: Mongo store code (`store/mongo/`), Nitrite store code
-  (`store/nitrite/`), the `mongo/init-mongo.js` seed script (it hand-writes
-  documents in the storage shape, so it has to change with it), new
-  `SchemaMigrationStep`s, and a migration pathway for existing production
-  data in both backends.
+  (`store/nitrite/`), new `SchemaMigrationStep`s, and a migration pathway
+  for existing production data in both backends.
+- **`mongo/init-mongo.js` seeds the new shape and declares the schema
+  already migrated.** It hand-writes documents in the storage shape, so it
+  changes with it — but changing the documents alone is not enough, and the
+  reason is worth stating because it is not obvious and it bites hard.
+
+  A fresh database starts at schema version 0, so `SchemaMigrationRunner`
+  would run every step on first startup. Step 0
+  (`MongoIndexInitializationStep`) creates a *unique* index on
+  `<type>.namespace`, permitting one document per namespace — which
+  new-shape seed data violates before any migration reaches the collection
+  (`finos.fluxnova` alone seeds six architectures). Step 0 would throw, the
+  runner would leave the migration lock held, and CalmHub would refuse
+  every request until an administrator cleared it by hand. Not a
+  degradation: the stack does not come up. Step 0 is a committed step and
+  therefore immutable, so it cannot be taught to skip that index.
+
+  So the seed script also writes the `schemaVersion` marker at the latest
+  version, and the runner returns before taking the lock. The cost is that
+  skipping step 0 skips *all* the indexes it creates, not just the
+  problematic one, so the seed script now creates them itself — including
+  for the six types that have not migrated. **That inventory is duplicated
+  and must be kept in step with `MongoIndexInitializationStep` and with
+  each new migration step.** When a type migrates, three things move
+  together: its seed documents, its entry in the seed's index list, and
+  `LATEST_SCHEMA_VERSION`.
+
+  This was chosen over the alternative of seeding the old shape and letting
+  the migration convert it on first startup, which would have kept the
+  index inventory in one place at the cost of a seed script permanently
+  expressing a shape the application cannot read.
+- **Also in scope, and easy to miss**: `MongoSearchStore` /
+  `NitriteSearchStore`. They read each entity collection directly rather
+  than through its store interface, so a type that migrates without its
+  search path moving too fails *silently* — the array lookup returns null
+  for a header document, the loop skips every document, and that type
+  returns no search results at all, with nothing logged. Both stores now
+  carry an array-shaped and a header-shaped path, since the two coexist
+  until all seven types have moved.
 - **Out of scope**: the domain interfaces (`ArchitectureStore` etc. stay
   unchanged — REST/service layers untouched). Controls and Decorators are
   deliberately deferred, not addressed by this ADR — see

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -1,7 +1,11 @@
 # ADR 0001: Versioned artefact storage redesign
 
-**Status**: Accepted — not yet implemented. No store uses this shape yet, so
-this describes the target design rather than current behaviour. Tracked in
+**Status**: Accepted — partially implemented. Architecture uses this shape on
+both backends; the other six versioned types still use the old one, which is
+the incremental rollout this ADR describes rather than a divergence from it.
+**No migration step exists yet**, so an existing deployment's data has not
+moved and the ported code would not find it — that lands with the rest of the
+Architecture work. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).
 
 ## Context

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -1,11 +1,11 @@
 # ADR 0001: Versioned artefact storage redesign
 
 **Status**: Accepted — partially implemented. Architecture uses this shape on
-both backends; the other six versioned types still use the old one, which is
-the incremental rollout this ADR describes rather than a divergence from it.
-**No migration step exists yet**, so an existing deployment's data has not
-moved and the ported code would not find it — that lands with the rest of the
-Architecture work. Tracked in
+both backends, complete with its version 2 → 3 migration
+(`MongoArchitectureVersionSplitStep` / `NitriteArchitectureVersionSplitStep`),
+so an existing deployment's data moves on first startup after upgrading. The
+other six versioned types still use the old shape, which is the incremental
+rollout this ADR describes rather than a divergence from it. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).
 
 ## Context
@@ -349,14 +349,18 @@ discriminator**:
   (`Mongo<X>Integration.java`) need updating plus a new migration-specific
   integration test. JaCoCo's 90%-per-class gate applies to new
   migration/helper code as usual.
-- Need a real "approaching/exceeding 16MB" regression test — currently zero
-  tests reference document size limits anywhere in the codebase. The only
-  suite hitting a real Mongo instance today is
-  `MongoConcurrencyIntegration.java` (via `../mvnw -P integration verify`,
-  TestContainers) — natural home for this, since mocked unit tests can only
-  simulate `MongoWriteException`, not trigger Mongo's real enforcement.
+- A real "approaching/exceeding 16MB" regression test now exists, in
+  `integration/performance/MongoDocumentSizeLimitIntegration.java` (via
+  `../mvnw -P integration verify`, TestContainers). It has to run against a
+  real Mongo because mocked unit tests can only simulate
+  `MongoWriteException`, never trigger the actual enforcement. It asserts
+  both halves of this ADR's claim with the same ~2MB payload: **Pattern**,
+  still one document per namespace, accumulates history until a write is
+  rejected and must surface an honest `413`; **Architecture**, now one
+  document per version, accepts ~24MB of history without any write failing.
+  When Pattern migrates, the `413` half moves to a type that hasn't yet.
 
-### Open questions (not yet decided)
+### Open questions (all now resolved)
 
 - ~~Keep dash-encoded version keys as a document field, or make version a
   proper indexed field now that it's not a map key?~~ Resolved: see

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -56,20 +56,26 @@ dead code once no store uses version as a map key.
     must be **left alone**: "fixing" it to split on `"."` would break the
     one thing still using it. It retires with Control, whenever that's
     redesigned.
-  - `versionCount()` is called by the migrating types
-    (Architecture/Pattern/Flow/Standard, both backends) and **never parses
+  - `versionCount()` is called by the migrating types and **never parses
     separators** — it is just `keys.size()`. Those call sites disappear as
     each type migrates, because `versionCount` becomes a stored field on the
-    header (ADR 0001). Once Control is the only caller left of the class,
-    `versionCount()` has none and can be deleted.
+    header (ADR 0001). Architecture's have already gone; Pattern, Flow and
+    Standard still call it on both backends. Once Control is the only caller
+    left of the class, `versionCount()` has none and can be deleted.
   - Ordering versions in the new shape is therefore **new code alongside**,
     not a modification or a fork of this class — nothing that parses `"-"`
     is used by a migrating type, and nothing a migrating type uses cares
     about the separator.
-- **Migration cost**: the `SchemaMigrationStep` that fans out old
-  documents into new version documents (ADR 0001) must convert each dash
-  key to dot form during the fan-out (`"1-0-0".replace('-', '.')`) —
-  trivial, one-time, contained entirely within that migration step.
+- **Migration cost**: the `SchemaMigrationStep` that fans out old documents
+  into new version documents (ADR 0001) must convert each dash key to dot
+  form during the fan-out — one-time, contained entirely within that step.
+  In practice it calls `CanonicalVersion.of(key)` rather than a local
+  `replace('-', '.')`, which an earlier draft of this ADR assumed. Two
+  reasons the shared helper is the right one: it is the same conversion the
+  write path applies, so migrated data is addressable by exactly the
+  spelling the store looks for; and it leaves anything the version regex
+  doesn't recognise untouched instead of mangling it into a new key, where
+  a blind character replace would silently invent one.
 - Dash-encoded keys do **not** disappear from the database entirely — the
   `controls` collection keeps them for as long as Control keeps the old
   shape (ADR 0004). What this ADR removes is any *shared* code path having

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -1,7 +1,12 @@
 # ADR 0002: Version field encoding — dots, not dashes
 
-**Status**: Accepted — not yet implemented. Stored versions are still
-dash-encoded everywhere today. Depends on
+**Status**: Accepted — partially implemented. Architecture stores
+dot-separated versions; the other six types are still dash-encoded. Note the
+implementation needed more than "write a dot instead of a dash":
+`VERSION_REGEX` makes both separators optional, so six spellings denote the
+same version and the old map-key encoding folded only some of them together.
+`CanonicalVersion` now folds all six at the version-store helpers' entry
+points — see [ADR 0003](0003-shared-version-store-helper.md). Depends on
 [ADR 0001](0001-versioned-artefact-storage.md).
 
 ## Context

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -1,9 +1,10 @@
 # ADR 0003: Shared header/version store helper
 
-**Status**: Accepted — partially implemented. The helpers themselves exist
+**Status**: Accepted — partially implemented. The helpers exist
 (`MongoVersionDocumentStore`, `NitriteVersionDocumentStore`,
-`SemanticVersionOrder`), but no store calls them yet, so nothing in running
-CALM Hub uses this design. Depends on
+`SemanticVersionOrder`, `CanonicalVersion`) and `MongoArchitectureStore` /
+`NitriteArchitectureStore` now compose them. The other six versioned types
+still hand-roll their own logic. Depends on
 [ADR 0001](0001-versioned-artefact-storage.md) and
 [ADR 0002](0002-version-key-encoding.md).
 
@@ -42,6 +43,32 @@ the primitive operations every store needs against its
 - `getVersion(namespace, resourceId, version) -> content or not-found`
 - `listVersions(namespace, resourceId) -> List<String>`
 - `listSummariesPaged(namespace, page) -> List<NamespaceResourceSummary>`
+- `updateHeaderDetails(namespace, resourceId, name, description)` — added
+  while porting Architecture, having been missed when this list was first
+  derived. Writing a version also *renames* the resource: the old shape
+  `$set` the entity's `name` and `description` in the same atomic update
+  that wrote the version content, so both version-write paths change the
+  display name. Without this operation that behaviour would have been
+  dropped silently.
+
+  Two consequences of the split worth stating, because neither is
+  reversible by the caller:
+
+  - **It must be called only after the version write succeeds.** Under the
+    old shape a rejected create — the version already exists — matched
+    nothing and so left the name untouched. Calling it first would rename
+    on a request that then fails with a 409.
+  - **The old shape's atomicity is genuinely gone.** A failure here reports
+    an error for a version that was in fact stored. It is still translated
+    and thrown rather than swallowed the way the `versionCount` write is:
+    that field is a derived counter whose drift ADR 0001 accepts, whereas
+    these are user-supplied values, and dropping a rename silently is a
+    wrong answer rather than a display number off by one.
+
+  Note this faithfully preserves a bug: a `null` name overwrites a stored
+  one, and `ArchitectureRequest` validates neither field, so a version
+  write carrying only `architectureJson` wipes the display name. Preserved
+  deliberately — fixing it is a behaviour change, not part of a port.
 
 ### Why composition rather than a shared base class
 

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -70,6 +70,43 @@ the primitive operations every store needs against its
   write carrying only `architectureJson` wipes the display name. Preserved
   deliberately — fixing it is a behaviour change, not part of a port.
 
+### Two supporting classes the helpers own
+
+Both are small, stateless, and shared by the two backends so the shape's
+rules can't drift apart between them.
+
+- **`SemanticVersionOrder`** — the comparator `listVersions` sorts with. An
+  unsorted Mongo query has no defined order and a plain string sort puts
+  `1.10.0` before `1.9.0`, so ordering had to become explicit once versions
+  were rows rather than map keys. Deliberately *not* a change to
+  `VersionKeySelector`, which keeps parsing dashes for Control — see
+  [ADR 0002](0002-version-key-encoding.md). It delegates to the existing
+  `Semver` record rather than parsing versions a second time.
+- **`CanonicalVersion`** — folds every accepted spelling of a version onto
+  one stored form, applied at every helper entry point that takes a version.
+  This is the part of [ADR 0002](0002-version-key-encoding.md) that turned
+  out to need more than writing a dot instead of a dash.
+  `VERSION_REGEX` makes *both* separators optional, so `1.0.0`, `1-0-0`,
+  `1.0-0`, `1-0.0`, `1.00` and `100` are six spellings of one version and
+  the API accepts all of them. The old shape wrote the version as a map key
+  via `replace('.', '-')`, which folded four of the six together and left
+  `100` and `1.00` as keys of their own — one logical version already stored
+  under three different keys. Storing the version as a *field value* without
+  canonicalising would have made each spelling its own document, invisible
+  to a read using any of the other five. Neither backend can catch that:
+  Mongo's unique index is per stored string, and Nitrite has no index at
+  all. Ordering can't fix it either — `SemanticVersionOrder` ranks the
+  spellings equally but cannot merge them.
+
+  It reuses `ResourceValidationConstants.VERSION_REGEX` rather than
+  restating the pattern, which points from the store layer at the resource
+  layer. That coupling is deliberate: the set of spellings to fold is
+  exactly the set the API accepts, so a second copy would be a bug waiting
+  on the two to drift. Input the regex rejects passes through untouched —
+  validation belongs to the resource layer, and a store that rewrote
+  unrecognised input would turn a rejectable request into a document stored
+  under a version nobody asked for.
+
 ### Why composition rather than a shared base class
 
 Not simply because the codebase has no base class today — it doesn't, but
@@ -110,8 +147,16 @@ neither leaks into the other.
   It exists to page into an array field on one shared document. Headers
   are now one document per resource, so `listSummariesPaged` is ordinary
   `skip()`/`limit()` on the header collection.
-- Both helpers stay in place for `MongoControlStore`, which keeps the old
-  shape (ADR 0001 excludes Control from this redesign).
+- Neither helper is deleted, and "retire" means only that the *migrated*
+  types stop calling them — an earlier draft of this ADR said both stay
+  solely for `MongoControlStore`, which was never accurate. As of
+  Architecture: `MongoUpsertPush` still has eight callers (Pattern, ADR,
+  Flow, Standard, Interface, Timeline, Decorator, Control), and
+  `MongoResourceSlice` has exactly one — `MongoPatternStore` — because it
+  only ever served Architecture and Pattern. So `MongoResourceSlice` is
+  deletable the moment Pattern migrates, while `MongoUpsertPush` outlives
+  the whole redesign: Decorator and Control both keep the old shape
+  permanently (ADR 0004).
 - `VersionKeySelector` (version-count/latest-version comparison) is
   unaffected — `versionCount` is now a stored field (see below), not
   computed from a loaded map, so its `versionCount()` method's callers
@@ -146,8 +191,8 @@ splitting header from version — see ADR 0001). So `listVersions` returning
 an empty list is **not** evidence the resource doesn't exist — callers that
 need to distinguish "exists with 0 versions" from "doesn't exist" must call
 `headerExists` explicitly, not infer non-existence from an empty version
-list the way `getArchitectureVersions` does today (its `ArchitectureDoc ==
-null` check conflates "namespace has no matching architecture array entry"
+list the way `getArchitectureVersions` used to (its `ArchitectureDoc ==
+null` check conflated "namespace has no matching architecture array entry"
 with "architecture not found," which happened to be safe under the old
 shape but would be wrong under the new one).
 

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -17,7 +17,10 @@ assuming anything here reflects current behaviour.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Accepted |
-| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Accepted |
-| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Accepted |
-| [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted |
+| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Accepted — partially implemented (Architecture only) |
+| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Accepted — partially implemented (Architecture only) |
+| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Accepted — partially implemented (Architecture only) |
+| [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted (no code of its own) |
+
+0001–0003 become `Implemented` when all seven versioned types have moved,
+not when the first one has.

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -6651,12 +6651,29 @@ logSection("Indexes");
 // createIndex is idempotent, so this is safe to re-run over an already-seeded database.
 const unique = { unique: true };
 
+// Every data block above is guarded by countDocuments() === 0, so running this script
+// against a database that already holds PRE-MIGRATION architectures skips the seeding but
+// would still reach the index and schema-version work below. Stamping the version then
+// tells SchemaMigrationRunner there is nothing to migrate, the split step never runs, and
+// the old-shape documents stay put while the store queries for the new shape — every
+// architecture silently disappears from listings, search and counts. So detect that case
+// and leave both the architecture indexes and the version marker alone, which lets the
+// migration do its job on next startup.
+const preMigrationArchitectures = db.architectures.countDocuments({ architectures: { $exists: true } });
+const architecturesAreMigrated = preMigrationArchitectures === 0;
+
 db.namespaces.createIndex({ name: 1 }, unique);
 db.domains.createIndex({ name: 1 }, unique);
 db.schemas.createIndex({ version: 1 }, unique);
 
-db.architectures.createIndex({ namespace: 1, architectureId: 1 }, unique);
-db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
+if (architecturesAreMigrated) {
+    db.architectures.createIndex({ namespace: 1, architectureId: 1 }, unique);
+    db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
+} else {
+    // The old {namespace: 1} unique index still applies to this data and is the migration
+    // step's to drop, not this script's.
+    logSkip(`Found ${preMigrationArchitectures} pre-migration architecture document(s) — leaving architecture indexes to the migration`);
+}
 
 for (const collection of ["patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"]) {
     db[collection].createIndex({ namespace: 1 }, unique);
@@ -6690,10 +6707,18 @@ logSection("Schema version");
 // Document shape must match MongoSchemaVersionStore: _id "schemaVersion", int version, in
 // the calm collection.
 const LATEST_SCHEMA_VERSION = 3;
-db.calm.updateOne(
-    { _id: "schemaVersion" },
-    { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
-    { upsert: true });
-logSuccess(`Recorded schema version ${LATEST_SCHEMA_VERSION} — startup migrations will be skipped`);
+if (architecturesAreMigrated) {
+    db.calm.updateOne(
+        { _id: "schemaVersion" },
+        { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
+        { upsert: true });
+    logSuccess(`Recorded schema version ${LATEST_SCHEMA_VERSION} — startup migrations will be skipped`);
+} else {
+    // Deliberately loud: the alternative is a database that looks fine and serves no
+    // architectures at all.
+    logFail(`Not recording schema version — this database still holds ${preMigrationArchitectures} `
+        + `pre-migration architecture document(s). Start CalmHub and let the migration convert them; `
+        + `stamping version ${LATEST_SCHEMA_VERSION} here would skip it and hide every architecture.`);
+}
 
 logSection("Initialization complete");

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -22,6 +22,63 @@ function logFail(message) {
     print(`  ❌ ${message}`);
 }
 
+// Mirror of CanonicalVersion.java, which folds every spelling the API accepts
+// ("1.0.0", "1-0-0", "100", ...) onto one form. The seed data below is already written
+// dot-separated, so this is a guard rather than a conversion: a version stored under any
+// other spelling would be invisible to the store, which canonicalizes the version it
+// looks for before querying. Keep the pattern identical to
+// ResourceValidationConstants.VERSION_REGEX.
+function canonicalVersion(version) {
+    const match = /^(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)$/.exec(version);
+    return match ? `${match[1]}.${match[2]}.${match[3]}` : version;
+}
+
+// Writes a versioned resource type in the header/version shape of
+// calm-hub/decisions/0001-versioned-artefact-storage.md: one header document per resource
+// in its own collection, plus one document per version in a sibling <type>Versions
+// collection.
+//
+// The seed data itself stays grouped by namespace because that reads far better than two
+// flat lists with the parent-child relationship left implicit — so what is written here is
+// deliberately NOT the literal shape of the source below. Change this function, not the
+// data, if the storage shape changes again.
+function seedVersionedResource(groupedByNamespace, headerCollection, versionCollection, arrayField, idField) {
+    const headers = [];
+    const versions = [];
+
+    for (const namespaceDocument of groupedByNamespace) {
+        for (const entry of namespaceDocument[arrayField]) {
+            const storedVersions = entry.versions || {};
+            headers.push({
+                namespace: namespaceDocument.namespace,
+                [idField]: entry[idField],
+                name: entry.name,
+                description: entry.description,
+                // NumberInt, not a plain JS number: a double here reads back as a Double and
+                // the store's getInteger call fails on it.
+                versionCount: NumberInt(Object.keys(storedVersions).length),
+                metadata: {}
+            });
+
+            for (const storedKey of Object.keys(storedVersions)) {
+                versions.push({
+                    namespace: namespaceDocument.namespace,
+                    [idField]: entry[idField],
+                    version: canonicalVersion(storedKey),
+                    content: storedVersions[storedKey],
+                    metadata: {}
+                });
+            }
+        }
+    }
+
+    db[headerCollection].insertMany(headers);
+    if (versions.length > 0) {
+        db[versionCollection].insertMany(versions);
+    }
+    return { headers: headers.length, versions: versions.length };
+}
+
 const dbName = (typeof process !== 'undefined' && process.env.CALM_DB_NAME)
     ? process.env.CALM_DB_NAME
     : 'calmSchemas';
@@ -1890,7 +1947,9 @@ if (db.flows.countDocuments() === 0) {
 
 logSection("Architectures");
 if (db.architectures.countDocuments() === 0) {
-    db.architectures.insertMany([
+    // Grouped by namespace for readability only — seedVersionedResource fans this out into
+    // one header document per architecture plus one document per version.
+    const architecturesByNamespace = [
         {
             namespace: "finos",
             architectures: [{
@@ -1899,7 +1958,7 @@ if (db.architectures.countDocuments() === 0) {
                 description: "This is a non-compliant arch document. Just creating something to simulate",
                 versions:
                 {
-                    "1-0-0": {
+                    "1.0.0": {
                         "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
                         "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/arch-1",
                         "title": "Architecture 1",
@@ -1917,7 +1976,7 @@ if (db.architectures.countDocuments() === 0) {
                     description: "Conference signup system with load-balanced services and Kubernetes deployment",
                     versions:
                     {
-                        "1-0-0": {
+                        "1.0.0": {
                             "nodes": [
                                 {
                                     "unique-id": "conference-website",
@@ -2070,7 +2129,7 @@ if (db.architectures.countDocuments() === 0) {
                 description: "Simple Trading System architecture",
                 versions:
                 {
-                    "1-0-0": {
+                    "1.0.0": {
                         "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
                         "nodes": [
                             {
@@ -2537,7 +2596,7 @@ if (db.architectures.countDocuments() === 0) {
                 name: "mcp-api-pipeline",
                 description: "User → MCP Server (cloud-hosted) → API Service → Database. FINOS AIR AI Governance controls applied directly on nodes and relationships.",
                 versions: {
-                    "1-0-0": {
+                    "1.0.0": {
                         "$schema": "https://calm.finos.org/draft/2025-03/meta/calm.json",
                         "unique-id": "mcp-api-pipeline",
                         "name": "MCP Server API Pipeline",
@@ -2984,7 +3043,7 @@ if (db.architectures.countDocuments() === 0) {
                 name: "Trades API and MCP Architecture (Conforming)",
                 description: "Conforming architecture with all required controls: micro-segmentation on cluster, permitted connections on all relationships, and MCP guardrail on MCP server",
                 versions: {
-                    "1-0-0": {
+                    "1.0.0": {
                         "$schema": "https://calm.finos.org/calm/namespaces/qcon/patterns/trades-api-and-mcp/versions/1.0.0",
                         "$id": "https://calm.finos.org/calm/namespaces/qcon/architectures/trades-api-and-mcp-conforming/versions/1.0.0",
                         "title": "Trades API and MCP Architecture (Conforming)",
@@ -3125,7 +3184,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: Platform",
                     description: "Base FluxNova BPM platform deployment topology with engine, web apps, REST API, and process database",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-platform.architecture.json",
                             "title": "FluxNova: Platform",
@@ -3398,7 +3457,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: Microservices Orchestration",
                     description: "FluxNova BPM orchestrating microservices via the external task worker pattern — payment, notification, and fraud-check workers with an async event bus and API gateway",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-microservices.architecture.json",
                             "title": "FluxNova: Microservices Orchestration",
@@ -3826,7 +3885,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: KYC Onboarding",
                     description: "Pre-trade KYC onboarding architecture with identity verification, sanctions screening, risk scoring, and compliance review built on FluxNova BPM platform",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-kyc-onboarding.architecture.json",
                             "title": "FluxNova: KYC Onboarding",
@@ -4796,7 +4855,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: Post-Trade Settlement",
                     description: "Post-trade settlement blueprint with counterparty gateway, clearing house connector, regulatory reporting, and settlement database built on FluxNova BPM platform",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-settlement.architecture.json",
                             "title": "FluxNova: Post-Trade Settlement",
@@ -5258,7 +5317,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: Flash Risk Management",
                     description: "Real-time flash risk management blueprint with on-premise and cloud compute, aggregation, and auto-provisioning for latency-sensitive financial risk calculations",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-flash-risk.architecture.json",
                             "title": "FluxNova: Flash Risk Management",
@@ -5705,7 +5764,7 @@ if (db.architectures.countDocuments() === 0) {
                     name: "FluxNova: AI Agent Orchestration",
                     description: "FluxNova BPM platform orchestrating autonomous AI agents with LLM inference, guardrails, and callable tools — AIGF governance controls pre-applied",
                     versions: {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/release/1.2/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/examples/fluxnova/fluxnova-ai-agent.architecture.json",
                             "title": "FluxNova: AI Agent Orchestration",
@@ -6075,8 +6134,10 @@ if (db.architectures.countDocuments() === 0) {
                 }
             ]
         }
-    ]);
-    logSuccess("Initialized architectures for finos, workshop, traderx, ai-governance-v2, qcon, and finos.fluxnova namespaces");
+    ];
+    const seededArchitectures = seedVersionedResource(
+        architecturesByNamespace, "architectures", "architectureVersions", "architectures", "architectureId");
+    logSuccess(`Initialized ${seededArchitectures.headers} architectures and ${seededArchitectures.versions} versions for finos, workshop, traderx, ai-governance-v2, qcon, and finos.fluxnova namespaces`);
 } else {
     logSkip("Architectures already initialized, skipping...");
 }
@@ -6572,5 +6633,67 @@ if (db.resource_mappings.countDocuments() === 0) {
 } else {
     logSkip("Resource mappings already exist, no initialization needed");
 }
+
+logSection("Indexes");
+// Normally created by MongoIndexInitializationStep, the version 0 -> 1 migration step.
+// This script pins the schema version to LATEST_SCHEMA_VERSION below, so that step — and
+// every other — is skipped on first startup and these indexes would otherwise never
+// exist, silently losing the duplicate-prevention the stores rely on for concurrent POSTs.
+//
+// MUST be kept in step with MongoIndexInitializationStep. Two deliberate differences,
+// both because architectures have moved to the header/version shape (ADR 0001):
+//   - architectures gets a unique (namespace, architectureId) instead of (namespace),
+//     which is what allows more than one architecture per namespace at all
+//   - architectureVersions gets a unique (namespace, architectureId, version)
+// The other six versioned types keep the one-document-per-namespace index until they
+// migrate, at which point their entry here moves the same way.
+//
+// createIndex is idempotent, so this is safe to re-run over an already-seeded database.
+const unique = { unique: true };
+
+db.namespaces.createIndex({ name: 1 }, unique);
+db.domains.createIndex({ name: 1 }, unique);
+db.schemas.createIndex({ version: 1 }, unique);
+
+db.architectures.createIndex({ namespace: 1, architectureId: 1 }, unique);
+db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
+
+for (const collection of ["patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"]) {
+    db[collection].createIndex({ namespace: 1 }, unique);
+}
+db.controls.createIndex({ domain: 1 }, unique);
+
+// Two partial indexes rather than one compound: namespace-scoped and domain-scoped grant
+// documents share no discriminating field.
+db.userAccess.createIndex({ username: 1, namespace: 1, permission: 1 },
+    { unique: true, partialFilterExpression: { namespace: { $exists: true } } });
+db.userAccess.createIndex({ username: 1, domain: 1, permission: 1 },
+    { unique: true, partialFilterExpression: { domain: { $exists: true } } });
+
+// Non-unique: the audit trail is append-only with no uniqueness invariant, so these only
+// support AuditLogStore's lookup shapes.
+db.auditLogs.createIndex({ namespace: 1, entityType: 1, entityId: 1, timestamp: -1 });
+db.auditLogs.createIndex({ domain: 1, entityType: 1, entityId: 1, timestamp: -1 });
+db.auditLogs.createIndex({ actor: 1, timestamp: -1 });
+db.auditLogs.createIndex({ timestamp: -1 });
+logSuccess("Created indexes (mirroring MongoIndexInitializationStep, with architectures in the header/version shape)");
+
+logSection("Schema version");
+// Everything this script writes is already in the shape the current code reads, so record
+// the schema as fully migrated. SchemaMigrationRunner then returns before taking the
+// migration lock instead of running steps that have nothing to do — and, in step 0's case,
+// would actively fail: its unique index on architectures.namespace permits one document
+// per namespace, which new-shape seed data violates (finos.fluxnova seeds six). A failed
+// step leaves the lock held and CalmHub refusing every request.
+//
+// Raise this whenever a migration step is added, and seed that step's target shape above.
+// Document shape must match MongoSchemaVersionStore: _id "schemaVersion", int version, in
+// the calm collection.
+const LATEST_SCHEMA_VERSION = 3;
+db.calm.updateOne(
+    { _id: "schemaVersion" },
+    { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
+    { upsert: true });
+logSuccess(`Recorded schema version ${LATEST_SCHEMA_VERSION} — startup migrations will be skipped`);
 
 logSection("Initialization complete");

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -48,24 +48,41 @@ function seedVersionedResource(groupedByNamespace, headerCollection, versionColl
 
     for (const namespaceDocument of groupedByNamespace) {
         for (const entry of namespaceDocument[arrayField]) {
-            const storedVersions = entry.versions || {};
+            // Collapse first: two source keys can canonicalise to one version (canonicalVersion
+            // accepts "1-0-0" and "100" as the same thing), and only one document can exist per
+            // (namespace, id, version). Counting raw keys and writing one document each would
+            // insert duplicates that the unique index — created further down, after these
+            // inserts — then refuses, aborting the script before it records the schema version.
+            // Mirrors collapseToCanonicalVersions in the two migration steps.
+            const contentByCanonicalVersion = new Map();
+            for (const storedKey of Object.keys(entry.versions || {})) {
+                const version = canonicalVersion(storedKey);
+                if (contentByCanonicalVersion.has(version)) {
+                    logFail(`Seed data has two keys meaning version ${version} for `
+                        + `${namespaceDocument.namespace}/${entry[idField]} — keeping the first, dropping '${storedKey}'`);
+                    continue;
+                }
+                contentByCanonicalVersion.set(version, entry.versions[storedKey]);
+            }
+
             headers.push({
                 namespace: namespaceDocument.namespace,
                 [idField]: entry[idField],
                 name: entry.name,
                 description: entry.description,
                 // NumberInt, not a plain JS number: a double here reads back as a Double and
-                // the store's getInteger call fails on it.
-                versionCount: NumberInt(Object.keys(storedVersions).length),
+                // the store's getInteger call fails on it. Counts the collapsed set, so the
+                // header can never advertise more versions than there are documents.
+                versionCount: NumberInt(contentByCanonicalVersion.size),
                 metadata: {}
             });
 
-            for (const storedKey of Object.keys(storedVersions)) {
+            for (const [version, content] of contentByCanonicalVersion) {
                 versions.push({
                     namespace: namespaceDocument.namespace,
                     [idField]: entry[idField],
-                    version: canonicalVersion(storedKey),
-                    content: storedVersions[storedKey],
+                    version: version,
+                    content: content,
                     metadata: {}
                 });
             }

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -102,6 +102,91 @@ const dbName = (typeof process !== 'undefined' && process.env.CALM_DB_NAME)
 logSuccess(`Using database: ${dbName}`);
 db = db.getSiblingDB(dbName);
 
+logSection("Schema baseline");
+// Runs BEFORE any data is written, and this ordering is load-bearing.
+//
+// This script seeds documents in the shape the current code reads, so on a database it
+// created there is nothing for SchemaMigrationRunner to do — and step 0 would actively
+// fail, because its unique index on architectures.namespace permits one document per
+// namespace while the new shape seeds several (finos.fluxnova alone has six). A failed
+// step leaves the migration lock held and CalmHub refusing every request. So the schema
+// version is pinned and the indexes step 0 would have created are created here instead.
+//
+// Two failure modes drive the ordering and the guard, both found reviewing #2923:
+//
+//   Pinning last meant a seed that died partway — the container killed, a disk full —
+//   left new-shape headers with no version marker. Startup then ran step 0, its index
+//   build failed on the duplicate namespaces, and the hub was bricked behind the held
+//   lock with no way back short of clearing migrationLock by hand. Nothing re-runs this
+//   script either: docker-entrypoint-initdb.d only fires on an empty data directory.
+//   Writing the marker and the indexes first means an interrupted seed leaves a
+//   startable hub with incomplete data instead of an unstartable one.
+//
+//   Guarding only on "no pre-migration architecture documents" was too narrow, because
+//   the pin suppresses EVERY step, not just the architecture split. A database with
+//   existing namespaces but no architectures passed that guard, so pinning silently
+//   skipped NamespaceAccessBackfillStep (version 1 -> 2) and those namespaces never
+//   received their `* read` grant — going dark once entitlements are enforced.
+//
+// Hence: pin only on a genuinely empty database, which is the only case this was ever
+// meant for. Anything else keeps version 0 and lets the real migrations run.
+//
+// Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
+// target shape below. Document shape must match MongoSchemaVersionStore: _id
+// "schemaVersion", int version, in the calm collection.
+const LATEST_SCHEMA_VERSION = 3;
+const unique = { unique: true };
+
+const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
+const isEmptyDatabase = existingSchemaVersion === null
+    && db.namespaces.countDocuments() === 0
+    && db.architectures.countDocuments() === 0;
+
+if (isEmptyDatabase) {
+    db.calm.updateOne(
+        { _id: "schemaVersion" },
+        { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
+        { upsert: true });
+
+    // Mirrors MongoIndexInitializationStep, which the pin above skips. Keep the two in
+    // step. Two deliberate differences, both because architectures have moved to the
+    // header/version shape (ADR 0001): architectures gets a unique
+    // (namespace, architectureId) instead of (namespace), which is what allows more than
+    // one architecture per namespace at all; and architectureVersions gets a unique
+    // (namespace, architectureId, version). The other six versioned types keep the
+    // one-document-per-namespace index until they migrate.
+    db.namespaces.createIndex({ name: 1 }, unique);
+    db.domains.createIndex({ name: 1 }, unique);
+    db.schemas.createIndex({ version: 1 }, unique);
+
+    db.architectures.createIndex({ namespace: 1, architectureId: 1 }, unique);
+    db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
+
+    for (const collection of ["patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"]) {
+        db[collection].createIndex({ namespace: 1 }, unique);
+    }
+    db.controls.createIndex({ domain: 1 }, unique);
+
+    // Two partial indexes rather than one compound: namespace-scoped and domain-scoped
+    // grant documents share no discriminating field.
+    db.userAccess.createIndex({ username: 1, namespace: 1, permission: 1 },
+        { unique: true, partialFilterExpression: { namespace: { $exists: true } } });
+    db.userAccess.createIndex({ username: 1, domain: 1, permission: 1 },
+        { unique: true, partialFilterExpression: { domain: { $exists: true } } });
+
+    // Non-unique: the audit trail is append-only with no uniqueness invariant, so these
+    // only support AuditLogStore's lookup shapes.
+    db.auditLogs.createIndex({ namespace: 1, entityType: 1, entityId: 1, timestamp: -1 });
+    db.auditLogs.createIndex({ domain: 1, entityType: 1, entityId: 1, timestamp: -1 });
+    db.auditLogs.createIndex({ actor: 1, timestamp: -1 });
+    db.auditLogs.createIndex({ timestamp: -1 });
+
+    logSuccess(`Recorded schema version ${LATEST_SCHEMA_VERSION} and created indexes — startup migrations will be skipped`);
+} else {
+    logSkip("Existing database — leaving the schema version and indexes to SchemaMigrationRunner. "
+        + "Any data seeded below is additive; the migrations will bring the rest of the database up to date.");
+}
+
 logSection("Counters");
 // Insert the initial counter document if it doesn't exist
 if (db.counters.countDocuments({ _id: "patternStoreCounter" }) === 0) {
@@ -1963,7 +2048,13 @@ if (db.flows.countDocuments() === 0) {
 }
 
 logSection("Architectures");
-if (db.architectures.countDocuments() === 0) {
+// Gated on the database being empty, unlike the other types. Architecture is the only one
+// seeded in the header/version shape, which needs the unique index swap above to permit
+// several documents per namespace. On a database this script did not create, that swap is
+// deliberately left to the migration — so seeding the new shape here anyway would leave
+// documents that step 0's index build then chokes on, bricking startup behind the
+// migration lock. The other types are seeded in the shape step 0's indexes already expect.
+if (isEmptyDatabase && db.architectures.countDocuments() === 0) {
     // Grouped by namespace for readability only — seedVersionedResource fans this out into
     // one header document per architecture plus one document per version.
     const architecturesByNamespace = [
@@ -6155,6 +6246,9 @@ if (db.architectures.countDocuments() === 0) {
     const seededArchitectures = seedVersionedResource(
         architecturesByNamespace, "architectures", "architectureVersions", "architectures", "architectureId");
     logSuccess(`Initialized ${seededArchitectures.headers} architectures and ${seededArchitectures.versions} versions for finos, workshop, traderx, ai-governance-v2, qcon, and finos.fluxnova namespaces`);
+} else if (!isEmptyDatabase) {
+    logSkip("Existing database — not seeding architectures; the new shape needs the index swap "
+        + "that SchemaMigrationRunner will perform on startup");
 } else {
     logSkip("Architectures already initialized, skipping...");
 }
@@ -6649,93 +6743,6 @@ if (db.resource_mappings.countDocuments() === 0) {
     logSuccess("Initialized resource_mappings with seed data");
 } else {
     logSkip("Resource mappings already exist, no initialization needed");
-}
-
-logSection("Indexes");
-// Normally created by MongoIndexInitializationStep, the version 0 -> 1 migration step.
-// This script pins the schema version to LATEST_SCHEMA_VERSION below, so that step — and
-// every other — is skipped on first startup and these indexes would otherwise never
-// exist, silently losing the duplicate-prevention the stores rely on for concurrent POSTs.
-//
-// MUST be kept in step with MongoIndexInitializationStep. Two deliberate differences,
-// both because architectures have moved to the header/version shape (ADR 0001):
-//   - architectures gets a unique (namespace, architectureId) instead of (namespace),
-//     which is what allows more than one architecture per namespace at all
-//   - architectureVersions gets a unique (namespace, architectureId, version)
-// The other six versioned types keep the one-document-per-namespace index until they
-// migrate, at which point their entry here moves the same way.
-//
-// createIndex is idempotent, so this is safe to re-run over an already-seeded database.
-const unique = { unique: true };
-
-// Every data block above is guarded by countDocuments() === 0, so running this script
-// against a database that already holds PRE-MIGRATION architectures skips the seeding but
-// would still reach the index and schema-version work below. Stamping the version then
-// tells SchemaMigrationRunner there is nothing to migrate, the split step never runs, and
-// the old-shape documents stay put while the store queries for the new shape — every
-// architecture silently disappears from listings, search and counts. So detect that case
-// and leave both the architecture indexes and the version marker alone, which lets the
-// migration do its job on next startup.
-const preMigrationArchitectures = db.architectures.countDocuments({ architectures: { $exists: true } });
-const architecturesAreMigrated = preMigrationArchitectures === 0;
-
-db.namespaces.createIndex({ name: 1 }, unique);
-db.domains.createIndex({ name: 1 }, unique);
-db.schemas.createIndex({ version: 1 }, unique);
-
-if (architecturesAreMigrated) {
-    db.architectures.createIndex({ namespace: 1, architectureId: 1 }, unique);
-    db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
-} else {
-    // The old {namespace: 1} unique index still applies to this data and is the migration
-    // step's to drop, not this script's.
-    logSkip(`Found ${preMigrationArchitectures} pre-migration architecture document(s) — leaving architecture indexes to the migration`);
-}
-
-for (const collection of ["patterns", "flows", "timelines", "standards", "interfaces", "adrs", "decorators"]) {
-    db[collection].createIndex({ namespace: 1 }, unique);
-}
-db.controls.createIndex({ domain: 1 }, unique);
-
-// Two partial indexes rather than one compound: namespace-scoped and domain-scoped grant
-// documents share no discriminating field.
-db.userAccess.createIndex({ username: 1, namespace: 1, permission: 1 },
-    { unique: true, partialFilterExpression: { namespace: { $exists: true } } });
-db.userAccess.createIndex({ username: 1, domain: 1, permission: 1 },
-    { unique: true, partialFilterExpression: { domain: { $exists: true } } });
-
-// Non-unique: the audit trail is append-only with no uniqueness invariant, so these only
-// support AuditLogStore's lookup shapes.
-db.auditLogs.createIndex({ namespace: 1, entityType: 1, entityId: 1, timestamp: -1 });
-db.auditLogs.createIndex({ domain: 1, entityType: 1, entityId: 1, timestamp: -1 });
-db.auditLogs.createIndex({ actor: 1, timestamp: -1 });
-db.auditLogs.createIndex({ timestamp: -1 });
-logSuccess("Created indexes (mirroring MongoIndexInitializationStep, with architectures in the header/version shape)");
-
-logSection("Schema version");
-// Everything this script writes is already in the shape the current code reads, so record
-// the schema as fully migrated. SchemaMigrationRunner then returns before taking the
-// migration lock instead of running steps that have nothing to do — and, in step 0's case,
-// would actively fail: its unique index on architectures.namespace permits one document
-// per namespace, which new-shape seed data violates (finos.fluxnova seeds six). A failed
-// step leaves the lock held and CalmHub refusing every request.
-//
-// Raise this whenever a migration step is added, and seed that step's target shape above.
-// Document shape must match MongoSchemaVersionStore: _id "schemaVersion", int version, in
-// the calm collection.
-const LATEST_SCHEMA_VERSION = 3;
-if (architecturesAreMigrated) {
-    db.calm.updateOne(
-        { _id: "schemaVersion" },
-        { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
-        { upsert: true });
-    logSuccess(`Recorded schema version ${LATEST_SCHEMA_VERSION} — startup migrations will be skipped`);
-} else {
-    // Deliberately loud: the alternative is a database that looks fine and serves no
-    // architectures at all.
-    logFail(`Not recording schema version — this database still holds ${preMigrationArchitectures} `
-        + `pre-migration architecture document(s). Start CalmHub and let the migration convert them; `
-        + `stamping version ${LATEST_SCHEMA_VERSION} here would skip it and hide every architecture.`);
 }
 
 logSection("Initialization complete");

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -4,6 +4,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
 import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,12 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
         try (MongoClient mongoClient = MongoClients.create(connectionString)) {
             MongoDatabase database = mongoClient.getDatabase(databaseName);
             new MongoIndexInitializationStep(database).createIndexes();
+            // That step creates a unique index on architectures.namespace alone, which
+            // enforces the pre-migration one-document-per-namespace shape and would make
+            // a second architecture in a namespace impossible. Architecture has since
+            // moved to the header/version shape, so its indexes have to be transitioned
+            // here too — the same swap the version 2 -> 3 migration performs.
+            new MongoArchitectureVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/MongoArchitectureMigrationIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoArchitectureMigrationIntegration.java
@@ -1,0 +1,202 @@
+package integration;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.bson.Document;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Exercises the version 2 → 3 architecture split against a real MongoDB, which is the only
+ * way to check the parts the mocked unit tests structurally cannot: that the unique indexes
+ * it creates actually admit the documents it writes, and that a second run is a genuine
+ * no-op rather than a duplicate-key failure.
+ *
+ * <p>Uses its own namespace so it neither sees nor disturbs the data the other integration
+ * tests set up in the shared container.</p>
+ */
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+public class MongoArchitectureMigrationIntegration {
+
+    private static final String NAMESPACE = "migration-fixture";
+    private static final String V1 = "{\"nodes\": [], \"relationships\": []}";
+    private static final String V2 = "{\"nodes\": [{\"unique-id\": \"n1\"}], \"relationships\": []}";
+
+    private MongoDatabase database(MongoClient client) {
+        return client.getDatabase(ConfigProvider.getConfig().getValue("quarkus.mongodb.database", String.class));
+    }
+
+    private MongoClient client() {
+        return MongoClients.create(
+                ConfigProvider.getConfig().getValue("quarkus.mongodb.connection-string", String.class));
+    }
+
+    /**
+     * Writes the old shape directly: one document for the whole namespace, holding an array
+     * of architectures, each with an embedded map of every version's full content, keyed by
+     * dash-encoded version.
+     */
+    private void seedOldShape(MongoDatabase database) {
+        clearFixture(database);
+        database.getCollection("architectures").insertOne(new Document("namespace", NAMESPACE)
+                .append("architectures", List.of(
+                        new Document("architectureId", 1)
+                                .append("name", "First")
+                                .append("description", "The first one")
+                                .append("versions", new Document("1-0-0", Document.parse(V1))
+                                        .append("1-1-0", Document.parse(V2))),
+                        new Document("architectureId", 2)
+                                .append("name", "Second")
+                                .append("description", "The second one")
+                                .append("versions", new Document("2-0-0", Document.parse(V1))))));
+    }
+
+    private void clearFixture(MongoDatabase database) {
+        database.getCollection("architectures").deleteMany(Filters.eq("namespace", NAMESPACE));
+        database.getCollection("architectureVersions").deleteMany(Filters.eq("namespace", NAMESPACE));
+    }
+
+    private List<Document> fixtureHeaders(MongoDatabase database) {
+        return sortedBy(database.getCollection("architectures"), "architectureId");
+    }
+
+    private List<Document> fixtureVersions(MongoDatabase database) {
+        return sortedBy(database.getCollection("architectureVersions"), "version");
+    }
+
+    private List<Document> sortedBy(MongoCollection<Document> collection, String field) {
+        List<Document> documents = new ArrayList<>();
+        collection.find(Filters.eq("namespace", NAMESPACE)).sort(new Document(field, 1)).forEach(documents::add);
+        return documents;
+    }
+
+    @Test
+    void fan_one_namespace_document_out_into_headers_and_versions() {
+        try (MongoClient client = client()) {
+            MongoDatabase database = database(client);
+            seedOldShape(database);
+
+            new MongoArchitectureVersionSplitStep(database).migrate();
+
+            List<Document> headers = fixtureHeaders(database);
+            assertThat(headers.size(), is(2));
+            assertThat(headers.get(0).getString("name"), is("First"));
+            assertThat(headers.get(0).getInteger("versionCount"), is(2));
+            assertThat(headers.get(1).getString("name"), is("Second"));
+            assertThat(headers.get(1).getInteger("versionCount"), is(1));
+            // The array the old shape hung everything off is gone, not merely emptied.
+            assertThat(headers.get(0).get("architectures"), is(nullValue()));
+
+            List<Document> versions = fixtureVersions(database);
+            assertThat(versions.stream().map(d -> d.getString("version")).toList(),
+                    contains("1.0.0", "1.1.0", "2.0.0"));
+
+            clearFixture(database);
+        }
+    }
+
+    @Test
+    void preserve_every_version_content_exactly() {
+        try (MongoClient client = client()) {
+            MongoDatabase database = database(client);
+            seedOldShape(database);
+
+            new MongoArchitectureVersionSplitStep(database).migrate();
+
+            List<Document> versions = fixtureVersions(database);
+            // The point of the migration is that nothing is lost in the move, so compare
+            // content rather than just counting documents.
+            assertThat(versions.get(0).get("content", Document.class), is(Document.parse(V1)));
+            assertThat(versions.get(1).get("content", Document.class), is(Document.parse(V2)));
+            assertThat(versions.get(2).get("content", Document.class), is(Document.parse(V1)));
+
+            clearFixture(database);
+        }
+    }
+
+    @Test
+    void leave_the_data_untouched_when_run_a_second_time() {
+        try (MongoClient client = client()) {
+            MongoDatabase database = database(client);
+            seedOldShape(database);
+
+            MongoArchitectureVersionSplitStep step = new MongoArchitectureVersionSplitStep(database);
+            step.migrate();
+            List<Document> headersAfterFirst = fixtureHeaders(database);
+            List<Document> versionsAfterFirst = fixtureVersions(database);
+
+            // A failed step leaves the schema version unadvanced and is retried on the next
+            // startup, so re-running has to be safe. Against a real database this also
+            // proves the unique indexes don't reject the second pass.
+            step.migrate();
+
+            assertThat(fixtureHeaders(database), is(headersAfterFirst));
+            assertThat(fixtureVersions(database), is(versionsAfterFirst));
+
+            clearFixture(database);
+        }
+    }
+
+    @Test
+    void complete_a_run_that_previously_stopped_part_way() {
+        try (MongoClient client = client()) {
+            MongoDatabase database = database(client);
+            seedOldShape(database);
+
+            // Stand in for a crash after the first architecture's header was written but
+            // before its source document was deleted: the header is already there, and the
+            // old document still lists both architectures.
+            database.getCollection("architectures").insertOne(new Document("namespace", NAMESPACE)
+                    .append("architectureId", 1)
+                    .append("name", "Stale")
+                    .append("versionCount", 99)
+                    .append("metadata", new Document()));
+
+            new MongoArchitectureVersionSplitStep(database).migrate();
+
+            List<Document> headers = fixtureHeaders(database);
+            assertThat(headers.size(), is(2));
+            // Rewritten from the source rather than left at the half-finished value.
+            assertThat(headers.get(0).getString("name"), is("First"));
+            assertThat(headers.get(0).getInteger("versionCount"), is(2));
+
+            clearFixture(database);
+        }
+    }
+
+    @Test
+    void admit_two_architectures_in_one_namespace_after_the_index_swap() {
+        try (MongoClient client = client()) {
+            MongoDatabase database = database(client);
+            clearFixture(database);
+
+            new MongoArchitectureVersionSplitStep(database).transitionIndexes();
+
+            // Impossible before the swap: the old unique index on namespace alone allowed
+            // exactly one architectures document per namespace. This is the constraint the
+            // whole shape change depends on being gone.
+            MongoCollection<Document> headers = database.getCollection("architectures");
+            headers.insertOne(new Document("namespace", NAMESPACE).append("architectureId", 1));
+            headers.insertOne(new Document("namespace", NAMESPACE).append("architectureId", 2));
+
+            assertThat(fixtureHeaders(database).size(), is(2));
+
+            clearFixture(database);
+        }
+    }
+}

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -25,22 +25,40 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Regression test for issue #2884: a MongoDB write that fails because the namespace's
- * one-document-per-namespace shape has exceeded the 16MB BSON document limit must surface as
- * an honest {@code 413} (via {@link org.finos.calm.domain.exception.StorageWriteException}),
- * not the misleading {@code 404} the store used to throw for any {@code MongoWriteException}.
+ * The two halves of issue #2884's document-size story, one per storage shape.
  *
- * <p>Grows a single architecture's version history against a real MongoDB instance until a
- * write is rejected for exceeding the document size limit, then asserts the response is 413.
+ * <p><b>Pattern</b> still uses the one-document-per-namespace shape, where every version's
+ * full content accumulates in a single document. Growing its history eventually crosses
+ * MongoDB's 16MB BSON ceiling, and that failure must surface as an honest {@code 413} via
+ * {@link org.finos.calm.domain.exception.StorageWriteException} — not the misleading
+ * {@code 404} the stores used to throw for any {@code MongoWriteException}. This is the
+ * original regression test, repointed from Architecture when Architecture migrated.</p>
+ *
+ * <p><b>Architecture</b> has moved to the header/version shape, where each version is its
+ * own document bounded by its own size. The same history that breaks Pattern must now be
+ * writable, which is the whole point of the redesign. Keeping both in one class means the
+ * ceiling and its removal are asserted against the same real MongoDB, with the same payload
+ * size, rather than being argued about.</p>
  */
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
 public class MongoDocumentSizeLimitIntegration {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     // Comfortably above the ~12-15 versions expected to be needed to cross the 16MB ceiling
     // with ~2MB versions, without letting a stuck test run indefinitely.
     private static final int MAX_VERSION_ATTEMPTS = 20;
+
+    /**
+     * Enough ~2MB versions to total roughly 24MB — well past the 16MB ceiling the old shape
+     * hits, so writing them all is only possible because history is no longer accumulated
+     * into one document.
+     */
+    private static final int VERSIONS_BEYOND_OLD_CEILING = 12;
+
+    /** Roughly 2MB, large enough to cross the ceiling in a handful of writes. */
+    private static final String LARGE_CONTENT = "A".repeat(2_000_000);
 
     @BeforeEach
     public void setup() {
@@ -55,53 +73,75 @@ public class MongoDocumentSizeLimitIntegration {
         }
     }
 
-    @Test
-    void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
-        Response createResponse = given()
+    private static String largeBody(String jsonField, String name) throws Exception {
+        return OBJECT_MAPPER.writeValueAsString(Map.of(
+                "name", name,
+                "description", "for document size limit test",
+                jsonField, OBJECT_MAPPER.writeValueAsString(Map.of("data", LARGE_CONTENT))));
+    }
+
+    private static int createResource(String path, String jsonField, String name) throws Exception {
+        Response response = given()
                 .contentType(ContentType.JSON)
                 .body(OBJECT_MAPPER.writeValueAsString(Map.of(
-                        "name", "size-limit-test-architecture",
+                        "name", name,
                         "description", "for document size limit test",
-                        "architectureJson", "{\"v\":\"1.0.0\"}"
-                )))
-                .when().post("/api/calm/namespaces/finos/architectures")
+                        jsonField, "{\"v\":\"1.0.0\"}")))
+                .when().post("/api/calm/namespaces/finos/" + path)
                 .thenReturn();
-        assertEquals(201, createResponse.getStatusCode());
+        assertEquals(201, response.getStatusCode());
+        return extractIdsFromLocations(List.of(response), path + "/(\\d+)").get(0);
+    }
 
-        List<Integer> architectureIds = extractIdsFromLocations(List.of(createResponse), "architectures/(\\d+)");
-        int architectureId = architectureIds.get(0);
+    private static Response putVersion(String path, int id, int major, String body) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().put("/api/calm/namespaces/finos/" + path + "/" + id + "/versions/" + major + ".0.0")
+                .thenReturn();
+    }
 
-        // Roughly 2MB of content per version; large enough to cross the 16MB document ceiling
-        // in a handful of writes without either request individually tripping an unrelated
-        // HTTP body-size limit.
-        String largeArchitectureJson = OBJECT_MAPPER.writeValueAsString(Map.of("data", "A".repeat(2_000_000)));
-
-        // The request body is identical on every iteration (only the path's version differs),
-        // so serialize it once rather than re-serializing the ~2MB payload each time.
-        String requestBody = OBJECT_MAPPER.writeValueAsString(Map.of(
-                "name", "size-limit-test-architecture",
-                "description", "for document size limit test",
-                "architectureJson", largeArchitectureJson
-        ));
+    @Test
+    void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
+        int patternId = createResource("patterns", "patternJson", "size-limit-test-pattern");
+        String requestBody = largeBody("patternJson", "size-limit-test-pattern");
 
         Response lastResponse = null;
         int version = 2;
         for (; version < MAX_VERSION_ATTEMPTS; version++) {
-            lastResponse = given()
-                    .contentType(ContentType.JSON)
-                    .body(requestBody)
-                    .when().put("/api/calm/namespaces/finos/architectures/" + architectureId + "/versions/" + version + ".0.0")
-                    .thenReturn();
-
+            lastResponse = putVersion("patterns", patternId, version, requestBody);
             if (lastResponse.getStatusCode() != 201) {
                 break;
             }
         }
 
         assertTrue(version < MAX_VERSION_ATTEMPTS,
-                "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS + " versions were written");
+                "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS
+                        + " versions were written. Patterns still accumulate every version's content into "
+                        + "one document per namespace, so this ceiling should still exist for them.");
         assertEquals(413, lastResponse.getStatusCode(),
                 "Expected 413 (capacity exceeded) once the document exceeds MongoDB's 16MB limit, got: "
                         + lastResponse.getStatusCode() + " body=" + lastResponse.getBody().asString());
+    }
+
+    @Test
+    void keep_accepting_architecture_versions_well_past_the_old_document_ceiling() throws Exception {
+        int architectureId = createResource("architectures", "architectureJson", "size-limit-test-architecture");
+        String requestBody = largeBody("architectureJson", "size-limit-test-architecture");
+
+        for (int version = 2; version < VERSIONS_BEYOND_OLD_CEILING + 2; version++) {
+            Response response = putVersion("architectures", architectureId, version, requestBody);
+            assertEquals(201, response.getStatusCode(),
+                    "Version " + version + ".0.0 was rejected with " + response.getStatusCode()
+                            + ". Under the header/version shape each version is its own document, so total "
+                            + "history size should no longer be able to fail a write. body="
+                            + response.getBody().asString());
+        }
+
+        // Roughly 24MB of history, against a 16MB per-document limit — proof the accumulated
+        // total is no longer what any single write is measured against.
+        assertEquals(VERSIONS_BEYOND_OLD_CEILING + 1,
+                given().when().get("/api/calm/namespaces/finos/architectures/" + architectureId + "/versions")
+                        .then().statusCode(200).extract().jsonPath().getList("values").size());
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
+++ b/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
@@ -101,6 +101,10 @@ public class NitriteDBConfig {
     private void initializeDatabase() throws IOException, JsonParseException {
         // Create collections - just getting the collection creates it if it doesn't exist
         db.getCollection("architectures");
+        // Architecture's version documents live in a sibling collection (ADR 0001). The
+        // store creates it on demand too, but it belongs in this list so the set of
+        // collections a fresh standalone database starts with stays honest.
+        db.getCollection("architectureVersions");
         db.getCollection("patterns");
         db.getCollection("namespaces");
         db.getCollection("domains");

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoArchitectureVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoArchitectureVersionSplitStep.java
@@ -1,0 +1,221 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.util.CanonicalVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits the {@code architectures} collection from one document per namespace into one
+ * <em>header</em> document per architecture plus one <em>version</em> document per version
+ * in the new {@code architectureVersions} collection.
+ *
+ * <p>Version 2 → 3 of the schema. Implements the Architecture slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}; the other six versioned
+ * types are migrated by their own later steps, which is what makes the rollout
+ * incremental.</p>
+ *
+ * <h2>This is a 1 → N fan-out, not an in-place shrink</h2>
+ * One old document holds an <em>array</em> of architectures, each with an embedded map of
+ * every version's full content. One such document therefore becomes N headers plus M
+ * version documents, and the original is deleted rather than edited down.
+ *
+ * <h2>Why the indexes have to move first</h2>
+ * {@code MongoIndexInitializationStep} created a unique index on {@code namespace} alone,
+ * which enforces exactly one {@code architectures} document per namespace — precisely the
+ * old shape. Writing N headers for one namespace is impossible until it is gone. That step
+ * is immutable (a committed migration step never changes, or fresh deployments would
+ * silently diverge from existing ones), so the drop belongs here.
+ *
+ * <h2>Idempotency</h2>
+ * {@link SchemaMigrationStep} asks steps to survive a partially-applied previous attempt,
+ * because a failure leaves the schema version unchanged and the step is retried next
+ * startup. Three things provide that here:
+ * <ul>
+ *   <li>The fan-out selects only documents that still have an {@code architectures} array,
+ *       so migrated headers are never re-processed.</li>
+ *   <li>Headers and versions are written with {@code replaceOne(upsert)}, so re-writing one
+ *       that a previous attempt already created succeeds instead of failing on the unique
+ *       index.</li>
+ *   <li>The old document is deleted only after its headers and versions are written, so a
+ *       crash mid-namespace leaves the source intact and the whole namespace is redone.</li>
+ * </ul>
+ * The index work is naturally idempotent: {@code createIndex} is a no-op when the index
+ * already exists, and the drop tolerates the index being absent.
+ *
+ * <h2>Version keys</h2>
+ * Old keys are dash-encoded ({@code 1-0-0}) because Mongo field names cannot contain a dot.
+ * They are converted with {@link CanonicalVersion} — the same conversion the write path
+ * uses — rather than a local {@code replace('-', '.')}, so migrated data is addressable by
+ * exactly the spelling the new store looks for. Anything the version regex doesn't
+ * recognise is carried across untouched rather than mangled into a new key.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoArchitectureVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoArchitectureVersionSplitStep.class);
+
+    private static final String HEADER_COLLECTION = "architectures";
+    private static final String VERSION_COLLECTION = "architectureVersions";
+    private static final String ID_FIELD = "architectureId";
+    private static final String ARRAY_FIELD = "architectures";
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String VERSIONS_FIELD = "versions";
+
+    /** The index {@code MongoIndexInitializationStep} created, in Mongo's default naming. */
+    private static final String OLD_NAMESPACE_INDEX = "namespace_1";
+
+    /** MongoDB's {@code IndexNotFound} error code. */
+    private static final int INDEX_NOT_FOUND = 27;
+
+    private final MongoDatabase database;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoArchitectureVersionSplitStep(MongoDatabase database) {
+        this.database = database;
+    }
+
+    @Override
+    public int fromVersion() {
+        return 2;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping architecture version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public, like
+     * {@code MongoIndexInitializationStep.createIndexes()} and for the same reason:
+     * integration tests with a known-real MongoDB container call it directly rather than
+     * faking the CDI-injected {@link #databaseMode} field that {@link #apply()} needs.
+     */
+    public void migrate() {
+        transitionIndexes();
+        fanOutNamespaceDocuments();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having
+     * any old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        MongoCollection<Document> headers = database.getCollection(HEADER_COLLECTION);
+        dropOldNamespaceIndex(headers);
+
+        IndexOptions unique = new IndexOptions().unique(true);
+        headers.createIndex(new Document(NAMESPACE_FIELD, 1).append(ID_FIELD, 1), unique);
+        LOG.info("Ensured unique index on {}.({}, {})", HEADER_COLLECTION, NAMESPACE_FIELD, ID_FIELD);
+
+        database.getCollection(VERSION_COLLECTION).createIndex(
+                new Document(NAMESPACE_FIELD, 1).append(ID_FIELD, 1).append("version", 1), unique);
+        LOG.info("Ensured unique index on {}.({}, {}, version)", VERSION_COLLECTION, NAMESPACE_FIELD, ID_FIELD);
+    }
+
+    private void dropOldNamespaceIndex(MongoCollection<Document> headers) {
+        try {
+            headers.dropIndex(OLD_NAMESPACE_INDEX);
+            LOG.info("Dropped the old unique index {}.{}", HEADER_COLLECTION, OLD_NAMESPACE_INDEX);
+        } catch (MongoCommandException e) {
+            if (e.getErrorCode() != INDEX_NOT_FOUND) {
+                throw e;
+            }
+            // Already dropped by a previous attempt, or never created — either way the
+            // constraint we need gone is gone, which is all this call is for.
+            LOG.info("Old unique index {}.{} was already absent", HEADER_COLLECTION, OLD_NAMESPACE_INDEX);
+        }
+    }
+
+    private void fanOutNamespaceDocuments() {
+        MongoCollection<Document> headers = database.getCollection(HEADER_COLLECTION);
+        MongoCollection<Document> versions = database.getCollection(VERSION_COLLECTION);
+
+        // Only old-shape documents carry the array; headers written by a previous attempt
+        // (or by the running application) don't, so re-running skips them.
+        List<Document> oldDocuments = new ArrayList<>();
+        headers.find(Filters.exists(ARRAY_FIELD)).forEach(oldDocuments::add);
+
+        int migratedArchitectures = 0;
+        int migratedVersions = 0;
+        for (Document oldDocument : oldDocuments) {
+            String namespace = oldDocument.getString(NAMESPACE_FIELD);
+            for (Document entry : oldDocument.getList(ARRAY_FIELD, Document.class, List.of())) {
+                migratedVersions += writeOneArchitecture(headers, versions, namespace, entry);
+                migratedArchitectures++;
+            }
+            // Only once its contents are safely rewritten.
+            headers.deleteOne(Filters.eq("_id", oldDocument.get("_id")));
+        }
+
+        LOG.info("Architecture version split complete: {} namespace document(s) fanned out into "
+                        + "{} header(s) and {} version document(s)",
+                oldDocuments.size(), migratedArchitectures, migratedVersions);
+    }
+
+    /**
+     * @return how many version documents were written for this architecture.
+     */
+    private int writeOneArchitecture(MongoCollection<Document> headers,
+                                     MongoCollection<Document> versions,
+                                     String namespace,
+                                     Document entry) {
+        Integer resourceId = entry.getInteger(ID_FIELD);
+        Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
+        int versionCount = storedVersions == null ? 0 : storedVersions.size();
+
+        ReplaceOptions upsert = new ReplaceOptions().upsert(true);
+
+        Document header = new Document(NAMESPACE_FIELD, namespace)
+                .append(ID_FIELD, resourceId)
+                .append("name", entry.getString("name"))
+                .append("description", entry.getString("description"))
+                .append("versionCount", versionCount)
+                .append("metadata", new Document());
+        headers.replaceOne(
+                Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(ID_FIELD, resourceId)),
+                header, upsert);
+
+        if (storedVersions == null) {
+            return 0;
+        }
+        for (String storedKey : storedVersions.keySet()) {
+            // CanonicalVersion handles the dash spelling directly — VERSION_REGEX treats
+            // both separators as interchangeable — so no replace('-', '.') first.
+            String version = CanonicalVersion.of(storedKey);
+            Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
+                    .append(ID_FIELD, resourceId)
+                    .append("version", version)
+                    .append("content", storedVersions.get(storedKey, Document.class))
+                    .append("metadata", new Document());
+            versions.replaceOne(
+                    Filters.and(Filters.eq(NAMESPACE_FIELD, namespace),
+                            Filters.eq(ID_FIELD, resourceId),
+                            Filters.eq("version", version)),
+                    versionDocument, upsert);
+        }
+        return storedVersions.size();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoArchitectureVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoArchitectureVersionSplitStep.java
@@ -5,6 +5,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.ReplaceOptions;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,7 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Splits the {@code architectures} collection from one document per namespace into one
@@ -153,26 +156,40 @@ public class MongoArchitectureVersionSplitStep implements SchemaMigrationStep {
         MongoCollection<Document> headers = database.getCollection(HEADER_COLLECTION);
         MongoCollection<Document> versions = database.getCollection(VERSION_COLLECTION);
 
+        // Ids only, not the documents themselves. These are precisely the documents this
+        // migration exists to break up — each up to MongoDB's 16MB ceiling, and several
+        // times that once parsed into a Document — so holding every one of them in memory
+        // at once is how a hub with a few large namespaces runs out of heap. An OOM here
+        // is not a clean failure either: the step throws, the runner leaves the migration
+        // lock held, and every instance sharing the database refuses requests until an
+        // administrator clears it. So they are re-read and released one at a time.
+        //
         // Only old-shape documents carry the array; headers written by a previous attempt
         // (or by the running application) don't, so re-running skips them.
-        List<Document> oldDocuments = new ArrayList<>();
-        headers.find(Filters.exists(ARRAY_FIELD)).forEach(oldDocuments::add);
+        List<Object> oldDocumentIds = new ArrayList<>();
+        headers.find(Filters.exists(ARRAY_FIELD))
+                .projection(Projections.include("_id"))
+                .forEach(document -> oldDocumentIds.add(document.get("_id")));
 
         int migratedArchitectures = 0;
         int migratedVersions = 0;
-        for (Document oldDocument : oldDocuments) {
+        for (Object oldDocumentId : oldDocumentIds) {
+            Document oldDocument = headers.find(Filters.eq("_id", oldDocumentId)).first();
+            if (oldDocument == null) {
+                continue;
+            }
             String namespace = oldDocument.getString(NAMESPACE_FIELD);
             for (Document entry : oldDocument.getList(ARRAY_FIELD, Document.class, List.of())) {
                 migratedVersions += writeOneArchitecture(headers, versions, namespace, entry);
                 migratedArchitectures++;
             }
             // Only once its contents are safely rewritten.
-            headers.deleteOne(Filters.eq("_id", oldDocument.get("_id")));
+            headers.deleteOne(Filters.eq("_id", oldDocumentId));
         }
 
         LOG.info("Architecture version split complete: {} namespace document(s) fanned out into "
                         + "{} header(s) and {} version document(s)",
-                oldDocuments.size(), migratedArchitectures, migratedVersions);
+                oldDocumentIds.size(), migratedArchitectures, migratedVersions);
     }
 
     /**
@@ -184,7 +201,7 @@ public class MongoArchitectureVersionSplitStep implements SchemaMigrationStep {
                                      Document entry) {
         Integer resourceId = entry.getInteger(ID_FIELD);
         Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
-        int versionCount = storedVersions == null ? 0 : storedVersions.size();
+        Map<String, String> keysByCanonicalVersion = collapseToCanonicalVersions(storedVersions, namespace, resourceId);
 
         ReplaceOptions upsert = new ReplaceOptions().upsert(true);
 
@@ -192,30 +209,63 @@ public class MongoArchitectureVersionSplitStep implements SchemaMigrationStep {
                 .append(ID_FIELD, resourceId)
                 .append("name", entry.getString("name"))
                 .append("description", entry.getString("description"))
-                .append("versionCount", versionCount)
+                // The collapsed count, not the raw key count: two old keys can mean one
+                // version, and a header claiming more versions than exist is exactly the
+                // drift the denormalised counter is supposed to avoid.
+                .append("versionCount", keysByCanonicalVersion.size())
                 .append("metadata", new Document());
         headers.replaceOne(
                 Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(ID_FIELD, resourceId)),
                 header, upsert);
 
+        for (Map.Entry<String, String> version : keysByCanonicalVersion.entrySet()) {
+            Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
+                    .append(ID_FIELD, resourceId)
+                    .append("version", version.getKey())
+                    .append("content", storedVersions.get(version.getValue(), Document.class))
+                    .append("metadata", new Document());
+            versions.replaceOne(
+                    Filters.and(Filters.eq(NAMESPACE_FIELD, namespace),
+                            Filters.eq(ID_FIELD, resourceId),
+                            Filters.eq("version", version.getKey())),
+                    versionDocument, upsert);
+        }
+        return keysByCanonicalVersion.size();
+    }
+
+    /**
+     * Maps each canonical version to the stored key it came from, keeping the first when
+     * several collapse onto one.
+     *
+     * <p>The old shape could hold several keys meaning the same version. It wrote them via
+     * {@code replace('.', '-')}, which folded {@code 1.0.0} and {@code 1-0-0} together but
+     * left {@code 100} and {@code 1.00} — both accepted by {@code VERSION_REGEX} — as keys
+     * of their own. All of them canonicalise to {@code 1.0.0}, and only one document can
+     * exist per {@code (namespace, id, version)}, so collapsing is unavoidable rather than
+     * a choice made here.</p>
+     *
+     * <p>What is a choice is doing it visibly: writing each key in turn would let the last
+     * silently overwrite the earlier ones' content and still report every key in
+     * {@code versionCount}. Logging at {@code WARN} names the discarded key so the loss is
+     * recoverable from a backup, which a silent overwrite would not be.</p>
+     */
+    private Map<String, String> collapseToCanonicalVersions(Document storedVersions, String namespace, Integer resourceId) {
+        Map<String, String> keysByCanonicalVersion = new LinkedHashMap<>();
         if (storedVersions == null) {
-            return 0;
+            return keysByCanonicalVersion;
         }
         for (String storedKey : storedVersions.keySet()) {
             // CanonicalVersion handles the dash spelling directly — VERSION_REGEX treats
             // both separators as interchangeable — so no replace('-', '.') first.
             String version = CanonicalVersion.of(storedKey);
-            Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
-                    .append(ID_FIELD, resourceId)
-                    .append("version", version)
-                    .append("content", storedVersions.get(storedKey, Document.class))
-                    .append("metadata", new Document());
-            versions.replaceOne(
-                    Filters.and(Filters.eq(NAMESPACE_FIELD, namespace),
-                            Filters.eq(ID_FIELD, resourceId),
-                            Filters.eq("version", version)),
-                    versionDocument, upsert);
+            String alreadyMapped = keysByCanonicalVersion.putIfAbsent(version, storedKey);
+            if (alreadyMapped != null) {
+                LOG.warn("Discarding version key '{}' [namespace={}, {}={}] — it means the same "
+                                + "version as '{}' ({}), which the new shape stores once. The "
+                                + "discarded content is only recoverable from a backup.",
+                        storedKey, namespace, ID_FIELD, resourceId, alreadyMapped, version);
+            }
         }
-        return storedVersions.size();
+        return keysByCanonicalVersion;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteArchitectureVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteArchitectureVersionSplitStep.java
@@ -1,0 +1,141 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.util.CanonicalVersion;
+import org.finos.calm.store.util.TypeSafeNitriteDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.dizitart.no2.filters.FluentFilter.where;
+
+/**
+ * NitriteDB counterpart to {@link MongoArchitectureVersionSplitStep}: the same version
+ * 2 → 3 fan-out of {@code architectures} into per-architecture headers plus a
+ * {@code architectureVersions} collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 2}, which {@code SchemaMigrationRunner}
+ * would reject as a duplicate — but they never coexist. Each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so
+ * exactly one is a CDI bean in any given deployment.</p>
+ *
+ * <h2>Two differences from the Mongo step</h2>
+ * <ul>
+ *   <li><b>No index work.</b> CalmHub creates no Nitrite indexes at all, so there is no
+ *       one-document-per-namespace constraint to drop and no uniqueness to establish —
+ *       {@code NitriteVersionDocumentStore} enforces it with a lock instead.</li>
+ *   <li><b>Version content is a JSON string</b>, not a parsed document, matching how the
+ *       Nitrite stores have always held it.</li>
+ * </ul>
+ *
+ * <h2>Idempotency</h2>
+ * As with the Mongo step: only documents that still carry the {@code architectures} array
+ * are processed, writes go through a remove-then-insert on the target key rather than a
+ * blind insert, and the old document is deleted only once its contents are rewritten.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteArchitectureVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NitriteArchitectureVersionSplitStep.class);
+
+    private static final String HEADER_COLLECTION = "architectures";
+    private static final String VERSION_COLLECTION = "architectureVersions";
+    private static final String ID_FIELD = "architectureId";
+    private static final String ARRAY_FIELD = "architectures";
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String VERSIONS_FIELD = "versions";
+
+    private final NitriteCollection headerCollection;
+    private final NitriteCollection versionCollection;
+
+    @Inject
+    public NitriteArchitectureVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.headerCollection = db.getCollection(HEADER_COLLECTION);
+        this.versionCollection = db.getCollection(VERSION_COLLECTION);
+    }
+
+    @Override
+    public int fromVersion() {
+        return 2;
+    }
+
+    @Override
+    public void apply() {
+        List<Document> oldDocuments = new ArrayList<>();
+        for (Document document : headerCollection.find()) {
+            // Nitrite has no "field exists" filter as convenient as Mongo's, and the
+            // collection is small enough that checking in memory costs nothing.
+            if (document.get(ARRAY_FIELD) != null) {
+                oldDocuments.add(document);
+            }
+        }
+
+        int migratedArchitectures = 0;
+        int migratedVersions = 0;
+        for (Document oldDocument : oldDocuments) {
+            String namespace = oldDocument.get(NAMESPACE_FIELD, String.class);
+            List<Document> entries = new TypeSafeNitriteDocument<>(oldDocument, Document.class).getList(ARRAY_FIELD);
+            if (entries != null) {
+                for (Document entry : entries) {
+                    migratedVersions += writeOneArchitecture(namespace, entry);
+                    migratedArchitectures++;
+                }
+            }
+            // By identity, not by a namespace filter: the headers just written share this
+            // namespace, and a filtered delete would take them with it.
+            headerCollection.remove(oldDocument);
+        }
+
+        LOG.info("Architecture version split complete: {} namespace document(s) fanned out into "
+                        + "{} header(s) and {} version document(s)",
+                oldDocuments.size(), migratedArchitectures, migratedVersions);
+    }
+
+    /**
+     * @return how many version documents were written for this architecture.
+     */
+    private int writeOneArchitecture(String namespace, Document entry) {
+        Integer resourceId = entry.get(ID_FIELD, Integer.class);
+        Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
+        int versionCount = storedVersions == null ? 0 : storedVersions.getFields().size();
+
+        Filter headerFilter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(ID_FIELD).eq(resourceId));
+        headerCollection.remove(headerFilter);
+        headerCollection.insert(Document.createDocument()
+                .put(NAMESPACE_FIELD, namespace)
+                .put(ID_FIELD, resourceId)
+                .put("name", entry.get("name", String.class))
+                .put("description", entry.get("description", String.class))
+                .put("versionCount", versionCount)
+                .put("metadata", Document.createDocument()));
+
+        if (storedVersions == null) {
+            return 0;
+        }
+        for (String storedKey : storedVersions.getFields()) {
+            // Same conversion the write path uses, so migrated data is addressable by
+            // exactly the spelling the new store looks for.
+            String version = CanonicalVersion.of(storedKey);
+            versionCollection.remove(Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(ID_FIELD).eq(resourceId), where("version").eq(version)));
+            versionCollection.insert(Document.createDocument()
+                    .put(NAMESPACE_FIELD, namespace)
+                    .put(ID_FIELD, resourceId)
+                    .put("version", version)
+                    .put("content", storedVersions.get(storedKey, String.class))
+                    .put("metadata", Document.createDocument()));
+        }
+        return storedVersions.getFields().size();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteArchitectureVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteArchitectureVersionSplitStep.java
@@ -15,7 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.dizitart.no2.filters.FluentFilter.where;
 
@@ -108,7 +110,7 @@ public class NitriteArchitectureVersionSplitStep implements SchemaMigrationStep 
     private int writeOneArchitecture(String namespace, Document entry) {
         Integer resourceId = entry.get(ID_FIELD, Integer.class);
         Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
-        int versionCount = storedVersions == null ? 0 : storedVersions.getFields().size();
+        Map<String, String> keysByCanonicalVersion = collapseToCanonicalVersions(storedVersions, namespace, resourceId);
 
         Filter headerFilter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(ID_FIELD).eq(resourceId));
         headerCollection.remove(headerFilter);
@@ -117,25 +119,47 @@ public class NitriteArchitectureVersionSplitStep implements SchemaMigrationStep 
                 .put(ID_FIELD, resourceId)
                 .put("name", entry.get("name", String.class))
                 .put("description", entry.get("description", String.class))
-                .put("versionCount", versionCount)
+                // The collapsed count, not the raw key count — see collapseToCanonicalVersions.
+                .put("versionCount", keysByCanonicalVersion.size())
                 .put("metadata", Document.createDocument()));
 
+        for (Map.Entry<String, String> version : keysByCanonicalVersion.entrySet()) {
+            versionCollection.remove(Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(ID_FIELD).eq(resourceId), where("version").eq(version.getKey())));
+            versionCollection.insert(Document.createDocument()
+                    .put(NAMESPACE_FIELD, namespace)
+                    .put(ID_FIELD, resourceId)
+                    .put("version", version.getKey())
+                    .put("content", storedVersions.get(version.getValue(), String.class))
+                    .put("metadata", Document.createDocument()));
+        }
+        return keysByCanonicalVersion.size();
+    }
+
+    /**
+     * Maps each canonical version to the stored key it came from, keeping the first when
+     * several collapse onto one. See
+     * {@code MongoArchitectureVersionSplitStep.collapseToCanonicalVersions} for why the
+     * old shape can hold several keys meaning one version, and why the collapse is logged
+     * rather than left to a silent overwrite.
+     */
+    private Map<String, String> collapseToCanonicalVersions(Document storedVersions, String namespace, Integer resourceId) {
+        Map<String, String> keysByCanonicalVersion = new LinkedHashMap<>();
         if (storedVersions == null) {
-            return 0;
+            return keysByCanonicalVersion;
         }
         for (String storedKey : storedVersions.getFields()) {
             // Same conversion the write path uses, so migrated data is addressable by
             // exactly the spelling the new store looks for.
             String version = CanonicalVersion.of(storedKey);
-            versionCollection.remove(Filter.and(where(NAMESPACE_FIELD).eq(namespace),
-                    where(ID_FIELD).eq(resourceId), where("version").eq(version)));
-            versionCollection.insert(Document.createDocument()
-                    .put(NAMESPACE_FIELD, namespace)
-                    .put(ID_FIELD, resourceId)
-                    .put("version", version)
-                    .put("content", storedVersions.get(storedKey, String.class))
-                    .put("metadata", Document.createDocument()));
+            String alreadyMapped = keysByCanonicalVersion.putIfAbsent(version, storedKey);
+            if (alreadyMapped != null) {
+                LOG.warn("Discarding version key '{}' [namespace={}, {}={}] — it means the same "
+                                + "version as '{}' ({}), which the new shape stores once. The "
+                                + "discarded content is only recoverable from a backup.",
+                        storedKey, namespace, ID_FIELD, resourceId, alreadyMapped, version);
+            }
         }
-        return storedVersions.getFields().size();
+        return keysByCanonicalVersion;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -10,6 +10,7 @@ import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.util.MongoVersionDocumentStore;
@@ -81,7 +82,7 @@ public class MongoArchitectureStore implements ArchitectureStore {
 
         int id = counterStore.getNextArchitectureSequenceValue();
         documentStore.createHeader(architecture.getNamespace(), id, architecture.getName(), architecture.getDescription());
-        documentStore.createVersion(architecture.getNamespace(), id, INITIAL_VERSION, content);
+        createInitialVersion(architecture.getNamespace(), id, content);
 
         return new Architecture.ArchitectureBuilder()
                 .setId(id)
@@ -136,6 +137,38 @@ public class MongoArchitectureStore implements ArchitectureStore {
 
         updateHeaderDetails(architecture);
         return architecture;
+    }
+
+    /**
+     * Writes the first version of a newly created architecture, removing the header again
+     * if that fails.
+     *
+     * <p>The old shape wrote the architecture and its first version in a single document
+     * push, so a failure left nothing behind. Two writes can fail between the two, and a
+     * header with no versions cannot be removed through the API — there is no delete
+     * endpoint — so it would sit in listings and search reporting
+     * {@code versionCount: 0} indefinitely. The compensating delete keeps the failure
+     * looking like the old all-or-nothing one.</p>
+     *
+     * <p>A {@code false} return means a version document already exists for an id the
+     * counter just issued, which is a storage inconsistency rather than a normal
+     * "already exists" outcome — returning the caller's payload as though it had been
+     * stored would report success for content that was never written.</p>
+     */
+    private void createInitialVersion(String namespace, int id, Document content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -1,18 +1,9 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
-import org.finos.calm.store.util.VersionKeySelector;
-import org.bson.conversions.Bson;
 import org.finos.calm.domain.Architecture;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.exception.ArchitectureNotFoundException;
@@ -21,256 +12,153 @@ import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link ArchitectureStore}.
  *
  * <h2>Document model</h2>
- * The {@code architectures} collection has <em>one document per namespace</em>, enforced by a
- * unique index on the {@code namespace} field (created by {@code MongoIndexInitializationStep}).
- * Each document contains an {@code architectures} array where individual architecture
- * entries are stored as sub-documents with a unique {@code architectureId}, versioned
- * content, and metadata.
+ * One <em>header</em> document per architecture in {@code architectures}, and one
+ * <em>version</em> document per version in {@code architectureVersions}. All document
+ * handling lives in {@link MongoVersionDocumentStore}; this class only translates
+ * between that and the domain's objects and exceptions. See
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md} for the shape and
+ * {@code 0003-shared-version-store-helper.md} for why this composes the helper rather
+ * than extending a base class.
  *
- * <h2>Concurrency strategy — create</h2>
- * New architectures are added via {@code updateOne} with {@code upsert: true} and
- * {@code $push}. The upsert creates the namespace document if it doesn't exist; the
- * unique index on {@code namespace} prevents two concurrent upserts from creating
- * duplicate namespace documents. The {@link MongoCounterStore} provides an atomically
- * unique {@code architectureId} via {@code findOneAndUpdate} with {@code $inc}.
+ * <p>Replaces a one-document-per-namespace shape that held every architecture and the
+ * full content of every version in a single document, which grew without bound against
+ * MongoDB's 16MB limit.</p>
  *
- * <h2>Concurrency strategy — new version</h2>
- * Adding a new version to an existing architecture uses an atomic conditional update:
- * the query filter includes {@code $elemMatch} with {@code $exists: false} on the target
- * version key. If a concurrent request already added the version, the filter won't match
- * and {@code matchedCount == 0} signals a conflict, throwing
- * {@link ArchitectureVersionExistsException}.
- *
- * @see MongoCounterStore
+ * <h2>Existence checks</h2>
+ * Every method that can report "no such architecture" asks
+ * {@link MongoVersionDocumentStore#headerExists} rather than inferring it from an empty
+ * version list. A header may legitimately have no versions, so the two are genuinely
+ * different questions under this shape — see ADR 0003.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoArchitectureStore.class)
 public class MongoArchitectureStore implements ArchitectureStore {
 
+    private static final String HEADER_COLLECTION = "architectures";
+    private static final String VERSION_COLLECTION = "architectureVersions";
+    private static final String ID_FIELD = "architectureId";
+    private static final String RESOURCE_LABEL = "Architecture";
+    private static final String INITIAL_VERSION = "1.0.0";
+
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final MongoCollection<Document> architectureCollection;
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final MongoVersionDocumentStore documentStore;
 
     public MongoArchitectureStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
         this.counterStore = counterStore;
         this.namespaceStore = namespaceStore;
-        this.architectureCollection = database.getCollection("architectures");
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
     }
 
     @Override
     public List<NamespaceResourceSummary> getArchitecturesForNamespace(String namespace, PageRequest page) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        // When paged, the window is pushed down to Mongo via a $slice projection so only the requested
-        // slice of the architectures array is returned rather than the whole list. Unpaged → no
-        // projection → full list (unchanged behaviour). See MongoResourceSlice.
-        Bson filter = Filters.eq("namespace", namespace);
-        Document namespaceDocument = MongoResourceSlice.findNamespaceDoc(architectureCollection, filter, "architectures", page);
-
-        //protects from an unpopulated mongo collection
-        if (namespaceDocument == null || namespaceDocument.isEmpty()) {
-            return List.of();
-        }
-
-        List<Document> architectures = namespaceDocument.getList("architectures", Document.class);
-        List<NamespaceResourceSummary> architectureSummaries = new ArrayList<>();
-
-        for (Document architectureDoc : architectures) {
-            Integer archId = architectureDoc.getInteger("architectureId");
-            String name = architectureDoc.getString("name");
-            String description = architectureDoc.getString("description");
-            if (name == null) name = "Architecture " + archId;
-            if (description == null) description = "";
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = architectureDoc.get("versions");
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.keySet() : null);
-            NamespaceResourceSummary summary = new NamespaceResourceSummary(
-                    name, description, archId, versionCount
-            );
-            architectureSummaries.add(summary);
-        }
-
-        return architectureSummaries;
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, page);
     }
 
     @Override
     public Architecture createArchitectureForNamespace(Architecture architecture) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(architecture.getNamespace());
+
+        // Parsed before the counter is drawn and before anything is written, so malformed
+        // JSON can't leave a header behind with no version to go with it.
+        Document content = Document.parse(architecture.getArchitectureJson());
 
         int id = counterStore.getNextArchitectureSequenceValue();
-        Document architectureDocument = new Document("architectureId", id)
-                .append("name", architecture.getName())
-                .append("description", architecture.getDescription())
-                .append("versions", new Document("1-0-0", Document.parse(architecture.getArchitectureJson())));
+        documentStore.createHeader(architecture.getNamespace(), id, architecture.getName(), architecture.getDescription());
+        documentStore.createVersion(architecture.getNamespace(), id, INITIAL_VERSION, content);
 
-        MongoUpsertPush.pushWithDuplicateRetry(architectureCollection,
-                Filters.eq("namespace", architecture.getNamespace()),
-                "architectures", architectureDocument);
-
-        Architecture persistedArchitecture = new Architecture.ArchitectureBuilder()
+        return new Architecture.ArchitectureBuilder()
                 .setId(id)
-                .setVersion("1.0.0")
+                .setVersion(INITIAL_VERSION)
                 .setNamespace(architecture.getNamespace())
                 .setArchitecture(architecture.getArchitectureJson())
                 .build();
-
-        return persistedArchitecture;
     }
 
     @Override
     public List<String> getArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        Document result = retrieveArchitectureVersions(architecture);
-
-        List<Document> architectures = result.getList("architectures", Document.class);
-        for (Document architectureDoc : architectures) {
-            if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
-                // Extract the versions map from the matching pattern
-                Document versions = (Document) architectureDoc.get("versions");
-                if (versions == null) {
-                    throw new ArchitectureNotFoundException();
-                }
-                Set<String> versionKeys = versions.keySet();
-
-                //Convert from Mongo representation
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
-                }
-                return resourceVersions;  // Return the list of version keys
-            }
-        }
-
-        throw new ArchitectureNotFoundException();
-    }
-
-    private Document retrieveArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", architecture.getNamespace());
-        Bson projection = Projections.fields(Projections.include("architectures"));
-
-        Document result = architectureCollection.find(filter).projection(projection).first();
-
-        if (result == null) {
-            throw new ArchitectureNotFoundException();
-        }
-
-        return result;
-    }
-
-    private void verifyArchitectureExists(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        Document result = retrieveArchitectureVersions(architecture);
-        List<Document> architectures = result.getList("architectures", Document.class);
-        for (Document architectureDoc : architectures) {
-            if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
-                return;
-            }
-        }
-        throw new ArchitectureNotFoundException();
+        requireArchitecture(architecture);
+        // An architecture with no versions yet returns an empty list rather than
+        // reporting itself missing — the header above already settled that question.
+        return documentStore.listVersions(architecture.getNamespace(), architecture.getId());
     }
 
     @Override
     public String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
-        Document result = retrieveArchitectureVersions(architecture);
+        requireArchitecture(architecture);
 
-        List<Document> architectures = result.getList("architectures", Document.class);
-        for (Document architectureDoc : architectures) {
-            if (architecture.getId() == architectureDoc.getInteger("architectureId")) {
-                // Retrieve the versions map from the matching pattern
-                Document versions = (Document) architectureDoc.get("versions");
-                if (versions == null) {
-                    throw new ArchitectureVersionNotFoundException();
-                }
-
-                // Return the pattern JSON blob for the specified version
-                Document versionDoc = (Document) versions.get(architecture.getMongoVersion());
-                log.info("Version [{}] found: {}", architecture.getMongoVersion(), versionDoc != null);
-                if (versionDoc == null) {
-                    throw new ArchitectureVersionNotFoundException();
-                }
-                return versionDoc.toJson();
-            }
+        Document content = documentStore.getVersion(
+                architecture.getNamespace(), architecture.getId(), architecture.getDotVersion());
+        if (content == null) {
+            throw new ArchitectureVersionNotFoundException();
         }
-        //Patterns is empty, no version to find
-        throw new ArchitectureVersionNotFoundException();
+        return content.toJson();
     }
 
     @Override
     public Architecture createArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionExistsException {
-        // Validates namespace and architecture existence
-        getArchitectureVersions(architecture);
+        requireArchitecture(architecture);
 
-        // Atomic conditional update: only succeeds if the version doesn't already exist
-        Document filter = new Document("namespace", architecture.getNamespace())
-                .append("architectures", new Document("$elemMatch",
-                        new Document("architectureId", architecture.getId())
-                                .append("versions." + architecture.getMongoVersion(), new Document("$exists", false))));
-
-        Document update = new Document("$set",
-                new Document("architectures.$.versions." + architecture.getMongoVersion(), Document.parse(architecture.getArchitectureJson()))
-                        .append("architectures.$.name", architecture.getName())
-                        .append("architectures.$.description", architecture.getDescription()));
-
-        if (architectureCollection.updateOne(filter, update).getMatchedCount() == 0) {
+        Document content = Document.parse(architecture.getArchitectureJson());
+        boolean created = documentStore.createVersion(
+                architecture.getNamespace(), architecture.getId(), architecture.getDotVersion(), content);
+        if (!created) {
             throw new ArchitectureVersionExistsException();
         }
 
+        updateHeaderDetails(architecture);
         return architecture;
     }
 
     @Override
     public Architecture updateArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
+        requireArchitecture(architecture);
 
-        writeArchitectureToMongo(architecture);
+        Document content = Document.parse(architecture.getArchitectureJson());
+        documentStore.upsertVersion(
+                architecture.getNamespace(), architecture.getId(), architecture.getDotVersion(), content);
+
+        updateHeaderDetails(architecture);
         return architecture;
     }
 
-    private void writeArchitectureToMongo(Architecture architecture) throws ArchitectureNotFoundException, NamespaceNotFoundException {
-        // Verifies the namespace AND the specific architecture entity exist, so any
-        // MongoWriteException from the update below is a genuine write failure, not a
-        // disguised not-found.
-        verifyArchitectureExists(architecture);
+    /**
+     * Applies the name and description that came with a version write. Called only
+     * <em>after</em> the version write succeeds: the old shape set both fields in the
+     * same conditional update that wrote the content, so a create rejected for an
+     * already-existing version left them untouched.
+     */
+    private void updateHeaderDetails(Architecture architecture) {
+        documentStore.updateHeaderDetails(architecture.getNamespace(), architecture.getId(),
+                architecture.getName(), architecture.getDescription());
+    }
 
-        Document filter = new Document("namespace", architecture.getNamespace())
-                .append("architectures.architectureId", architecture.getId());
-
-        Document update = new Document("$set", new Document("architectures.$.versions." + architecture.getMongoVersion(), Document.parse(architecture.getArchitectureJson()))
-                .append("architectures.$.name", architecture.getName())
-                .append("architectures.$.description", architecture.getDescription())
-        );
-
-        try {
-            architectureCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (MongoWriteException ex) {
-            // Log identifying fields only, not the full architecture object — its toString()
-            // includes the entire (potentially near-16MB) architectureJson payload.
-            log.error("Failed to write architecture [namespace={}, id={}, version={}] to mongo",
-                    architecture.getNamespace(), architecture.getId(), architecture.getMongoVersion(), ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
         }
     }
 
+    private void requireArchitecture(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        requireNamespace(architecture.getNamespace());
+        if (!documentStore.headerExists(architecture.getNamespace(), architecture.getId())) {
+            throw new ArchitectureNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -57,7 +57,7 @@ public class MongoSearchStore implements SearchStore {
         String lowerQuery = query.toLowerCase();
 
         return new GroupedSearchResults(
-                searchNamespacedCollection(architectureCollection, "architectures", "architectureId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(patternCollection, "patterns", "patternId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(flowCollection, "flows", "flowId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
@@ -65,6 +65,46 @@ public class MongoSearchStore implements SearchStore {
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)
         );
+    }
+
+    /**
+     * Searches a collection in the header/version shape, where each document <em>is</em> one
+     * resource rather than a namespace-wide array of them.
+     *
+     * <p>Separate from {@link #searchNamespacedCollection} rather than replacing it because
+     * the two shapes coexist: ADR 0001 migrates one resource type at a time, so Architecture
+     * reads this way while patterns, flows, standards and interfaces still read the other.
+     * Note the failure mode if a migrated type is left on the old method — {@code getList}
+     * returns null for a header document, so the loop skips every document and the type
+     * silently returns no results at all, with nothing logged.</p>
+     */
+    private List<SearchResult> searchHeaderCollection(MongoCollection<Document> collection,
+                                                      String idField,
+                                                      String lowerQuery,
+                                                      Optional<Set<String>> readableNamespaces) {
+        List<SearchResult> results = new ArrayList<>();
+
+        for (Document header : collection.find()) {
+            if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
+                return results;
+            }
+            String namespace = header.getString("namespace");
+            if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
+                continue;
+            }
+            String name = header.getString("name");
+            String description = header.getString("description");
+            if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
+                results.add(new SearchResult(
+                        namespace,
+                        header.getInteger(idField),
+                        SearchTextMatcher.nullToEmpty(name),
+                        SearchTextMatcher.nullToEmpty(description)
+                ));
+            }
+        }
+
+        return results;
     }
 
     private List<SearchResult> searchNamespacedCollection(MongoCollection<Document> collection,

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -12,6 +12,7 @@ import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.util.NitriteVersionDocumentStore;
@@ -85,7 +86,7 @@ public class NitriteArchitectureStore implements ArchitectureStore {
 
         int id = counterStore.getNextArchitectureSequenceValue();
         documentStore.createHeader(architecture.getNamespace(), id, architecture.getName(), architecture.getDescription());
-        documentStore.createVersion(architecture.getNamespace(), id, INITIAL_VERSION, architecture.getArchitectureJson());
+        createInitialVersion(architecture.getNamespace(), id, architecture.getArchitectureJson());
 
         LOG.info("Created architecture with ID {} for namespace '{}'", id, architecture.getNamespace());
         return new Architecture.ArchitectureBuilder()
@@ -170,6 +171,27 @@ public class NitriteArchitectureStore implements ArchitectureStore {
             // Rethrow the original so the parse failure's stack trace is preserved for observability
             LOG.error("Invalid JSON format for architecture: {}", e.getMessage());
             throw e;
+        }
+    }
+
+    /**
+     * Writes the first version of a newly created architecture, removing the header again
+     * if that fails. See {@code MongoArchitectureStore.createInitialVersion} for why the
+     * compensation is needed — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, String content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -5,9 +5,6 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.json.JsonParseException;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.Architecture;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
@@ -17,23 +14,35 @@ import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.PageRequest;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
-import org.finos.calm.store.util.VersionKeySelector;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the ArchitectureStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link ArchitectureStore}, used in standalone mode.
+ *
+ * <h2>Document model</h2>
+ * One <em>header</em> document per architecture in {@code architectures}, and one
+ * <em>version</em> document per version in {@code architectureVersions}, mirroring
+ * {@link org.finos.calm.store.mongo.MongoArchitectureStore}. All document handling and
+ * locking live in {@link NitriteVersionDocumentStore}; this class only translates
+ * between that and the domain's objects and exceptions.
+ *
+ * <p>Two differences from the Mongo implementation are deliberate rather than
+ * incidental, and both predate this shape:</p>
+ * <ul>
+ *   <li><b>Content is stored as a JSON string</b>, not a parsed document, matching the
+ *       other Nitrite stores.</li>
+ *   <li><b>JSON is validated up front</b> by {@link #validateArchitectureJson}, before
+ *       the architecture's existence is checked — so a request that is both malformed
+ *       and aimed at a missing architecture reports the parse failure here and the
+ *       missing architecture on Mongo. Preserved as-is; changing it is a behaviour
+ *       change rather than part of moving to the new shape.</li>
+ * </ul>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -41,251 +50,104 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 public class NitriteArchitectureStore implements ArchitectureStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteArchitectureStore.class);
-    private static final String COLLECTION_NAME = "architectures";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String ARCHITECTURE_ID_FIELD = "architectureId";
-    private static final String ARCHITECTURES_FIELD = "architectures";
-    private static final String VERSIONS_FIELD = "versions";
-    private static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    private static final String HEADER_COLLECTION = "architectures";
+    private static final String VERSION_COLLECTION = "architectureVersions";
+    private static final String ID_FIELD = "architectureId";
+    private static final String RESOURCE_LABEL = "Architecture";
+    private static final String INITIAL_VERSION = "1.0.0";
 
-    private final NitriteCollection architectureCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final NitriteVersionDocumentStore documentStore;
 
     @Inject
     public NitriteArchitectureStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.architectureCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
-        LOG.info("NitriteArchitectureStore initialized with collection: {}", COLLECTION_NAME);
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
+        LOG.info("NitriteArchitectureStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
 
     @Override
     public List<NamespaceResourceSummary> getArchitecturesForNamespace(String namespace, PageRequest page) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving architectures", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        lock.readLock().lock();
-        try {
-            TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(architectureCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
-            List<Document> architectures = namespaceDocument.getList(ARCHITECTURES_FIELD);
-            if (architectures == null || architectures.isEmpty()) {
-                return List.of();
-            }
-
-            List<NamespaceResourceSummary> architectureSummaries = new ArrayList<>();
-            for (Document architecture : architectures) {
-                Integer archId = architecture.get(ARCHITECTURE_ID_FIELD, Integer.class);
-                String name = architecture.get(NAME_FIELD, String.class);
-                String description = architecture.get(DESCRIPTION_FIELD, String.class);
-                if (name == null) name = "Architecture " + archId;
-                if (description == null) description = "";
-                // Count versions from the already-in-memory sub-document (O(1), no extra query).
-                Object rawVersions = architecture.get(VERSIONS_FIELD);
-                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-                NamespaceResourceSummary summary = new NamespaceResourceSummary(
-                        name, description, archId, versionCount
-                );
-                architectureSummaries.add(summary);
-            }
-
-            // Nitrite has no array-slice projection, so apply the limit/offset window in memory.
-            List<NamespaceResourceSummary> pageResults = page.apply(architectureSummaries);
-            LOG.debug("Retrieved {} of {} architectures for namespace '{}'", pageResults.size(), architectureSummaries.size(), namespace);
-            return pageResults;
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, page);
     }
 
     @Override
     public Architecture createArchitectureForNamespace(Architecture architecture) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when creating architecture", architecture.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(architecture.getNamespace());
         validateArchitectureJson(architecture.getArchitectureJson());
 
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextArchitectureSequenceValue();
-            // Store the architecture JSON as a string
-            Document architectureDocument = Document.createDocument()
-                .put(NAME_FIELD, architecture.getName())
-                .put(DESCRIPTION_FIELD, architecture.getDescription())
-                .put(ARCHITECTURE_ID_FIELD, id)
-                .put(VERSIONS_FIELD, Document.createDocument()
-                        .put("1-0-0", architecture.getArchitectureJson()));
+        int id = counterStore.getNextArchitectureSequenceValue();
+        documentStore.createHeader(architecture.getNamespace(), id, architecture.getName(), architecture.getDescription());
+        documentStore.createVersion(architecture.getNamespace(), id, INITIAL_VERSION, architecture.getArchitectureJson());
 
-        Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
-        Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
-
-        if (namespaceDoc == null) {
-            // Create a new namespace document with the architecture
-            namespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, architecture.getNamespace())
-                    .put(ARCHITECTURES_FIELD, List.of(architectureDocument));
-            architectureCollection.insert(namespaceDoc);
-        } else {
-            // Add the architecture to the existing namespace document
-            List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
-            if (architectures == null) {
-                architectures = new ArrayList<>();
-            } else {
-                architectures = new ArrayList<>(architectures); // Make a mutable copy
-            }
-            architectures.add(architectureDocument);
-            namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
-            architectureCollection.update(filter, namespaceDoc);
-        }
-
-            LOG.info("Created architecture with ID {} for namespace '{}'", id, architecture.getNamespace());
-            return new Architecture.ArchitectureBuilder()
-                    .setId(id)
-                    .setVersion("1.0.0")
-                    .setNamespace(architecture.getNamespace())
-                    .setName(architecture.getName())
-                    .setDescription(architecture.getDescription())
-                    .setArchitecture(architecture.getArchitectureJson())
-                    .build();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        LOG.info("Created architecture with ID {} for namespace '{}'", id, architecture.getNamespace());
+        return new Architecture.ArchitectureBuilder()
+                .setId(id)
+                .setVersion(INITIAL_VERSION)
+                .setNamespace(architecture.getNamespace())
+                .setName(architecture.getName())
+                .setDescription(architecture.getDescription())
+                .setArchitecture(architecture.getArchitectureJson())
+                .build();
     }
 
     @Override
     public List<String> getArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveArchitectureVersions(architecture);
-
-            List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
-            for (Document architectureDoc : architectures) {
-                if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
-                    // Extract the versions map from the matching architecture
-                    Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions == null) {
-                        throw new ArchitectureNotFoundException();
-                    }
-                    Set<String> versionKeys = versions.getFields();
-
-                    // Convert from Nitrite representation
-                    List<String> resourceVersions = new ArrayList<>();
-                    for (String versionKey : versionKeys) {
-                        resourceVersions.add(versionKey.replace('-', '.'));
-                    }
-                    LOG.debug("Retrieved {} versions for architecture {} in namespace '{}'",
-                            resourceVersions.size(), architecture.getId(), architecture.getNamespace());
-                    return resourceVersions;
-                }
-            }
-
-            LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
-            throw new ArchitectureNotFoundException();
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    private Document retrieveArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when retrieving architecture versions", architecture.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
-        Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
-        Document result = architectureCollection.find(filter).firstOrNull();
-
-        if (result == null) {
-            LOG.warn("No architectures found for namespace '{}'", architecture.getNamespace());
-            throw new ArchitectureNotFoundException();
-        }
-
-        return result;
+        requireArchitecture(architecture);
+        // An architecture with no versions yet returns an empty list rather than
+        // reporting itself missing — the header above already settled that question.
+        return documentStore.listVersions(architecture.getNamespace(), architecture.getId());
     }
 
     @Override
     public String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveArchitectureVersions(architecture);
+        requireArchitecture(architecture);
 
-            List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
-            for (Document architectureDoc : architectures) {
-                if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
-                    // Retrieve the versions map from the matching architecture
-                    Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions == null) {
-                        throw new ArchitectureVersionNotFoundException();
-                    }
-
-                    // Return the architecture JSON blob for the specified version
-                    String mongoVersion = architecture.getMongoVersion();
-                    Object versionObj = versions.get(mongoVersion);
-                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
-
-                    if (!(versionObj instanceof String)) {
-                        LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",
-                                architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                        throw new ArchitectureVersionNotFoundException();
-                    }
-
-                    return (String) versionObj;
-                }
-            }
-
-            // Architectures is empty, no version to find
-            LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
+        String content = documentStore.getVersion(
+                architecture.getNamespace(), architecture.getId(), architecture.getDotVersion());
+        if (content == null) {
+            LOG.warn("Version '{}' not found for architecture {} in namespace '{}'",
+                    architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
             throw new ArchitectureVersionNotFoundException();
-        } finally {
-            lock.readLock().unlock();
         }
+        return content;
     }
 
     @Override
     public Architecture createArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionExistsException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when creating architecture version", architecture.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(architecture.getNamespace());
         validateArchitectureJson(architecture.getArchitectureJson());
+        requireArchitectureExists(architecture);
 
-        lock.writeLock().lock();
-        try {
-            if (versionExists(architecture)) {
-                LOG.warn("Version '{}' already exists for architecture {} in namespace '{}'",
-                        architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                throw new ArchitectureVersionExistsException();
-            }
-
-            writeArchitectureToNitrite(architecture);
-        } finally {
-            lock.writeLock().unlock();
+        boolean created = documentStore.createVersion(architecture.getNamespace(), architecture.getId(),
+                architecture.getDotVersion(), architecture.getArchitectureJson());
+        if (!created) {
+            LOG.warn("Version '{}' already exists for architecture {} in namespace '{}'",
+                    architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
+            throw new ArchitectureVersionExistsException();
         }
+
+        updateHeaderDetails(architecture);
         return architecture;
     }
 
     @Override
     public Architecture updateArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        if (!namespaceStore.namespaceExists(architecture.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when updating architecture version", architecture.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(architecture.getNamespace());
         validateArchitectureJson(architecture.getArchitectureJson());
+        requireArchitectureExists(architecture);
 
-        lock.writeLock().lock();
-        try {
-            writeArchitectureToNitrite(architecture);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        documentStore.upsertVersion(architecture.getNamespace(), architecture.getId(),
+                architecture.getDotVersion(), architecture.getArchitectureJson());
+
+        updateHeaderDetails(architecture);
         return architecture;
     }
 
@@ -311,78 +173,33 @@ public class NitriteArchitectureStore implements ArchitectureStore {
         }
     }
 
-    private void writeArchitectureToNitrite(Architecture architecture) throws ArchitectureNotFoundException {
-        try {
-            // First verify the architecture exists
-            retrieveArchitectureVersions(architecture);
+    /**
+     * Applies the name and description that came with a version write. Called only
+     * <em>after</em> the version write succeeds, matching the Mongo implementation —
+     * see {@code MongoVersionDocumentStore.updateHeaderDetails} for why the ordering
+     * matters.
+     */
+    private void updateHeaderDetails(Architecture architecture) {
+        documentStore.updateHeaderDetails(architecture.getNamespace(), architecture.getId(),
+                architecture.getName(), architecture.getDescription());
+    }
 
-            // Store the architecture JSON as a string directly
-            // No need to parse it to a Document
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
 
-            // Find the namespace document
-            Filter filter = where(NAMESPACE_FIELD).eq(architecture.getNamespace());
-            Document namespaceDoc = architectureCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc != null) {
-                // Find the architecture document
-                List<Document> architectures = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ARCHITECTURES_FIELD);
-                if (architectures != null) {
-                    // Create a mutable copy of the list
-                    architectures = new ArrayList<>(architectures);
-                    boolean found = false;
-                    for (int i = 0; i < architectures.size(); i++) {
-                        Document architectureDoc = architectures.get(i);
-                        if (architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class) == architecture.getId()) {
-                            // Found the architecture, update its version
-                            Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                            if (versions == null) {
-                                throw new ArchitectureNotFoundException();
-                            }
-                            versions.put(architecture.getMongoVersion(), architecture.getArchitectureJson());
-                            architectureDoc.put(NAME_FIELD, architecture.getName());
-                            architectureDoc.put(DESCRIPTION_FIELD, architecture.getDescription());
-                            architectureDoc.put(VERSIONS_FIELD, versions);
-                            architectures.set(i, architectureDoc);
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if (found) {
-                        // Update the namespace document with the modified architectures list
-                        namespaceDoc.put(ARCHITECTURES_FIELD, architectures);
-                        architectureCollection.update(filter, namespaceDoc);
-                        LOG.info("Updated version '{}' for architecture {} in namespace '{}'",
-                                architecture.getDotVersion(), architecture.getId(), architecture.getNamespace());
-                        return;
-                    }
-                }
-            }
-
-            LOG.error("Failed to write architecture to Nitrite [{}]", architecture);
-            throw new ArchitectureNotFoundException();
-        } catch (NamespaceNotFoundException e) {
-            LOG.error("Namespace not found when writing architecture to Nitrite [{}]", architecture);
+    private void requireArchitectureExists(Architecture architecture) throws ArchitectureNotFoundException {
+        if (!documentStore.headerExists(architecture.getNamespace(), architecture.getId())) {
+            LOG.warn("Architecture with ID {} not found in namespace '{}'", architecture.getId(), architecture.getNamespace());
             throw new ArchitectureNotFoundException();
         }
     }
 
-    private boolean versionExists(Architecture architecture) {
-        try {
-            Document result = retrieveArchitectureVersions(architecture);
-
-            List<Document> architectures = new TypeSafeNitriteDocument<>(result, Document.class).getList(ARCHITECTURES_FIELD);
-            for (Document architectureDoc : architectures) {
-                if (architecture.getId() == architectureDoc.get(ARCHITECTURE_ID_FIELD, Integer.class)) {
-                    Document versions = architectureDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions != null && versions.containsKey(architecture.getMongoVersion())) {
-                        return true;  // The version already exists
-                    }
-                }
-            }
-            return false;
-        } catch (NamespaceNotFoundException | ArchitectureNotFoundException e) {
-            return false;
-        }
+    private void requireArchitecture(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        requireNamespace(architecture.getNamespace());
+        requireArchitectureExists(architecture);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -63,7 +63,7 @@ public class NitriteSearchStore implements SearchStore {
         String lowerQuery = query.toLowerCase();
 
         return new GroupedSearchResults(
-                searchNamespacedCollection(architectureCollection, "architectures", "architectureId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(patternCollection, "patterns", "patternId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(flowCollection, "flows", "flowId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
@@ -71,6 +71,42 @@ public class NitriteSearchStore implements SearchStore {
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)
         );
+    }
+
+    /**
+     * Searches a collection in the header/version shape, where each document <em>is</em> one
+     * resource rather than a namespace-wide array of them. See
+     * {@code MongoSearchStore.searchHeaderCollection} for why both shapes have to be
+     * supported at once, and for the silent failure mode if a migrated type is left on the
+     * array-shaped method.
+     */
+    private List<SearchResult> searchHeaderCollection(NitriteCollection collection,
+                                                      String idField,
+                                                      String lowerQuery,
+                                                      Optional<Set<String>> readableNamespaces) {
+        List<SearchResult> results = new ArrayList<>();
+
+        for (Document header : collection.find()) {
+            if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
+                return results;
+            }
+            String namespace = header.get("namespace", String.class);
+            if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
+                continue;
+            }
+            String name = header.get("name", String.class);
+            String description = header.get("description", String.class);
+            if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
+                results.add(new SearchResult(
+                        namespace,
+                        header.get(idField, Integer.class),
+                        SearchTextMatcher.nullToEmpty(name),
+                        SearchTextMatcher.nullToEmpty(description)
+                ));
+            }
+        }
+
+        return results;
     }
 
     private List<SearchResult> searchNamespacedCollection(NitriteCollection collection,

--- a/calm-hub/src/main/java/org/finos/calm/store/util/CanonicalVersion.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/CanonicalVersion.java
@@ -1,0 +1,71 @@
+package org.finos.calm.store.util;
+
+import org.finos.calm.resources.ResourceValidationConstants;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Folds every accepted spelling of a version onto one canonical
+ * dot-separated form, so that one logical version is always one stored
+ * document.
+ *
+ * <h2>Why this is needed now and wasn't before</h2>
+ * {@code VERSION_REGEX} makes both separators optional:
+ * {@code ^(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)[-.]?(0|[1-9][0-9]*)$}. Six
+ * different request paths therefore denote version 1.0.0 — {@code 1.0.0},
+ * {@code 1-0-0}, {@code 1.0-0}, {@code 1-0.0}, {@code 1.00} and {@code 100}
+ * — and the API accepts all of them.
+ *
+ * <p>Under the old shape the version was a <em>map key</em> written via
+ * {@code Architecture.getMongoVersion()}, i.e. {@code replace('.', '-')}.
+ * That folded the four dotted/dashed spellings together but left
+ * {@code 100} and {@code 1.00} as keys of their own, so the old shape
+ * already stored one logical version under three different keys.</p>
+ *
+ * <p>Under {@link org.finos.calm.store.util.MongoVersionDocumentStore}'s shape the version is a
+ * <em>field value</em> on its own document. Writing it verbatim would make
+ * each spelling a separate document — six documents for one version, each
+ * invisible to a read using any of the other five. {@link SemanticVersionOrder}
+ * already ranks the spellings equally, but ordering them consistently cannot
+ * merge them; only canonicalising on the way in can.</p>
+ *
+ * <h2>Where it is applied</h2>
+ * At the version-store helpers' entry points, so every caller inherits it
+ * and reads and writes cannot disagree about the spelling. Canonicalising in
+ * the callers instead would mean seven resource types each having to
+ * remember to do it.
+ *
+ * <h2>Coupling note</h2>
+ * This deliberately reuses {@code ResourceValidationConstants.VERSION_REGEX}
+ * rather than restating the pattern, even though it points from the store
+ * layer at the resource layer. The set of spellings this must fold is
+ * exactly the set the API accepts, so a second copy of the pattern would be
+ * a correctness bug waiting for the two to drift apart.
+ */
+public final class CanonicalVersion {
+
+    private static final Pattern VERSION = Pattern.compile(ResourceValidationConstants.VERSION_REGEX);
+
+    private CanonicalVersion() {
+    }
+
+    /**
+     * @param version any accepted spelling, or {@code null}
+     * @return the {@code major.minor.patch} form. Input that doesn't match
+     * {@code VERSION_REGEX} (including {@code null}) is returned unchanged:
+     * validation belongs to the resource layer, and a store that quietly
+     * rewrote unrecognised input would turn a rejectable request into a
+     * document stored under a version nobody asked for.
+     */
+    public static String of(String version) {
+        if (version == null) {
+            return null;
+        }
+        Matcher matcher = VERSION.matcher(version);
+        if (!matcher.matches()) {
+            return version;
+        }
+        return matcher.group(1) + "." + matcher.group(2) + "." + matcher.group(3);
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -130,6 +130,31 @@ public class MongoVersionDocumentStore {
     }
 
     /**
+     * Removes a header, used to compensate a resource creation whose first version write
+     * failed.
+     *
+     * <p>The old shape pushed the resource and its first version in one document write, so
+     * a failure left nothing behind. Splitting them means a failed version write can strand
+     * a header that no API can remove — there is no delete endpoint for these types — and it
+     * would show up in listings and search with {@code versionCount: 0} forever.</p>
+     *
+     * <p>Not a general-purpose delete: nothing else calls this, and it deliberately does not
+     * touch the version collection, because the only caller has just failed to write the
+     * one version that could exist.</p>
+     */
+    public void deleteHeader(String namespace, int resourceId) {
+        try {
+            headerCollection.deleteOne(headerFilter(namespace, resourceId));
+        } catch (MongoException e) {
+            // Best-effort: the caller is already failing, and reporting this instead would
+            // replace a real write failure with a misleading one.
+            LOG.warn("Failed to remove the header after a failed first version write "
+                    + "[namespace={}, {}={}] — it may be left with no versions",
+                    namespace, idField, resourceId, e);
+        }
+    }
+
+    /**
      * Writes a version that must not already exist.
      *
      * @return {@code false} if that version is already present — the caller decides

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -51,6 +51,13 @@ import java.util.List;
  * writer fail with {@code DUPLICATE_KEY}, which {@link #createVersion} reports as
  * {@code false}. Those indexes are created by the per-type schema migration step,
  * not by this class.
+ *
+ * <h2>Version spelling</h2>
+ * Every method taking a {@code version} canonicalises it on entry via
+ * {@link CanonicalVersion}, so the several spellings the API accepts address one
+ * document rather than one each. Any method added here that takes a version must do
+ * the same — the database's uniqueness guarantee is per stored string, so it cannot
+ * catch a spelling that slipped through uncanonicalised.
  */
 public class MongoVersionDocumentStore {
 
@@ -129,9 +136,10 @@ public class MongoVersionDocumentStore {
      * which domain exception that means. Never overwrites.
      */
     public boolean createVersion(String namespace, int resourceId, String version, Document content) {
+        String canonicalVersion = CanonicalVersion.of(version);
         Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
                 .append(idField, resourceId)
-                .append(VERSION_FIELD, version)
+                .append(VERSION_FIELD, canonicalVersion)
                 .append(CONTENT_FIELD, content)
                 .append(METADATA_FIELD, new Document());
         try {
@@ -142,7 +150,7 @@ public class MongoVersionDocumentStore {
             }
             // Log identifying fields only — the content can be megabytes.
             LOG.error("Failed to create version [namespace={}, {}={}, version={}]",
-                    namespace, idField, resourceId, version, e);
+                    namespace, idField, resourceId, canonicalVersion, e);
             throw MongoWriteFailures.toStorageWriteException(e);
         }
         incrementVersionCount(namespace, resourceId);
@@ -162,17 +170,20 @@ public class MongoVersionDocumentStore {
      * inserted; otherwise the count would drift permanently low.</p>
      */
     public void upsertVersion(String namespace, int resourceId, String version, Document content) {
+        // Canonical before the filter is built, so an upsert-insert derives its stored
+        // version field from the canonical form via the filter's equality conditions.
+        String canonicalVersion = CanonicalVersion.of(version);
         Bson update = Updates.combine(
                 Updates.set(CONTENT_FIELD, content),
                 Updates.setOnInsert(METADATA_FIELD, new Document()));
         boolean inserted;
         try {
             UpdateResult result = versionCollection.updateOne(
-                    versionFilter(namespace, resourceId, version), update, new UpdateOptions().upsert(true));
+                    versionFilter(namespace, resourceId, canonicalVersion), update, new UpdateOptions().upsert(true));
             inserted = result.getUpsertedId() != null;
         } catch (MongoWriteException e) {
             LOG.error("Failed to write version [namespace={}, {}={}, version={}]",
-                    namespace, idField, resourceId, version, e);
+                    namespace, idField, resourceId, canonicalVersion, e);
             throw MongoWriteFailures.toStorageWriteException(e);
         }
         // Outside the try, matching createVersion: the count is best-effort follow-up
@@ -187,7 +198,8 @@ public class MongoVersionDocumentStore {
      * (or the resource) doesn't exist.
      */
     public Document getVersion(String namespace, int resourceId, String version) {
-        Document versionDocument = versionCollection.find(versionFilter(namespace, resourceId, version)).first();
+        Document versionDocument = versionCollection
+                .find(versionFilter(namespace, resourceId, CanonicalVersion.of(version))).first();
         return versionDocument == null ? null : versionDocument.get(CONTENT_FIELD, Document.class);
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -194,6 +194,39 @@ public class MongoVersionDocumentStore {
     }
 
     /**
+     * Overwrites the header's {@code name} and {@code description}.
+     *
+     * <p>Exists because writing a version also renames the resource: the old shape set
+     * both fields in the same atomic update that wrote the version content, so the API
+     * lets a version write change the display name. Preserved deliberately, including
+     * the fact that a {@code null} name overwrites a real one — see the bug noted
+     * against {@code ArchitectureRequest}, which validates neither field.</p>
+     *
+     * <p><b>Call this after the version write succeeds, never before.</b> The old shape
+     * did both in one update, so a rejected create — the version already exists — left
+     * the name untouched. Calling this first would rename on a request that then fails
+     * with a 409, which no caller expects.</p>
+     *
+     * <p>Unlike {@link #incrementVersionCount}, a failure here is translated and thrown
+     * rather than swallowed: this is user-supplied data, not a derived counter, so
+     * silently dropping a rename is a wrong answer rather than a stale display number.
+     * The cost is that the atomicity the old shape had is genuinely gone — a failure
+     * here reports an error for a version that was in fact stored.</p>
+     */
+    public void updateHeaderDetails(String namespace, int resourceId, String name, String description) {
+        try {
+            UpdateResult result = headerCollection.updateOne(headerFilter(namespace, resourceId),
+                    Updates.combine(Updates.set(NAME_FIELD, name), Updates.set(DESCRIPTION_FIELD, description)));
+            if (result.getMatchedCount() == 0) {
+                LOG.warn("No header to update details on [namespace={}, {}={}]", namespace, idField, resourceId);
+            }
+        } catch (MongoWriteException e) {
+            LOG.error("Failed to update header details [namespace={}, {}={}]", namespace, idField, resourceId, e);
+            throw MongoWriteFailures.toStorageWriteException(e);
+        }
+    }
+
+    /**
      * @return the stored content for one version, or {@code null} if that version
      * (or the resource) doesn't exist.
      */

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -177,6 +177,29 @@ public class NitriteVersionDocumentStore {
     }
 
     /**
+     * Overwrites the header's {@code name} and {@code description}. See
+     * {@link MongoVersionDocumentStore#updateHeaderDetails} for why this operation
+     * exists, why a {@code null} is allowed to overwrite a real value, and why it must
+     * be called only after the version write succeeds.
+     */
+    public void updateHeaderDetails(String namespace, int resourceId, String name, String description) {
+        lock.writeLock().lock();
+        try {
+            Filter filter = headerFilter(namespace, resourceId);
+            Document header = headerCollection.find(filter).firstOrNull();
+            if (header == null) {
+                LOG.warn("No header to update details on [namespace={}, {}={}]", namespace, idField, resourceId);
+                return;
+            }
+            header.put(NAME_FIELD, name);
+            header.put(DESCRIPTION_FIELD, description);
+            headerCollection.update(filter, header);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
      * @return the stored content for one version, or {@code null} if that version
      * (or the resource) doesn't exist.
      */

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -43,6 +43,13 @@ import static org.dizitart.no2.filters.FluentFilter.where;
  * that any narrower lock must still serialise writes to the same
  * {@code (namespace, resourceId, version)}, or the uniqueness guarantee above stops
  * holding.
+ *
+ * <h2>Version spelling</h2>
+ * Every method taking a {@code version} canonicalises it on entry via
+ * {@link CanonicalVersion}, so the several spellings the API accepts address one
+ * document rather than one each. Any method added here that takes a version must do
+ * the same — and it matters more here than in the Mongo helper, since there is no
+ * unique index to fall back on at all.
  */
 public class NitriteVersionDocumentStore {
 
@@ -118,15 +125,16 @@ public class NitriteVersionDocumentStore {
      * @return {@code false} if that version is already present. Never overwrites.
      */
     public boolean createVersion(String namespace, int resourceId, String version, String content) {
+        String canonicalVersion = CanonicalVersion.of(version);
         lock.writeLock().lock();
         try {
-            if (versionCollection.find(versionFilter(namespace, resourceId, version)).firstOrNull() != null) {
+            if (versionCollection.find(versionFilter(namespace, resourceId, canonicalVersion)).firstOrNull() != null) {
                 return false;
             }
             versionCollection.insert(Document.createDocument()
                     .put(NAMESPACE_FIELD, namespace)
                     .put(idField, resourceId)
-                    .put(VERSION_FIELD, version)
+                    .put(VERSION_FIELD, canonicalVersion)
                     .put(CONTENT_FIELD, content)
                     .put(METADATA_FIELD, Document.createDocument()));
             incrementVersionCount(namespace, resourceId);
@@ -146,15 +154,16 @@ public class NitriteVersionDocumentStore {
      * as well as overwrite.</p>
      */
     public void upsertVersion(String namespace, int resourceId, String version, String content) {
+        String canonicalVersion = CanonicalVersion.of(version);
         lock.writeLock().lock();
         try {
-            Filter filter = versionFilter(namespace, resourceId, version);
+            Filter filter = versionFilter(namespace, resourceId, canonicalVersion);
             Document existing = versionCollection.find(filter).firstOrNull();
             if (existing == null) {
                 versionCollection.insert(Document.createDocument()
                         .put(NAMESPACE_FIELD, namespace)
                         .put(idField, resourceId)
-                        .put(VERSION_FIELD, version)
+                        .put(VERSION_FIELD, canonicalVersion)
                         .put(CONTENT_FIELD, content)
                         .put(METADATA_FIELD, Document.createDocument()));
                 incrementVersionCount(namespace, resourceId);
@@ -174,7 +183,8 @@ public class NitriteVersionDocumentStore {
     public String getVersion(String namespace, int resourceId, String version) {
         lock.readLock().lock();
         try {
-            Document versionDocument = versionCollection.find(versionFilter(namespace, resourceId, version)).firstOrNull();
+            Document versionDocument = versionCollection
+                    .find(versionFilter(namespace, resourceId, CanonicalVersion.of(version))).firstOrNull();
             return versionDocument == null ? null : versionDocument.get(CONTENT_FIELD, String.class);
         } finally {
             lock.readLock().unlock();

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -116,6 +116,23 @@ public class NitriteVersionDocumentStore {
     }
 
     /**
+     * Removes a header, used to compensate a resource creation whose first version write
+     * failed. See {@link MongoVersionDocumentStore#deleteHeader} for why this exists.
+     */
+    public void deleteHeader(String namespace, int resourceId) {
+        lock.writeLock().lock();
+        try {
+            headerCollection.remove(headerFilter(namespace, resourceId));
+        } catch (NitriteException e) {
+            LOG.warn("Failed to remove the header after a failed first version write "
+                    + "[namespace={}, {}={}] — it may be left with no versions",
+                    namespace, idField, resourceId, e);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
      * Writes a version that must not already exist.
      *
      * <p>The existence check and the insert both happen under the write lock, so no

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoArchitectureVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoArchitectureVersionSplitStepShould.java
@@ -65,14 +65,35 @@ class TestMongoArchitectureVersionSplitStepShould {
         stubOldDocuments(List.of());
     }
 
+    /**
+     * Models the step's two-pass read: one scan projecting {@code _id} only, then a
+     * re-read of each document by that id. A single shared iterable would return the same
+     * document for every id, hiding any per-document mistake, so lookups resolve against
+     * the filter.
+     */
     private void stubOldDocuments(List<Document> documents) {
-        FindIterable<Document> iterable = mock(DocumentFindIterable.class);
-        when(headers.find(any(Bson.class))).thenReturn(iterable);
-        doAnswer(invocation -> {
-            Consumer<Document> consumer = invocation.getArgument(0);
-            documents.forEach(consumer);
-            return null;
-        }).when(iterable).forEach(any());
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+
+            if (filter.contains("architectures")) {
+                // The exists() scan — the step only reads _id off these.
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+
+            Document match = documents.stream()
+                    .filter(document -> filter.contains(String.valueOf(document.get("_id"))))
+                    .findFirst()
+                    .orElse(null);
+            when(iterable.first()).thenReturn(match);
+            return iterable;
+        });
     }
 
     /** One old-shape namespace document holding one architecture with two versions. */
@@ -179,6 +200,45 @@ class TestMongoArchitectureVersionSplitStepShould {
                 .replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
         // A crash before this point leaves the source intact and the namespace is redone.
         order.verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void collapse_two_old_keys_that_mean_the_same_version_into_one_document() {
+        // The old shape wrote keys via replace('.', '-'), which folded 1.0.0 and 1-0-0
+        // together but left 100 — also accepted by VERSION_REGEX — as a key of its own.
+        // Both canonicalise to 1.0.0 and only one document can exist per version.
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("architectures", List.of(new Document("architectureId", 1)
+                        .append("versions", new Document("1-0-0", new Document("keep", true))
+                                .append("100", new Document("discard", true)))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+        // First key wins; writing both in turn would let the second silently overwrite it.
+        assertThat(versionCaptor.getValue().get("content", Document.class),
+                is(new Document("keep", true)));
+    }
+
+    @Test
+    void count_collapsed_versions_once_on_the_header() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("architectures", List.of(new Document("architectureId", 1)
+                        .append("versions", new Document("1-0-0", new Document())
+                                .append("100", new Document())
+                                .append("2-0-0", new Document()))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        // Three keys, two versions. Counting keys would leave the header advertising a
+        // version that has no document — the exact drift the stored counter exists to avoid.
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(2));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoArchitectureVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoArchitectureVersionSplitStepShould.java
@@ -1,0 +1,219 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoArchitectureVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoDatabase database;
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoArchitectureVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("architectures")).thenReturn(headers);
+        when(database.getCollection("architectureVersions")).thenReturn(versions);
+
+        step = new MongoArchitectureVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+        when(headers.find(any(Bson.class))).thenReturn(iterable);
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    /** One old-shape namespace document holding one architecture with two versions. */
+    private static Document oldNamespaceDocument() {
+        return new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("architectures", List.of(new Document("architectureId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("versions", new Document("1-0-0", new Document("nodes", List.of()))
+                                .append("1-1-0", new Document("nodes", List.of())))));
+    }
+
+    private static MongoCommandException commandException(int code, String message) {
+        BsonDocument response = new BsonDocument("ok", new BsonInt32(0))
+                .append("code", new BsonInt32(code))
+                .append("errmsg", new BsonString(message));
+        return new MongoCommandException(response, new ServerAddress());
+    }
+
+    @Test
+    void run_at_schema_version_two() {
+        assertThat(step.fromVersion(), is(2));
+    }
+
+    // --- index transition ---
+
+    @Test
+    void drop_the_one_document_per_namespace_index_before_creating_the_new_ones() {
+        step.apply();
+
+        // The old unique index on namespace alone enforces the shape being migrated away
+        // from, so headers for two architectures in one namespace cannot exist until it
+        // is gone. MongoIndexInitializationStep is immutable, so the drop lives here.
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("architectureId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("architectureId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void tolerate_the_old_index_already_being_absent() {
+        doThrow(commandException(27, "index not found with name [namespace_1]"))
+                .when(headers).dropIndex(anyString());
+
+        // A retried step, or a deployment that never had the index, must still proceed.
+        assertDoesNotThrow(() -> step.apply());
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("architectureId", 1)), any());
+    }
+
+    @Test
+    void propagate_index_drop_failures_that_are_not_a_missing_index() {
+        doThrow(commandException(13, "not authorized")).when(headers).dropIndex(anyString());
+
+        // Swallowing this would leave the old constraint in place and the fan-out failing
+        // on every insert, with nothing to say why.
+        assertThrows(MongoCommandException.class, () -> step.apply());
+    }
+
+    // --- fan-out ---
+
+    @Test
+    void write_one_header_per_architecture_with_a_counted_version_total() {
+        stubOldDocuments(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), captor.capture(), any(ReplaceOptions.class));
+        Document header = captor.getValue();
+        assertThat(header.getString("namespace"), is("finos"));
+        assertThat(header.getInteger("architectureId"), is(1));
+        assertThat(header.getString("name"), is("Sample"));
+        assertThat(header.getInteger("versionCount"), is(2));
+        assertThat(header.get("metadata", Document.class), is(new Document()));
+    }
+
+    @Test
+    void write_one_version_document_per_stored_version_with_dot_separated_keys() {
+        stubOldDocuments(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versions, org.mockito.Mockito.times(2))
+                .replaceOne(any(Bson.class), captor.capture(), any(ReplaceOptions.class));
+        // Dash-encoded keys existed only because Mongo field names can't contain a dot.
+        // Now the version is a field value, so it converts to the spelling the store reads.
+        assertThat(captor.getAllValues().stream().map(d -> d.getString("version")).toList(),
+                contains("1.0.0", "1.1.0"));
+        assertThat(captor.getAllValues().get(0).get("content", Document.class),
+                is(new Document("nodes", List.of())));
+    }
+
+    @Test
+    void delete_the_old_namespace_document_only_after_rewriting_its_contents() {
+        stubOldDocuments(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        org.mockito.InOrder order = org.mockito.Mockito.inOrder(headers, versions);
+        order.verify(headers).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+        order.verify(versions, org.mockito.Mockito.atLeastOnce())
+                .replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+        // A crash before this point leaves the source intact and the namespace is redone.
+        order.verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void write_a_header_but_no_versions_for_an_architecture_that_has_none() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("architectures", List.of(new Document("architectureId", 9).append("name", "Empty")))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), captor.capture(), any(ReplaceOptions.class));
+        assertThat(captor.getValue().getInteger("versionCount"), is(0));
+        verify(versions, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void do_nothing_to_a_collection_that_holds_only_headers() {
+        // Headers carry no architectures array, so the selection finds nothing — this is
+        // what makes a re-run a no-op rather than a duplicate-key failure.
+        stubOldDocuments(List.of());
+
+        step.apply();
+
+        verify(headers, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteArchitectureVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteArchitectureVersionSplitStepShould.java
@@ -1,0 +1,157 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteArchitectureVersionSplitStepShould {
+
+    private static final String CONTENT_1_0_0 = "{\"nodes\":[]}";
+    private static final String CONTENT_1_1_0 = "{\"nodes\":[1]}";
+
+    private Nitrite db;
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteArchitectureVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("architectures")).thenReturn(headers);
+        when(db.getCollection("architectureVersions")).thenReturn(versions);
+
+        step = new NitriteArchitectureVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+    }
+
+    /** One old-shape namespace document holding one architecture with two versions. */
+    private static Document oldNamespaceDocument() {
+        return Document.createDocument()
+                .put("namespace", "finos")
+                .put("architectures", List.of(Document.createDocument()
+                        .put("architectureId", 1)
+                        .put("name", "Sample")
+                        .put("description", "A description")
+                        .put("versions", Document.createDocument()
+                                .put("1-0-0", CONTENT_1_0_0)
+                                .put("1-1-0", CONTENT_1_1_0))));
+    }
+
+    @Test
+    void run_at_schema_version_two() {
+        // Same version as the Mongo step. The two never coexist — each is gated on a
+        // different calm.database.mode, so only one is ever a bean.
+        assertThat(step.fromVersion(), is(2));
+    }
+
+    @Test
+    void write_one_header_per_architecture_with_a_counted_version_total() {
+        stubCollectionContents(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(captor.capture());
+        Document header = captor.getValue();
+        assertThat(header.get("namespace", String.class), is("finos"));
+        assertThat(header.get("architectureId", Integer.class), is(1));
+        assertThat(header.get("name", String.class), is("Sample"));
+        assertThat(header.get("versionCount", Integer.class), is(2));
+    }
+
+    @Test
+    void write_one_version_document_per_stored_version_with_dot_separated_keys() {
+        stubCollectionContents(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versions, times(2)).insert(captor.capture());
+        assertThat(captor.getAllValues().stream().map(d -> d.get("version", String.class)).toList(),
+                contains("1.0.0", "1.1.0"));
+        // Content stays a JSON string in this backend rather than becoming a document.
+        assertThat(captor.getAllValues().get(0).get("content", String.class), is(CONTENT_1_0_0));
+    }
+
+    @Test
+    void remove_the_old_namespace_document_by_identity_not_by_filter() {
+        Document oldDocument = oldNamespaceDocument();
+        stubCollectionContents(List.of(oldDocument));
+
+        step.apply();
+
+        // The headers just written share this namespace, so a namespace-filtered delete
+        // would take them with it.
+        verify(headers).remove(oldDocument);
+    }
+
+    @Test
+    void write_a_header_but_no_versions_for_an_architecture_that_has_none() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("architectures", List.of(Document.createDocument()
+                        .put("architectureId", 9).put("name", "Empty")))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(captor.capture());
+        assertThat(captor.getValue().get("versionCount", Integer.class), is(0));
+        verify(versions, never()).insert(any(Document.class));
+    }
+
+    @Test
+    void ignore_documents_that_are_already_headers() {
+        // A header has no architectures array. This is what makes a re-run a no-op.
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos").put("architectureId", 1).put("versionCount", 2)));
+
+        step.apply();
+
+        verify(headers, never()).insert(any(Document.class));
+        verify(headers, never()).remove(any(Document.class));
+    }
+
+    @Test
+    void clear_any_partially_written_target_documents_before_inserting() {
+        stubCollectionContents(List.of(oldNamespaceDocument()));
+
+        step.apply();
+
+        // Nitrite has no upsert, so a retried step would otherwise insert a second copy
+        // of a header it already wrote — there is no unique index here to stop it.
+        verify(headers).remove(any(Filter.class));
+        verify(versions, times(2)).remove(any(Filter.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteArchitectureVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteArchitectureVersionSplitStepShould.java
@@ -117,6 +117,31 @@ class TestNitriteArchitectureVersionSplitStepShould {
     }
 
     @Test
+    void collapse_two_old_keys_that_mean_the_same_version_and_count_them_once() {
+        // 1-0-0 and 100 are both accepted by VERSION_REGEX and both canonicalise to 1.0.0,
+        // so the new shape can only store one of them.
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("architectures", List.of(Document.createDocument()
+                        .put("architectureId", 1)
+                        .put("versions", Document.createDocument()
+                                .put("1-0-0", CONTENT_1_0_0)
+                                .put("100", CONTENT_1_1_0))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // First key wins rather than the last silently overwriting it.
+        assertThat(versionCaptor.getValue().get("content", String.class), is(CONTENT_1_0_0));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+    }
+
+    @Test
     void write_a_header_but_no_versions_for_an_architecture_that_has_none() {
         stubCollectionContents(List.of(Document.createDocument()
                 .put("namespace", "finos")

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -213,6 +213,39 @@ public class TestMongoArchitectureStoreShould {
         assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
     }
 
+    @Test
+    void remove_the_header_again_when_the_first_version_write_fails() {
+        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        // The old shape pushed the architecture and its first version in one document
+        // write, so a failure left nothing behind. Without compensating, a >16MB payload
+        // strands a header that no endpoint can delete, showing up in listings and search
+        // with versionCount 0 forever.
+        assertThrows(StorageWriteException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        // A version document already present for an id the counter just issued is a storage
+        // inconsistency, not a normal "already exists". Returning the caller's payload with
+        // a 201 would report success for content that was never stored.
+        assertThrows(StorageWriteException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
     // --- getArchitectureVersions ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -6,10 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -27,22 +24,32 @@ import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. The document mechanics themselves are
+ * covered by {@code TestMongoVersionDocumentStoreShould} — what matters here is the glue
+ * this class owns: which domain exception each missing thing produces, and the ordering
+ * between a version write and the header details that accompany it.
+ */
 @QuarkusTest
 public class TestMongoArchitectureStoreShould {
 
@@ -55,533 +62,349 @@ public class TestMongoArchitectureStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private MongoCollection<Document> architectureCollection;
-    private MongoArchitectureStore mongoArchitectureStore;
-    private final String NAMESPACE = "finos";
-
-    private final String validJson = "{\"test\": \"test\"}";
-
-    @BeforeEach
-    void setup() {
-        architectureCollection = Mockito.mock(DocumentMongoCollection.class);
-
-        when(mongoDatabase.getCollection("architectures")).thenReturn(architectureCollection);
-        mongoArchitectureStore = new MongoArchitectureStore(mongoDatabase, counterStore, namespaceStore);
-    }
-
-    @Test
-    void get_architectures_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("architectures", Document.class))
-                .thenReturn(new ArrayList<>());
-
-        assertThat(mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_architectures_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        assertThat(mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_architecture_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitecturesForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void get_architecture_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        Map<String, Object> archDetailMap1 = new HashMap<>();
-        archDetailMap1.put("architectureId", 1001);
-        archDetailMap1.put("name", "Arch One");
-        archDetailMap1.put("description", "First architecture");
-        archDetailMap1.put("versions", new Document("1-0-0", new Document()).append("2-0-0", new Document()));
-        Document doc1 = new Document(archDetailMap1);
-
-        Map<String, Object> archDetailMap2 = new HashMap<>();
-        archDetailMap2.put("architectureId", 1002);
-        archDetailMap2.put("name", "Arch Two");
-        archDetailMap2.put("description", "Second architecture");
-        archDetailMap2.put("versions", new Document("1-0-0", new Document()));
-        Document doc2 = new Document(archDetailMap2);
-
-        when(documentMock.getList("architectures", Document.class))
-                .thenReturn(Arrays.asList(doc1, doc2));
-
-        List<NamespaceResourceSummary> architectures = mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        assertThat(architectures.size(), is(2));
-        assertThat(architectures.get(0).getName(), is("Arch One"));
-        assertThat(architectures.get(0).getDescription(), is("First architecture"));
-        assertThat(architectures.get(0).getId(), is(1001));
-        assertThat(architectures.get(0).getVersionCount(), is(2));
-        assertThat(architectures.get(1).getName(), is("Arch Two"));
-        assertThat(architectures.get(1).getDescription(), is("Second architecture"));
-        assertThat(architectures.get(1).getId(), is(1002));
-        assertThat(architectures.get(1).getVersionCount(), is(1));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_architectures_for_namespace_applies_slice_projection_when_limit_provided() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any())).thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("architectures", Document.class)).thenReturn(new ArrayList<>());
-
-        mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE, new PageRequest(3, 6));
-
-        // The limit/offset is pushed down to Mongo as a $slice projection on the architectures array,
-        // rather than being sliced in memory after loading the whole namespace document.
-        verify(findIterable).projection(eq(Projections.slice("architectures", 6, 3)));
-    }
-
-    @Test
-    void get_architectures_for_namespace_does_not_project_when_no_limit_provided() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE, PageRequest.UNPAGED);
-
-        // No limit → full list → no $slice projection (unchanged behaviour).
-        verify(findIterable, times(0)).projection(any());
-    }
-
-    @Test
-    void get_architectures_for_namespace_defaults_offset_to_zero_when_only_limit_provided() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any())).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE, new PageRequest(3, null));
-
-        verify(findIterable).projection(eq(Projections.slice("architectures", 0, 3)));
-    }
-
-    @Test
-    void get_architectures_for_namespace_clamps_a_negative_offset_to_zero() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any())).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE, new PageRequest(3, -5));
-
-        // A negative offset is clamped to 0 rather than passed to $slice, which Mongo would otherwise
-        // interpret as "count from the end" — matching the in-memory Nitrite path.
-        verify(findIterable).projection(eq(Projections.slice("architectures", 0, 3)));
-    }
-
-    @Test
-    void get_architecture_for_namespace_returns_fallback_for_legacy_documents() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        // Legacy document without name or description
-        Document legacyDoc = new Document("architectureId", 42);
-
-        when(documentMock.getList("architectures", Document.class))
-                .thenReturn(List.of(legacyDoc));
-
-        List<NamespaceResourceSummary> architectures = mongoArchitectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        assertThat(architectures.size(), is(1));
-        assertThat(architectures.get(0).getName(), is("Architecture 42"));
-        assertThat(architectures.get(0).getDescription(), is(""));
-        assertThat(architectures.get(0).getId(), is(42));
-        // Legacy document carries no versions sub-document → count guards to 0.
-        assertThat(architectures.get(0).getVersionCount(), is(0));
-    }
-
-    private FindIterable<Document> setupInvalidArchitecture() {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        //Return the same find iterable as the projection unboxes, then return null
-        when(architectureCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-
-        return findIterable;
-    }
-
-    private void mockSetupArchitectureDocumentWithVersions() {
-        Document mainDocument = setupArchitectureVersionDocument();
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_an_architecture() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(namespace).build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.createArchitectureForNamespace(architecture));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_a_json_parse_exception_when_an_invalid_json_object_is_presented() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(42);
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setArchitecture("Invalid JSON")
-                .build();
-
-        assertThrows(JsonParseException.class,
-                () -> mongoArchitectureStore.createArchitectureForNamespace(architecture));
-    }
-
-    @Test
-    void return_created_architecture_when_parameters_are_valid() throws NamespaceNotFoundException {
-        String validNamespace = NAMESPACE;
-        int sequenceNumber = 42;
-        String validName = "test-name";
-        String validDescription = "test description";
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(sequenceNumber);
-
-        Architecture architectureToCreate = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
-                .setName(validName)
-                .setDescription(validDescription)
-                .setNamespace(validNamespace)
-                .build();
-
-        Architecture architecture = mongoArchitectureStore.createArchitectureForNamespace(architectureToCreate);
-
-        Architecture expectedArchitecture = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
-                .setNamespace(validNamespace)
-                .setName(validName)
-                .setDescription(validDescription)
-                .setVersion("1.0.0")
-                .setId(sequenceNumber)
-                .build();
-
-        assertThat(architecture, is(expectedArchitecture));
-        Document expectedDoc = new Document("architectureId", architecture.getId())
-                .append("name", validName)
-                .append("description", validDescription)
-                .append("versions", new Document("1-0-0", Document.parse(architecture.getArchitectureJson())));
-
-        verify(architectureCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("architectures", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(42);
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-
-        Architecture architectureToCreate = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
-                .setNamespace(NAMESPACE)
-                .build();
-
-        mongoArchitectureStore.createArchitectureForNamespace(architectureToCreate);
-
-        verify(architectureCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_an_architecture() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(42);
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-
-        Architecture architectureToCreate = new Architecture.ArchitectureBuilder().setArchitecture(validJson)
-                .setNamespace(NAMESPACE)
-                .build();
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoArchitectureStore.createArchitectureForNamespace(architectureToCreate));
-    }
-
-    @Test
-    void get_architecture_version_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace("does-not-exist").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureVersions(architecture));
-
-        verify(namespaceStore).namespaceExists(architecture.getNamespace());
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoArchitectureStore store;
+
+    private static final String NAMESPACE = "finos";
+    private static final int ARCHITECTURE_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
+
+    @BeforeEach
+    void setup() {
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
+
+        when(mongoDatabase.getCollection("architectures")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("architectureVersions")).thenReturn(versionCollection);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new MongoArchitectureStore(mongoDatabase, counterStore, namespaceStore);
+    }
+
+    private FindIterable<Document> stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+        return iterable;
+    }
+
+    /** The architecture exists: its header is found, and the count write is acknowledged. */
+    private void architectureExists() {
+        stubFind(headerCollection, List.of(new Document("architectureId", ARCHITECTURE_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void architectureDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static Architecture architecture(String version) {
+        return new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(version)
+                .setName("architecture-name")
+                .setDescription("architecture-description")
+                .setArchitecture(VALID_JSON)
+                .build();
+    }
+
+    // --- getArchitecturesForNamespace ---
+
     @Test
-    void get_architecture_version_for_invalid_pattern_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidArchitecture();
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).build();
+    void throw_a_namespace_exception_when_listing_architectures_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        assertThrows(ArchitectureNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureVersions(architecture));
-
-        verify(architectureCollection).find(new Document("namespace", architecture.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("architectures")));
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitecturesForNamespace(NAMESPACE));
     }
 
     @Test
-    void throw_architecture_not_found_when_versions_document_is_missing_on_get_versions() {
-        Document architectureWithNoVersions = new Document("namespace", NAMESPACE)
-                .append("architectures", List.of(new Document("architectureId", 42)));
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(architectureWithNoVersions);
+    void return_an_empty_list_when_a_namespace_has_no_architectures() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).setId(42).build();
-
-        assertThrows(ArchitectureNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureVersions(architecture));
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void throw_architecture_version_not_found_when_versions_document_is_missing_on_get_for_version() {
-        Document architectureWithNoVersions = new Document("namespace", NAMESPACE)
-                .append("architectures", List.of(new Document("architectureId", 42)));
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(architectureCollection.find(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(architectureWithNoVersions);
+    void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                new Document("architectureId", 1).append("name", "First").append("description", "d1")
+                        .append("versionCount", 2),
+                new Document("architectureId", 2).append("name", "Second").append("description", "d2")
+                        .append("versionCount", 0)));
 
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).setId(42).setVersion("1.0.0").build();
+        // versionCount now comes off the header rather than being counted from a loaded
+        // versions map — including 0, which the old shape could not represent at all.
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
+    }
+
+    @Test
+    void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(new Document("architectureId", 7)));
+
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("Architecture 7", "", 7, 0)));
+    }
+
+    // --- createArchitectureForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_creating_an_architecture_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
+    }
+
+    @Test
+    void reject_invalid_json_before_drawing_an_id_or_writing_anything() {
+        Architecture invalid = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE).setArchitecture("{invalid json}").build();
+
+        assertThrows(JsonParseException.class, () -> store.createArchitectureForNamespace(invalid));
+
+        // Parsing first means a malformed payload can't burn a sequence value or leave a
+        // header behind with no version to go with it.
+        verify(counterStore, never()).getNextArchitectureSequenceValue();
+        verify(headerCollection, never()).insertOne(any(Document.class));
+    }
+
+    @Test
+    void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(counterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        Architecture created = store.createArchitectureForNamespace(architecture(null));
+
+        assertThat(created.getId(), is(99));
+        assertThat(created.getDotVersion(), is("1.0.0"));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().getInteger("architectureId"), is(99));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(0));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+    }
+
+    // --- getArchitectureVersions ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_versions_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitectureVersions(architecture(null)));
+    }
+
+    @Test
+    void throw_an_architecture_exception_when_listing_versions_for_a_missing_architecture() {
+        architectureDoesNotExist();
+
+        assertThrows(ArchitectureNotFoundException.class, () -> store.getArchitectureVersions(architecture(null)));
+    }
+
+    @Test
+    void list_versions_in_semantic_order() throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        stubFind(headerCollection, List.of(new Document("architectureId", ARCHITECTURE_ID)));
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.getArchitectureVersions(architecture(null)), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void return_no_versions_rather_than_not_found_for_an_architecture_with_none() throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        stubFind(headerCollection, List.of(new Document("architectureId", ARCHITECTURE_ID)));
+        stubFind(versionCollection, List.of());
+
+        // New under this shape (ADR 0003): the header proves the architecture exists, so an
+        // empty version list is an answer rather than evidence of a missing architecture.
+        // The old shape conflated the two because it had nowhere else to look.
+        assertThat(store.getArchitectureVersions(architecture(null)), is(empty()));
+    }
+
+    // --- getArchitectureForVersion ---
+
+    @Test
+    void throw_a_namespace_exception_when_getting_a_version_from_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitectureForVersion(architecture("1.0.0")));
+    }
+
+    @Test
+    void throw_an_architecture_exception_when_getting_a_version_of_a_missing_architecture() {
+        architectureDoesNotExist();
+
+        assertThrows(ArchitectureNotFoundException.class, () -> store.getArchitectureForVersion(architecture("1.0.0")));
+    }
+
+    @Test
+    void throw_a_version_exception_when_the_version_is_not_stored() {
+        stubFind(headerCollection, List.of(new Document("architectureId", ARCHITECTURE_ID)));
+        stubFind(versionCollection, List.of());
 
         assertThrows(ArchitectureVersionNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureForVersion(architecture));
+                () -> store.getArchitectureForVersion(architecture("9.0.0")));
     }
 
     @Test
-    void get_architecture_versions_for_valid_architecture_returns_list_of_versions() throws ArchitectureNotFoundException, NamespaceNotFoundException {
-        mockSetupArchitectureDocumentWithVersions();
+    void return_the_content_of_a_stored_version() throws Exception {
+        stubFind(headerCollection, List.of(new Document("architectureId", ARCHITECTURE_ID)));
+        stubFind(versionCollection, List.of(new Document("content", new Document("test", "test"))));
 
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).setId(42).build();
-        List<String> architectureVersions = mongoArchitectureStore.getArchitectureVersions(architecture);
-
-        assertThat(architectureVersions, is(List.of("1.0.0")));
+        assertThat(store.getArchitectureForVersion(architecture("1.0.0")), containsString("\"test\""));
     }
 
+    // --- createArchitectureForVersion ---
+
     @Test
-    void throw_an_exception_for_an_invalid_namespace_when_retrieving_architecture_for_version() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace("does-not-exist").build();
+    void throw_a_namespace_exception_when_creating_a_version_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureVersions(architecture));
-
-        verify(namespaceStore).namespaceExists(architecture.getNamespace());
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_architecture_when_retrieving_architecture_for_version() {
-        FindIterable<Document> findIterable = setupInvalidArchitecture();
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).build();
+    void throw_an_architecture_exception_when_creating_a_version_for_a_missing_architecture() {
+        architectureDoesNotExist();
 
         assertThrows(ArchitectureNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureForVersion(architecture));
-
-        verify(architectureCollection).find(new Document("namespace", architecture.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("architectures")));
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
     }
 
     @Test
-    void return_an_architecture_for_a_given_version() throws ArchitectureNotFoundException, ArchitectureVersionNotFoundException, NamespaceNotFoundException {
-        mockSetupArchitectureDocumentWithVersions();
-
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").build();
-
-        String architectureForVersion = mongoArchitectureStore.getArchitectureForVersion(architecture);
-        assertThat(architectureForVersion, is(validJson));
-    }
-
-
-    private Document setupArchitectureVersionDocument() {
-        //Set up an architecture document with 2 architectures in (one with a valid version)
-        Map<String, Document> versionMap = new HashMap<>();
-        versionMap.put("1-0-0", Document.parse(validJson));
-        Document targetStoredArchitecture = new Document("architectureId", 42)
-                .append("versions", new Document(versionMap));
-
-        Document paddingArchitecture = new Document("architectureId", 0);
-
-        return new Document("namespace", NAMESPACE)
-                .append("architectures", Arrays.asList(paddingArchitecture, targetStoredArchitecture));
-    }
-
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
-    }
-
-    @Test
-    void throw_an_exception_when_architecture_for_given_version_does_not_exist() {
-        mockSetupArchitectureDocumentWithVersions();
-
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
-
-        assertThrows(ArchitectureVersionNotFoundException.class,
-                () -> mongoArchitectureStore.getArchitectureForVersion(architecture));
-    }
-
-    @Test
-    void throw_an_exception_when_create_or_update_architecture_for_version_with_a_namespace_that_doesnt_exists() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.createArchitectureForVersion(architecture));
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
-
-        verify(namespaceStore, times(2)).namespaceExists(architecture.getNamespace());
-    }
-
-    @Test
-    void throw_an_exception_when_create_on_a_version_that_exists() {
-        mockSetupArchitectureDocumentWithVersions();
-
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(0, 0L, null));
-
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").setArchitecture(validJson).build();
+    void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        architectureExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
         assertThrows(ArchitectureVersionExistsException.class,
-                () -> mongoArchitectureStore.createArchitectureForVersion(architecture));
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
     }
 
     @Test
-    void throw_an_architecture_not_found_exception_when_creating_or_updating_a_version_for_a_missing_architecture() {
-        mockSetupArchitectureDocumentWithVersions();
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(50).setVersion("1.0.1")
-                .setArchitecture(validJson).build();
+    void not_rename_the_architecture_when_the_version_already_exists() {
+        architectureExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
-        assertThrows(ArchitectureNotFoundException.class,
-                () -> mongoArchitectureStore.createArchitectureForVersion(architecture));
-        assertThrows(ArchitectureNotFoundException.class,
-                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+        assertThrows(ArchitectureVersionExistsException.class,
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
 
-        // The entity-existence pre-check catches the missing architecture before any write is
-        // attempted, so no update is ever sent to Mongo (either overload).
-        verify(architectureCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(architectureCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class));
+        // The old shape set name/description in the same conditional update that wrote the
+        // content, so a rejected create changed nothing. Splitting the two writes makes it
+        // possible to rename on a request that then 409s — this pins that we don't.
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
-        mockSetupArchitectureDocumentWithVersions();
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setArchitecture(validJson).build();
+    void write_the_version_and_then_the_header_details() throws Exception {
+        architectureExists();
 
-        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+        store.createArchitectureForVersion(architecture("1.0.1"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.1"));
+        // Two header writes: the versionCount increment and the name/description update.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- updateArchitectureForVersion ---
+
+    @Test
+    void throw_a_namespace_exception_when_updating_a_version_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    void throw_an_architecture_exception_when_updating_a_version_for_a_missing_architecture() {
+        architectureDoesNotExist();
+
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    void force_write_a_version_on_update() throws Exception {
+        architectureExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        store.updateArchitectureForVersion(architecture("1.0.1"));
+
+        verify(versionCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        // Replacing an existing version doesn't move the count, so the only header write
+        // here is the name/description update.
+        verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void report_capacity_exceeded_when_a_version_write_hits_the_document_size_limit() {
+        architectureExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10334, "object to insert too large"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
-        mockSetupArchitectureDocumentWithVersions();
-        Architecture architecture = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setArchitecture(validJson).build();
-
-        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+    void report_a_plain_write_failure_for_other_version_write_errors() {
+        architectureExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10107, "not master"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoArchitectureStore.updateArchitectureForVersion(architecture));
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
     }
 
     @Test
-    void accept_the_creation_or_update_of_a_valid_version() throws ArchitectureNotFoundException, NamespaceNotFoundException, ArchitectureVersionExistsException {
-        mockSetupArchitectureDocumentWithVersions();
+    void page_the_summary_window_at_the_database() throws NamespaceNotFoundException {
+        FindIterable<Document> iterable = stubFind(headerCollection, List.of());
 
-        when(architectureCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+        store.getArchitecturesForNamespace(NAMESPACE, new PageRequest(2, 1)); // limit 2, offset 1
 
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setName("architecture-name")
-                .setDescription("architecture-description")
-                .setVersion("1.0.1")
-                .setArchitecture(validJson).build();
-
-        mongoArchitectureStore.updateArchitectureForVersion(architecture);
-        mongoArchitectureStore.createArchitectureForVersion(architecture);
-
-        verify(architectureCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(architectureCollection).updateOne(any(Bson.class), any(Bson.class));
+        // No $slice projection any more — headers are one document per architecture, so
+        // paging is ordinary skip/limit rather than slicing into an array field.
+        verify(iterable).skip(1);
+        verify(iterable).limit(2);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -65,15 +65,26 @@ class TestMongoSearchStoreShould {
         searchStore = new MongoSearchStore(database);
     }
 
+    /**
+     * Architecture has moved to the header/version shape, so each of its documents is one
+     * architecture rather than a namespace-wide array of them. The other namespaced types
+     * still use the array shape, which is why both fixtures appear in this class.
+     */
+    private static Document architectureHeader(int id, String name, String description) {
+        return architectureHeader("finos", id, name, description);
+    }
+
+    private static Document architectureHeader(String namespace, int id, String name, String description) {
+        return new Document("namespace", namespace)
+                .append("architectureId", id)
+                .append("name", name)
+                .append("description", description);
+    }
+
     @Test
     void return_matching_architecture_results() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "Payment Architecture")
-                .append("description", "Handles payments");
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "Handles payments")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -89,13 +100,8 @@ class TestMongoSearchStoreShould {
 
     @Test
     void return_matching_results_case_insensitive() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "Payment Architecture")
-                .append("description", "desc");
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -106,13 +112,8 @@ class TestMongoSearchStoreShould {
 
     @Test
     void return_matching_results_from_description() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "Some Architecture")
-                .append("description", "Handles payment processing");
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Some Architecture", "Handles payment processing")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -123,13 +124,8 @@ class TestMongoSearchStoreShould {
 
     @Test
     void return_empty_results_when_no_matches() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "Payment Architecture")
-                .append("description", "desc");
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -140,11 +136,7 @@ class TestMongoSearchStoreShould {
 
     @Test
     void return_results_from_multiple_collections() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "Demo Architecture")
-                .append("description", "demo");
-        Document archDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
+        Document archDoc = architectureHeader(1, "Demo Architecture", "demo");
 
         Document patternEntry = new Document("patternId", 2)
                 .append("name", "Demo Pattern")
@@ -223,16 +215,18 @@ class TestMongoSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
+        // Uses a pattern rather than an architecture: only the array-shaped types can have a
+        // null entries array at all, so this covers the branch where it still exists.
         Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", null);
+                .append("patterns", null);
 
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
-        mockEmptyCollections(patternCollection, flowCollection, standardCollection,
+        mockCollectionFind(patternCollection, List.of(namespaceDoc));
+        mockEmptyCollections(architectureCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
 
-        assertTrue(results.getArchitectures().isEmpty());
+        assertTrue(results.getPatterns().isEmpty());
     }
 
     @Test
@@ -253,13 +247,7 @@ class TestMongoSearchStoreShould {
 
     @Test
     void match_literal_special_characters_in_query() {
-        Document archEntry = new Document("architectureId", 1)
-                .append("name", "test.arch")
-                .append("description", "desc");
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection, List.of(architectureHeader(1, "test.arch", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -274,16 +262,14 @@ class TestMongoSearchStoreShould {
 
     @Test
     void cap_results_at_max_per_type() {
-        List<Document> entries = new ArrayList<>();
+        List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
-            entries.add(new Document("architectureId", i)
-                    .append("name", "Match " + i)
-                    .append("description", "desc"));
+            headers.add(architectureHeader(i, "Match " + i, "desc"));
         }
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("architectures", entries);
 
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        // One document per architecture now, so the cap has to be applied across documents
+        // rather than within a single document's array.
+        mockCollectionFind(architectureCollection, headers);
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -300,22 +286,15 @@ class TestMongoSearchStoreShould {
      */
     @Test
     void filter_namespaced_results_by_readable_namespaces_before_cap() {
-        List<Document> secretEntries = new ArrayList<>();
+        List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
-            secretEntries.add(new Document("architectureId", i)
-                    .append("name", "Match " + i)
-                    .append("description", "desc"));
+            headers.add(architectureHeader("secret-ns", i, "Match " + i, "desc"));
         }
-        Document secretNs = new Document("namespace", "secret-ns")
-                .append("architectures", secretEntries);
+        // Ordered after the unreadable ones, so a cap applied before the namespace filter
+        // would drop it.
+        headers.add(architectureHeader(999, "Allowed Match", "desc"));
 
-        Document allowedEntry = new Document("architectureId", 999)
-                .append("name", "Allowed Match")
-                .append("description", "desc");
-        Document allowedNs = new Document("namespace", "finos")
-                .append("architectures", List.of(allowedEntry));
-
-        mockCollectionFind(architectureCollection, List.of(secretNs, allowedNs));
+        mockCollectionFind(architectureCollection, headers);
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -4,6 +4,7 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Architecture;
@@ -12,6 +13,7 @@ import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -211,6 +213,35 @@ public class TestNitriteArchitectureStoreShould {
         assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
         // Content stays a JSON string in this backend rather than a parsed document.
         assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
+    }
+
+    @Test
+    public void remove_the_header_again_when_the_first_version_write_fails() {
+        when(mockCounterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of());
+        when(versionCollection.insert(any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
+
+        // Matches the Mongo store: a header with no versions cannot be removed through the
+        // API, so a failed first version write must not leave one behind.
+        assertThrows(NitriteException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
+
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    @Test
+    public void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(mockCounterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        // A version document already present for a freshly allocated id.
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.0")));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
+
+        verify(headerCollection).remove(any(Filter.class));
     }
 
     // --- getArchitectureVersions ---

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -16,34 +16,39 @@ import org.finos.calm.store.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestNitriteVersionDocumentStoreShould}; what this class pins is the glue —
+ * which domain exception each missing thing produces, the JSON validation this backend
+ * does and Mongo doesn't, and the ordering between a version write and the header
+ * details that accompany it.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteArchitectureStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -51,834 +56,343 @@ public class TestNitriteArchitectureStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteArchitectureStore architectureStore;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteArchitectureStore store;
 
     private static final String NAMESPACE = "finos";
     private static final int ARCHITECTURE_ID = 42;
-    private static final String VERSION = "1.0.0";
     private static final String VALID_JSON = "{\"test\": \"test\"}";
     private static final String ARCHITECTURE_NAME = "architecture-name";
     private static final String ARCHITECTURE_DESCRIPTION = "architecture description";
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        architectureStore = new NitriteArchitectureStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("architectures")).thenReturn(headerCollection);
+        when(mockDb.getCollection("architectureVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteArchitectureStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
-    @Test
-    public void testGetArchitecturesForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.getArchitecturesForNamespace(NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetArchitecturesForNamespace_whenNamespaceExistsButNoArchitectures_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
         DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
     }
 
-    @Test
-    public void testGetArchitecturesForNamespace_whenNamespaceExistsButEmptyArchitectures_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    private void architectureExists() {
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("architectureId", ARCHITECTURE_ID)
+                .put("versionCount", 1)));
     }
 
-    @Test
-    public void testGetArchitecturesForNamespace_whenNamespaceExistsButNoArchitecturesField_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    private void architectureDoesNotExist() {
+        stubFind(headerCollection, List.of());
     }
 
-    @Test
-    public void testGetArchitecturesForNamespace_whenArchitecturesExist_returnsArchitectureSummaries() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document doc1 = Document.createDocument()
-                .put("architectureId", 1001)
-                .put("name", "Arch One")
-                .put("description", "First architecture")
-                .put("versions", Document.createDocument().put("1-0-0", "{}").put("2-0-0", "{}"));
-        Document doc2 = Document.createDocument()
-                .put("architectureId", 1002)
-                .put("name", "Arch Two")
-                .put("description", "Second architecture")
-                .put("versions", Document.createDocument().put("1-0-0", "{}"));
-        List<Document> architectures = Arrays.asList(doc1, doc2);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.size(), is(2));
-        assertThat(result.get(0).getId(), is(1001));
-        assertThat(result.get(0).getName(), is("Arch One"));
-        assertThat(result.get(0).getDescription(), is("First architecture"));
-        assertThat(result.get(0).getVersionCount(), is(2));
-        assertThat(result.get(1).getId(), is(1002));
-        assertThat(result.get(1).getName(), is("Arch Two"));
-        assertThat(result.get(1).getDescription(), is("Second architecture"));
-        assertThat(result.get(1).getVersionCount(), is(1));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void get_architectures_for_namespace_applies_limit_and_offset_in_memory() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        List<Document> architectures = new java.util.ArrayList<>();
-        for (int i = 1; i <= 5; i++) {
-            architectures.add(Document.createDocument()
-                    .put("architectureId", 1000 + i)
-                    .put("name", "Arch " + i)
-                    .put("description", "Architecture " + i)
-                    .put("versions", Document.createDocument().put("1-0-0", "{}")));
-        }
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Nitrite has no array-slice projection, so the limit/offset window is applied in memory.
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE, new PageRequest(2, 1));
-
-        assertThat(result.size(), is(2));
-        assertThat(result.get(0).getId(), is(1002));
-        assertThat(result.get(1).getId(), is(1003));
-    }
-
-    @Test
-    public void get_architectures_for_namespace_returns_full_list_when_no_limit() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document doc1 = Document.createDocument()
-                .put("architectureId", 1001)
-                .put("name", "Arch One")
-                .put("description", "First")
-                .put("versions", Document.createDocument().put("1-0-0", "{}"));
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", Arrays.asList(doc1));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE, PageRequest.UNPAGED);
-
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getId(), is(1001));
-    }
-
-    @Test
-    public void testGetArchitecturesForNamespace_whenLegacyDocumentsMissingNameAndDescription_returnsFallbacks() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document legacyDoc = Document.createDocument()
-                .put("architectureId", 42);
-        List<Document> architectures = List.of(legacyDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceResourceSummary> result = architectureStore.getArchitecturesForNamespace(NAMESPACE);
-
-        assertThat(result.size(), is(1));
-        assertThat(result.get(0).getId(), is(42));
-        assertThat(result.get(0).getName(), is("Architecture 42"));
-        assertThat(result.get(0).getDescription(), is(""));
-        // Legacy document carries no versions sub-document → count guards to 0.
-        assertThat(result.get(0).getVersionCount(), is(0));
-    }
-
-    @Test
-    public void testCreateArchitectureForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
+    private static Architecture architecture(String version) {
+        return new Architecture.ArchitectureBuilder()
                 .setNamespace(NAMESPACE)
-                .build();
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.createArchitectureForNamespace(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testCreateArchitectureForNamespace_whenInvalidJson_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setArchitecture("Invalid JSON")
-                .build();
-
-        // Act & Assert
-        assertThrows(Exception.class, () -> architectureStore.createArchitectureForNamespace(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testCreateArchitectureForNamespace_whenValidParameters_returnsCreatedArchitecture() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextArchitectureSequenceValue()).thenReturn(ARCHITECTURE_ID);
-
-        Architecture architectureToCreate = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
+                .setId(ARCHITECTURE_ID)
+                .setVersion(version)
                 .setName(ARCHITECTURE_NAME)
                 .setDescription(ARCHITECTURE_DESCRIPTION)
                 .setArchitecture(VALID_JSON)
                 .build();
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Architecture result = architectureStore.createArchitectureForNamespace(architectureToCreate);
-
-        // Assert
-        assertThat(result.getId(), is(ARCHITECTURE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getName(), is(ARCHITECTURE_NAME));
-        assertThat(result.getDescription(), is(ARCHITECTURE_DESCRIPTION));
-        assertThat(result.getArchitectureJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextArchitectureSequenceValue();
-        verify(mockCollection).insert(any(Document.class));
     }
 
-    @Test
-    public void testCreateArchitectureForNamespace_whenNamespaceExistsWithArchitectures_updatesExistingDocument() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextArchitectureSequenceValue()).thenReturn(ARCHITECTURE_ID);
-
-        Architecture architectureToCreate = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setArchitecture(VALID_JSON)
-                .setName(ARCHITECTURE_NAME)
-                .setDescription(ARCHITECTURE_DESCRIPTION)
-                .build();
-
-        List<Document> existingArchitectures = new ArrayList<>();
-        existingArchitectures.add(Document.createDocument().put("architectureId", 1001));
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", existingArchitectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Architecture result = architectureStore.createArchitectureForNamespace(architectureToCreate);
-
-        // Assert
-        assertThat(result.getId(), is(ARCHITECTURE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getName(), is(ARCHITECTURE_NAME));
-        assertThat(result.getDescription(), is(ARCHITECTURE_DESCRIPTION));
-        assertThat(result.getArchitectureJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextArchitectureSequenceValue();
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
+    // --- getArchitecturesForNamespace ---
 
     @Test
-    public void testGetArchitectureVersions_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void throw_a_namespace_exception_when_listing_architectures_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.getArchitectureVersions(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitecturesForNamespace(NAMESPACE));
     }
 
     @Test
-    public void testGetArchitectureVersions_whenArchitectureDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_an_empty_list_when_a_namespace_has_no_architectures() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .build();
-
-        // Act & Assert
-        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.getArchitectureVersions(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    public void testGetArchitectureVersions_whenArchitectureExists_returnsVersions() throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("architectureId", 1).put("name", "First")
+                        .put("description", "d1").put("versionCount", 2),
+                Document.createDocument().put("architectureId", 2).put("name", "Second")
+                        .put("description", "d2").put("versionCount", 0)));
 
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON)
-                .put("1-1-0", VALID_JSON);
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .build();
-
-        // Act
-        List<String> result = architectureStore.getArchitectureVersions(architecture);
-
-        // Assert
-        assertThat(result.size(), is(2));
-        assertThat(result, hasItem("1.0.0"));
-        assertThat(result, hasItem("1.1.0"));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
     }
 
     @Test
-    public void testGetArchitectureVersions_whenVersionsDocumentIsNull_throwsArchitectureNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(Document.createDocument().put("architectureId", 7)));
 
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", List.of(architectureDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .build();
-
-        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.getArchitectureVersions(architecture));
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("Architecture 7", "", 7, 0)));
     }
 
     @Test
-    public void testGetArchitectureForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void apply_the_paging_window_in_memory() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("architectureId", 1).put("name", "First").put("versionCount", 1),
+                Document.createDocument().put("architectureId", 2).put("name", "Second").put("versionCount", 1),
+                Document.createDocument().put("architectureId", 3).put("name", "Third").put("versionCount", 1)));
+
+        // Nitrite has no server-side skip/limit, so the window is applied after materialising.
+        assertThat(store.getArchitecturesForNamespace(NAMESPACE, new PageRequest(1, 1)), contains(
+                new NamespaceResourceSummary("Second", "", 2, 1)));
+    }
+
+    // --- createArchitectureForNamespace ---
+
+    @Test
+    public void throw_a_namespace_exception_when_creating_an_architecture_in_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.createArchitectureForNamespace(architecture(null)));
     }
 
     @Test
-    public void testGetArchitectureForVersion_whenArchitectureDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void reject_invalid_json_when_creating_an_architecture() {
+        Architecture invalid = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE).setArchitecture("{invalid json}").build();
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act & Assert
-        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(JsonParseException.class, () -> store.createArchitectureForNamespace(invalid));
+        verify(headerCollection, never()).insert(any(Document.class));
     }
 
     @Test
-    public void testGetArchitectureForVersion_whenVersionDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void reject_null_json_when_creating_an_architecture() {
+        Architecture noJson = new Architecture.ArchitectureBuilder().setNamespace(NAMESPACE).build();
 
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON);
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act & Assert
-        assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        // This backend validates up front; Mongo would NPE inside Document.parse instead.
+        assertThrows(JsonParseException.class, () -> store.createArchitectureForNamespace(noJson));
     }
 
     @Test
-    public void testGetArchitectureForVersion_whenVersionsDocumentIsNull_throwsArchitectureVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextArchitectureSequenceValue()).thenReturn(99);
+        // The header the insert below creates, so the count increment that follows the
+        // version write finds something to increment.
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("architectureId", 99).put("versionCount", 0)));
+        stubFind(versionCollection, List.of());
 
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID);
+        Architecture created = store.createArchitectureForNamespace(architecture(null));
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", List.of(architectureDoc));
+        assertThat(created.getId(), is(99));
+        assertThat(created.getDotVersion(), is("1.0.0"));
+        // Unlike the Mongo store, this one echoes name/description back on the created
+        // object. Long-standing difference between the two, preserved deliberately.
+        assertThat(created.getName(), is(ARCHITECTURE_NAME));
+        assertThat(created.getDescription(), is(ARCHITECTURE_DESCRIPTION));
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("architectureId", Integer.class), is(99));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(0));
 
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend rather than a parsed document.
+        assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
     }
 
-    @Test
-    public void testGetArchitectureForVersion_whenVersionObjIsNotAString_throwsArchitectureVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("1-0-0", 12345);
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", List.of(architectureDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        assertThrows(ArchitectureVersionNotFoundException.class, () -> architectureStore.getArchitectureForVersion(architecture));
-    }
+    // --- getArchitectureVersions ---
 
     @Test
-    public void testGetArchitectureForVersion_whenVersionExists_returnsArchitecture() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act
-        String result = architectureStore.getArchitectureForVersion(architecture);
-
-        // Assert
-        assertThat(result, is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testCreateArchitectureForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void throw_a_namespace_exception_when_listing_versions_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.createArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitectureVersions(architecture(null)));
     }
 
     @Test
-    public void testCreateArchitectureForVersion_whenVersionExists_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_an_architecture_exception_when_listing_versions_for_a_missing_architecture() {
+        architectureDoesNotExist();
 
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
-
-        // Act & Assert
-        assertThrows(ArchitectureVersionExistsException.class, () -> architectureStore.createArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(ArchitectureNotFoundException.class, () -> store.getArchitectureVersions(architecture(null)));
     }
 
     @Test
-    public void testCreateArchitectureForVersion_whenVersionDoesNotExist_createsVersion() throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionExistsException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void list_versions_in_semantic_order() throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        architectureExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.10.0"),
+                Document.createDocument().put("version", "1.9.0"),
+                Document.createDocument().put("version", "1.0.0")));
 
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON); // Different version
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION) // 1.0.0
-                .setArchitecture(VALID_JSON)
-                .build();
-
-        // Act
-        Architecture result = architectureStore.createArchitectureForVersion(architecture);
-
-        // Assert
-        assertThat(result, is(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        assertThat(store.getArchitectureVersions(architecture(null)), contains("1.0.0", "1.9.0", "1.10.0"));
     }
 
     @Test
-    public void testCreateArchitectureForVersion_whenInvalidJson_throwsJsonParseException() {
-        // Arrange - JSON is validated immediately after the namespace check, before any version/existence lookup
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_no_versions_rather_than_not_found_for_an_architecture_with_none() throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        architectureExists();
+        stubFind(versionCollection, List.of());
 
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture("{ not json")
-                .build();
-
-        // Act & Assert
-        assertThrows(JsonParseException.class, () -> architectureStore.createArchitectureForVersion(architecture));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
+        // ADR 0003: the header proves existence, so an empty version list is an answer
+        // rather than evidence of a missing architecture.
+        assertThat(store.getArchitectureVersions(architecture(null)), is(empty()));
     }
 
-    @Test
-    public void testUpdateArchitectureForVersion_whenInvalidJson_throwsJsonParseException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture("{ not json")
-                .build();
-
-        // Act & Assert
-        assertThrows(JsonParseException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
-    }
+    // --- getArchitectureForVersion ---
 
     @Test
-    public void testUpdateArchitectureForVersion_whenNullJson_throwsJsonParseException() {
-        // Arrange - null JSON is rejected by the explicit null guard before any parse/lookup
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(null)
-                .build();
-
-        // Act & Assert
-        assertThrows(JsonParseException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testVersionExists_whenVersionDoesNotExist_returnsFalse() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON); // Different version
-
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("versions", versions);
-
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION) // 1.0.0
-                .setArchitecture(VALID_JSON)
-                .build();
-
-        // Act & Assert
-        assertDoesNotThrow(() -> architectureStore.createArchitectureForVersion(architecture));
-    }
-
-    @Test
-    public void testUpdateArchitectureForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void throw_a_namespace_exception_when_getting_a_version_from_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class, () -> store.getArchitectureForVersion(architecture("1.0.0")));
     }
 
     @Test
-    public void testUpdateArchitectureForVersion_whenArchitectureDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_an_architecture_exception_when_getting_a_version_of_a_missing_architecture() {
+        architectureDoesNotExist();
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
-
-        // Act & Assert
-        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(ArchitectureNotFoundException.class, () -> store.getArchitectureForVersion(architecture("1.0.0")));
     }
 
     @Test
-    public void testUpdateArchitectureForVersion_whenVersionsDocumentIsNull_throwsArchitectureNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_a_version_exception_when_the_version_is_not_stored() {
+        architectureExists();
+        stubFind(versionCollection, List.of());
 
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", List.of(architectureDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
-
-        assertThrows(ArchitectureNotFoundException.class, () -> architectureStore.updateArchitectureForVersion(architecture));
+        assertThrows(ArchitectureVersionNotFoundException.class,
+                () -> store.getArchitectureForVersion(architecture("9.0.0")));
     }
 
     @Test
-    public void testUpdateArchitectureForVersion_whenValidParameters_returnsUpdatedArchitecture() throws NamespaceNotFoundException, ArchitectureNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_the_content_of_a_stored_version() throws Exception {
+        architectureExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("content", VALID_JSON)));
 
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
+        assertThat(store.getArchitectureForVersion(architecture("1.0.0")), is(VALID_JSON));
+    }
 
-        Document architectureDoc = Document.createDocument()
-                .put("architectureId", ARCHITECTURE_ID)
-                .put("name", ARCHITECTURE_NAME)
-                .put("description", ARCHITECTURE_DESCRIPTION)
-                .put("versions", versions);
+    // --- createArchitectureForVersion ---
 
-        List<Document> architectures = new ArrayList<>();
-        architectures.add(architectureDoc);
+    @Test
+    public void throw_a_namespace_exception_when_creating_a_version_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("architectures", architectures);
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
+    }
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+    @Test
+    public void reject_invalid_json_before_checking_the_architecture_exists() {
+        architectureDoesNotExist();
+        Architecture invalid = new Architecture.ArchitectureBuilder()
+                .setNamespace(NAMESPACE).setId(ARCHITECTURE_ID).setVersion("1.0.1")
+                .setArchitecture("{invalid json}").build();
 
-        Architecture architecture = new Architecture.ArchitectureBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ARCHITECTURE_ID)
-                .setName(ARCHITECTURE_NAME)
-                .setDescription(ARCHITECTURE_DESCRIPTION)
-                .setVersion(VERSION)
-                .setArchitecture(VALID_JSON)
-                .build();
+        // Deliberate divergence from Mongo, which reports the missing architecture first.
+        // Pinned so the ordering is a decision rather than an accident.
+        assertThrows(JsonParseException.class, () -> store.createArchitectureForVersion(invalid));
+    }
 
-        // Act
-        Architecture result = architectureStore.updateArchitectureForVersion(architecture);
+    @Test
+    public void throw_an_architecture_exception_when_creating_a_version_for_a_missing_architecture() {
+        architectureDoesNotExist();
 
-        // Assert
-        assertThat(result, is(architecture));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    public void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        architectureExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
+
+        assertThrows(ArchitectureVersionExistsException.class,
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    public void not_rename_the_architecture_when_the_version_already_exists() {
+        architectureExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
+
+        assertThrows(ArchitectureVersionExistsException.class,
+                () -> store.createArchitectureForVersion(architecture("1.0.1")));
+
+        // A rejected create must leave name/description untouched, as the old single
+        // atomic update did.
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void write_the_version_and_then_the_header_details() throws Exception {
+        architectureExists();
+        stubFind(versionCollection, List.of());
+
+        store.createArchitectureForVersion(architecture("1.0.1"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.1"));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        // Two header writes: the versionCount increment, then the name/description update.
+        verify(headerCollection, org.mockito.Mockito.times(2)).update(any(Filter.class), headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("name", String.class), is(ARCHITECTURE_NAME));
+    }
+
+    // --- updateArchitectureForVersion ---
+
+    @Test
+    public void throw_a_namespace_exception_when_updating_a_version_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    public void throw_an_architecture_exception_when_updating_a_version_for_a_missing_architecture() {
+        architectureDoesNotExist();
+
+        assertThrows(ArchitectureNotFoundException.class,
+                () -> store.updateArchitectureForVersion(architecture("1.0.1")));
+    }
+
+    @Test
+    public void replace_the_content_of_an_existing_version_on_update() throws Exception {
+        architectureExists();
+        stubFind(versionCollection, List.of(Document.createDocument()
+                .put("version", "1.0.1").put("content", "{\"old\":true}")));
+
+        store.updateArchitectureForVersion(architecture("1.0.1"));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("content", String.class), is(VALID_JSON));
+        // Replacing doesn't move the count, so the only header write is the details update.
+        verify(headerCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void create_the_version_when_updating_one_that_does_not_exist() throws Exception {
+        architectureExists();
+        stubFind(versionCollection, List.of());
+
+        // Preserves the known create-on-PUT behaviour (bugs.md #1) rather than changing it.
+        store.updateArchitectureForVersion(architecture("2.0.0"));
+
+        verify(versionCollection).insert(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -66,15 +66,26 @@ class TestNitriteSearchStoreShould {
         searchStore = new NitriteSearchStore(db);
     }
 
+    /**
+     * Architecture has moved to the header/version shape, so each of its documents is one
+     * architecture rather than a namespace-wide array of them. The other namespaced types
+     * still use the array shape, which is why both fixtures appear in this class.
+     */
+    private static Document architectureHeader(int id, String name, String description) {
+        return architectureHeader("finos", id, name, description);
+    }
+
+    private static Document architectureHeader(String namespace, int id, String name, String description) {
+        return Document.createDocument("namespace", namespace)
+                .put("architectureId", id)
+                .put("name", name)
+                .put("description", description);
+    }
+
     @Test
     void return_matching_architecture_results() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "Payment Architecture")
-                .put("description", "Handles payments");
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "Handles payments")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -89,13 +100,8 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void return_matching_results_case_insensitive() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "Payment Architecture")
-                .put("description", "desc");
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -106,13 +112,8 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void return_empty_results_when_no_matches() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "Payment Architecture")
-                .put("description", "desc");
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Payment Architecture", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -123,13 +124,8 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void return_matching_results_from_description() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "Some Architecture")
-                .put("description", "Handles payment processing");
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "Some Architecture", "Handles payment processing")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -211,11 +207,13 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
+        // Uses a pattern rather than an architecture: only the array-shaped types can have a
+        // null entries array at all, so this covers the branch where it still exists.
         Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", null);
+                .put("patterns", null);
 
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
-        mockEmptyCollections(patternCollection, flowCollection, standardCollection,
+        mockCollectionFind(patternCollection, List.of(namespaceDoc));
+        mockEmptyCollections(architectureCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
@@ -225,13 +223,8 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void match_literal_special_characters_in_query() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "test.arch")
-                .put("description", "desc");
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
-
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        mockCollectionFind(architectureCollection,
+                List.of(architectureHeader(1, "test.arch", "desc")));
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -244,11 +237,7 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void return_results_from_multiple_collections() {
-        Document archEntry = Document.createDocument("architectureId", 1)
-                .put("name", "Demo Architecture")
-                .put("description", "demo");
-        Document archDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(archEntry));
+        Document archDoc = architectureHeader(1, "Demo Architecture", "demo");
 
         Document flowEntry = Document.createDocument("flowId", 3)
                 .put("name", "Demo Flow")
@@ -269,16 +258,14 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void cap_results_at_max_per_type() {
-        List<Document> entries = new ArrayList<>();
+        List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
-            entries.add(Document.createDocument("architectureId", i)
-                    .put("name", "Match " + i)
-                    .put("description", "desc"));
+            headers.add(architectureHeader(i, "Match " + i, "desc"));
         }
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("architectures", entries);
 
-        mockCollectionFind(architectureCollection, List.of(namespaceDoc));
+        // One document per architecture now, so the cap has to be applied across documents
+        // rather than within a single document's array.
+        mockCollectionFind(architectureCollection, headers);
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
@@ -295,24 +282,16 @@ class TestNitriteSearchStoreShould {
      */
     @Test
     void filter_namespaced_results_by_readable_namespaces_before_cap() {
-        // First namespace document is "secret-ns" and contains MAX+10 matches the
-        // user is NOT allowed to read; second is "finos" with one allowed match.
-        List<Document> secretEntries = new ArrayList<>();
+        // MAX+10 headers in "secret-ns" the user is NOT allowed to read, then one allowed
+        // match in "finos" — ordered last, so a cap applied before the namespace filter
+        // would drop it.
+        List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
-            secretEntries.add(Document.createDocument("architectureId", i)
-                    .put("name", "Match " + i)
-                    .put("description", "desc"));
+            headers.add(architectureHeader("secret-ns", i, "Match " + i, "desc"));
         }
-        Document secretNs = Document.createDocument("namespace", "secret-ns")
-                .put("architectures", secretEntries);
+        headers.add(architectureHeader(999, "Allowed Match", "desc"));
 
-        Document allowedEntry = Document.createDocument("architectureId", 999)
-                .put("name", "Allowed Match")
-                .put("description", "desc");
-        Document allowedNs = Document.createDocument("namespace", "finos")
-                .put("architectures", List.of(allowedEntry));
-
-        mockCollectionFind(architectureCollection, List.of(secretNs, allowedNs));
+        mockCollectionFind(architectureCollection, headers);
         mockEmptyCollections(patternCollection, flowCollection, standardCollection,
                 interfaceCollection, controlCollection, adrCollection);
 

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestCanonicalVersionShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestCanonicalVersionShould.java
@@ -1,0 +1,63 @@
+package org.finos.calm.store.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.regex.Pattern;
+
+import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class TestCanonicalVersionShould {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0.0", "1-0-0", "1.0-0", "1-0.0", "1.00", "100"})
+    void fold_every_accepted_spelling_of_a_version_onto_one_document_key(String spelling) {
+        // All six are accepted by VERSION_REGEX, so all six can arrive as a path parameter.
+        // Storing them verbatim would give one logical version six documents, each invisible
+        // to a read using any of the other five.
+        assertThat(CanonicalVersion.of(spelling), is("1.0.0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0.0", "1-0-0", "1.0-0", "1-0.0", "1.00", "100"})
+    void agree_with_the_regex_about_which_spellings_are_accepted(String spelling) {
+        // Pins the premise of the test above: these are folded because the API lets them in,
+        // not because they were picked arbitrarily. If VERSION_REGEX is ever tightened, this
+        // fails rather than leaving the fold list quietly over-broad.
+        assertThat(Pattern.matches(VERSION_REGEX, spelling), is(true));
+    }
+
+    @Test
+    void leave_an_already_canonical_version_untouched() {
+        assertThat(CanonicalVersion.of("2.13.7"), is("2.13.7"));
+    }
+
+    @Test
+    void keep_multi_digit_segments_intact() {
+        // Guards against a canonicalizer that splits on characters rather than segments.
+        assertThat(CanonicalVersion.of("10-20-30"), is("10.20.30"));
+    }
+
+    @Test
+    void canonicalize_an_all_zero_version() {
+        // 0 is matched by its own regex alternative, separate from [1-9][0-9]*.
+        assertThat(CanonicalVersion.of("0-0-0"), is("0.0.0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.2", "01.0.0", "1.0.0.0", "not-a-version", ""})
+    void return_input_the_regex_rejects_unchanged_rather_than_guessing(String rejected) {
+        // The resource layer rejects these with a 400. If the store rewrote them instead,
+        // a request that should have been refused would land under a version nobody asked for.
+        assertThat(CanonicalVersion.of(rejected), is(rejected));
+    }
+
+    @Test
+    void pass_a_null_version_through_rather_than_throwing() {
+        assertThat(CanonicalVersion.of(null), is(nullValue()));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -302,6 +302,54 @@ class TestMongoVersionDocumentStoreShould {
                 () -> store.upsertVersion(NAMESPACE, RESOURCE_ID, "1.0.0", new Document()));
     }
 
+    // --- updateHeaderDetails ---
+
+    @Test
+    void overwrite_the_headers_name_and_description() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, "Renamed", "A new description");
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        String update = asJson(updateCaptor.getValue());
+        assertThat(update, containsString("Renamed"));
+        assertThat(update, containsString("A new description"));
+    }
+
+    @Test
+    void let_a_null_name_overwrite_a_stored_one() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        // Faithful to the old shape, which $set both fields unconditionally: a version
+        // write carrying no name wipes the display name. ArchitectureRequest validates
+        // neither field, so this is reachable from the API — logged as a known bug rather
+        // than quietly fixed here, since fixing it is a behaviour change, not a port.
+        store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, null, null);
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        assertThat(asJson(updateCaptor.getValue()), containsString("null"));
+    }
+
+    @Test
+    void warn_rather_than_throw_when_there_is_no_header_to_update_details_on() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(0, null));
+
+        assertDoesNotThrow(() -> store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, "Renamed", "d"));
+    }
+
+    @Test
+    void translate_a_write_failure_when_updating_header_details() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenThrow(writeError(10334, "object to insert too large"));
+
+        // Unlike the versionCount write, this is user-supplied data — dropping a rename
+        // silently would be a wrong answer, not a stale display number.
+        assertThrows(StorageWriteException.class,
+                () -> store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, "Renamed", "d"));
+    }
+
     // --- getVersion ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -157,6 +157,26 @@ class TestMongoVersionDocumentStoreShould {
                 () -> store.createHeader(NAMESPACE, RESOURCE_ID, "name", "description"));
     }
 
+    // --- deleteHeader ---
+
+    @Test
+    void delete_a_header_by_namespace_and_id() {
+        store.deleteHeader(NAMESPACE, RESOURCE_ID);
+
+        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).deleteOne(filterCaptor.capture());
+        assertThat(asJson(filterCaptor.getValue()), containsString(NAMESPACE));
+    }
+
+    @Test
+    void swallow_a_failure_to_delete_a_header() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenThrow(new MongoTimeoutException("no server"));
+
+        // The only caller is already failing a create. Propagating this would replace the
+        // real write failure with a misleading one about the cleanup.
+        assertDoesNotThrow(() -> store.deleteHeader(NAMESPACE, RESOURCE_ID));
+    }
+
     // --- createVersion ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -83,6 +84,14 @@ class TestMongoVersionDocumentStoreShould {
             return null;
         }).when(iterable).forEach(any());
         return iterable;
+    }
+
+    /**
+     * Renders a captured filter as JSON, so assertions about what it matches on don't
+     * depend on how {@code Filters.and(...)} happens to nest its operands.
+     */
+    private static String asJson(Bson filter) {
+        return filter.toBsonDocument().toJson();
     }
 
     private static MongoWriteException writeError(int code, String message) {
@@ -164,6 +173,20 @@ class TestMongoVersionDocumentStoreShould {
         assertThat(inserted.get("content", Document.class), is(new Document("nodes", List.of())));
         assertThat(inserted.get("metadata", Document.class), is(new Document()));
         verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void store_a_dash_spelled_version_under_its_canonical_form() {
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        // 1-0-0 and 1.0.0 are both accepted by VERSION_REGEX. The old shape folded them
+        // together via replace('.', '-') on the map key; storing the version as a field
+        // value means they have to be folded here or the same version gets two documents.
+        store.createVersion(NAMESPACE, RESOURCE_ID, "1-0-0", new Document());
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(captor.capture());
+        assertThat(captor.getValue().getString("version"), is("1.0.0"));
     }
 
     @Test
@@ -256,6 +279,21 @@ class TestMongoVersionDocumentStoreShould {
     }
 
     @Test
+    void address_the_canonical_document_when_upserting_a_dash_spelled_version() {
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(acknowledged(1, null));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "1-0-0", new Document());
+
+        // The upsert filter has to carry the canonical form: on insert, Mongo derives the
+        // new document's fields from the filter's equality conditions, so a dash-spelled
+        // filter would both miss the existing document and create a duplicate.
+        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(versionCollection).updateOne(filterCaptor.capture(), any(Bson.class), any(UpdateOptions.class));
+        assertThat(asJson(filterCaptor.getValue()), containsString("1.0.0"));
+    }
+
+    @Test
     void translate_a_write_failure_when_upserting_a_version() {
         when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
                 .thenThrow(writeError(10334, "object to insert too large"));
@@ -279,6 +317,20 @@ class TestMongoVersionDocumentStoreShould {
         stubFind(versionCollection, List.of());
 
         assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "9.9.9"), is(nullValue()));
+    }
+
+    @Test
+    void look_up_a_dash_spelled_version_by_its_canonical_form() {
+        Document content = new Document("title", "My Architecture");
+        stubFind(versionCollection, List.of(new Document("version", "1.0.0").append("content", content)));
+
+        // Reads have to canonicalise too, or a version written as 1.0.0 would be
+        // unreadable via the equally-valid 1-0-0 spelling of the same path.
+        assertThat(store.getVersion(NAMESPACE, RESOURCE_ID, "1-0-0"), is(content));
+
+        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(versionCollection).find(filterCaptor.capture());
+        assertThat(asJson(filterCaptor.getValue()), containsString("1.0.0"));
     }
 
     // --- listVersions ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -101,6 +102,23 @@ class TestNitriteVersionDocumentStoreShould {
         assertThat(inserted.get("description", String.class), is("A description"));
         assertThat(inserted.get("versionCount", Integer.class), is(0));
         assertThat(inserted.get("metadata", Document.class), is(Document.createDocument()));
+    }
+
+    // --- deleteHeader ---
+
+    @Test
+    void delete_a_header_by_namespace_and_id() {
+        store.deleteHeader(NAMESPACE, RESOURCE_ID);
+
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    @Test
+    void swallow_a_failure_to_delete_a_header() {
+        when(headerCollection.remove(any(Filter.class))).thenThrow(new NitriteException("store is closed"));
+
+        // Matches the Mongo helper: the caller is already failing a create.
+        assertDoesNotThrow(() -> store.deleteHeader(NAMESPACE, RESOURCE_ID));
     }
 
     // --- createVersion ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -239,6 +239,44 @@ class TestNitriteVersionDocumentStoreShould {
         verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
     }
 
+    // --- updateHeaderDetails ---
+
+    @Test
+    void overwrite_the_headers_name_and_description() {
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "Old name", "Old description", 2)));
+
+        store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, "Renamed", "A new description");
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("name", String.class), is("Renamed"));
+        assertThat(captor.getValue().get("description", String.class), is("A new description"));
+        // The count must survive a rename — it lives on the same document.
+        assertThat(captor.getValue().get("versionCount", Integer.class), is(2));
+    }
+
+    @Test
+    void let_a_null_name_overwrite_a_stored_one() {
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "Old name", "Old description", 1)));
+
+        // Faithful to the old shape: a version write carrying no name wipes the display
+        // name. Known bug, preserved deliberately rather than fixed during a port.
+        store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, null, null);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("name", String.class), is(nullValue()));
+    }
+
+    @Test
+    void warn_rather_than_throw_when_there_is_no_header_to_update_details_on() {
+        stubFind(headerCollection, List.of());
+
+        store.updateHeaderDetails(NAMESPACE, RESOURCE_ID, "Renamed", "d");
+
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
     // --- getVersion ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -137,6 +137,21 @@ class TestNitriteVersionDocumentStoreShould {
     }
 
     @Test
+    void store_a_dash_spelled_version_under_its_canonical_form() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+
+        // Both spellings are accepted by VERSION_REGEX. It matters more here than in the
+        // Mongo helper: Nitrite has no unique index at all, so an uncanonicalised spelling
+        // would sail past the check-then-insert and become a second document silently.
+        store.createVersion(NAMESPACE, RESOURCE_ID, "1-0-0", CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("version", String.class), is("1.0.0"));
+    }
+
+    @Test
     void treat_a_missing_version_count_as_zero_when_incrementing() {
         stubFind(versionCollection, List.of());
         stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", null)));
@@ -182,6 +197,18 @@ class TestNitriteVersionDocumentStoreShould {
 
         verify(versionCollection).insert(any(Document.class));
         verify(headerCollection).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    void store_the_canonical_form_when_an_upsert_inserts_a_dash_spelled_version() {
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 1)));
+
+        store.upsertVersion(NAMESPACE, RESOURCE_ID, "2-0-0", CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("version", String.class), is("2.0.0"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Implements [#2884](https://github.com/finos/architecture-as-code/issues/2884) — the versioned-artefact storage redesign — **for Architecture only**. The other six versioned types follow in later PRs.

> **Scope, up front:** this is the pilot type, not the whole redesign. After this merges, `architectures` uses the new header/version shape while `patterns`, `flows`, `adrs`, `interfaces`, `standards` and `timelines` still use the old one. That mixed state is the incremental rollout ADR 0001 describes, and this PR proves it works before the pattern is repeated six times. Controls and Decorators are deliberately excluded for good (ADR 0004).

### The problem (as described in issue #2884)

Every Mongo store uses **one document per namespace**, holding an array of entities, each with a `versions` map containing the full content of every version ever written. Nothing is deleted. MongoDB enforces a hard **16MB per document**, so at ~40KB per architecture a single namespace hits the ceiling after roughly 400 version-writes — plausible for any long-lived shared namespace. Nitrite has the same shape and does a full read-modify-write of the whole namespace document under a store-wide lock on every access.

### The change (as proposed, documented and agreed in #2907 and started in #2908)

One **header** document per architecture in `architectures`, plus one **version** document per version in a new `architectureVersions` collection. Each document is now bounded by a single version's size rather than accumulated history.

Both store implementations shrink to translation — which domain exception each missing thing produces, and building the domain object — with all document handling and, on Nitrite, all locking behind shared helpers. `ArchitectureStore` is unchanged, so nothing above the store layer moves.

Included:

- **Shared helpers** (`MongoVersionDocumentStore` / `NitriteVersionDocumentStore`) that the remaining six types will reuse.
- **A version 2 → 3 migration** per backend: index transition, then a 1 → N fan-out. Existing deployments migrate on first startup.
- **`CanonicalVersion`**, which turned out to be load-bearing — see below.
- Search, seed data, and the 16MB regression test moved across with it.

### Three things worth a reviewer's attention

**`VERSION_REGEX` makes both separators optional**, so `1.0.0`, `1-0-0`, `1.0-0`, `1-0.0`, `1.00` and `100` are all accepted and all mean the same version. The old shape wrote the version as a map key via `replace('.', '-')`, which folded four of the six together but left `100` and `1.00` as keys of their own — so today's database can already hold one logical version under three keys. Storing the version as a *field value* without canonicalising would have given each spelling its own document, invisible to a read using any of the other five. Neither backend can catch that: Mongo's unique index is per stored string, Nitrite has no index at all. Hence `CanonicalVersion`, applied at every helper entry point, and the migration collapsing colliding keys with a `WARN` rather than silently overwriting.

**The search stores read entity collections directly**, not through a store interface. A type that migrates without its search path moving fails *silently* — the array lookup returns null for a header document, every document is skipped, and that type returns no results with nothing logged. Both stores now carry a header-shaped path alongside the array-shaped one, since the two shapes coexist until all seven types have moved. Caught by the integration suite, not by review.

**`init-mongo.js` could not simply be reshaped.** A fresh database starts at schema version 0, so every migration step runs on first startup — and step 0 creates a unique index on `architectures.namespace`, which new-shape seed data violates before the migration ever reaches the collection (`finos.fluxnova` alone seeds six architectures). Step 0 would throw, the runner would leave the migration lock held, and CalmHub would refuse every request. Step 0 is immutable, so the seed instead declares the schema already migrated — which means it also has to create the indexes step 0 would have, for all seven types. That duplication is a standing maintenance coupling, documented in ADR 0001 and `calm-hub/AGENTS.md`.

### Behaviour changes

Two, both consequences of the shape rather than choices:

- An architecture with **no versions** now returns an empty list instead of reporting itself missing. The old shape had nowhere to look but the versions map, so it conflated the two; the header settles it.
- **Malformed JSON on create** is rejected before the counter is drawn, so it no longer burns a sequence value or risks a header with no version.

Deliberately **preserved**, including where it's wrong, because a port shouldn't smuggle in behaviour changes: `PUT` still creates a version that never existed, a version write carrying no `name` still wipes the display name, and Nitrite still validates JSON before checking existence while Mongo reports the missing architecture first. The first two are logged as known bugs with tests pinning them.

### ADRs

`calm-hub/decisions/` 0001–0003 are updated to `Accepted — partially implemented`. They stay that way until all seven types have moved — per `decisions/README.md`, only `Implemented` means the code works that way today.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (no functional changes)
- [x] 📚 Documentation update

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

**Unit:** 2487 tests, 0 failures, JaCoCo 90%-per-class gate met — every new class at 100% line and branch coverage.

**Integration** (`../mvnw -P integration verify`, TestContainers against real MongoDB): 504 tests, 0 failures. Includes a migration test covering the fan-out, content preserved byte-for-byte, a re-run being a genuine no-op, resumption after a part-way failure, and two architectures finally coexisting in one namespace.

**Read-only Docker image** built and run: logs `Schema already at latest version 3 — no migration lock needed`, zero ERROR lines, `smoke-test.sh readonly` passes. It also exercises multi-version data the Mongo seed doesn't have — versions come back semver-ordered (`1.0.0, 1.1.0, 2.0.0, 3.0.0`), `versionCount` matches reality, and `/versions/1.0.0` and `/versions/1-0-0` return byte-identical responses.

**16MB regression test** now asserts both halves against a real MongoDB with the same ~2MB payload: Pattern, still one document per namespace, hits the ceiling and must return `413`; Architecture accepts ~24MB of history without a failed write. When Pattern migrates, the `413` half moves to a type that hasn't.

**Seed script** verified by running it against a real MongoDB — correct document shapes and BSON types, index inventory diffed collection-by-collection against `MongoIndexInitializationStep`, and the pre-migration-database case checked in both directions.

Partial screenshot of a localhost MongoDB showing migrated `architectures` and `architectureVersions` collections. A local CALMHub was also run to check architecture accessibility and rendering.

<img width="546" height="418" alt="image" src="https://github.com/user-attachments/assets/6da2f709-4e31-464b-8a25-79a98fe6450a" />


## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
