### PR TITLE
docs: replace migrated governance documents with pointers to calm-governance

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
 # Code of Conduct for architecture-as-code
 
 Please see the [Community Code of Conduct](https://www.finos.org/code-of-conduct).
+
+It applies to every repository in the FINOS Architecture as Code (CALM) project. The project-wide copy is maintained in the governance repository: [finos/calm-governance/CODE_OF_CONDUCT.md](https://github.com/finos/calm-governance/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,60 +1,25 @@
 # Contributing to architecture-as-code
 
-architecture-as-code is [Apache 2.0 licensed](LICENSE) and accepts contributions via git pull requests.  Each commit must include a DCO line in the git commit message:
+architecture-as-code is [Apache 2.0 licensed](../LICENSE) and accepts contributions via git pull requests.
 
-`Signed-off-by: GitHub User Name <your.email@example.com>`
+Contribution guidance lives in two places:
 
-This sign-off means you agree the commit satisfies the
-[Developer Certificate of Origin (DCO).](https://developercertificate.org/)
+## Project-wide
 
-## Contributing Issues
+The FINOS Architecture as Code project (also known as CALM) spans several repositories, and its contribution guidelines apply to all of them. They are maintained in the governance repository, [finos/calm-governance](https://github.com/finos/calm-governance):
 
-### Prerequisites
+| Document | Covers |
+|---|---|
+| [CONTRIBUTING.md](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md) | DCO sign-off, raising issues, pull request etiquette, commit and PR message style, and the responsible use of AI coding assistants |
+| [GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md) | Roles, contribution rules, Maintainer voting, and how Maintainers are added and removed |
+| [MAINTAINERS.md](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md) | The project-wide Maintainer roster and the Lead Maintainer |
+| [CODE_OF_CONDUCT.md](https://github.com/finos/calm-governance/blob/main/CODE_OF_CONDUCT.md) | The Code of Conduct all participants are subject to |
 
-* [ ] Have you [searched for duplicates](https://github.com/finos/architecture-as-code/issues?utf8=%E2%9C%93&q=)?  A simple search for exception error messages or a summary of the unexpected behaviour should suffice.
-* [ ] Are you running the latest version?
-* [ ] Are you sure this is a bug or missing capability?
+## Specific to this repository
 
-### Raising an Issue
-* Create your issue [here](https://github.com/finos/architecture-as-code/issues/new).
-* New issues contain two templates in the description: bug report and enhancement request. Please pick the most appropriate for your issue, **then delete the other**.
-  * Please also tag the new issue with either "Bug" or "Enhancement".
-* Please use [Markdown formatting](https://help.github.com/categories/writing-on-github/)
-liberally to assist in readability.
-  * [Code fences](https://help.github.com/articles/creating-and-highlighting-code-blocks/) for exception stack traces and log entries, for example, massively improve readability.
+[CONTRIBUTING.md](../CONTRIBUTING.md) at the repository root covers what is particular to this monorepo — the Conventional Commits types and scopes we enforce, the semantic-release process, and the checks to run before you commit.
 
-## Contributing Pull Requests (Code & Docs)
-To make review of PRs easier, please:
-
- * Please make sure your PRs will merge cleanly - PRs that don't are unlikely to be accepted.
- * For code contributions, follow the existing code layout.
- * For documentation contributions, follow the general structure, language, and tone of the [existing docs](https://github.com/finos/architecture-as-code/wiki).
- * Keep commits small and cohesive - if you have multiple contributions, please submit them as independent commits (and ideally as independent PRs too).
- * Reference issues if your PR has anything to do with an issue (even if it doesn't address it).
- * Minimise non-functional changes (e.g. whitespace).
- * Ensure all new files include a header comment block containing the [Apache License v2.0 and your copyright information](http://www.apache.org/licenses/LICENSE-2.0#apply).
- * If necessary (e.g. due to 3rd party dependency licensing requirements), update the [NOTICE file](https://github.com/finos/architecture-as-code/blob/master/NOTICE) with any new attribution or other notices
-
-### Responsible Use of AI Coding Assistants
-
-AI coding assistants are welcome, but their output must be treated as draft input.
-Before submitting a PR, contributors must understand and be able to explain all
-changes, validate behavior with the project's required checks, and review the
-full diff for correctness, security, privacy, licensing, and dependency impact.
-
-Do not share credentials, confidential information, or private data with AI
-services unless authorized. Contributors remain responsible for the entire
-submission, including any AI-assisted portions.
-
-For full guidance, see [CONTRIBUTING.md](../CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
-
-
-### Commit and PR Messages
-
-* **Reference issues, wiki pages, and pull requests liberally!**
-* Use the present tense ("Add feature" not "Added feature")
-* Use the imperative mood ("Move button left..." not "Moves button left...")
-* Limit the first line to 72 characters or less
+Issues and pull requests for the code, documentation and schema in this repository belong here. Governance matters — including changes to the Maintainer roster — belong in [finos/calm-governance](https://github.com/finos/calm-governance/issues).
 
 ## Style guide
 

--- a/.github/ISSUE_TEMPLATE/Maintainer_update.md
+++ b/.github/ISSUE_TEMPLATE/Maintainer_update.md
@@ -75,7 +75,7 @@ about: Propose adding a new maintainer or removing an existing maintainer
 - Confirm the maintainer has had no commits AND no involvement in issues/PRs for **3+ months**
 - Specify the period of inactivity (e.g., "no activity since [DATE]")
 - Note: This removal proposal does NOT reflect negatively on the individual, but rather acknowledges changes in their ability to contribute
-- Explain why having the README.md reflect active maintainers is important for the project
+- Explain why having the project's Maintainer roster reflect active maintainers is important for the project
 
 ### Notice Period:
 
@@ -99,7 +99,7 @@ about: Propose adding a new maintainer or removing an existing maintainer
 
 ## Voting Process
 
-As per [Governance.md](https://github.com/finos/architecture-as-code/blob/main/Governance.md):
+As per [GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md) in the project's governance repository:
 
 - All members of **@finos/architecture-as-code-maintainers** are eligible to participate
 - Please register your vote by commenting with:
@@ -131,14 +131,18 @@ Unless consensus is reached earlier, this issue will remain open for voting and 
 
 **For Additions:**
 - [ ] Add maintainer to the GitHub team: `@finos/architecture-as-code-maintainers`
-- [ ] Update `README.md` to list the new maintainer
+- [ ] Raise a PR against [MAINTAINERS.md in finos/calm-governance](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md) to add them to the project roster, linking this issue as the vote record
+- [ ] Update the [Projects table in `README.md`](https://github.com/finos/architecture-as-code#projects) if they will be maintaining a specific subproject
 - [ ] Update `.github/CODEOWNERS` if they will be owning specific components
+- [ ] Email **help@finos.org** to notify FINOS of the maintainership change
 - [ ] Welcome the new maintainer in the project channels
 
 **For Removals:**
 - [ ] Remove maintainer from the GitHub team: `@finos/architecture-as-code-maintainers`
-- [ ] Update `README.md` to remove the maintainer from the list
+- [ ] Raise a PR against [MAINTAINERS.md in finos/calm-governance](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md) to remove them from the project roster, linking this issue as the vote record
+- [ ] Update the [Projects table in `README.md`](https://github.com/finos/architecture-as-code#projects) to remove them from any subproject they maintained
 - [ ] Update `.github/CODEOWNERS` to reassign their owned components
+- [ ] Email **help@finos.org** to notify FINOS of the maintainership change
 - [ ] Thank the maintainer for their contributions in the project channels (if appropriate)
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thank you for your interest in contributing to the Architecture as Code project! This guide will help you understand our development workflow and contribution standards.
 
+> **Project-wide guidance lives in [finos/calm-governance](https://github.com/finos/calm-governance).**
+> The Architecture as Code project (also known as CALM) spans several repositories. Its
+> [governance policies](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md),
+> [contribution guidelines](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md)
+> (DCO sign-off, raising issues, pull request etiquette, and the responsible use of AI coding
+> assistants), [Code of Conduct](https://github.com/finos/calm-governance/blob/main/CODE_OF_CONDUCT.md)
+> and [Maintainer roster](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md)
+> apply to every repository in the project and are maintained there. This document covers what is
+> specific to *this* repository: our commit conventions and release process.
+
 ## 🚀 Why We Use Semantic Release
 
 We use [Semantic Release](https://semantic-release.gitbook.io/) to automate our release process for the **CLI module**, with plans to expand to other modules in the future. This ensures:
@@ -111,51 +121,11 @@ For complete details on our commit message rules, see our [`commitlint.config.js
 
 ## Responsible Use of AI Coding Assistants
 
-This project welcomes the responsible use of AI coding assistants. They can accelerate learning, improve productivity, and help contributors understand the codebase, but AI-generated output should be treated as a draft, not a finished contribution. Contributors remain responsible for every change they submit.
+AI coding assistants are welcome, but their output must be treated as draft input. Before submitting a PR, contributors must understand and be able to explain all changes, validate behaviour with the project's required checks, and review the full diff for correctness, security, privacy, licensing, and dependency impact.
 
-### Understand Before You Submit
+Do not share credentials, confidential information, or private data with AI services unless authorized. Contributors remain responsible for the entire submission, including any AI-assisted portions.
 
-Do not submit code you cannot explain. Before opening a pull request, ensure you understand why the change is needed, how it works, its impact on the project, and how you verified that it behaves correctly.
-
-### Use AI as an Assistant, Not an Authority
-
-Treat AI suggestions like code from any unfamiliar contributor. Review and validate them against the project's architecture, coding conventions, documentation, and testing practices rather than assuming they are correct because they compile or appear plausible.
-
-### Start With the Problem
-
-Take time to understand the issue before asking AI to generate code. Focused prompts based on a clear understanding of the problem consistently produce better contributions than asking AI to implement an entire feature from scratch.
-
-### Keep Contributions Focused
-
-AI assistants often generate broader solutions than necessary. Keep pull requests narrowly focused on the problem being solved, minimize unrelated changes, and avoid introducing new abstractions or dependencies unless they are clearly justified.
-
-### Validate Every Change
-
-AI-generated code requires the same level of review and testing as any other contribution. Carefully review the complete diff, run the project's required validation steps, and ensure the implementation and tests accurately solve the intended problem.
-
-### Protect Sensitive Information
-
-Do not share credentials, confidential information, private repository content, or other sensitive data with AI services unless you are authorized to do so. Contributors are responsible for understanding the privacy and data-retention policies of the tools they use.
-
-### Verify, Don't Assume
-
-AI assistants can produce incorrect code, invent APIs, misinterpret project conventions, or generate flawed tests. Verify technical claims using authoritative sources and your own testing rather than relying solely on AI-generated responses.
-
-### Own Your Contribution
-
-AI can help draft code, but it cannot take responsibility for it. Be prepared to explain your design decisions, respond thoughtfully to maintainer feedback, and revise your implementation based on code review.
-
-### Contributor Responsibility
-
-By submitting a contribution, you confirm that you:
-
-1. Reviewed the complete change.
-2. Understand and can explain the implementation.
-3. Verified the change using the project's required validation steps.
-4. Considered security, privacy, licensing, and dependency implications.
-5. Accept responsibility for the entire contribution, including any AI-assisted portions.
-
-Maintainers may reject contributions that appear to be AI-generated but are not sufficiently understood, reviewed, or validated by the contributor.
+The full policy is project-wide and is maintained in [calm-governance/CONTRIBUTING.md](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
 
 ## 🚫 What Not to Do
 

--- a/Governance.md
+++ b/Governance.md
@@ -1,69 +1,20 @@
 # Architecture as Code Governance Policies
 
-This document describes the governance policies of the FINOS Architecture as Code project. The project is also governed by the [Linux Foundation Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/), and the FINOS [IP Policy]( https://community.finos.org/governance-docs/IP-policy.pdf), [Code of Conduct](https://community.finos.org/docs/governance/code-of-conduct), [Collaborative Principles](https://community.finos.org/docs/governance/collaborative-principles/), and [Meeting Procedures](https://community.finos.org/docs/governance/meeting-procedures/).
+**This document has moved.** The governance policies of the FINOS Architecture as Code project (also known as CALM) are maintained in the project's governance repository:
 
-## Governance
+### → [finos/calm-governance/GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md)
 
-### Roles
+Governance applies across every repository in the project, so it is held in a neutral, code-free location rather than alongside the code of any one repository. This file remains as a pointer so that existing links to it continue to resolve.
 
-The project community consists of Contributors and Maintainers:
-* A **Contributor** is anyone who submits a contribution to the project. (Contributions may include code, issues, comments, documentation, media, or any combination of the above.)
-* A **Maintainer** is a Contributor who, by virtue of their contribution history, has been given write access to project repositories and may merge approved contributions.
-* The **Lead Maintainer** is the project's interface with the FINOS team and Board. They are responsible for approving [quarterly project reports](https://community.finos.org/docs/governance/#project-governing-board-reporting) and communicating on behalf of the project. The Lead Maintainer is elected by a vote of the Maintainers. 
+| Looking for | Now at |
+|---|---|
+| Roles, contribution rules, Maintainer voting, and how Maintainers are added and removed | [GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md) |
+| The Maintainer roster and the Lead Maintainer | [MAINTAINERS.md](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md) |
+| Project-wide contribution guidelines | [CONTRIBUTING.md](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md) |
+| The Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/finos/calm-governance/blob/main/CODE_OF_CONDUCT.md) |
 
-### Contribution Rules
+Guidance specific to *this* repository — build steps, test commands and the commit conventions we enforce — is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Anyone is welcome to submit a contribution to the project. The rules below apply to all contributions. (The key words "MUST", "SHALL", "SHOULD", "MAY", etc. in this document are to be interpreted as described in [IETF RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).)
+## Proposing a governance change
 
-* All contributions MUST be submitted as pull requests, including contributions by Maintainers.
-* All pull requests SHOULD be reviewed by a Maintainer (other than the Contributor) before being merged.
-* Pull requests for non-trivial contributions SHOULD remain open for a review period sufficient to give all Maintainers a sufficient opportunity to review and comment on them.
-* After the review period, if no Maintainer has an objection to the pull request, any Maintainer MAY merge it.
-* If any Maintainer objects to a pull request, the Maintainers SHOULD try to come to consensus through discussion. If no consensus can be reached, any Maintainer MAY call for a vote on the contribution.
-
-### Maintainer Voting
-
-The Maintainers MAY hold votes only when they are unable to reach consensus on an issue. Any Maintainer MAY call a vote on a contested issue, after which Maintainers SHALL have 36 hours to register their votes. Votes SHALL take the form of "+1" (agree), "-1" (disagree), "+0" (abstain). Issues SHALL be decided by the majority of votes cast. If there is only one Maintainer, they SHALL decide any issue otherwise requiring a Maintainer vote. If a vote is tied, the Lead Maintainer MAY cast an additional tie-breaker vote.
-
-The Maintainers SHALL decide the following matters by consensus or, if necessary, a vote:
-* Contested pull requests
-* Election and removal of the Lead Maintainer
-* Election and removal of Maintainers
-
-All Maintainer votes MUST be carried out transparently, with all discussion and voting occurring in public, either:
-* in comments associated with the relevant issue or pull request, if applicable;
-* on the project mailing list or other official public communication channel; or
-* during a regular, minuted project meeting.
-
-### Maintainer Qualifications
-
-Any Contributor who has made a substantial contribution to the project MAY apply (or be nominated) to become a Maintainer. The existing Maintainers SHALL vote on whether to approve the nomination according to the Maintainer Voting process above. A nomination MUST receive a majority of votes to be approved.
-
-### Removal of Maintainers
-
-A Maintainer MAY be removed due to inactivity or by their own request, subject to the following processes:
-
-#### Voluntary Removal
-
-1. A Maintainer wishing to step down MUST raise a GitHub issue stating their intent to be removed.
-2. The remaining Maintainers SHALL acknowledge the request and proceed with removal.
-3. No vote is required for voluntary removal.
-
-#### Removal Due to Inactivity
-
-A Maintainer is considered inactive if they have had no commits and no involvement in any issue or pull request discussions for a period of **3 months** or more.
-
-1. A Maintainer MUST raise a GitHub issue proposing the removal, clearly stating the reason (e.g., period of inactivity) and tagging the inactive Maintainer.
-2. The inactive Maintainer SHALL be notified via the issue and any other known contact methods (e.g., email).
-3. A minimum notice period of **4 weeks** MUST be observed from the date the issue is raised before any vote on removal may occur.
-4. During the notice period, the inactive Maintainer MAY respond to the issue to contest the removal or indicate their intent to resume activity.
-5. After the notice period, if the Maintainer has not responded or resumed activity, the remaining Maintainers SHALL vote on removal according to the Maintainer Voting process above.
-6. If the Maintainer resumes meaningful activity during the notice period, the removal issue SHOULD be closed without a vote.
-
-#### Reinstatement
-
-A Maintainer who has been removed due to inactivity MAY be reinstated at any time if they resume activity and wish to rejoin. The reinstatement process follows the standard Maintainer Qualifications process above.
-
-### Changes to this Document
-
-This document MAY be amended by a vote of the Maintainers according to the Maintainer Voting process above.
+Raise an issue in [finos/calm-governance](https://github.com/finos/calm-governance/issues) describing the change and the problem it addresses, then open a pull request against the relevant document there. Amendments to `GOVERNANCE.md` require a vote of the Maintainers, following the Maintainer Voting process set out in that document.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,38 +1,19 @@
 # Maintainers
 
-This file lists the maintainers of this repository.
+**This roster has moved.** The Maintainers of the FINOS Architecture as Code project (also known as CALM) are listed in the project's governance repository:
 
-## Current maintainers
+### → [finos/calm-governance/MAINTAINERS.md](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md)
 
-| GitHub Username   | Name                     | Organization          | Email                            |
-|-------------------|--------------------------|-----------------------|----------------------------------|
-| @Budlee           | Matthew Auburn           | Morgan Stanley        | matthew.auburn@morganstanley.com |
-| @LeighFinegold    | LeighF                   | Morgan Stanley        | leigh_finegold@hotmail.co.uk     |
-| @Thels            | Ross Maden               | Morgan Stanley        | ross.maden@morganstanley.com     |
-| @YoofiTT96        | Joseph Yoofi Brown-Pobee | turntabl              | yoofi.brownpobee@outlook.com     |
-| @aamanrebello     | Aaman Rebello            | Morgan Stanley        | aaman.rebello@morganstanley.com  |
-| @aidanm3341       | Aidan McPhelim           | Morgan Stanley        | aidan.mcphelim@morganstanley.com |
-| @dc-ms            | Denis Coffaro            | Morgan Stanley        | denis.coffaro@morganstanley.com  |
-| @eddie-knight     | Eddie Knight             | Revanite Incorporated | knight@linux.com                 |
-| @gjs-opsflo       | Gourav J. Shah           | OpsFlow.Sh            | gjs@opsflow.sh                   |
-| @grahampacker-ms  | Graham Packer            | Morgan Stanley        | graham.packer@morganstanley.com  |
-| @jimthompson5802  | Jim Thompson             | Freddie Mac           | jimthompson5802@gmail.com        |
-| @jpgough-ms       | James Gough              | Morgan Stanley        | james.gough@morganstanley.com    |
-| @lbulanti-ms      | Luigi Bulanti            | Morgan Stanley        | bulantiluigi@gmail.com           |
-| @markscott-ms     | Mark Scott               | Morgan Stanley        | markscot@morganstanley.com       |
-| @opsflowanoop     | Anoop Mehendale          | Opsflow               | anoop@opsflow.sh                 |
-| @rocketstack-matt | Matthew Bain             | Morgan Stanley        | matt@rocketstack.co              |
-| @willosborne      | Will Osborne             | Morgan Stanley        | willfosborne@gmail.com           |
-| @yt-ms            | Yan                      | Morgan Stanley        | yan.tordoff@morganstanley.com    |
+The roster is project-wide and covers every repository in the project, so it is held in one place rather than duplicated per repository. That file also records the **Lead Maintainer**. This file remains as a pointer so that existing links to it continue to resolve.
 
-For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
+The roles of Maintainer and Lead Maintainer, the qualifications for becoming a Maintainer, and the processes for electing and removing Maintainers are defined in [GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md).
 
-## Updating this file
+## Maintainers of the projects in this monorepo
 
-All changes to the maintainer list are managed openly:
+Each subproject in this repository has its own maintainers, listed against that project in the [Projects table in README.md](README.md#projects). They are drawn from the project-wide roster above.
 
-- **Submit a Pull Request** to this file for any addition, removal, or update.
-- **If your project's governance requires a vote**, document or link to the vote outcome in the PR description or comments.
-- This process creates a public audit trail of project leadership over time.
+## Proposing a change to the roster
 
-Please email **help@finos.org** whenever this file is updated with a change to maintainership.
+Raise a [Maintainer Update issue](https://github.com/finos/architecture-as-code/issues/new?template=Maintainer_update.md) to open the nomination and hold the vote, then submit the resulting pull request against [MAINTAINERS.md in finos/calm-governance](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md), linking the vote outcome.
+
+Please email **help@finos.org** whenever the roster is updated with a change to maintainership.

--- a/README.md
+++ b/README.md
@@ -68,11 +68,28 @@ We accept contributions via Pull Request, to make a contribution:
 1. Pick an issue you are interested in contributing to (or raise one yourself) and speak to the lead maintainers about what you plan to do either in the issue itself or come to a meetup. [Some issues](https://github.com/finos/architecture-as-code/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are suggested for first time contributors.
 2. Fork the repo (<https://github.com/finos/architecture-as-code/fork>)
 3. Create your feature branch (`git checkout -b feature/fooBar`)
-4. Read our [contribution guidelines](.github/CONTRIBUTING.md)
-   and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
+4. Read this repository's [contribution guidelines](CONTRIBUTING.md), the project-wide
+   [contribution guidelines](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md)
+   and the [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 5. Commit your changes (`git commit -am 'Add some fooBar'`)
 6. Push to the branch (`git push origin feature/fooBar`)
 7. Create a new Pull Request
+
+## Governance
+
+The project's governance policies, Maintainer roster and Code of Conduct are maintained in
+[finos/calm-governance](https://github.com/finos/calm-governance) and apply across every repository
+in the project.
+
+| Document | Covers |
+|---|---|
+| [GOVERNANCE.md](https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md) | Roles, contribution rules, Maintainer voting, and how Maintainers are added and removed |
+| [MAINTAINERS.md](https://github.com/finos/calm-governance/blob/main/MAINTAINERS.md) | The project-wide Maintainer roster and the Lead Maintainer |
+| [CONTRIBUTING.md](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md) | Project-wide contribution guidelines |
+| [CODE_OF_CONDUCT.md](https://github.com/finos/calm-governance/blob/main/CODE_OF_CONDUCT.md) | The Code of Conduct all participants are subject to |
+
+The maintainers of each subproject in this monorepo are listed in the [Projects](#projects) table
+above.
 
 ## GitHub actions
 

--- a/docs/src/pages/learn/contribute.md
+++ b/docs/src/pages/learn/contribute.md
@@ -90,8 +90,8 @@ Do not share credentials or confidential information with AI tools unless you
 are authorized to do so. By opening a PR, you remain responsible for the full
 change, including any AI-assisted portions.
 
-For full guidance, see the repository contributor policy:
-[Responsible Use of AI Coding Assistants](https://github.com/finos/architecture-as-code/blob/main/CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
+For full guidance, see the project-wide contributor policy:
+[Responsible Use of AI Coding Assistants](https://github.com/finos/calm-governance/blob/main/CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
 
 ## 6. Open your pull request
 

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -123,7 +123,7 @@ repository:
       primary: false
   documentation:
     contributing-guide: https://github.com/finos/architecture-as-code/blob/main/CONTRIBUTING.md
-    governance: https://github.com/finos/architecture-as-code/blob/main/Governance.md
+    governance: https://github.com/finos/calm-governance/blob/main/GOVERNANCE.md
     security-policy: https://github.com/finos/architecture-as-code/security
   license:
     url: https://github.com/finos/architecture-as-code/blob/main/LICENSE


### PR DESCRIPTION
## Description

[finos/calm-governance#2](https://github.com/finos/calm-governance/issues/2) moved the project's governance documentation into a neutral, code-free repository, and [finos/calm-governance#1](https://github.com/finos/calm-governance/pull/1) landed it there. This repository's copies are now duplicates, so this PR replaces them with pointers and fixes every reference that named a moved file.

This is the follow-up work listed at the end of finos/calm-governance#1.

### Documents replaced with pointers

| File | Change |
|---|---|
| `Governance.md` | Stub. It was a **verbatim** duplicate of `calm-governance/GOVERNANCE.md` — it diffed on the `(also known as CALM)` parenthetical and a trailing newline. Now a pointer with a "looking for X → now at Y" table. |
| `MAINTAINERS.md` | Stub pointing at the project-wide roster, which also records the Lead Maintainer. Directs readers to the per-subproject maintainers in `README.md#projects`. |
| `.github/CODE_OF_CONDUCT.md` | Keeps the finos.org link GitHub surfaces in the repository UI; adds the `calm-governance` pointer. |
| `.github/CONTRIBUTING.md` | Held only content that has moved (DCO sign-off, issue prerequisites, PR etiquette, commit and PR message style, the AI-assistant policy). Reduced to a two-way signpost — project-wide vs. this repository — keeping the repository-specific `STYLE_GUIDE.md` link. |

`Governance.md` and `MAINTAINERS.md` are **stubs rather than deletions**, as finos/calm-governance#1 asked, because external links to both exist.

`CONTRIBUTING.md` at the root is **kept**: per the proposal, each code repository keeps a `CONTRIBUTING.md` for repository-specific matters — build steps, test commands and commit conventions. Its duplicated AI-assistant policy is reduced to a summary and a pointer, keeping the heading so the `#responsible-use-of-ai-coding-assistants` anchor still resolves for anyone linking it.

### References repointed

- **`security-insights.yml`** — `repository.documentation.governance` now names `calm-governance/GOVERNANCE.md`.
- **`.github/ISSUE_TEMPLATE/Maintainer_update.md`** — the voting-process link named `Governance.md`, and the implementation checklist said "Update `README.md` to list the new maintainer", which was already wrong: the README has never held a flat roster. The roster PR now goes to `calm-governance`, and the `help@finos.org` notification the old `MAINTAINERS.md` carried is preserved as a checklist item.
- **`README.md`** — the contribution link moved off `.github/CONTRIBUTING.md` onto the root one, plus a new **Governance** section indexing the four `calm-governance` documents.
- **`docs/src/pages/learn/contribute.md`** — the AI-policy link pointed at this repository's `CONTRIBUTING.md`; it now points at the project-wide policy.

### Points for reviewer attention

1. **`MAINTAINERS.md` is a pointer, not a mirror.** finos/calm-governance#1's follow-up list offered "mirror the Lead Maintainer entry into the monorepo's `MAINTAINERS.md` so the two rosters agree". A pointer is taken instead — two rosters that must be kept in agreement are the duplication being removed, and finos/calm-governance#2's `architecture-as-code` tree lists no `MAINTAINERS.md`. Easy to change if the maintainers prefer a mirror.
2. **`SECURITY.md` is deliberately untouched.** `calm-governance` has one, but it is not a copy — this repository's names `calm-maintainers@lists.finos.org` where the governance one does not — and vulnerability reporting is per-repository. It was not in finos/calm-governance#1's change table either.
3. **Maintainer-update issues are still raised here.** `calm-governance` currently offers only a Meeting Minutes issue template, so the Maintainer Update template stays in this repository and now directs the resulting *pull request* to `calm-governance`. Moving the template is a call for that repository.

### Noticed but out of scope

`calm-studio/README.md` links `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` and `MAINTAINERS.md`, and `calm-guard/README.md` links `.github/CONTRIBUTING.md` — none of those files exist in this repository. Pre-existing broken links from the CALM Suite import, unrelated to this move.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [x] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

Also touches repository-root governance documents, `.github/` templates and `security-insights.yml`, which the list above has no entry for.

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Documentation only — no code changes, so no tests were added. Verified by hand:

- Every relative link in the changed files resolves (`LICENSE`, `commitlint.config.js`, `.github/STYLE_GUIDE.md`, `README.md#projects`, `CONTRIBUTING.md`).
- `security-insights.yml` still parses, and `repository.documentation.governance` reads back as the new URL.
- No reference to `blob/main/Governance.md` remains anywhere in the repository.
- The verbatim-duplicate claim for `Governance.md` was confirmed by diffing against `calm-governance/GOVERNANCE.md` before replacing it.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
