### PR TITLE
feat(calm-hub): versioned artefact storage redesign — remaining five types (#2884)

### DIFF
--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -1,11 +1,17 @@
 # ADR 0001: Versioned artefact storage redesign
 
-**Status**: Accepted — partially implemented. Architecture uses this shape on
-both backends, complete with its version 2 → 3 migration
-(`MongoArchitectureVersionSplitStep` / `NitriteArchitectureVersionSplitStep`),
-so an existing deployment's data moves on first startup after upgrading. The
-other six versioned types still use the old shape, which is the incremental
-rollout this ADR describes rather than a divergence from it. Tracked in
+**Status**: Implemented. All seven versioned types — Architecture, Pattern,
+Flow, Standard, Interface, Timeline and ADR — use this shape on both
+backends, each with its own migration step, so an existing deployment's data
+moves on first startup after upgrading. Schema versions 2 → 9, one pair of
+steps per type.
+
+`decorators` is the only namespace-scoped collection still on the
+one-document-per-namespace shape, and deliberately so: it is not versioned at
+all, so it never had the growth problem this ADR addresses. `controls` keeps
+the old shape too. Both are excluded by
+[ADR 0004](0004-defer-control-and-decorator-storage.md), which is now worth
+revisiting with the implementation experience it was waiting for. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).
 
 ## Context

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -1,13 +1,23 @@
 # ADR 0002: Version field encoding — dots, not dashes
 
-**Status**: Accepted — partially implemented. Architecture stores
-dot-separated versions; the other six types are still dash-encoded. Note the
-implementation needed more than "write a dot instead of a dash":
-`VERSION_REGEX` makes both separators optional, so six spellings denote the
-same version and the old map-key encoding folded only some of them together.
-`CanonicalVersion` now folds all six at the version-store helpers' entry
-points — see [ADR 0003](0003-shared-version-store-helper.md). Depends on
-[ADR 0001](0001-versioned-artefact-storage.md).
+**Status**: Implemented. Six of the seven versioned types store dot-separated
+versions; ADR is the exception, and not a violation — its history is a
+revision *number*, so it was never dash-encoded and has nothing to convert.
+It is ranked by `NumericVersionOrder` rather than the semantic comparator,
+for reasons recorded in [ADR 0003](0003-shared-version-store-helper.md).
+
+Two things the implementation needed beyond "write a dot instead of a dash":
+
+- `VERSION_REGEX` makes both separators optional, so six spellings denote the
+  same version and the old map-key encoding folded only some of them
+  together. `CanonicalVersion` now folds all six at the version-store
+  helpers' entry points.
+- `VersionKeySelector.versionCount()` lost its last caller exactly as
+  predicted below and has been deleted. `latestVersionKey()` remains, used
+  only by the two Control stores, and retires with them.
+
+Dash-encoded keys survive in `controls` alone, as this ADR anticipated.
+Depends on [ADR 0001](0001-versioned-artefact-storage.md).
 
 ## Context
 

--- a/calm-hub/decisions/0002-version-key-encoding.md
+++ b/calm-hub/decisions/0002-version-key-encoding.md
@@ -11,7 +11,12 @@ Two things the implementation needed beyond "write a dot instead of a dash":
 - `VERSION_REGEX` makes both separators optional, so six spellings denote the
   same version and the old map-key encoding folded only some of them
   together. `CanonicalVersion` now folds all six at the version-store
-  helpers' entry points.
+  helpers' entry points — but only for the semantically-versioned types.
+  ADR is exempt, and the exemption is not cosmetic: its revisions are
+  integers, and `100` is one of the six spellings of `1.0.0`, so folding
+  would have stored revision 100 as `1.0.0`. Which spelling rule applies is
+  now carried by `VersionScheme` together with the ordering rule, because
+  the two must agree and separating them is what let them disagree.
 - `VersionKeySelector.versionCount()` lost its last caller exactly as
   predicted below and has been deleted. `latestVersionKey()` remains, used
   only by the two Control stores, and retires with them.

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -18,11 +18,19 @@ reading as a record of what the original design missed:
 - `createFirstVersion` — that compensation used correctly, which every store
   had been repeating. Not a new primitive; it exists because getting it wrong
   strands a header no endpoint can remove.
-- `getLatestVersion` / `getLatestVersionContent` and a pluggable version
-  comparator — both for ADR, whose revisions are integers and whose summary
-  is built from the latest revision's content rather than from the entity.
-  Neither reinstates the `latestVersion` header pointer ADR 0001 rejected;
-  they recompute.
+- `getLatestVersion` / `getLatestVersionContent` and a pluggable
+  `VersionScheme` — both for ADR, whose revisions are integers and whose
+  summary is built from the latest revision's content rather than from the
+  entity. Neither reinstates the `latestVersion` header pointer ADR 0001
+  rejected; they recompute.
+
+  The scheme started as a pluggable *comparator* alone, and that was a bug:
+  canonicalisation stayed hard-wired, so ADR got numeric ordering but
+  semantic spelling, and revision 100 was stored as `1.0.0` — sorting below
+  99 and making every "latest revision" read return stale content. Spelling
+  and ordering are one decision and are now one type. Worth remembering the
+  next time a per-type behaviour is made pluggable: the question is not just
+  what varies, but what has to vary *with* it.
 
 `MongoVersionSplitMigration` / `NitriteVersionSplitMigration` were extracted
 when Pattern became the second type to need the fan-out, and are shared by
@@ -126,7 +134,12 @@ rules can't drift apart between them.
   [ADR 0002](0002-version-key-encoding.md). It delegates to the existing
   `Semver` record rather than parsing versions a second time.
 - **`CanonicalVersion`** — folds every accepted spelling of a version onto
-  one stored form, applied at every helper entry point that takes a version.
+  one stored form, applied at every helper entry point that takes a version
+  *for the semantically-versioned types*. Reached through `VersionScheme`
+  rather than called directly: ADR's integer revisions must be stored
+  verbatim, since `100` is one of the accepted spellings of `1.0.0` and
+  folding it stored revision 100 as `1.0.0`, below revision 99 in numeric
+  order and unparseable by the ADR store.
   This is the part of [ADR 0002](0002-version-key-encoding.md) that turned
   out to need more than writing a dot instead of a dash.
   `VERSION_REGEX` makes *both* separators optional, so `1.0.0`, `1-0-0`,

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -1,11 +1,32 @@
 # ADR 0003: Shared header/version store helper
 
-**Status**: Accepted — partially implemented. The helpers exist
-(`MongoVersionDocumentStore`, `NitriteVersionDocumentStore`,
-`SemanticVersionOrder`, `CanonicalVersion`) and the Architecture and Pattern
-stores now compose them on both backends. The other five versioned types
-still hand-roll their own logic. Depends on
-[ADR 0001](0001-versioned-artefact-storage.md) and
+**Status**: Implemented. All fourteen store implementations — seven types, two
+backends — compose `MongoVersionDocumentStore` / `NitriteVersionDocumentStore`
+rather than hand-rolling their own read/write/version logic.
+
+The operation list below grew five times during the rollout, each time
+because a type's existing behaviour could not otherwise be preserved. Worth
+reading as a record of what the original design missed:
+
+- `updateHeaderDetails` — a version write also renames the resource.
+- `updatePresentHeaderDetails` — Pattern, Flow and Timeline guard those
+  fields on blank where Architecture, Standard and Interface overwrite
+  unconditionally. That is a real difference between the types, not an
+  inconsistency to tidy, so both operations exist.
+- `deleteHeader` — compensation for a failed first version write, which the
+  old shape's single atomic push made impossible.
+- `createFirstVersion` — that compensation used correctly, which every store
+  had been repeating. Not a new primitive; it exists because getting it wrong
+  strands a header no endpoint can remove.
+- `getLatestVersion` / `getLatestVersionContent` and a pluggable version
+  comparator — both for ADR, whose revisions are integers and whose summary
+  is built from the latest revision's content rather than from the entity.
+  Neither reinstates the `latestVersion` header pointer ADR 0001 rejected;
+  they recompute.
+
+`MongoVersionSplitMigration` / `NitriteVersionSplitMigration` were extracted
+when Pattern became the second type to need the fan-out, and are shared by
+all seven. Depends on [ADR 0001](0001-versioned-artefact-storage.md) and
 [ADR 0002](0002-version-key-encoding.md).
 
 ## Context

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -17,10 +17,12 @@ assuming anything here reflects current behaviour.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Accepted — partially implemented (Architecture only) |
-| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Accepted — partially implemented (Architecture only) |
-| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Accepted — partially implemented (Architecture only) |
+| [0001](0001-versioned-artefact-storage.md) | Versioned artefact storage redesign | Implemented |
+| [0002](0002-version-key-encoding.md) | Version field encoding — dots, not dashes | Implemented |
+| [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Implemented |
 | [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted (no code of its own) |
 
-0001–0003 become `Implemented` when all seven versioned types have moved,
-not when the first one has.
+0001–0003 cover the seven *versioned* resource types. Control and Decorator
+keep the one-document-per-namespace shape by decision, not by omission — see
+0004, which is now due a revisit with the implementation experience it was
+deferring for.

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -134,7 +134,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 7;
+const LATEST_SCHEMA_VERSION = 8;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -171,10 +171,16 @@ if (isEmptyDatabase) {
     db.standardVersions.createIndex({ namespace: 1, standardId: 1, version: 1 }, unique);
     db.interfaces.createIndex({ namespace: 1, interfaceId: 1 }, unique);
     db.interfaceVersions.createIndex({ namespace: 1, interfaceId: 1, version: 1 }, unique);
+    // Timelines are not seeded by this script, but the indexes still have to match the
+    // shape the store reads, since pinning the version skips the migration that creates them.
+    db.timelines.createIndex({ namespace: 1, timelineId: 1 }, unique);
+    db.timelineVersions.createIndex({ namespace: 1, timelineId: 1, version: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.
-    for (const collection of ["timelines", "adrs", "decorators"]) {
+    // ADR and Decorator keep the one-document-per-namespace shape: ADR has not migrated
+    // yet, and Decorator is not versioned at all (ADR 0004).
+    for (const collection of ["adrs", "decorators"]) {
         db[collection].createIndex({ namespace: 1 }, unique);
     }
     db.controls.createIndex({ domain: 1 }, unique);

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -42,9 +42,14 @@ function canonicalVersion(version) {
 // flat lists with the parent-child relationship left implicit — so what is written here is
 // deliberately NOT the literal shape of the source below. Change this function, not the
 // data, if the storage shape changes again.
-function seedVersionedResource(groupedByNamespace, headerCollection, versionCollection, arrayField, idField, versionsField) {
+function seedVersionedResource(groupedByNamespace, headerCollection, versionCollection, arrayField, idField, versionsField, versionScheme) {
     // "versions" for every type but ADR, whose map is called "revisions".
     const versionsKey = versionsField || "versions";
+    // "semantic" for every type but ADR, whose revisions are integers and must be stored
+    // verbatim: VERSION_REGEX makes both separators optional, so canonicalVersion reads
+    // "100" as a spelling of 1.0.0 and would store revision 100 as "1.0.0". Mirrors
+    // VersionScheme on the Java side — see calm-hub/decisions/0003.
+    const canonicalise = versionScheme !== "numeric";
     const headers = [];
     const versions = [];
 
@@ -58,7 +63,7 @@ function seedVersionedResource(groupedByNamespace, headerCollection, versionColl
             // Mirrors collapseToCanonicalVersions in the two migration steps.
             const contentByCanonicalVersion = new Map();
             for (const storedKey of Object.keys(entry[versionsKey] || {})) {
-                const version = canonicalVersion(storedKey);
+                const version = canonicalise ? canonicalVersion(storedKey) : storedKey;
                 if (contentByCanonicalVersion.has(version)) {
                     logFail(`Seed data has two keys meaning version ${version} for `
                         + `${namespaceDocument.namespace}/${entry[idField]} — keeping the first, dropping '${storedKey}'`);
@@ -6513,7 +6518,7 @@ if (isEmptyDatabase && db.adrs.countDocuments() === 0) {
         },
     ];
     const seededAdrs = seedVersionedResource(
-        adrsByNamespace, "adrs", "adrVersions", "adrs", "adrId", "revisions");
+        adrsByNamespace, "adrs", "adrVersions", "adrs", "adrId", "revisions", "numeric");
     logSuccess(`Initialized ${seededAdrs.headers} ADRs and ${seededAdrs.versions} revisions`);
 } else if (!isEmptyDatabase) {
     logSkip("Existing database — not seeding ADRs; the new shape needs the index swap "

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -134,7 +134,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 4;
+const LATEST_SCHEMA_VERSION = 5;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -163,10 +163,12 @@ if (isEmptyDatabase) {
     db.architectureVersions.createIndex({ namespace: 1, architectureId: 1, version: 1 }, unique);
     db.patterns.createIndex({ namespace: 1, patternId: 1 }, unique);
     db.patternVersions.createIndex({ namespace: 1, patternId: 1, version: 1 }, unique);
+    db.flows.createIndex({ namespace: 1, flowId: 1 }, unique);
+    db.flowVersions.createIndex({ namespace: 1, flowId: 1, version: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.
-    for (const collection of ["flows", "timelines", "standards", "interfaces", "adrs", "decorators"]) {
+    for (const collection of ["timelines", "standards", "interfaces", "adrs", "decorators"]) {
         db[collection].createIndex({ namespace: 1 }, unique);
     }
     db.controls.createIndex({ domain: 1 }, unique);
@@ -1928,8 +1930,11 @@ if (isEmptyDatabase && db.patterns.countDocuments() === 0) {
 }
 
 logSection("Flows");
-if (db.flows.countDocuments() === 0) {
-    db.flows.insertMany([
+// Gated on the database being empty, like the other migrated types — the new shape
+// depends on the index swap the schema baseline performs.
+if (isEmptyDatabase && db.flows.countDocuments() === 0) {
+    // Grouped by namespace for readability only — seedVersionedResource fans this out.
+    const flowsByNamespace = [
         {
             namespace: "finos",
             flows: [
@@ -1939,7 +1944,7 @@ if (db.flows.countDocuments() === 0) {
                     description: "This is a non-compliant flow document. Just creating something to simulate",
                     versions:
                     {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow/flow-1",
                             "title": "Flow 1",
@@ -1953,7 +1958,7 @@ if (db.flows.countDocuments() === 0) {
                     description: "This is a non-compliant flow document. Just creating something to simulate",
                     versions:
                     {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
                             "$id": "https://raw.githubusercontent.com/finos/architecture-as-code/main/calm/flow/flow-2",
                             "title": "Flow 2",
@@ -1974,7 +1979,7 @@ if (db.flows.countDocuments() === 0) {
                     description: "Flow for adding or updating account information in the database",
                     versions:
                     {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/draft/2024-10/meta/flow.json",
                             "$id": "https://calm.finos.org/traderx/flows/add-update-account.json",
                             "unique-id": "flow-add-update-account",
@@ -2019,7 +2024,7 @@ if (db.flows.countDocuments() === 0) {
                     description: "Flow for loading a list of accounts from the database to populate the GUI drop-down for user account selection",
                     versions:
                     {
-                        "1-0-0": {
+                        "1.0.0": {
                             "$schema": "https://calm.finos.org/draft/2024-10/meta/flow.json",
                             "$id": "https://calm.finos.org/samples/traderx/flows/load-list-of-accounts.json",
                             "unique-id": "flow-load-list-of-accounts",
@@ -2055,9 +2060,14 @@ if (db.flows.countDocuments() === 0) {
                 }
             ]
         }
-    ]
-    );
-    logSuccess("Initialized flows for finos and traderx namespaces");
+    ];
+
+    const seededFlows = seedVersionedResource(
+        flowsByNamespace, "flows", "flowVersions", "flows", "flowId");
+    logSuccess(`Initialized ${seededFlows.headers} flows and ${seededFlows.versions} versions for finos and traderx namespaces`);
+} else if (!isEmptyDatabase) {
+    logSkip("Existing database — not seeding flows; the new shape needs the index swap "
+        + "that SchemaMigrationRunner will perform on startup");
 } else {
     logSkip("Flows already initialized, skipping...");
 }

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -156,12 +156,12 @@ if (isEmptyDatabase) {
         { upsert: true });
 
     // Mirrors MongoIndexInitializationStep, which the pin above skips. Keep the two in
-    // step. Two deliberate differences, both because architectures have moved to the
-    // header/version shape (ADR 0001): architectures gets a unique
-    // (namespace, architectureId) instead of (namespace), which is what allows more than
-    // one architecture per namespace at all; and architectureVersions gets a unique
-    // (namespace, architectureId, version). The other six versioned types keep the
-    // one-document-per-namespace index until they migrate.
+    // step. All seven versioned types now use the header/version shape (ADR 0001), so each
+    // gets a unique (namespace, <type>Id) instead of the old unique (namespace) — which is
+    // what allows more than one resource of a type per namespace at all — plus a unique
+    // (namespace, <type>Id, version) on its sibling versions collection. Controls and
+    // decorators keep the one-document-per-namespace index, by ADR 0004 rather than
+    // pending migration.
     db.namespaces.createIndex({ name: 1 }, unique);
     db.domains.createIndex({ name: 1 }, unique);
     db.schemas.createIndex({ version: 1 }, unique);

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -134,7 +134,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 6;
+const LATEST_SCHEMA_VERSION = 7;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -169,10 +169,12 @@ if (isEmptyDatabase) {
     // shape the store reads, since pinning the version skips the migration that creates them.
     db.standards.createIndex({ namespace: 1, standardId: 1 }, unique);
     db.standardVersions.createIndex({ namespace: 1, standardId: 1, version: 1 }, unique);
+    db.interfaces.createIndex({ namespace: 1, interfaceId: 1 }, unique);
+    db.interfaceVersions.createIndex({ namespace: 1, interfaceId: 1, version: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.
-    for (const collection of ["timelines", "interfaces", "adrs", "decorators"]) {
+    for (const collection of ["timelines", "adrs", "decorators"]) {
         db[collection].createIndex({ namespace: 1 }, unique);
     }
     db.controls.createIndex({ domain: 1 }, unique);
@@ -6666,8 +6668,10 @@ if (db.decorators.countDocuments() === 0) {
 
 logSection("Interfaces");
 // Insert a sample Host Port interface for the finos namespace
-if (db.interfaces.countDocuments() === 0) {
-    db.interfaces.insertOne({
+// Gated on the database being empty, like the other migrated types.
+if (isEmptyDatabase && db.interfaces.countDocuments() === 0) {
+    // Grouped by namespace for readability only — seedVersionedResource fans this out.
+    const interfacesByNamespace = [{
         namespace: "finos",
         interfaces: [
             {
@@ -6675,7 +6679,7 @@ if (db.interfaces.countDocuments() === 0) {
                 name: "Host Port Interface",
                 description: "A standard host and port interface definition for network-accessible services",
                 versions: {
-                    "1-0-0": {
+                    "1.0.0": {
                         "$schema": "https://json-schema.org/draft/2020-12/schema",
                         "$id": "https://calm.finos.org/calm/namespaces/finos/interfaces/1/versions/1.0.0",
                         "title": "Host Port Interface",
@@ -6737,8 +6741,13 @@ if (db.interfaces.countDocuments() === 0) {
                 }
             }
         ]
-    });
-    logSuccess("Initialized interfaces for finos namespace");
+    }];
+    const seededInterfaces = seedVersionedResource(
+        interfacesByNamespace, "interfaces", "interfaceVersions", "interfaces", "interfaceId");
+    logSuccess(`Initialized ${seededInterfaces.headers} interfaces and ${seededInterfaces.versions} versions for finos namespace`);
+} else if (!isEmptyDatabase) {
+    logSkip("Existing database — not seeding interfaces; the new shape needs the index swap "
+        + "that SchemaMigrationRunner will perform on startup");
 } else {
     logSkip("Interfaces already initialized, skipping...");
 }

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -134,7 +134,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 5;
+const LATEST_SCHEMA_VERSION = 6;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -165,10 +165,14 @@ if (isEmptyDatabase) {
     db.patternVersions.createIndex({ namespace: 1, patternId: 1, version: 1 }, unique);
     db.flows.createIndex({ namespace: 1, flowId: 1 }, unique);
     db.flowVersions.createIndex({ namespace: 1, flowId: 1, version: 1 }, unique);
+    // Standards are not seeded by this script, but the indexes still have to match the
+    // shape the store reads, since pinning the version skips the migration that creates them.
+    db.standards.createIndex({ namespace: 1, standardId: 1 }, unique);
+    db.standardVersions.createIndex({ namespace: 1, standardId: 1, version: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.
-    for (const collection of ["timelines", "standards", "interfaces", "adrs", "decorators"]) {
+    for (const collection of ["timelines", "interfaces", "adrs", "decorators"]) {
         db[collection].createIndex({ namespace: 1 }, unique);
     }
     db.controls.createIndex({ domain: 1 }, unique);

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -42,7 +42,9 @@ function canonicalVersion(version) {
 // flat lists with the parent-child relationship left implicit — so what is written here is
 // deliberately NOT the literal shape of the source below. Change this function, not the
 // data, if the storage shape changes again.
-function seedVersionedResource(groupedByNamespace, headerCollection, versionCollection, arrayField, idField) {
+function seedVersionedResource(groupedByNamespace, headerCollection, versionCollection, arrayField, idField, versionsField) {
+    // "versions" for every type but ADR, whose map is called "revisions".
+    const versionsKey = versionsField || "versions";
     const headers = [];
     const versions = [];
 
@@ -55,14 +57,14 @@ function seedVersionedResource(groupedByNamespace, headerCollection, versionColl
             // inserts — then refuses, aborting the script before it records the schema version.
             // Mirrors collapseToCanonicalVersions in the two migration steps.
             const contentByCanonicalVersion = new Map();
-            for (const storedKey of Object.keys(entry.versions || {})) {
+            for (const storedKey of Object.keys(entry[versionsKey] || {})) {
                 const version = canonicalVersion(storedKey);
                 if (contentByCanonicalVersion.has(version)) {
                     logFail(`Seed data has two keys meaning version ${version} for `
                         + `${namespaceDocument.namespace}/${entry[idField]} — keeping the first, dropping '${storedKey}'`);
                     continue;
                 }
-                contentByCanonicalVersion.set(version, entry.versions[storedKey]);
+                contentByCanonicalVersion.set(version, entry[versionsKey][storedKey]);
             }
 
             headers.push({
@@ -134,7 +136,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 8;
+const LATEST_SCHEMA_VERSION = 9;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -175,12 +177,14 @@ if (isEmptyDatabase) {
     // shape the store reads, since pinning the version skips the migration that creates them.
     db.timelines.createIndex({ namespace: 1, timelineId: 1 }, unique);
     db.timelineVersions.createIndex({ namespace: 1, timelineId: 1, version: 1 }, unique);
+    db.adrs.createIndex({ namespace: 1, adrId: 1 }, unique);
+    db.adrVersions.createIndex({ namespace: 1, adrId: 1, version: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.
-    // ADR and Decorator keep the one-document-per-namespace shape: ADR has not migrated
-    // yet, and Decorator is not versioned at all (ADR 0004).
-    for (const collection of ["adrs", "decorators"]) {
+    // Decorator is the only namespaced collection left on the one-document-per-namespace
+    // shape — it is not versioned at all, so this redesign does not touch it (ADR 0004).
+    for (const collection of ["decorators"]) {
         db[collection].createIndex({ namespace: 1 }, unique);
     }
     db.controls.createIndex({ domain: 1 }, unique);
@@ -6372,8 +6376,11 @@ if (db.userAccess.countDocuments() === 0) {
 }
 
 logSection("ADRs");
-if (db.adrs.countDocuments() === 0) {
-    db.adrs.insertMany([
+// Gated on the database being empty, like the other migrated types.
+if (isEmptyDatabase && db.adrs.countDocuments() === 0) {
+    // Grouped by namespace for readability only — seedVersionedResource fans this out.
+    // ADR keys its map "revisions", by integer, so the field name is passed explicitly.
+    const adrsByNamespace = [
         {
             namespace: 'finos',
             adrs: [
@@ -6504,8 +6511,13 @@ if (db.adrs.countDocuments() === 0) {
                 },
             ],
         },
-    ]);
-    logSuccess("Initialized ADRs for finos and workshop namespaces");
+    ];
+    const seededAdrs = seedVersionedResource(
+        adrsByNamespace, "adrs", "adrVersions", "adrs", "adrId", "revisions");
+    logSuccess(`Initialized ${seededAdrs.headers} ADRs and ${seededAdrs.versions} revisions`);
+} else if (!isEmptyDatabase) {
+    logSkip("Existing database — not seeding ADRs; the new shape needs the index swap "
+        + "that SchemaMigrationRunner will perform on startup");
 } else {
     logSkip("ADRs already initialized, skipping...");
 }

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -9,6 +9,7 @@ import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoInterfaceVersionSplitStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
+import org.finos.calm.migration.steps.MongoTimelineVersionSplitStep;
 import org.finos.calm.migration.steps.MongoStandardVersionSplitStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,7 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             new MongoFlowVersionSplitStep(database).transitionIndexes();
             new MongoStandardVersionSplitStep(database).transitionIndexes();
             new MongoInterfaceVersionSplitStep(database).transitionIndexes();
+            new MongoTimelineVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -6,6 +6,7 @@ import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
 import org.finos.calm.migration.steps.MongoIndexInitializationStep;
+import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,7 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             // second resource in a namespace.
             new MongoArchitectureVersionSplitStep(database).transitionIndexes();
             new MongoPatternVersionSplitStep(database).transitionIndexes();
+            new MongoFlowVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -7,6 +7,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
 import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
+import org.finos.calm.migration.steps.MongoInterfaceVersionSplitStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
 import org.finos.calm.migration.steps.MongoStandardVersionSplitStep;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             new MongoPatternVersionSplitStep(database).transitionIndexes();
             new MongoFlowVersionSplitStep(database).transitionIndexes();
             new MongoStandardVersionSplitStep(database).transitionIndexes();
+            new MongoInterfaceVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -8,6 +8,7 @@ import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
 import org.finos.calm.migration.steps.MongoIndexInitializationStep;
 import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
+import org.finos.calm.migration.steps.MongoStandardVersionSplitStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
@@ -50,6 +51,7 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             new MongoArchitectureVersionSplitStep(database).transitionIndexes();
             new MongoPatternVersionSplitStep(database).transitionIndexes();
             new MongoFlowVersionSplitStep(database).transitionIndexes();
+            new MongoStandardVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -6,6 +6,7 @@ import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.finos.calm.migration.steps.MongoArchitectureVersionSplitStep;
 import org.finos.calm.migration.steps.MongoIndexInitializationStep;
+import org.finos.calm.migration.steps.MongoAdrVersionSplitStep;
 import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoInterfaceVersionSplitStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
@@ -56,6 +57,7 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             new MongoStandardVersionSplitStep(database).transitionIndexes();
             new MongoInterfaceVersionSplitStep(database).transitionIndexes();
             new MongoTimelineVersionSplitStep(database).transitionIndexes();
+            new MongoAdrVersionSplitStep(database).transitionIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,15 +74,7 @@ public class MongoAdrIntegration {
         try(MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no adrId, so the
-            // header reader surfaces it as an ADR titled "ADR null" with no revisions.
-            // Creating the empty collection is all that is needed.
-            if(!database.listCollectionNames().into(new ArrayList<>()).contains("adrs")) {
-                database.createCollection("adrs");
-            }
+            primeHeaderCollection(database, "adrs");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
@@ -7,7 +7,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.bson.Document;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.finos.calm.domain.adr.Adr;
 import org.finos.calm.domain.adr.AdrMeta;

--- a/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoAdrIntegration.java
@@ -75,11 +75,14 @@ public class MongoAdrIntegration {
         try(MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
+            // The collection used to be primed with an empty one-document-per-namespace
+            // document, because that shape needed one to exist before anything could be
+            // pushed into it. Under the header/version shape there is no per-namespace
+            // document at all, and priming one is actively harmful: it has no adrId, so the
+            // header reader surfaces it as an ADR titled "ADR null" with no revisions.
+            // Creating the empty collection is all that is needed.
             if(!database.listCollectionNames().into(new ArrayList<>()).contains("adrs")) {
                 database.createCollection("adrs");
-                database.getCollection("adrs").insertOne(
-                        new Document("namespace", "finos").append("adrs", new ArrayList<>())
-                );
             }
 
             counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.bson.Document;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;

--- a/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
@@ -41,11 +41,14 @@ public class MongoFlowIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
+            // The collection used to be primed with an empty one-document-per-namespace
+            // document, because that shape needed one to exist before anything could be
+            // pushed into it. Under the header/version shape there is no per-namespace
+            // document at all, and priming one is actively harmful: it has no flowId, so the
+            // header reader surfaces it as a flow named "Flow null" with zero versions.
+            // Creating the empty collection is all that is needed.
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("flows")) {
                 database.createCollection("flows");
-                database.getCollection("flows").insertOne(
-                        new Document("namespace", "finos").append("flows", new ArrayList<>())
-                );
             }
 
             counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoFlowIntegration.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 
 import static io.restassured.RestAssured.given;
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -40,15 +40,7 @@ public class MongoFlowIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no flowId, so the
-            // header reader surfaces it as a flow named "Flow null" with zero versions.
-            // Creating the empty collection is all that is needed.
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("flows")) {
-                database.createCollection("flows");
-            }
+            primeHeaderCollection(database, "flows");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -47,15 +47,7 @@ public class MongoInterfaceIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no interfaceId, so the
-            // header reader surfaces it as a interface named "Interface null" with zero versions.
-            // Creating the empty collection is all that is needed.
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("interfaces")) {
-                database.createCollection("interfaces");
-            }
+            primeHeaderCollection(database, "interfaces");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
@@ -48,11 +48,14 @@ public class MongoInterfaceIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
+            // The collection used to be primed with an empty one-document-per-namespace
+            // document, because that shape needed one to exist before anything could be
+            // pushed into it. Under the header/version shape there is no per-namespace
+            // document at all, and priming one is actively harmful: it has no interfaceId, so the
+            // header reader surfaces it as a interface named "Interface null" with zero versions.
+            // Creating the empty collection is all that is needed.
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("interfaces")) {
                 database.createCollection("interfaces");
-                database.getCollection("interfaces").insertOne(
-                        new Document("namespace", NAMESPACE).append("interfaces", new ArrayList<>())
-                );
             }
 
             counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoInterfaceIntegration.java
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.bson.Document;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.junit.jupiter.api.*;

--- a/calm-hub/src/integration-test/java/integration/MongoMcpIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMcpIntegration.java
@@ -170,24 +170,16 @@ public class MongoMcpIntegration {
                 );
             }
 
+            // flows and timelines are header collections now, so they need no priming — and a
+            // primed per-namespace document is harmful, carrying no id and so surfacing as a
+            // phantom "Flow null" / "Timeline null" row in every listing for that namespace.
+            // decorators above keeps the old shape by ADR 0004, so its priming stays.
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("flows")) {
                 database.createCollection("flows");
-                database.getCollection("flows").insertOne(
-                        new Document("namespace", "finos").append("flows", new ArrayList<>())
-                );
             }
 
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("timelines")) {
                 database.createCollection("timelines");
-                database.getCollection("timelines").insertOne(
-                        new Document("namespace", "finos").append("timelines", new ArrayList<>())
-                );
-            }
-
-            if (database.getCollection("timelines").countDocuments(new Document("namespace", "mcp-integration")) == 0) {
-                database.getCollection("timelines").insertOne(
-                        new Document("namespace", "mcp-integration").append("timelines", new ArrayList<>())
-                );
             }
 
             MongoSetup.counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoPatternIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoPatternIntegration.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 
 import static io.restassured.RestAssured.given;
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -74,15 +74,7 @@ public class MongoPatternIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no patternId, so
-            // the header reader surfaces it as a pattern named "Pattern null" with zero
-            // versions. Creating the empty collection is all that is needed.
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("patterns")) {
-                database.createCollection("patterns");
-            }
+            primeHeaderCollection(database, "patterns");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoSetup.java
+++ b/calm-hub/src/integration-test/java/integration/MongoSetup.java
@@ -3,9 +3,31 @@ package integration;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 public class MongoSetup {
+
+    /**
+     * Creates a header collection if it is absent, and deliberately puts nothing in it.
+     *
+     * <p>These collections used to be primed with an empty one-document-per-namespace
+     * document, because the old shape needed that document to exist before anything could be
+     * pushed into it. Under the header/version shape there is no per-namespace document at
+     * all, and priming one is actively harmful: it carries no {@code <type>Id}, so the header
+     * reader surfaces it as a resource named "&lt;Type&gt; null" with zero versions, which then
+     * shows up in every listing the tests assert on.</p>
+     *
+     * <p>Creating the empty collection is all that is needed. Shared rather than repeated per
+     * test class so that the next change to this reasoning lands in one place — the previous
+     * copy-per-file version drifted, and one copy went on inserting the phantom document
+     * after the others had stopped.</p>
+     */
+    public static void primeHeaderCollection(MongoDatabase database, String collectionName) {
+        if (!database.listCollectionNames().into(new ArrayList<>()).contains(collectionName)) {
+            database.createCollection(collectionName);
+        }
+    }
 
     public static void namespaceSetup(MongoDatabase database) {
         if (database.getCollection("namespaces").countDocuments() == 0) {

--- a/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -50,15 +50,7 @@ public class MongoStandardIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no standardId, so the
-            // header reader surfaces it as a standard named "Standard null" with zero versions.
-            // Creating the empty collection is all that is needed.
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("standards")) {
-                database.createCollection("standards");
-            }
+            primeHeaderCollection(database, "standards");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
@@ -51,11 +51,14 @@ public class MongoStandardIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
+            // The collection used to be primed with an empty one-document-per-namespace
+            // document, because that shape needed one to exist before anything could be
+            // pushed into it. Under the header/version shape there is no per-namespace
+            // document at all, and priming one is actively harmful: it has no standardId, so the
+            // header reader surfaces it as a standard named "Standard null" with zero versions.
+            // Creating the empty collection is all that is needed.
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("standards")) {
                 database.createCollection("standards");
-                database.getCollection("standards").insertOne(
-                        new Document("namespace", "finos").append("standards", new ArrayList<>())
-                );
             }
 
             counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoStandardIntegration.java
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.bson.Document;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.standards.CreateStandardRequest;

--- a/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.bson.Document;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;

--- a/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
@@ -10,13 +10,13 @@ import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.restassured.RestAssured.given;
 import static integration.MongoSetup.counterSetup;
 import static integration.MongoSetup.namespaceSetup;
+import static integration.MongoSetup.primeHeaderCollection;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -46,15 +46,7 @@ public class MongoTimelineIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
-            // The collection used to be primed with an empty one-document-per-namespace
-            // document, because that shape needed one to exist before anything could be
-            // pushed into it. Under the header/version shape there is no per-namespace
-            // document at all, and priming one is actively harmful: it has no timelineId, so the
-            // header reader surfaces it as a timeline named "Timeline null" with zero versions.
-            // Creating the empty collection is all that is needed.
-            if (!database.listCollectionNames().into(new ArrayList<>()).contains("timelines")) {
-                database.createCollection("timelines");
-            }
+            primeHeaderCollection(database, "timelines");
 
             counterSetup(database);
             namespaceSetup(database);

--- a/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoTimelineIntegration.java
@@ -47,11 +47,14 @@ public class MongoTimelineIntegration {
         try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
             MongoDatabase database = mongoClient.getDatabase(mongoDatabase);
 
+            // The collection used to be primed with an empty one-document-per-namespace
+            // document, because that shape needed one to exist before anything could be
+            // pushed into it. Under the header/version shape there is no per-namespace
+            // document at all, and priming one is actively harmful: it has no timelineId, so the
+            // header reader surfaces it as a timeline named "Timeline null" with zero versions.
+            // Creating the empty collection is all that is needed.
             if (!database.listCollectionNames().into(new ArrayList<>()).contains("timelines")) {
                 database.createCollection("timelines");
-                database.getCollection("timelines").insertOne(
-                        new Document("namespace", "finos").append("timelines", new ArrayList<>())
-                );
             }
 
             counterSetup(database);

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -28,22 +28,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * The two halves of issue #2884's document-size story, one per storage shape.
  *
- * <p><b>Flow</b> still uses the one-document-per-namespace shape, where every version's full
+ * <p><b>Standard</b> still uses the one-document-per-namespace shape, where every version's full
  * content accumulates in a single document. Growing its history eventually crosses MongoDB's
  * 16MB BSON ceiling, and that failure must surface as an honest {@code 413} via
  * {@link org.finos.calm.domain.exception.StorageWriteException} — not the misleading
  * {@code 404} the stores used to throw for any {@code MongoWriteException}.</p>
  *
  * <p><b>Architecture and Pattern</b> have moved to the header/version shape, where each
- * version is its own document bounded by its own size. The same history that breaks Flow
+ * version is its own document bounded by its own size. The same history that breaks Standard
  * must now be writable, which is the whole point of the redesign. Keeping both halves in one
  * class means the ceiling and its removal are asserted against the same real MongoDB, with
  * the same payload size, rather than being argued about.</p>
  *
  * <p><b>This test relocates each time a type migrates.</b> It began on Architecture, moved to
- * Pattern when Architecture migrated, and is now on Flow. When Flow migrates it must move
- * again — Timeline, Interface, Standard and ADR are the remaining candidates, and Control
- * keeps the old shape permanently (ADR 0004). A failure here reading "expected a write to
+ * Pattern when Architecture migrated, then Flow, and is now on Standard. Once all seven
+ * versioned types have migrated the only old-shape resource left is Control, which keeps
+ * that shape permanently (ADR 0004) — so this test's final home is Control, or the 413 half
+ * retires with a note explaining why nothing can reach the ceiling any more. A failure here reading "expected a write to
  * fail" usually means the type under test has just been migrated, not that the 413 mapping
  * broke.</p>
  */
@@ -135,13 +136,13 @@ public class MongoDocumentSizeLimitIntegration {
 
     @Test
     void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
-        int flowId = createResource("flows", "flowJson", "size-limit-test-flow");
-        String requestBody = largeBody("flowJson", "size-limit-test-flow");
+        int standardId = createResource("standards", "standardJson", "size-limit-test-standard");
+        String requestBody = largeBody("standardJson", "size-limit-test-standard");
 
         Response lastResponse = null;
         int version = 2;
         for (; version < MAX_VERSION_ATTEMPTS; version++) {
-            lastResponse = putVersion("flows", flowId, version, requestBody);
+            lastResponse = putVersion("standards", standardId, version, requestBody);
             if (lastResponse.getStatusCode() != 201) {
                 break;
             }
@@ -149,8 +150,8 @@ public class MongoDocumentSizeLimitIntegration {
 
         assertTrue(version < MAX_VERSION_ATTEMPTS,
                 "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS
-                        + " versions were written. Flows still accumulate every version's content into "
-                        + "one document per namespace, so this ceiling should still exist for them. If Flow "
+                        + " versions were written. Standards still accumulate every version's content into "
+                        + "one document per namespace, so this ceiling should still exist for them. If Standard "
                         + "has just been migrated, this test needs to move to a type that has not.");
         assertEquals(413, lastResponse.getStatusCode(),
                 "Expected 413 (capacity exceeded) once the document exceeds MongoDB's 16MB limit, got: "

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -26,27 +26,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * The two halves of issue #2884's document-size story, one per storage shape.
+ * What issue #2884 set out to remove: MongoDB's 16MB per-document ceiling, reachable because
+ * every version's full content accumulated in one document per namespace.
  *
- * <p><b>Timeline</b> still uses the one-document-per-namespace shape, where every version's full
- * content accumulates in a single document. Growing its history eventually crosses MongoDB's
- * 16MB BSON ceiling, and that failure must surface as an honest {@code 413} via
- * {@link org.finos.calm.domain.exception.StorageWriteException} — not the misleading
- * {@code 404} the stores used to throw for any {@code MongoWriteException}.</p>
+ * <p>Asserted against a real MongoDB with ~2MB versions — roughly 24MB of history written to
+ * a single architecture without any write failing. Under the old shape that was impossible
+ * by construction; each version is now its own document, bounded by its own size.</p>
  *
- * <p><b>Architecture and Pattern</b> have moved to the header/version shape, where each
- * version is its own document bounded by its own size. The same history that breaks Timeline
- * must now be writable, which is the whole point of the redesign. Keeping both halves in one
- * class means the ceiling and its removal are asserted against the same real MongoDB, with
- * the same payload size, rather than being argued about.</p>
+ * <h2>The 413 half of this test has retired</h2>
+ * It asserted the opposite property — that a type still accumulating history into one
+ * document eventually fails, and that the failure surfaces as an honest {@code 413} via
+ * {@link org.finos.calm.domain.exception.StorageWriteException} rather than the misleading
+ * {@code 404} the stores once threw for any {@code MongoWriteException}. It moved to a
+ * still-unmigrated type on each round — Architecture, Pattern, Flow, Standard, Timeline —
+ * and ran out of homes: every namespace-scoped versioned type now uses the header/version
+ * shape, so nothing reachable through these endpoints can hit the ceiling any more.
  *
- * <p><b>This test relocates each time a type migrates.</b> It began on Architecture, moved to
- * Pattern when Architecture migrated, then Flow, then Standard, and is now on Timeline. Once all seven
- * versioned types have migrated the only old-shape resource left is Control, which keeps
- * that shape permanently (ADR 0004) — so this test's final home is Control, or the 413 half
- * retires with a note explaining why nothing can reach the ceiling any more. A failure here reading "expected a write to
- * fail" usually means the type under test has just been migrated, not that the 413 mapping
- * broke.</p>
+ * <p>Control is the one resource that keeps the old shape permanently (ADR 0004), but it is
+ * domain-scoped with a different path and envelope, so hosting the assertion there would
+ * have meant rewriting it to test a resource this redesign deliberately excludes. Retired
+ * instead. {@code MongoWriteFailures} still classifies {@code BSONObjectTooLarge}, and its
+ * unit tests still cover that mapping — what is gone is the end-to-end route to provoking
+ * it.</p>
  */
 @QuarkusTest
 @TestProfile(IntegrationTestProfile.class)
@@ -54,9 +55,6 @@ public class MongoDocumentSizeLimitIntegration {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    // Comfortably above the ~12-15 versions expected to be needed to cross the 16MB ceiling
-    // with ~2MB versions, without letting a stuck test run indefinitely.
-    private static final int MAX_VERSION_ATTEMPTS = 20;
 
     /**
      * Enough ~2MB versions to total roughly 24MB — well past the 16MB ceiling the old shape
@@ -134,29 +132,6 @@ public class MongoDocumentSizeLimitIntegration {
                 .thenReturn();
     }
 
-    @Test
-    void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
-        int timelineId = createResource("timelines", "timelineJson", "size-limit-test-timeline");
-        String requestBody = largeBody("timelineJson", "size-limit-test-timeline");
-
-        Response lastResponse = null;
-        int version = 2;
-        for (; version < MAX_VERSION_ATTEMPTS; version++) {
-            lastResponse = putVersion("timelines", timelineId, version, requestBody);
-            if (lastResponse.getStatusCode() != 201) {
-                break;
-            }
-        }
-
-        assertTrue(version < MAX_VERSION_ATTEMPTS,
-                "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS
-                        + " versions were written. Timelines still accumulate every version's content into "
-                        + "one document per namespace, so this ceiling should still exist for them. If Timeline "
-                        + "has just been migrated, this test needs to move to a type that has not.");
-        assertEquals(413, lastResponse.getStatusCode(),
-                "Expected 413 (capacity exceeded) once the document exceeds MongoDB's 16MB limit, got: "
-                        + lastResponse.getStatusCode() + " body=" + lastResponse.getBody().asString());
-    }
 
     @Test
     void keep_accepting_architecture_versions_well_past_the_old_document_ceiling() throws Exception {

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -28,20 +28,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * The two halves of issue #2884's document-size story, one per storage shape.
  *
- * <p><b>Standard</b> still uses the one-document-per-namespace shape, where every version's full
+ * <p><b>Timeline</b> still uses the one-document-per-namespace shape, where every version's full
  * content accumulates in a single document. Growing its history eventually crosses MongoDB's
  * 16MB BSON ceiling, and that failure must surface as an honest {@code 413} via
  * {@link org.finos.calm.domain.exception.StorageWriteException} — not the misleading
  * {@code 404} the stores used to throw for any {@code MongoWriteException}.</p>
  *
  * <p><b>Architecture and Pattern</b> have moved to the header/version shape, where each
- * version is its own document bounded by its own size. The same history that breaks Standard
+ * version is its own document bounded by its own size. The same history that breaks Timeline
  * must now be writable, which is the whole point of the redesign. Keeping both halves in one
  * class means the ceiling and its removal are asserted against the same real MongoDB, with
  * the same payload size, rather than being argued about.</p>
  *
  * <p><b>This test relocates each time a type migrates.</b> It began on Architecture, moved to
- * Pattern when Architecture migrated, then Flow, and is now on Standard. Once all seven
+ * Pattern when Architecture migrated, then Flow, then Standard, and is now on Timeline. Once all seven
  * versioned types have migrated the only old-shape resource left is Control, which keeps
  * that shape permanently (ADR 0004) — so this test's final home is Control, or the 413 half
  * retires with a note explaining why nothing can reach the ceiling any more. A failure here reading "expected a write to
@@ -136,13 +136,13 @@ public class MongoDocumentSizeLimitIntegration {
 
     @Test
     void return_413_when_a_version_write_exceeds_the_document_size_limit() throws Exception {
-        int standardId = createResource("standards", "standardJson", "size-limit-test-standard");
-        String requestBody = largeBody("standardJson", "size-limit-test-standard");
+        int timelineId = createResource("timelines", "timelineJson", "size-limit-test-timeline");
+        String requestBody = largeBody("timelineJson", "size-limit-test-timeline");
 
         Response lastResponse = null;
         int version = 2;
         for (; version < MAX_VERSION_ATTEMPTS; version++) {
-            lastResponse = putVersion("standards", standardId, version, requestBody);
+            lastResponse = putVersion("timelines", timelineId, version, requestBody);
             if (lastResponse.getStatusCode() != 201) {
                 break;
             }
@@ -150,8 +150,8 @@ public class MongoDocumentSizeLimitIntegration {
 
         assertTrue(version < MAX_VERSION_ATTEMPTS,
                 "Expected a write to fail with document-too-large before " + MAX_VERSION_ATTEMPTS
-                        + " versions were written. Standards still accumulate every version's content into "
-                        + "one document per namespace, so this ceiling should still exist for them. If Standard "
+                        + " versions were written. Timelines still accumulate every version's content into "
+                        + "one document per namespace, so this ceiling should still exist for them. If Timeline "
                         + "has just been migrated, this test needs to move to a type that has not.");
         assertEquals(413, lastResponse.getStatusCode(),
                 "Expected 413 (capacity exceeded) once the document exceeds MongoDB's 16MB limit, got: "

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -67,20 +67,15 @@ public class MongoDocumentSizeLimitIntegration {
     private static final String LARGE_CONTENT = "A".repeat(2_000_000);
 
     /**
-     * Both tests run against their own namespace rather than {@code finos}, because neither
-     * of them can clean up after itself.
+     * Runs against its own namespace rather than {@code finos}, because it cannot clean up
+     * after itself: it leaves roughly 24MB of version documents behind, which would otherwise
+     * turn up in any later listing of {@code finos} architectures.
      *
-     * <p>The 413 test deliberately drives the flows document <i>past</i> the 16MB ceiling and
-     * leaves it there — that is the state it asserts on. Nothing drops {@code flows} between
-     * classes ({@code MongoFlowIntegration} creates the collection only when absent), so under
-     * {@code finos} that wedged document would outlive this class: {@code
-     * end_to_end_get_with_no_flow} would find a flow, and every later flow write in the
-     * namespace would fail with 413 rather than 201. Today that is masked only by the order
-     * failsafe happens to run these classes in, which is not a guarantee.</p>
-     *
-     * <p>The same applies to the header/version half, for a less destructive reason: it leaves
-     * roughly 24MB of version documents behind, which would otherwise show up in any later
-     * listing of {@code finos} architectures.</p>
+     * <p>This mattered more while the 413 half still existed — that one wedged the shared
+     * {@code flows} document past the ceiling and left it there, so every later flow write in
+     * the namespace failed with 413 rather than 201, masked only by the order failsafe
+     * happened to run these classes in. Isolation is cheap enough to keep now that the
+     * surviving test's leftovers are merely noisy rather than destructive.</p>
      */
     private static final String NAMESPACE = "size-limit";
 

--- a/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/performance/MongoDocumentSizeLimitIntegration.java
@@ -23,7 +23,6 @@ import static integration.MongoSetup.namespaceSetup;
 import static integration.performance.ConcurrencyTestHelper.extractIdsFromLocations;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What issue #2884 set out to remove: MongoDB's 16MB per-document ceiling, reachable because

--- a/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
+++ b/calm-hub/src/main/java/org/finos/calm/config/NitriteDBConfig.java
@@ -99,19 +99,33 @@ public class NitriteDBConfig {
      * @throws JsonParseException
      */
     private void initializeDatabase() throws IOException, JsonParseException {
-        // Create collections - just getting the collection creates it if it doesn't exist
+        // Create collections - just getting the collection creates it if it doesn't exist.
+        //
+        // Each of the seven versioned types is a header collection plus a sibling
+        // <type>Versions collection (ADR 0001). The stores create both on demand, but they
+        // belong in this list so the set of collections a fresh standalone database starts
+        // with stays honest — a read-only image is seeded from exactly this.
         db.getCollection("architectures");
-        // Architecture's version documents live in a sibling collection (ADR 0001). The
-        // store creates it on demand too, but it belongs in this list so the set of
-        // collections a fresh standalone database starts with stays honest.
         db.getCollection("architectureVersions");
         db.getCollection("patterns");
+        db.getCollection("patternVersions");
+        db.getCollection("flows");
+        db.getCollection("flowVersions");
+        db.getCollection("standards");
+        db.getCollection("standardVersions");
+        db.getCollection("interfaces");
+        db.getCollection("interfaceVersions");
+        db.getCollection("timelines");
+        db.getCollection("timelineVersions");
+        db.getCollection("adrs");
+        db.getCollection("adrVersions");
+        // decorators keeps the one-document-per-namespace shape (ADR 0004), so it has no
+        // sibling versions collection.
+        db.getCollection("decorators");
         db.getCollection("namespaces");
         db.getCollection("domains");
-        db.getCollection("flows");
         db.getCollection("schemas");
         db.getCollection("counters");
-        db.getCollection("decorators");
         db.getCollection("calm");
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
@@ -313,6 +313,14 @@ public class AdrTools {
         } catch (AdrRevisionExistsException e) {
             logger.warn("Concurrent update created a conflicting revision for ADR [{}] in namespace [{}]", adrId, namespace, e);
             return ToolResponse.error("Error: ADR " + adrId + " was concurrently updated, please retry.");
+        } catch (Exception e) {
+            // Every checked exception the store declares is handled above, so this exists for
+            // the unchecked ones — chiefly StorageWriteException, which the write path raises
+            // for an operational failure rather than a missing resource. Without it such a
+            // failure propagates out of the @Tool method instead of returning an error
+            // response. The five sibling methods in this class already end this way.
+            logger.error("Unexpected error updating status for ADR [{}] in namespace [{}]", adrId, namespace, e);
+            return ToolResponse.error("Error: Failed to update status for ADR " + adrId + ".");
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * <em>header</em> document per adr plus one <em>version</em> document per version in the
  * new {@code adrVersions} collection.
  *
- * <p>Version 3 → 4 of the schema, and the Adr slice of
+ * <p>Version 8 → 9 of the schema, and the ADR slice of
  * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
  * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
  * is immutable: a deployment already past version 8 never re-runs it, so changing it would
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * {@code revisions}, keyed by an integer rather than a semantic version. The shared
  * migration takes that field name as a parameter for exactly this case; the revision keys
  * themselves pass through canonicalisation untouched, since the version regex does not
- * recognise a bare integer.</p></p>
+ * recognise a bare integer.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.finos.calm.migration.SchemaMigrationStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.finos.calm.store.util.VersionScheme;
 
 /**
  * Splits the {@code adrs} collection from one document per namespace into one
@@ -42,7 +43,7 @@ public class MongoAdrVersionSplitStep implements SchemaMigrationStep {
 
     public MongoAdrVersionSplitStep(MongoDatabase database) {
         this.migration = new MongoVersionSplitMigration(
-                database, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR");
+                database, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR", VersionScheme.NUMERIC);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
@@ -1,0 +1,80 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits the {@code adrs} collection from one document per namespace into one
+ * <em>header</em> document per adr plus one <em>version</em> document per version in the
+ * new {@code adrVersions} collection.
+ *
+ * <p>Version 3 → 4 of the schema, and the Adr slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
+ * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
+ * is immutable: a deployment already past version 8 never re-runs it, so changing it would
+ * alter fresh deployments only and silently diverge them from existing ones.</p>
+ *
+ * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
+ * versioned type; this class supplies the collection and field names and the version it
+ * applies at.
+ *
+ * <p>ADR is the only type whose version map is not called {@code versions} — it stores
+ * {@code revisions}, keyed by an integer rather than a semantic version. The shared
+ * migration takes that field name as a parameter for exactly this case; the revision keys
+ * themselves pass through canonicalisation untouched, since the version regex does not
+ * recognise a bare integer.</p></p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoAdrVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoAdrVersionSplitStep.class);
+
+    private final MongoVersionSplitMigration migration;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoAdrVersionSplitStep(MongoDatabase database) {
+        this.migration = new MongoVersionSplitMigration(
+                database, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 8;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping adr version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public for the
+     * same reason as the Architecture step's: integration tests with a known-real MongoDB
+     * container call it directly rather than faking the CDI-injected {@link #databaseMode}.
+     */
+    public void migrate() {
+        migration.migrate();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having any
+     * old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        migration.transitionIndexes();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrVersionSplitStep.java
@@ -22,13 +22,21 @@ import org.finos.calm.store.util.VersionScheme;
  *
  * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
  * versioned type; this class supplies the collection and field names and the version it
- * applies at.
+ * applies at.</p>
  *
  * <p>ADR is the only type whose version map is not called {@code versions} — it stores
  * {@code revisions}, keyed by an integer rather than a semantic version. The shared
- * migration takes that field name as a parameter for exactly this case; the revision keys
- * themselves pass through canonicalisation untouched, since the version regex does not
- * recognise a bare integer.</p>
+ * migration takes that field name as a parameter for exactly this case.</p>
+ *
+ * <p><strong>Revision keys survive because of the {@link VersionScheme#NUMERIC} argument
+ * below, not because the regex ignores them.</strong> {@code VERSION_REGEX} makes both
+ * separators optional, so {@code "100"} is an accepted spelling of {@code 1.0.0}:
+ * canonicalising a revision key rewrites 100 to {@code "1.0.0"}, 123 to {@code "1.2.3"}, and
+ * so on from revision 100 upward — writing the corruption permanently into migrated data.
+ * {@code NUMERIC} supplies an identity canonicaliser, which is what actually leaves the keys
+ * alone. Revisions 1-99 are unaffected either way, which is why this went unnoticed until it
+ * was reasoned about rather than run. Do not drop the scheme argument on the belief that a
+ * bare integer is not a version — it is one.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoFlowVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoFlowVersionSplitStep.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * <em>header</em> document per flow plus one <em>version</em> document per version in the
  * new {@code flowVersions} collection.
  *
- * <p>Version 3 → 4 of the schema, and the Flow slice of
+ * <p>Version 4 → 5 of the schema, and the Flow slice of
  * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
  * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
  * is immutable: a deployment already past version 4 never re-runs it, so changing it would

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoFlowVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoFlowVersionSplitStep.java
@@ -1,0 +1,74 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits the {@code flows} collection from one document per namespace into one
+ * <em>header</em> document per flow plus one <em>version</em> document per version in the
+ * new {@code flowVersions} collection.
+ *
+ * <p>Version 3 → 4 of the schema, and the Flow slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
+ * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
+ * is immutable: a deployment already past version 4 never re-runs it, so changing it would
+ * alter fresh deployments only and silently diverge them from existing ones.</p>
+ *
+ * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
+ * versioned type; this class supplies the collection and field names and the version it
+ * applies at.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoFlowVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoFlowVersionSplitStep.class);
+
+    private final MongoVersionSplitMigration migration;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoFlowVersionSplitStep(MongoDatabase database) {
+        this.migration = new MongoVersionSplitMigration(
+                database, "flows", "flowVersions", "flowId", "flows", "Flow");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 4;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping flow version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public for the
+     * same reason as the Architecture step's: integration tests with a known-real MongoDB
+     * container call it directly rather than faking the CDI-injected {@link #databaseMode}.
+     */
+    public void migrate() {
+        migration.migrate();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having any
+     * old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        migration.transitionIndexes();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoInterfaceVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoInterfaceVersionSplitStep.java
@@ -1,0 +1,74 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits the {@code interfaces} collection from one document per namespace into one
+ * <em>header</em> document per interface plus one <em>version</em> document per version in the
+ * new {@code interfaceVersions} collection.
+ *
+ * <p>Version 3 → 4 of the schema, and the Interface slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
+ * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
+ * is immutable: a deployment already past version 6 never re-runs it, so changing it would
+ * alter fresh deployments only and silently diverge them from existing ones.</p>
+ *
+ * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
+ * versioned type; this class supplies the collection and field names and the version it
+ * applies at.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoInterfaceVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoInterfaceVersionSplitStep.class);
+
+    private final MongoVersionSplitMigration migration;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoInterfaceVersionSplitStep(MongoDatabase database) {
+        this.migration = new MongoVersionSplitMigration(
+                database, "interfaces", "interfaceVersions", "interfaceId", "interfaces", "Interface");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 6;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping interface version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public for the
+     * same reason as the Architecture step's: integration tests with a known-real MongoDB
+     * container call it directly rather than faking the CDI-injected {@link #databaseMode}.
+     */
+    public void migrate() {
+        migration.migrate();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having any
+     * old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        migration.transitionIndexes();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoInterfaceVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoInterfaceVersionSplitStep.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * <em>header</em> document per interface plus one <em>version</em> document per version in the
  * new {@code interfaceVersions} collection.
  *
- * <p>Version 3 → 4 of the schema, and the Interface slice of
+ * <p>Version 6 → 7 of the schema, and the Interface slice of
  * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
  * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
  * is immutable: a deployment already past version 6 never re-runs it, so changing it would

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoStandardVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoStandardVersionSplitStep.java
@@ -1,0 +1,74 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits the {@code standards} collection from one document per namespace into one
+ * <em>header</em> document per standard plus one <em>version</em> document per version in the
+ * new {@code standardVersions} collection.
+ *
+ * <p>Version 3 → 4 of the schema, and the Standard slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
+ * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
+ * is immutable: a deployment already past version 5 never re-runs it, so changing it would
+ * alter fresh deployments only and silently diverge them from existing ones.</p>
+ *
+ * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
+ * versioned type; this class supplies the collection and field names and the version it
+ * applies at.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoStandardVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoStandardVersionSplitStep.class);
+
+    private final MongoVersionSplitMigration migration;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoStandardVersionSplitStep(MongoDatabase database) {
+        this.migration = new MongoVersionSplitMigration(
+                database, "standards", "standardVersions", "standardId", "standards", "Standard");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 5;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping standard version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public for the
+     * same reason as the Architecture step's: integration tests with a known-real MongoDB
+     * container call it directly rather than faking the CDI-injected {@link #databaseMode}.
+     */
+    public void migrate() {
+        migration.migrate();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having any
+     * old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        migration.transitionIndexes();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoStandardVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoStandardVersionSplitStep.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * <em>header</em> document per standard plus one <em>version</em> document per version in the
  * new {@code standardVersions} collection.
  *
- * <p>Version 3 → 4 of the schema, and the Standard slice of
+ * <p>Version 5 → 6 of the schema, and the Standard slice of
  * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
  * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
  * is immutable: a deployment already past version 5 never re-runs it, so changing it would

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoTimelineVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoTimelineVersionSplitStep.java
@@ -1,0 +1,74 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoDatabase;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits the {@code timelines} collection from one document per namespace into one
+ * <em>header</em> document per timeline plus one <em>version</em> document per version in the
+ * new {@code timelineVersions} collection.
+ *
+ * <p>Version 3 → 4 of the schema, and the Timeline slice of
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
+ * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
+ * is immutable: a deployment already past version 7 never re-runs it, so changing it would
+ * alter fresh deployments only and silently diverge them from existing ones.</p>
+ *
+ * <p>The fan-out itself lives in {@link MongoVersionSplitMigration}, shared with every other
+ * versioned type; this class supplies the collection and field names and the version it
+ * applies at.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoTimelineVersionSplitStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoTimelineVersionSplitStep.class);
+
+    private final MongoVersionSplitMigration migration;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoTimelineVersionSplitStep(MongoDatabase database) {
+        this.migration = new MongoVersionSplitMigration(
+                database, "timelines", "timelineVersions", "timelineId", "timelines", "Timeline");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 7;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping timeline version split (database mode: {})", databaseMode);
+            return;
+        }
+        migrate();
+    }
+
+    /**
+     * Runs the migration unconditionally — no {@code databaseMode} check. Public for the
+     * same reason as the Architecture step's: integration tests with a known-real MongoDB
+     * container call it directly rather than faking the CDI-injected {@link #databaseMode}.
+     */
+    public void migrate() {
+        migration.migrate();
+    }
+
+    /**
+     * Replaces the old one-document-per-namespace constraint with the two the new shape
+     * needs. Public separately from {@link #migrate()} because integration-test
+     * infrastructure needs a database whose indexes match the new shape without having any
+     * old-shape data to fan out.
+     */
+    public void transitionIndexes() {
+        migration.transitionIndexes();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoTimelineVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoTimelineVersionSplitStep.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * <em>header</em> document per timeline plus one <em>version</em> document per version in the
  * new {@code timelineVersions} collection.
  *
- * <p>Version 3 → 4 of the schema, and the Timeline slice of
+ * <p>Version 7 → 8 of the schema, and the Timeline slice of
  * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}. A separate step from
  * Architecture's rather than an edit to it, because a committed {@code SchemaMigrationStep}
  * is immutable: a deployment already past version 7 never re-runs it, so changing it would

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoVersionSplitMigration.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoVersionSplitMigration.java
@@ -8,7 +8,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
-import org.finos.calm.store.util.CanonicalVersion;
+import org.finos.calm.store.util.VersionScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +75,7 @@ public class MongoVersionSplitMigration {
     private final String arrayField;
     private final String versionsField;
     private final String resourceLabel;
+    private final VersionScheme versionScheme;
 
     /**
      * @param headerCollection  the existing per-type collection, which becomes the headers
@@ -86,15 +87,22 @@ public class MongoVersionSplitMigration {
      */
     public MongoVersionSplitMigration(MongoDatabase database, String headerCollection, String versionCollection,
                                       String idField, String arrayField, String resourceLabel) {
-        this(database, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel);
+        this(database, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel,
+                VersionScheme.SEMANTIC);
     }
 
     /**
      * @param versionsField the field holding the version map on each old-shape entry.
      *                      "versions" for every type but ADR, whose map is named "revisions".
+     * @param versionScheme how this type's version keys are spelled. ADR passes
+     *                      {@link VersionScheme#NUMERIC}: its keys are integer revisions, and
+     *                      canonicalising them would rewrite revision 100 to "1.0.0" — a
+     *                      corruption written straight into the migrated data, where it also
+     *                      sorts below 99 and breaks the parseInt in the ADR store.
      */
     public MongoVersionSplitMigration(MongoDatabase database, String headerCollection, String versionCollection,
-                                      String idField, String arrayField, String versionsField, String resourceLabel) {
+                                      String idField, String arrayField, String versionsField, String resourceLabel,
+                                      VersionScheme versionScheme) {
         this.database = database;
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
@@ -102,6 +110,7 @@ public class MongoVersionSplitMigration {
         this.arrayField = arrayField;
         this.versionsField = versionsField;
         this.resourceLabel = resourceLabel;
+        this.versionScheme = versionScheme;
     }
 
     public void migrate() {
@@ -264,7 +273,7 @@ public class MongoVersionSplitMigration {
         for (String storedKey : storedVersions.keySet()) {
             // CanonicalVersion handles the dash spelling directly — VERSION_REGEX treats
             // both separators as interchangeable — so no replace('-', '.') first.
-            String version = CanonicalVersion.of(storedKey);
+            String version = versionScheme.canonicalise(storedKey);
             String alreadyMapped = keysByCanonicalVersion.putIfAbsent(version, storedKey);
             if (alreadyMapped != null) {
                 LOG.warn("Discarding version key '{}' [namespace={}, {}={}] — it means the same "

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoVersionSplitMigration.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoVersionSplitMigration.java
@@ -60,7 +60,6 @@ public class MongoVersionSplitMigration {
     private static final Logger LOG = LoggerFactory.getLogger(MongoVersionSplitMigration.class);
 
     private static final String NAMESPACE_FIELD = "namespace";
-    private static final String VERSIONS_FIELD = "versions";
     private static final String VERSION_FIELD = "version";
 
     /** The index {@code MongoIndexInitializationStep} created, in Mongo's default naming. */
@@ -74,6 +73,7 @@ public class MongoVersionSplitMigration {
     private final String versionCollection;
     private final String idField;
     private final String arrayField;
+    private final String versionsField;
     private final String resourceLabel;
 
     /**
@@ -86,11 +86,21 @@ public class MongoVersionSplitMigration {
      */
     public MongoVersionSplitMigration(MongoDatabase database, String headerCollection, String versionCollection,
                                       String idField, String arrayField, String resourceLabel) {
+        this(database, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel);
+    }
+
+    /**
+     * @param versionsField the field holding the version map on each old-shape entry.
+     *                      "versions" for every type but ADR, whose map is named "revisions".
+     */
+    public MongoVersionSplitMigration(MongoDatabase database, String headerCollection, String versionCollection,
+                                      String idField, String arrayField, String versionsField, String resourceLabel) {
         this.database = database;
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
         this.idField = idField;
         this.arrayField = arrayField;
+        this.versionsField = versionsField;
         this.resourceLabel = resourceLabel;
     }
 
@@ -173,7 +183,7 @@ public class MongoVersionSplitMigration {
     private int writeOneResource(MongoCollection<Document> headers, MongoCollection<Document> versions,
                                  String namespace, Document entry) {
         Integer resourceId = entry.getInteger(idField);
-        Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
+        Document storedVersions = entry.get(versionsField, Document.class);
         Map<String, String> keysByCanonicalVersion = collapseToCanonicalVersions(storedVersions, namespace, resourceId);
 
         ReplaceOptions upsert = new ReplaceOptions().upsert(true);

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrVersionSplitStep.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.dizitart.no2.Nitrite;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.util.VersionScheme;
 
 /**
  * NitriteDB counterpart to {@link MongoAdrVersionSplitStep}: the same version 8 → 9
@@ -28,7 +29,7 @@ public class NitriteAdrVersionSplitStep implements SchemaMigrationStep {
     @Inject
     public NitriteAdrVersionSplitStep(@StandaloneQualifier Nitrite db) {
         this.migration = new NitriteVersionSplitMigration(
-                db, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR");
+                db, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR", VersionScheme.NUMERIC);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrVersionSplitStep.java
@@ -1,0 +1,43 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+
+/**
+ * NitriteDB counterpart to {@link MongoAdrVersionSplitStep}: the same version 8 → 9
+ * fan-out of {@code adrs} into per-adr headers plus a {@code adrVersions}
+ * collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 8} but never coexist — each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so exactly
+ * one is a CDI bean in any given deployment.</p>
+ *
+ * <p>The fan-out itself lives in {@link NitriteVersionSplitMigration}, shared with every
+ * other versioned type.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteAdrVersionSplitStep implements SchemaMigrationStep {
+
+    private final NitriteVersionSplitMigration migration;
+
+    @Inject
+    public NitriteAdrVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.migration = new NitriteVersionSplitMigration(
+                db, "adrs", "adrVersions", "adrId", "adrs", "revisions", "ADR");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 8;
+    }
+
+    @Override
+    public void apply() {
+        migration.migrate();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteFlowVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteFlowVersionSplitStep.java
@@ -1,0 +1,43 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+
+/**
+ * NitriteDB counterpart to {@link MongoFlowVersionSplitStep}: the same version 4 → 5
+ * fan-out of {@code flows} into per-flow headers plus a {@code flowVersions}
+ * collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 4} but never coexist — each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so exactly
+ * one is a CDI bean in any given deployment.</p>
+ *
+ * <p>The fan-out itself lives in {@link NitriteVersionSplitMigration}, shared with every
+ * other versioned type.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteFlowVersionSplitStep implements SchemaMigrationStep {
+
+    private final NitriteVersionSplitMigration migration;
+
+    @Inject
+    public NitriteFlowVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.migration = new NitriteVersionSplitMigration(
+                db, "flows", "flowVersions", "flowId", "flows", "Flow");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 4;
+    }
+
+    @Override
+    public void apply() {
+        migration.migrate();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteInterfaceVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteInterfaceVersionSplitStep.java
@@ -1,0 +1,43 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+
+/**
+ * NitriteDB counterpart to {@link MongoInterfaceVersionSplitStep}: the same version 6 → 7
+ * fan-out of {@code interfaces} into per-interface headers plus a {@code interfaceVersions}
+ * collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 6} but never coexist — each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so exactly
+ * one is a CDI bean in any given deployment.</p>
+ *
+ * <p>The fan-out itself lives in {@link NitriteVersionSplitMigration}, shared with every
+ * other versioned type.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteInterfaceVersionSplitStep implements SchemaMigrationStep {
+
+    private final NitriteVersionSplitMigration migration;
+
+    @Inject
+    public NitriteInterfaceVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.migration = new NitriteVersionSplitMigration(
+                db, "interfaces", "interfaceVersions", "interfaceId", "interfaces", "Interface");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 6;
+    }
+
+    @Override
+    public void apply() {
+        migration.migrate();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteStandardVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteStandardVersionSplitStep.java
@@ -1,0 +1,43 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+
+/**
+ * NitriteDB counterpart to {@link MongoStandardVersionSplitStep}: the same version 5 → 6
+ * fan-out of {@code standards} into per-standard headers plus a {@code standardVersions}
+ * collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 5} but never coexist — each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so exactly
+ * one is a CDI bean in any given deployment.</p>
+ *
+ * <p>The fan-out itself lives in {@link NitriteVersionSplitMigration}, shared with every
+ * other versioned type.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteStandardVersionSplitStep implements SchemaMigrationStep {
+
+    private final NitriteVersionSplitMigration migration;
+
+    @Inject
+    public NitriteStandardVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.migration = new NitriteVersionSplitMigration(
+                db, "standards", "standardVersions", "standardId", "standards", "Standard");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 5;
+    }
+
+    @Override
+    public void apply() {
+        migration.migrate();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteTimelineVersionSplitStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteTimelineVersionSplitStep.java
@@ -1,0 +1,43 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+
+/**
+ * NitriteDB counterpart to {@link MongoTimelineVersionSplitStep}: the same version 7 → 8
+ * fan-out of {@code timelines} into per-timeline headers plus a {@code timelineVersions}
+ * collection.
+ *
+ * <p>Both steps declare {@code fromVersion() == 7} but never coexist — each is gated by
+ * {@code @LookupIfProperty} on a different value of {@code calm.database.mode}, so exactly
+ * one is a CDI bean in any given deployment.</p>
+ *
+ * <p>The fan-out itself lives in {@link NitriteVersionSplitMigration}, shared with every
+ * other versioned type.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteTimelineVersionSplitStep implements SchemaMigrationStep {
+
+    private final NitriteVersionSplitMigration migration;
+
+    @Inject
+    public NitriteTimelineVersionSplitStep(@StandaloneQualifier Nitrite db) {
+        this.migration = new NitriteVersionSplitMigration(
+                db, "timelines", "timelineVersions", "timelineId", "timelines", "Timeline");
+    }
+
+    @Override
+    public int fromVersion() {
+        return 7;
+    }
+
+    @Override
+    public void apply() {
+        migration.migrate();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteVersionSplitMigration.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteVersionSplitMigration.java
@@ -42,21 +42,31 @@ public class NitriteVersionSplitMigration {
     private static final Logger LOG = LoggerFactory.getLogger(NitriteVersionSplitMigration.class);
 
     private static final String NAMESPACE_FIELD = "namespace";
-    private static final String VERSIONS_FIELD = "versions";
     private static final String VERSION_FIELD = "version";
 
     private final NitriteCollection headerCollection;
     private final NitriteCollection versionCollection;
     private final String idField;
     private final String arrayField;
+    private final String versionsField;
     private final String resourceLabel;
 
     public NitriteVersionSplitMigration(Nitrite db, String headerCollection, String versionCollection,
                                         String idField, String arrayField, String resourceLabel) {
+        this(db, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel);
+    }
+
+    /**
+     * @param versionsField the field holding the version map on each old-shape entry.
+     *                      "versions" for every type but ADR, whose map is named "revisions".
+     */
+    public NitriteVersionSplitMigration(Nitrite db, String headerCollection, String versionCollection,
+                                      String idField, String arrayField, String versionsField, String resourceLabel) {
         this.headerCollection = db.getCollection(headerCollection);
         this.versionCollection = db.getCollection(versionCollection);
         this.idField = idField;
         this.arrayField = arrayField;
+        this.versionsField = versionsField;
         this.resourceLabel = resourceLabel;
     }
 
@@ -105,7 +115,7 @@ public class NitriteVersionSplitMigration {
      */
     private int writeOneResource(String namespace, Document entry) {
         Integer resourceId = entry.get(idField, Integer.class);
-        Document storedVersions = entry.get(VERSIONS_FIELD, Document.class);
+        Document storedVersions = entry.get(versionsField, Document.class);
         Map<String, String> keysByCanonicalVersion = collapseToCanonicalVersions(storedVersions, namespace, resourceId);
 
         Filter headerFilter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(idField).eq(resourceId));

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteVersionSplitMigration.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteVersionSplitMigration.java
@@ -5,7 +5,7 @@ import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.collection.NitriteId;
 import org.dizitart.no2.filters.Filter;
-import org.finos.calm.store.util.CanonicalVersion;
+import org.finos.calm.store.util.VersionScheme;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,24 +50,32 @@ public class NitriteVersionSplitMigration {
     private final String arrayField;
     private final String versionsField;
     private final String resourceLabel;
+    private final VersionScheme versionScheme;
 
     public NitriteVersionSplitMigration(Nitrite db, String headerCollection, String versionCollection,
                                         String idField, String arrayField, String resourceLabel) {
-        this(db, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel);
+        this(db, headerCollection, versionCollection, idField, arrayField, "versions", resourceLabel,
+                VersionScheme.SEMANTIC);
     }
 
     /**
      * @param versionsField the field holding the version map on each old-shape entry.
      *                      "versions" for every type but ADR, whose map is named "revisions".
+     * @param versionScheme how this type's version keys are spelled. See
+     *                      {@link MongoVersionSplitMigration} — ADR passes
+     *                      {@link VersionScheme#NUMERIC} so revision 100 is not rewritten to
+     *                      "1.0.0" on the way into the new shape.
      */
     public NitriteVersionSplitMigration(Nitrite db, String headerCollection, String versionCollection,
-                                      String idField, String arrayField, String versionsField, String resourceLabel) {
+                                      String idField, String arrayField, String versionsField, String resourceLabel,
+                                      VersionScheme versionScheme) {
         this.headerCollection = db.getCollection(headerCollection);
         this.versionCollection = db.getCollection(versionCollection);
         this.idField = idField;
         this.arrayField = arrayField;
         this.versionsField = versionsField;
         this.resourceLabel = resourceLabel;
+        this.versionScheme = versionScheme;
     }
 
     public void migrate() {
@@ -182,7 +190,7 @@ public class NitriteVersionSplitMigration {
         for (String storedKey : storedVersions.getFields()) {
             // Same conversion the write path uses, so migrated data is addressable by
             // exactly the spelling the new store looks for.
-            String version = CanonicalVersion.of(storedKey);
+            String version = versionScheme.canonicalise(storedKey);
             String alreadyMapped = keysByCanonicalVersion.putIfAbsent(version, storedKey);
             if (alreadyMapped != null) {
                 LOG.warn("Discarding version key '{}' [namespace={}, {}={}] — it means the same "

--- a/calm-hub/src/main/java/org/finos/calm/services/CountsService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/CountsService.java
@@ -133,7 +133,7 @@ public class CountsService {
                 sizeOrZero(() -> patternStore.getPatternsForNamespace(namespace)),
                 sizeOrZero(() -> flowStore.getFlowsForNamespace(namespace)),
                 sizeOrZero(() -> standardStore.getStandardsForNamespace(namespace)),
-                sizeOrZero(() -> adrStore.getAdrsForNamespace(namespace)),
+                countOrZero(() -> adrStore.countAdrsForNamespace(namespace)),
                 sizeOrZero(() -> interfaceStore.getInterfacesForNamespace(namespace))
         );
     }
@@ -185,9 +185,34 @@ public class CountsService {
     }
 
     /** Supplier of a namespace-scoped store list that may report the namespace as missing. */
+    /**
+     * Counts a resource type directly, with the same failure policy as {@link #sizeOrZero}.
+     *
+     * <p>Used for ADR alone. Every other type's summary is built from its header, so sizing
+     * the list a store already returns costs nothing extra; an ADR summary carries the
+     * latest revision's title and status, so building the list to call {@code size()} on it
+     * read and parsed every ADR's content — for a number that discards all of it. This
+     * endpoint runs that per namespace, so the waste multiplied across the whole hub.</p>
+     */
+    private int countOrZero(NamespaceCountSupplier supplier) {
+        try {
+            return supplier.get();
+        } catch (NamespaceNotFoundException e) {
+            return 0;
+        } catch (RuntimeException e) {
+            logger.warn("Failed to count a resource type while aggregating counts; treating as 0", e);
+            return 0;
+        }
+    }
+
     @FunctionalInterface
     private interface NamespaceListSupplier {
         List<?> get() throws NamespaceNotFoundException;
+    }
+
+    @FunctionalInterface
+    private interface NamespaceCountSupplier {
+        int get() throws NamespaceNotFoundException;
     }
 
     /** A cached value with an absolute expiry timestamp (epoch millis). */

--- a/calm-hub/src/main/java/org/finos/calm/services/CountsService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/CountsService.java
@@ -184,7 +184,6 @@ public class CountsService {
         return value;
     }
 
-    /** Supplier of a namespace-scoped store list that may report the namespace as missing. */
     /**
      * Counts a resource type directly, with the same failure policy as {@link #sizeOrZero}.
      *
@@ -205,6 +204,7 @@ public class CountsService {
         }
     }
 
+    /** Supplier of a namespace-scoped store list that may report the namespace as missing. */
     @FunctionalInterface
     private interface NamespaceListSupplier {
         List<?> get() throws NamespaceNotFoundException;

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
@@ -62,7 +62,7 @@ public class NamespaceContentService {
                 || isNotEmpty(() -> patternStore.getPatternsForNamespace(namespace))
                 || isNotEmpty(() -> flowStore.getFlowsForNamespace(namespace))
                 || isNotEmpty(() -> standardStore.getStandardsForNamespace(namespace))
-                || isNotEmpty(() -> adrStore.getAdrsForNamespace(namespace))
+                || hasAny(() -> adrStore.countAdrsForNamespace(namespace))
                 || isNotEmpty(() -> interfaceStore.getInterfacesForNamespace(namespace))
                 || isNotEmpty(() -> timelineStore.getTimelinesForNamespace(namespace))
                 || isNotEmpty(() -> decoratorStore.getDecoratorsForNamespace(namespace, null, null));
@@ -85,8 +85,30 @@ public class NamespaceContentService {
         }
     }
 
+    /**
+     * The counting equivalent of {@link #isNotEmpty}, for ADR — whose summary list costs two
+     * reads and a parse per ADR to build, all of it discarded by an emptiness check.
+     *
+     * <p>Keeps that method's failure policy exactly: a missing namespace is empty, and
+     * anything else propagates rather than being swallowed, because this gates an
+     * irreversible delete and must not report "no content" for content it never confirmed
+     * absent.</p>
+     */
+    private boolean hasAny(NamespaceCountSupplier supplier) {
+        try {
+            return supplier.get() > 0;
+        } catch (NamespaceNotFoundException e) {
+            return false;
+        }
+    }
+
     @FunctionalInterface
     private interface NamespaceListSupplier {
         List<?> get() throws NamespaceNotFoundException;
+    }
+
+    @FunctionalInterface
+    private interface NamespaceCountSupplier {
+        int get() throws NamespaceNotFoundException;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
@@ -15,6 +15,17 @@ import java.util.List;
 public interface AdrStore {
 
     List<NamespaceAdrSummary> getAdrsForNamespace(String namespace) throws NamespaceNotFoundException;
+
+    /**
+     * @return how many ADRs the namespace holds.
+     *
+     * <p>Deliberately not {@code getAdrsForNamespace(namespace).size()}. An ADR summary
+     * carries the latest revision's title and status, so building the list costs two reads
+     * and a JSON parse per ADR; callers that only want a number would pay that for nothing.
+     * Every other type's summary comes straight off its header, which is why only ADR needs
+     * this.</p>
+     */
+    int countAdrsForNamespace(String namespace) throws NamespaceNotFoundException;
     AdrMeta createAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrParseException;
     AdrMeta getAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException;
     List<Integer> getAdrRevisions(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException;

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -99,6 +99,12 @@ public class MongoAdrStore implements AdrStore {
         return summaries;
     }
 
+    @Override
+    public int countAdrsForNamespace(String namespace) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+        return documentStore.countHeaders(namespace);
+    }
+
     /**
      * Builds a summary from the latest revision's content, falling back to the same
      * placeholders the old shape used when an ADR has no readable revision.

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -16,7 +16,7 @@ import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.AdrStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.util.MongoVersionDocumentStore;
-import org.finos.calm.store.util.NumericVersionOrder;
+import org.finos.calm.store.util.VersionScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +36,16 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * Two things set it apart from the other six, and both are load-bearing:
  * <ul>
  *   <li><b>Revisions are integers, not semantic versions.</b> The helper is built with
- *       {@link NumericVersionOrder}; the default comparator maps every non-semver value to
- *       {@code 0.0.0} and falls back to a string sort, which would rank {@code 10} below
- *       {@code 2} and make every "latest revision" read silently return stale content once an
- *       ADR reached double figures.</li>
+ *       {@link VersionScheme#NUMERIC}, which governs both how revisions are <em>ordered</em>
+ *       and how they are <em>spelled</em>. Ordering, because the semantic comparator maps
+ *       every non-semver value to {@code 0.0.0} and falls back to a string sort, ranking
+ *       {@code 10} below {@code 2} and making every "latest revision" read return stale
+ *       content once an ADR reached double figures. Spelling, because {@code VERSION_REGEX}
+ *       treats {@code "100"} as a spelling of {@code 1.0.0}: canonicalising revisions would
+ *       have rewritten revision 100 to {@code "1.0.0"}, which then sorts below {@code 99} and
+ *       breaks the {@code Integer.parseInt} in {@link #getAdrRevisions}. Both halves have to
+ *       agree, which is why the scheme carries them together rather than the store choosing a
+ *       comparator and separately remembering a spelling rule.</li>
  *   <li><b>The summary is built from content, not from the entity.</b> Every other type reads
  *       {@code name}/{@code description}/{@code versionCount} straight off the header;
  *       {@link NamespaceAdrSummary} carries the <em>latest revision's</em> title and status.
@@ -76,7 +82,7 @@ public class MongoAdrStore implements AdrStore {
                 database.getCollection(VERSION_COLLECTION),
                 ID_FIELD,
                 RESOURCE_LABEL,
-                NumericVersionOrder.ASCENDING);
+                VersionScheme.NUMERIC);
         this.objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -113,15 +113,15 @@ public class MongoAdrStore implements AdrStore {
         String title = "ADR " + adrId;
         String status = "unknown";
 
+        // A header carrying no adrId is malformed rather than missing, and
+        // listSummariesPaged deliberately renders it instead of failing — it sorts null ids
+        // first for exactly that reason. Resolving its latest revision would unbox this null
+        // and undo that tolerance, turning one bad document into a 500 for every ADR in the
+        // namespace. Render the placeholder and move on, which is what the row is worth.
         if (adrId == null) {
             return new NamespaceAdrSummary(title, status, null);
         }
 
-        // A header carrying no adrId is malformed rather than missing, and
-        // listSummariesPaged deliberately renders it instead of failing — it sorts null ids
-        // last for exactly that reason. Resolving its latest revision would unbox this null
-        // and undo that tolerance, turning one bad document into a 500 for every ADR in the
-        // namespace. Render the placeholder and move on, which is what the row is worth.
         Document latest = documentStore.getLatestVersionContent(namespace, adrId);
         if (latest != null) {
             String documentTitle = latest.getString("title");
@@ -145,7 +145,8 @@ public class MongoAdrStore implements AdrStore {
         int id = counterStore.getNextAdrSequenceValue();
         // ADRs carry no name or description of their own — both live in the revision content.
         documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
-        createFirstRevision(adrMeta, id, content);
+        documentStore.createFirstVersion(adrMeta.getNamespace(), id,
+                String.valueOf(adrMeta.getRevision()), content);
 
         return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
     }
@@ -241,26 +242,6 @@ public class MongoAdrStore implements AdrStore {
                 .build();
     }
 
-    /**
-     * Writes the first revision of a newly created ADR, removing the header again if that
-     * fails — a header with no revisions cannot be removed through the API.
-     */
-    private void createFirstRevision(AdrMeta adrMeta, int id, Document content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(
-                    adrMeta.getNamespace(), id, String.valueOf(adrMeta.getRevision()), content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(adrMeta.getNamespace(), id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(adrMeta.getNamespace(), id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Revision " + adrMeta.getRevision() + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + adrMeta.getNamespace()));
-        }
-    }
 
     /**
      * Writes a new revision, rejecting one that already exists.

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -3,297 +3,286 @@ package org.finos.calm.store.mongo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.bson.conversions.Bson;
 import org.finos.calm.domain.adr.Adr;
 import org.finos.calm.domain.adr.AdrMeta;
 import org.finos.calm.domain.adr.NamespaceAdrSummary;
 import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.*;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.AdrStore;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
+import org.finos.calm.store.util.NumericVersionOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link AdrStore}.
  *
- * <h2>Document model &amp; concurrency</h2>
- * Follows the same namespace-scoped document pattern as {@link MongoArchitectureStore}:
- * one document per namespace (enforced by a unique index on {@code adrs.namespace}), with
- * an array of ADR sub-documents each holding a {@code revisions} map (revision number → JSON).
- * New ADRs are added via upsert + {@code $push}. New revisions use an atomic conditional
- * update with {@code $elemMatch} / {@code $exists: false} on the target revision key: if a
- * concurrent writer already wrote that revision, {@code matchedCount == 0} signals the
- * conflict and {@link org.finos.calm.domain.exception.AdrRevisionExistsException} is thrown
- * instead of silently overwriting the other writer's revision.
+ * <h2>Document model</h2>
+ * One <em>header</em> document per ADR in {@code adrs}, and one document per revision in
+ * {@code adrVersions}. The collection follows the {@code <type>Versions} naming of ADR 0001
+ * even though the domain calls these <em>revisions</em>, so the shape stays uniform across
+ * all seven types; the domain's term is preserved everywhere it is user-facing.
  *
- * @see MongoCounterStore
+ * <h2>Why ADR needed the helpers extended</h2>
+ * Two things set it apart from the other six, and both are load-bearing:
+ * <ul>
+ *   <li><b>Revisions are integers, not semantic versions.</b> The helper is built with
+ *       {@link NumericVersionOrder}; the default comparator maps every non-semver value to
+ *       {@code 0.0.0} and falls back to a string sort, which would rank {@code 10} below
+ *       {@code 2} and make every "latest revision" read silently return stale content once an
+ *       ADR reached double figures.</li>
+ *   <li><b>The summary is built from content, not from the entity.</b> Every other type reads
+ *       {@code name}/{@code description}/{@code versionCount} straight off the header;
+ *       {@link NamespaceAdrSummary} carries the <em>latest revision's</em> title and status.
+ *       Hence {@code getLatestVersionContent}.</li>
+ * </ul>
+ *
+ * <p>Consequence worth stating: listing a namespace's ADRs is no longer one document read.
+ * It is one query for the headers plus two small ones per ADR to resolve and fetch the latest
+ * revision. That is more round-trips and far fewer bytes — the old single read pulled every
+ * revision of every ADR in the namespace into memory, which is the growth problem this
+ * redesign exists to remove.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoAdrStore.class)
 public class MongoAdrStore implements AdrStore {
 
+    private static final String HEADER_COLLECTION = "adrs";
+    private static final String VERSION_COLLECTION = "adrVersions";
+    private static final String ID_FIELD = "adrId";
+    private static final String RESOURCE_LABEL = "ADR";
+
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final MongoCollection<Document> adrCollection;
+    private final MongoVersionDocumentStore documentStore;
     private final ObjectMapper objectMapper;
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     public MongoAdrStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
         this.counterStore = counterStore;
         this.namespaceStore = namespaceStore;
-        this.adrCollection = database.getCollection("adrs");
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL,
+                NumericVersionOrder.ASCENDING);
         this.objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
     }
 
     @Override
     public List<NamespaceAdrSummary> getAdrsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        requireNamespace(namespace);
+
+        List<NamespaceAdrSummary> summaries = new java.util.ArrayList<>();
+        for (NamespaceResourceSummary header : documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED)) {
+            summaries.add(toAdrSummary(namespace, header.getId()));
         }
-
-        Document namespaceDocument = adrCollection.find(Filters.eq("namespace", namespace)).first();
-
-        //protects from an unpopulated mongo collection
-        if(namespaceDocument == null || namespaceDocument.isEmpty()) {
-            return List.of();
-        }
-
-        List<Document> adrs = namespaceDocument.getList("adrs", Document.class);
-        List<NamespaceAdrSummary> summaries = new ArrayList<>();
-
-        for (Document adr : adrs) {
-            int adrId = adr.getInteger("adrId");
-            String title = "ADR " + adrId;
-            String status = "unknown";
-
-            Document revisions = (Document) adr.get("revisions");
-            if (revisions != null && !revisions.isEmpty()) {
-                int latestRevision = revisions.keySet().stream()
-                        .map(Integer::parseInt)
-                        .mapToInt(i -> i)
-                        .max()
-                        .getAsInt();
-                Document revisionDoc = (Document) revisions.get(String.valueOf(latestRevision));
-                if (revisionDoc != null) {
-                    String docTitle = revisionDoc.getString("title");
-                    String docStatus = revisionDoc.getString("status");
-                    if (docTitle != null) title = docTitle;
-                    if (docStatus != null) status = docStatus;
-                }
-            }
-
-            summaries.add(new NamespaceAdrSummary(title, status, adrId));
-        }
-
         return summaries;
+    }
+
+    /**
+     * Builds a summary from the latest revision's content, falling back to the same
+     * placeholders the old shape used when an ADR has no readable revision.
+     */
+    private NamespaceAdrSummary toAdrSummary(String namespace, Integer adrId) {
+        String title = "ADR " + adrId;
+        String status = "unknown";
+
+        Document latest = documentStore.getLatestVersionContent(namespace, adrId);
+        if (latest != null) {
+            String documentTitle = latest.getString("title");
+            String documentStatus = latest.getString("status");
+            if (documentTitle != null) {
+                title = documentTitle;
+            }
+            if (documentStatus != null) {
+                status = documentStatus;
+            }
+        }
+        return new NamespaceAdrSummary(title, status, adrId);
     }
 
     @Override
     public AdrMeta createAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrParseException {
-        if(!namespaceStore.namespaceExists(adrMeta.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(adrMeta.getNamespace());
 
-        String adrStr;
-        try {
-        adrStr = objectMapper.writeValueAsString(adrMeta.getAdr());
-        } catch(JsonProcessingException e) {
-            log.error("Could not write ADR Content to String", e);
-            throw new AdrParseException();
-        }
+        Document content = toContent(adrMeta);
 
         int id = counterStore.getNextAdrSequenceValue();
-        Document adrDocument = new Document("adrId", id).append("revisions",
-                new Document(String.valueOf(adrMeta.getRevision()), Document.parse(adrStr)));
-
-        MongoUpsertPush.pushWithDuplicateRetry(adrCollection,
-                Filters.eq("namespace", adrMeta.getNamespace()),
-                "adrs", adrDocument);
+        // ADRs carry no name or description of their own — both live in the revision content.
+        documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
+        createFirstRevision(adrMeta, id, content);
 
         return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
     }
 
     @Override
     public AdrMeta getAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        return retrieveLatestRevision(adrMeta, adrDoc);
+        requireAdr(adrMeta);
+        return latestRevision(adrMeta);
     }
 
     @Override
     public List<Integer> getAdrRevisions(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        Document revisions = retrieveRevisionsDoc(adrDoc, adrMeta);
-        return revisions.keySet()
-                .stream()
-                .map(Integer::parseInt)
-                .toList();
+        requireAdr(adrMeta);
+
+        List<String> revisions = documentStore.listVersions(adrMeta.getNamespace(), adrMeta.getId());
+        if (revisions.isEmpty()) {
+            log.error("Could not find any revision of ADR [{}]", adrMeta.getId());
+            throw new AdrRevisionNotFoundException();
+        }
+        // Ascending, where the old shape returned incidental map-key order. Same fix applied
+        // to every other type's version listing.
+        return revisions.stream().map(Integer::parseInt).toList();
     }
 
     @Override
     public AdrMeta getAdrRevision(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
+        requireAdr(adrMeta);
 
-        // Return the ADR JSON blob for the specified revision
-        Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(adrMeta.getRevision()));
-        log.info("Revision [{}] found: {}", adrMeta.getRevision(), revisionDoc != null);
-        if(revisionDoc == null) {
+        Document revision = documentStore.getVersion(
+                adrMeta.getNamespace(), adrMeta.getId(), String.valueOf(adrMeta.getRevision()));
+        log.info("Revision [{}] found: {}", adrMeta.getRevision(), revision != null);
+        if (revision == null) {
             throw new AdrRevisionNotFoundException();
         }
-        try {
-            return new AdrMeta.AdrMetaBuilder(adrMeta)
-                    .setAdr(objectMapper.readValue(revisionDoc.toJson(), Adr.class))
-                    .build();
-        } catch(JsonProcessingException e) {
-            log.error("Could not parse stored ADR to ADR Content.", e);
-            throw new AdrParseException();
-        }
+        return new AdrMeta.AdrMetaBuilder(adrMeta).setAdr(toAdr(revision)).build();
     }
 
     @Override
     public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
+        requireAdr(adrMeta);
+        AdrMeta latest = latestRevision(adrMeta);
 
-        int newRevision = latestRevision.getRevision() + 1;
         AdrMeta newAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
                 .setAdr(new Adr.AdrBuilder(adrMeta.getAdr())
-                        .setStatus(latestRevision.getAdr().getStatus())
-                        .setCreationDateTime(latestRevision.getAdr().getCreationDateTime())
+                        .setStatus(latest.getAdr().getStatus())
+                        .setCreationDateTime(latest.getAdr().getCreationDateTime())
                         .build())
-                .setRevision(newRevision)
+                .setRevision(latest.getRevision() + 1)
                 .build();
 
-        writeAdrToMongo(newAdrMeta);
+        writeRevision(newAdrMeta);
         return newAdrMeta;
     }
 
     @Override
     public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
-        Document adrDoc = retrieveAdrDoc(adrMeta);
-        AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
+        requireAdr(adrMeta);
+        AdrMeta latest = latestRevision(adrMeta);
 
-        int newRevisionNum = latestRevision.getRevision() + 1;
-        AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latestRevision)
-                .setRevision(newRevisionNum)
-                .setAdr(new Adr.AdrBuilder(latestRevision.getAdr())
-                        .setStatus(status)
-                        .build())
+        AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latest)
+                .setRevision(latest.getRevision() + 1)
+                .setAdr(new Adr.AdrBuilder(latest.getAdr()).setStatus(status).build())
                 .build();
-        writeAdrToMongo(newRevision);
+
+        writeRevision(newRevision);
         return newRevision;
     }
 
-    private List<Document> retrieveAdrsDocs(String namespace) throws NamespaceNotFoundException, AdrNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", namespace);
-        Bson projection = Projections.fields(Projections.include("adrs"));
-
-        Document result = adrCollection.find(filter).projection(projection).first();
-
-        if(result == null) {
-            throw new AdrNotFoundException();
-        }
-
-        return result.getList("adrs", Document.class);
-    }
-
-    private Document retrieveAdrDoc(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException {
-        List<Document> adrsDoc = retrieveAdrsDocs(adrMeta.getNamespace());
-        Optional<Document> adrOpt = adrsDoc.stream().filter(adrDoc -> adrMeta.getId() == adrDoc.getInteger("adrId")).findAny();
-        return adrOpt.orElseThrow(AdrNotFoundException::new);
-    }
-
-    private Document retrieveRevisionsDoc(Document adrDoc, AdrMeta adrMeta) throws AdrRevisionNotFoundException {
-        Document revisionsDoc = (Document) adrDoc.get("revisions");
-
-        if(revisionsDoc == null || revisionsDoc.isEmpty()) {
+    /**
+     * @return the ADR at its highest revision.
+     * @throws AdrRevisionNotFoundException if it has none — an ADR always has at least one,
+     *                                      so this means the data is inconsistent rather than
+     *                                      that the caller asked for something missing.
+     */
+    private AdrMeta latestRevision(AdrMeta adrMeta) throws AdrRevisionNotFoundException, AdrParseException {
+        String latest = documentStore.getLatestVersion(adrMeta.getNamespace(), adrMeta.getId());
+        if (latest == null) {
             log.error("Could not find the latest revision of ADR [{}]", adrMeta.getId());
             throw new AdrRevisionNotFoundException();
         }
-
-        return revisionsDoc;
+        Document content = documentStore.getVersion(adrMeta.getNamespace(), adrMeta.getId(), latest);
+        if (content == null) {
+            log.error("Latest revision [{}] of ADR [{}] disappeared between resolving and reading it",
+                    latest, adrMeta.getId());
+            throw new AdrRevisionNotFoundException();
+        }
+        log.info("Resolved latest revision: [{}]", latest);
+        return new AdrMeta.AdrMetaBuilder()
+                .setNamespace(adrMeta.getNamespace())
+                .setId(adrMeta.getId())
+                .setRevision(Integer.parseInt(latest))
+                .setAdr(toAdr(content))
+                .build();
     }
 
-    private AdrMeta retrieveLatestRevision(AdrMeta adrMeta, Document adrDoc) throws AdrRevisionNotFoundException, AdrParseException {
-        Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
-
-        Set<String> revisionKeys = revisionsDoc.keySet();
-        int latestRevision = revisionKeys.stream()
-                .map(Integer::parseInt)
-                .mapToInt(i -> i)
-                .max()
-                .getAsInt();
-
-        // Return the ADR JSON blob for the specified revision
-        Document revisionDoc = (Document) revisionsDoc.get(String.valueOf(latestRevision));
-        log.info("Resolved latest revision: [{}]", latestRevision);
+    /**
+     * Writes the first revision of a newly created ADR, removing the header again if that
+     * fails — a header with no revisions cannot be removed through the API.
+     */
+    private void createFirstRevision(AdrMeta adrMeta, int id, Document content) {
+        boolean created;
         try {
-            return new AdrMeta.AdrMetaBuilder()
-                    .setNamespace(adrMeta.getNamespace())
-                    .setId(adrMeta.getId())
-                    .setRevision(latestRevision)
-                    .setAdr(objectMapper.readValue(revisionDoc.toJson(), Adr.class))
-                    .build();
-        } catch(JsonProcessingException e) {
+            created = documentStore.createVersion(
+                    adrMeta.getNamespace(), id, String.valueOf(adrMeta.getRevision()), content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(adrMeta.getNamespace(), id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(adrMeta.getNamespace(), id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Revision " + adrMeta.getRevision() + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + adrMeta.getNamespace()));
+        }
+    }
+
+    /**
+     * Writes a new revision, rejecting one that already exists.
+     *
+     * <p>Both callers compute {@code latest + 1}, so two concurrent writers can arrive at the
+     * same number. The loser is told the revision exists rather than silently overwriting the
+     * winner — the same guarantee the old shape's conditional update gave.</p>
+     */
+    private void writeRevision(AdrMeta adrMeta) throws AdrParseException, AdrRevisionExistsException {
+        Document content = toContent(adrMeta);
+        if (!documentStore.createVersion(adrMeta.getNamespace(), adrMeta.getId(),
+                String.valueOf(adrMeta.getRevision()), content)) {
+            throw new AdrRevisionExistsException();
+        }
+    }
+
+    private Document toContent(AdrMeta adrMeta) throws AdrParseException {
+        try {
+            return Document.parse(objectMapper.writeValueAsString(adrMeta.getAdr()));
+        } catch (JsonProcessingException e) {
+            log.error("Could not write ADR Content to String", e);
+            throw new AdrParseException();
+        }
+    }
+
+    private Adr toAdr(Document content) throws AdrParseException {
+        try {
+            return objectMapper.readValue(content.toJson(), Adr.class);
+        } catch (JsonProcessingException e) {
             log.error("Could not parse stored ADR to ADR Content.", e);
             throw new AdrParseException();
         }
     }
 
-    private void writeAdrToMongo(AdrMeta adrMeta) throws AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
-
-        try {
-            Document adrDocument = Document.parse(objectMapper.writeValueAsString(adrMeta.getAdr()));
-
-            // Atomic conditional update: only succeeds if this revision doesn't already exist.
-            // Two concurrent writers both computing the same "latest + 1" revision will race here;
-            // the loser gets matchedCount == 0 instead of silently overwriting the winner's write.
-            Document filter = new Document("namespace", adrMeta.getNamespace())
-                    .append("adrs", new Document("$elemMatch",
-                            new Document("adrId", adrMeta.getId())
-                                    .append("revisions." + adrMeta.getRevision(), new Document("$exists", false))));
-
-            Document update = new Document("$set",
-                    new Document("adrs.$.revisions." + adrMeta.getRevision(), adrDocument));
-
-            if (adrCollection.updateOne(filter, update).getMatchedCount() == 0) {
-                throw new AdrRevisionExistsException();
-            }
-        } catch(MongoWriteException ex) {
-            // Log identifying fields only, not the full adrMeta object — its toString()
-            // includes the entire nested ADR content.
-            // Both callers (updateAdrForNamespace/updateAdrStatus) already verify the ADR
-            // entity exists via retrieveAdrDoc/retrieveLatestRevision before reaching this
-            // write, so any MongoWriteException here is a genuine write failure.
-            log.error("Failed to write ADR [namespace={}, id={}, revision={}] to mongo",
-                    adrMeta.getNamespace(), adrMeta.getId(), adrMeta.getRevision(), ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
-        } catch(JsonProcessingException e) {
-            log.error("Could not write ADR Content to String", e);
-            throw new AdrParseException();
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
         }
+    }
 
+    private void requireAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException {
+        requireNamespace(adrMeta.getNamespace());
+        if (!documentStore.headerExists(adrMeta.getNamespace(), adrMeta.getId())) {
+            throw new AdrNotFoundException();
+        }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -20,6 +20,7 @@ import org.finos.calm.store.util.VersionScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
@@ -91,7 +92,7 @@ public class MongoAdrStore implements AdrStore {
     public List<NamespaceAdrSummary> getAdrsForNamespace(String namespace) throws NamespaceNotFoundException {
         requireNamespace(namespace);
 
-        List<NamespaceAdrSummary> summaries = new java.util.ArrayList<>();
+        List<NamespaceAdrSummary> summaries = new ArrayList<>();
         for (NamespaceResourceSummary header : documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED)) {
             summaries.add(toAdrSummary(namespace, header.getId()));
         }
@@ -106,6 +107,15 @@ public class MongoAdrStore implements AdrStore {
         String title = "ADR " + adrId;
         String status = "unknown";
 
+        if (adrId == null) {
+            return new NamespaceAdrSummary(title, status, null);
+        }
+
+        // A header carrying no adrId is malformed rather than missing, and
+        // listSummariesPaged deliberately renders it instead of failing — it sorts null ids
+        // last for exactly that reason. Resolving its latest revision would unbox this null
+        // and undo that tolerance, turning one bad document into a 500 for every ADR in the
+        // namespace. Render the placeholder and move on, which is what the row is worth.
         Document latest = documentStore.getLatestVersionContent(namespace, adrId);
         if (latest != null) {
             String documentTitle = latest.getString("title");

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -9,7 +9,6 @@ import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.FlowStore;
@@ -19,6 +18,8 @@ import org.finos.calm.store.util.MongoVersionDocumentStore;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.MongoVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * MongoDB-backed implementation of {@link FlowStore}.
@@ -45,7 +46,6 @@ public class MongoFlowStore implements FlowStore {
     private static final String VERSION_COLLECTION = "flowVersions";
     private static final String ID_FIELD = "flowId";
     private static final String RESOURCE_LABEL = "Flow";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
@@ -77,7 +77,7 @@ public class MongoFlowStore implements FlowStore {
 
         int id = counterStore.getNextFlowSequenceValue();
         documentStore.createHeader(namespace, id, flowRequest.getName(), flowRequest.getDescription());
-        createInitialVersion(namespace, id, content);
+        documentStore.createFirstVersion(namespace, id, content);
 
         return new Flow.FlowBuilder()
                 .setId(id)
@@ -128,25 +128,6 @@ public class MongoFlowStore implements FlowStore {
         return flow;
     }
 
-    /**
-     * Writes the first version of a newly created flow, removing the header again if that
-     * fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, Document content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     /**
      * Applies the name and description that came with a version write, ignoring either that

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -1,255 +1,172 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.bson.conversions.Bson;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
-import org.finos.calm.store.util.VersionKeySelector;
 import org.finos.calm.domain.Flow;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.FlowStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link FlowStore}.
  *
- * <h2>Document model &amp; concurrency</h2>
- * Follows the same namespace-scoped document pattern as {@link MongoArchitectureStore}:
- * one document per namespace (enforced by a unique index on {@code flows.namespace}),
- * with an array of flow sub-documents. New flows are added via upsert + {@code $push},
- * and new versions use an atomic conditional update with {@code $elemMatch} /
- * {@code $exists: false} to prevent duplicate version creation under concurrency.
- * Unique flow IDs are generated atomically by {@link MongoCounterStore}.
+ * <h2>Document model</h2>
+ * One <em>header</em> document per flow in {@code flows}, and one <em>version</em> document
+ * per version in {@code flowVersions}. All document handling lives in
+ * {@link MongoVersionDocumentStore}; this class only translates between that and the
+ * domain's objects and exceptions. See
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}.
  *
- * @see MongoCounterStore
+ * <p>Like Pattern and unlike Architecture, version writes update the header's name and
+ * description only when they are non-blank — Flow's old shape guarded those fields.</p>
+ *
+ * <p>{@link FlowStore} exposes no paged listing, so summaries are always fetched
+ * {@link PageRequest#UNPAGED}. The helper supports paging whenever the interface grows one.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoFlowStore.class)
 public class MongoFlowStore implements FlowStore {
-    private final MongoCollection<Document> flowCollection;
+
+    private static final String HEADER_COLLECTION = "flows";
+    private static final String VERSION_COLLECTION = "flowVersions";
+    private static final String ID_FIELD = "flowId";
+    private static final String RESOURCE_LABEL = "Flow";
+    private static final String INITIAL_VERSION = "1.0.0";
+
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final MongoVersionDocumentStore documentStore;
 
     public MongoFlowStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
         this.counterStore = counterStore;
         this.namespaceStore = namespaceStore;
-        this.flowCollection = database.getCollection("flows");
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
     }
 
     @Override
     public List<NamespaceResourceSummary> getFlowsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Document namespaceDocument = flowCollection.find(Filters.eq("namespace", namespace)).first();
-
-        //protects from an unpopulated mongo collection
-        if(namespaceDocument == null || namespaceDocument.isEmpty()) {
-            return List.of();
-        }
-
-        List<Document> flows = namespaceDocument.getList("flows", Document.class);
-        List<NamespaceResourceSummary> flowSummaries = new ArrayList<>();
-
-        for (Document flow : flows) {
-            Integer flowId = flow.getInteger("flowId");
-            String name = flow.getString("name");
-            String description = flow.getString("description");
-            if (name == null) name = "Flow " + flowId;
-            if (description == null) description = "";
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = flow.get("versions");
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.keySet() : null);
-            flowSummaries.add(new NamespaceResourceSummary(name, description, flowId, versionCount));
-        }
-
-        return flowSummaries;
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED);
     }
 
     @Override
     public Flow createFlowForNamespace(CreateFlowRequest flowRequest, String namespace) throws NamespaceNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+
+        // Parsed before the counter is drawn and before anything is written, so malformed
+        // JSON can't leave a header behind with no version to go with it.
+        Document content = Document.parse(flowRequest.getFlowJson());
 
         int id = counterStore.getNextFlowSequenceValue();
-        Document flowDocument = new Document("flowId", id)
-                .append("name", flowRequest.getName())
-                .append("description", flowRequest.getDescription())
-                .append("versions",
-                new Document("1-0-0", Document.parse(flowRequest.getFlowJson())));
+        documentStore.createHeader(namespace, id, flowRequest.getName(), flowRequest.getDescription());
+        createInitialVersion(namespace, id, content);
 
-        MongoUpsertPush.pushWithDuplicateRetry(flowCollection,
-                Filters.eq("namespace", namespace),
-                "flows", flowDocument);
-
-        Flow persistedFlow = new Flow.FlowBuilder()
+        return new Flow.FlowBuilder()
                 .setId(id)
-                .setVersion("1.0.0")
+                .setVersion(INITIAL_VERSION)
                 .setNamespace(namespace)
                 .setFlow(flowRequest.getFlowJson())
                 .build();
-
-        return persistedFlow;
     }
 
     @Override
     public List<String> getFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        Document result = retrieveFlowVersions(flow);
-
-        List<Document> flows = result.getList("flows", Document.class);
-        for (Document flowDoc : flows) {
-            if (flow.getId() == flowDoc.getInteger("flowId")) {
-                // Extract the versions map from the matching flow
-                Document versions = (Document) flowDoc.get("versions");
-                Set<String> versionKeys = versions.keySet();
-
-                // Convert from Mongo representation
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
-                }
-                return resourceVersions;  // Return the list of version keys
-            }
-        }
-
-        throw new FlowNotFoundException();
-    }
-
-    private Document retrieveFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        if(!namespaceStore.namespaceExists(flow.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", flow.getNamespace());
-        Bson projection = Projections.fields(Projections.include("flows"));
-
-        Document result = flowCollection.find(filter).projection(projection).first();
-
-        if (result == null) {
-            throw new FlowNotFoundException();
-        }
-
-        return result;
-    }
-
-    private void verifyFlowExists(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        Document result = retrieveFlowVersions(flow);
-        List<Document> flows = result.getList("flows", Document.class);
-        for (Document flowDoc : flows) {
-            if (flow.getId() == flowDoc.getInteger("flowId")) {
-                return;
-            }
-        }
-        throw new FlowNotFoundException();
+        requireFlow(flow);
+        return documentStore.listVersions(flow.getNamespace(), flow.getId());
     }
 
     @Override
     public String getFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException {
-        Document result = retrieveFlowVersions(flow);
+        requireFlow(flow);
 
-        List<Document> flows = result.getList("flows", Document.class);
-        for (Document flowDoc : flows) {
-            if (flow.getId() == flowDoc.getInteger("flowId")) {
-                // Retrieve the versions map from the matching flow
-                Document versions = (Document) flowDoc.get("versions");
-
-                // Return the flow JSON blob for the specified version
-                Document versionDoc = (Document) versions.get(flow.getMongoVersion());
-                log.info("Version [{}] found: {}", flow.getMongoVersion(), versionDoc != null);
-                if(versionDoc == null) {
-                    throw new FlowVersionNotFoundException();
-                }
-                return versionDoc.toJson();
-            }
+        Document content = documentStore.getVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion());
+        if (content == null) {
+            throw new FlowVersionNotFoundException();
         }
-        // Flows is empty, no version to find
-        throw new FlowVersionNotFoundException();
+        return content.toJson();
     }
 
     @Override
     public Flow createFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionExistsException {
-        // Validates namespace and flow existence
-        getFlowVersions(flow);
+        requireFlow(flow);
 
-        // Atomic conditional update: only succeeds if the version doesn't already exist
-        Document filter = new Document("namespace", flow.getNamespace())
-                .append("flows", new Document("$elemMatch",
-                        new Document("flowId", flow.getId())
-                                .append("versions." + flow.getMongoVersion(), new Document("$exists", false))));
-
-        Document update = new Document("$set", buildVersionSetFields(flow));
-
-        if (flowCollection.updateOne(filter, update).getMatchedCount() == 0) {
+        Document content = Document.parse(flow.getFlowJson());
+        if (!documentStore.createVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion(), content)) {
             throw new FlowVersionExistsException();
         }
 
+        updateHeaderDetails(flow);
         return flow;
     }
 
     @Override
     public Flow updateFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        if(!namespaceStore.namespaceExists(flow.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
-        writeFlowToMongo(flow);
+        requireFlow(flow);
+
+        Document content = Document.parse(flow.getFlowJson());
+        documentStore.upsertVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion(), content);
+
+        updateHeaderDetails(flow);
         return flow;
     }
 
-    private void writeFlowToMongo(Flow flow) throws FlowNotFoundException, NamespaceNotFoundException {
-        // Verifies the namespace AND the specific flow entity exist, so any
-        // MongoWriteException from the update below is a genuine write failure, not a
-        // disguised not-found.
-        verifyFlowExists(flow);
-
-        Document filter = new Document("namespace", flow.getNamespace())
-                .append("flows.flowId", flow.getId());
-        Document update = new Document("$set", buildVersionSetFields(flow));
-
+    /**
+     * Writes the first version of a newly created flow, removing the header again if that
+     * fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, Document content) {
+        boolean created;
         try {
-            flowCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (MongoWriteException ex) {
-            // Log identifying fields only, not the full flow object — its toString()
-            // includes the entire (potentially near-16MB) flowJson payload.
-            log.error("Failed to write flow [namespace={}, id={}, version={}] to mongo",
-                    flow.getNamespace(), flow.getId(), flow.getMongoVersion(), ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
         }
     }
 
-    private Document buildVersionSetFields(Flow flow) {
-        Document setFields = new Document("flows.$.versions." + flow.getMongoVersion(), Document.parse(flow.getFlowJson()));
-        // Defensive: the REST layer enforces @NotBlank on name/description via CreateFlowRequest,
-        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-        if (flow.getName() != null && !flow.getName().isBlank()) {
-            setFields.append("flows.$.name", flow.getName());
-        }
-        if (flow.getDescription() != null && !flow.getDescription().isBlank()) {
-            setFields.append("flows.$.description", flow.getDescription());
-        }
-        return setFields;
+    /**
+     * Applies the name and description that came with a version write, ignoring either that
+     * is blank, and only after the version write succeeds.
+     */
+    private void updateHeaderDetails(Flow flow) {
+        documentStore.updatePresentHeaderDetails(flow.getNamespace(), flow.getId(),
+                flow.getName(), flow.getDescription());
     }
 
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireFlow(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
+        requireNamespace(flow.getNamespace());
+        if (!documentStore.headerExists(flow.getNamespace(), flow.getId())) {
+            throw new FlowNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -9,7 +9,6 @@ import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
@@ -20,6 +19,8 @@ import org.finos.calm.store.util.MongoVersionDocumentStore;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.MongoVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * MongoDB-backed implementation of {@link InterfaceStore}.
@@ -44,7 +45,6 @@ public class MongoInterfaceStore implements InterfaceStore {
     private static final String VERSION_COLLECTION = "interfaceVersions";
     private static final String ID_FIELD = "interfaceId";
     private static final String RESOURCE_LABEL = "Interface";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
@@ -82,7 +82,7 @@ public class MongoInterfaceStore implements InterfaceStore {
 
         int id = counterStore.getNextInterfaceSequenceValue();
         documentStore.createHeader(namespace, id, interfaceRequest.getName(), interfaceRequest.getDescription());
-        createInitialVersion(namespace, id, content);
+        documentStore.createFirstVersion(namespace, id, content);
 
         createdInterface.setId(id);
         createdInterface.setVersion(INITIAL_VERSION);
@@ -125,25 +125,6 @@ public class MongoInterfaceStore implements InterfaceStore {
         return calmInterface;
     }
 
-    /**
-     * Writes the first version of a newly created interface, removing the header again if
-     * that fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, Document content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void requireNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -1,202 +1,160 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.bson.conversions.Bson;
 import org.finos.calm.domain.CalmInterface;
-import org.finos.calm.domain.exception.*;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
+import org.finos.calm.domain.exception.InterfaceNotFoundException;
+import org.finos.calm.domain.exception.InterfaceVersionExistsException;
+import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.InterfaceStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link InterfaceStore}.
  *
- * <h2>Document model &amp; concurrency</h2>
- * Follows the same namespace-scoped document pattern as {@link MongoArchitectureStore}:
- * one document per namespace (enforced by a unique index on {@code interfaces.namespace}),
- * with an array of interface sub-documents. New interfaces are added via upsert + {@code $push},
- * and new versions use an atomic conditional update with {@code $elemMatch} /
- * {@code $exists: false} to prevent duplicate version creation under concurrency.
- * Unique interface IDs are generated atomically by {@link MongoCounterStore}.
+ * <h2>Document model</h2>
+ * One <em>header</em> document per interface in {@code interfaces}, and one <em>version</em>
+ * document per version in {@code interfaceVersions}. All document handling lives in
+ * {@link MongoVersionDocumentStore}.
  *
- * @see MongoCounterStore
+ * <p>Like Standard: version writes set name and description unconditionally, and there is no
+ * update path. Unlike every other type, its listing returns {@link NamespaceInterfaceSummary},
+ * which carries no version count — so the helper's summary is mapped down rather than
+ * returned directly. The count is computed either way; this just doesn't expose it, which is
+ * the interface's existing contract.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoInterfaceStore.class)
 public class MongoInterfaceStore implements InterfaceStore {
 
-    private static final Logger logger = LoggerFactory.getLogger(MongoInterfaceStore.class);
+    private static final String HEADER_COLLECTION = "interfaces";
+    private static final String VERSION_COLLECTION = "interfaceVersions";
+    private static final String ID_FIELD = "interfaceId";
+    private static final String RESOURCE_LABEL = "Interface";
+    private static final String INITIAL_VERSION = "1.0.0";
 
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final MongoCollection<Document> interfaceCollection;
+    private final MongoVersionDocumentStore documentStore;
 
-    public MongoInterfaceStore(MongoDatabase database, MongoCounterStore mongoCounterStore, MongoNamespaceStore mongoNamespaceStore) {
-        this.counterStore = mongoCounterStore;
-        this.namespaceStore = mongoNamespaceStore;
-        this.interfaceCollection = database.getCollection("interfaces");
+    public MongoInterfaceStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
+        this.counterStore = counterStore;
+        this.namespaceStore = namespaceStore;
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
     }
 
     @Override
     public List<NamespaceInterfaceSummary> getInterfacesForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED).stream()
+                .map(MongoInterfaceStore::toInterfaceSummary)
+                .toList();
+    }
 
-        Document namespaceDocument = interfaceCollection.find(Filters.eq("namespace", namespace)).first();
-
-        if (namespaceDocument == null) {
-            return List.of();
-        }
-
-        List<Document> interfaces = namespaceDocument.getList("interfaces", Document.class);
-        List<NamespaceInterfaceSummary> namespaceInterfaceSummary = new ArrayList<>();
-
-        for (Document interfaceDoc : interfaces) {
-            NamespaceInterfaceSummary summary = new NamespaceInterfaceSummary(
-                    interfaceDoc.getString("name"),
-                    interfaceDoc.getString("description"),
-                    interfaceDoc.getInteger("interfaceId")
-            );
-            namespaceInterfaceSummary.add(summary);
-        }
-
-        return namespaceInterfaceSummary;
+    /** Drops the version count, which {@link NamespaceInterfaceSummary} does not carry. */
+    private static NamespaceInterfaceSummary toInterfaceSummary(NamespaceResourceSummary summary) {
+        return new NamespaceInterfaceSummary(summary.getName(), summary.getDescription(), summary.getId());
     }
 
     @Override
     public CalmInterface createInterfaceForNamespace(CreateInterfaceRequest interfaceRequest, String namespace) throws NamespaceNotFoundException {
         CalmInterface createdInterface = new CalmInterface(interfaceRequest);
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+
+        Document content = Document.parse(interfaceRequest.getInterfaceJson());
 
         int id = counterStore.getNextInterfaceSequenceValue();
-        Document interfaceDocument = new Document("interfaceId", id)
-                .append("name", interfaceRequest.getName())
-                .append("description", interfaceRequest.getDescription())
-                .append("versions",
-                        new Document("1-0-0", Document.parse(interfaceRequest.getInterfaceJson())));
-
-        MongoUpsertPush.pushWithDuplicateRetry(interfaceCollection,
-                Filters.eq("namespace", namespace),
-                "interfaces", interfaceDocument);
+        documentStore.createHeader(namespace, id, interfaceRequest.getName(), interfaceRequest.getDescription());
+        createInitialVersion(namespace, id, content);
 
         createdInterface.setId(id);
-        createdInterface.setVersion("1.0.0");
-
+        createdInterface.setVersion(INITIAL_VERSION);
         return createdInterface;
     }
 
     @Override
     public List<String> getInterfaceVersions(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
-        Document result = retrieveInterfaceVersions(namespace);
-
-        List<Document> interfaces = result.getList("interfaces", Document.class);
-        for (Document interfaceDoc : interfaces) {
-            if (interfaceId.equals(interfaceDoc.getInteger("interfaceId"))) {
-                Document versions = (Document) interfaceDoc.get("versions");
-                if (versions == null) {
-                    throw new InterfaceNotFoundException();
-                }
-                Set<String> versionKeys = versions.keySet();
-
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
-                }
-                return resourceVersions;
-            }
-        }
-
-        throw new InterfaceNotFoundException();
-    }
-
-    private Document retrieveInterfaceVersions(String namespace) throws NamespaceNotFoundException, InterfaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", namespace);
-        Bson projection = Projections.fields(Projections.include("interfaces"));
-
-        Document result = interfaceCollection.find(filter).projection(projection).first();
-
-        if (result == null) {
-            throw new InterfaceNotFoundException();
-        }
-
-        return result;
+        requireInterface(namespace, interfaceId);
+        return documentStore.listVersions(namespace, interfaceId);
     }
 
     @Override
     public String getInterfaceForVersion(String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionNotFoundException {
-        Document result = retrieveInterfaceVersions(namespace);
-        List<Document> interfaces = result.getList("interfaces", Document.class);
-        for (Document interfaceDoc : interfaces) {
-            if (interfaceId.equals(interfaceDoc.getInteger("interfaceId"))) {
-                Document versions = (Document) interfaceDoc.get("versions");
-                if (versions == null) {
-                    throw new InterfaceVersionNotFoundException();
-                }
-                Document versionDoc = (Document) versions.get(version.replace('.', '-'));
-                if (versionDoc == null) {
-                    throw new InterfaceVersionNotFoundException();
-                }
-                return versionDoc.toJson();
-            }
+        requireInterface(namespace, interfaceId);
+
+        Document content = documentStore.getVersion(namespace, interfaceId, version);
+        if (content == null) {
+            throw new InterfaceVersionNotFoundException();
         }
-        throw new InterfaceNotFoundException();
+        return content.toJson();
     }
 
     @Override
     public CalmInterface createInterfaceForVersion(CreateInterfaceRequest interfaceRequest, String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionExistsException {
-        // Validates namespace and interface existence
-        getInterfaceVersions(namespace, interfaceId);
+        requireInterface(namespace, interfaceId);
 
-        String mongoVersion = version.replace('.', '-');
-
-        // Atomic conditional update: only succeeds if the version doesn't already exist
-        Document filter = new Document("namespace", namespace)
-                .append("interfaces", new Document("$elemMatch",
-                        new Document("interfaceId", interfaceId)
-                                .append("versions." + mongoVersion, new Document("$exists", false))));
-
-        Document update = new Document("$set", new Document()
-                .append("interfaces.$.name", interfaceRequest.getName())
-                .append("interfaces.$.description", interfaceRequest.getDescription())
-                .append("interfaces.$.versions." + mongoVersion, Document.parse(interfaceRequest.getInterfaceJson())));
-
-        try {
-            if (interfaceCollection.updateOne(filter, update).getMatchedCount() == 0) {
-                throw new InterfaceVersionExistsException();
-            }
-        } catch (MongoWriteException ex) {
-            logger.error("Failed to write interface [namespace={}, id={}, version={}] to mongo",
-                    namespace, interfaceId, version, ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
+        Document content = Document.parse(interfaceRequest.getInterfaceJson());
+        if (!documentStore.createVersion(namespace, interfaceId, version, content)) {
+            throw new InterfaceVersionExistsException();
         }
+
+        // Unconditional, matching the old shape.
+        documentStore.updateHeaderDetails(namespace, interfaceId,
+                interfaceRequest.getName(), interfaceRequest.getDescription());
 
         CalmInterface calmInterface = new CalmInterface(interfaceRequest);
         calmInterface.setId(interfaceId);
         calmInterface.setVersion(version);
         return calmInterface;
+    }
+
+    /**
+     * Writes the first version of a newly created interface, removing the header again if
+     * that fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, Document content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireInterface(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
+        requireNamespace(namespace);
+        if (!documentStore.headerExists(namespace, interfaceId)) {
+            throw new InterfaceNotFoundException();
+        }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -161,6 +161,11 @@ public class MongoSearchStore implements SearchStore {
                 continue;
             }
             Integer adrId = header.getInteger("adrId");
+            if (adrId == null) {
+                // SearchResult takes a primitive id, and resolving the latest revision would
+                // unbox this too. An ADR with no id is not addressable, so it is not a result.
+                continue;
+            }
             String title = "ADR " + adrId;
 
             Document latest = adrDocuments.getLatestVersionContent(namespace, adrId);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -97,12 +97,21 @@ public class MongoSearchStore implements SearchStore {
             if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
                 continue;
             }
+            Integer id = header.getInteger(idField);
+            if (id == null) {
+                // Same reason the ADR branch below skips these: SearchResult takes a
+                // primitive id, so a header missing its id field unboxes to a
+                // NullPointerException thrown out of search() — which builds every type's
+                // results eagerly, so one malformed document fails the whole request rather
+                // than one resource type. A resource with no id is not addressable anyway.
+                continue;
+            }
             String name = header.getString("name");
             String description = header.getString("description");
             if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
                 results.add(new SearchResult(
                         namespace,
-                        header.getInteger(idField),
+                        id,
                         SearchTextMatcher.nullToEmpty(name),
                         SearchTextMatcher.nullToEmpty(description)
                 ));

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -8,6 +8,8 @@ import org.bson.Document;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
+import org.finos.calm.store.util.NumericVersionOrder;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,7 @@ public class MongoSearchStore implements SearchStore {
     private final MongoCollection<Document> interfaceCollection;
     private final MongoCollection<Document> controlCollection;
     private final MongoCollection<Document> adrCollection;
+    private final MongoVersionDocumentStore adrDocuments;
 
     public MongoSearchStore(MongoDatabase database) {
         this.architectureCollection = database.getCollection("architectures");
@@ -50,6 +53,8 @@ public class MongoSearchStore implements SearchStore {
         this.interfaceCollection = database.getCollection("interfaces");
         this.controlCollection = database.getCollection("controls");
         this.adrCollection = database.getCollection("adrs");
+        this.adrDocuments = new MongoVersionDocumentStore(adrCollection,
+                database.getCollection("adrVersions"), "adrId", "ADR", NumericVersionOrder.ASCENDING);
     }
 
     @Override
@@ -137,44 +142,34 @@ public class MongoSearchStore implements SearchStore {
         return results;
     }
 
+    /**
+     * ADR searches on the latest revision's title, so unlike every other type this cannot be
+     * answered from the header alone — the header carries no name. The latest revision is
+     * resolved through the same helper the ADR store uses, which is also what keeps the
+     * integer ordering correct: ranking revisions as strings would make 2 the latest once an
+     * ADR passed revision 9.
+     */
     private List<SearchResult> searchAdrCollection(String lowerQuery, Optional<Set<String>> readableNamespaces) {
         List<SearchResult> results = new ArrayList<>();
 
-        for (Document namespaceDoc : adrCollection.find()) {
-            String namespace = namespaceDoc.getString("namespace");
+        for (Document header : adrCollection.find()) {
+            if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
+                return results;
+            }
+            String namespace = header.getString("namespace");
             if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
                 continue;
             }
-            List<Document> adrs = namespaceDoc.getList("adrs", Document.class);
-            if (adrs == null) {
-                continue;
+            Integer adrId = header.getInteger("adrId");
+            String title = "ADR " + adrId;
+
+            Document latest = adrDocuments.getLatestVersionContent(namespace, adrId);
+            if (latest != null && latest.getString("title") != null) {
+                title = latest.getString("title");
             }
-            for (Document adr : adrs) {
-                if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
-                    return results;
-                }
-                int adrId = adr.getInteger("adrId");
-                String title = "ADR " + adrId;
 
-                Document revisions = (Document) adr.get("revisions");
-                if (revisions != null && !revisions.isEmpty()) {
-                    int latestRevision = revisions.keySet().stream()
-                            .map(Integer::parseInt)
-                            .mapToInt(i -> i)
-                            .max()
-                            .getAsInt();
-                    Document revisionDoc = (Document) revisions.get(String.valueOf(latestRevision));
-                    if (revisionDoc != null) {
-                        String docTitle = revisionDoc.getString("title");
-                        if (docTitle != null) {
-                            title = docTitle;
-                        }
-                    }
-                }
-
-                if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {
-                    results.add(new SearchResult(namespace, adrId, title, ""));
-                }
+            if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {
+                results.add(new SearchResult(namespace, adrId, title, ""));
             }
         }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -60,7 +60,7 @@ public class MongoSearchStore implements SearchStore {
                 searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(standardCollection, "standardId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -61,7 +61,7 @@ public class MongoSearchStore implements SearchStore {
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(standardCollection, "standardId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(interfaceCollection, "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)
         );
@@ -71,12 +71,12 @@ public class MongoSearchStore implements SearchStore {
      * Searches a collection in the header/version shape, where each document <em>is</em> one
      * resource rather than a namespace-wide array of them.
      *
-     * <p>Separate from {@link #searchNamespacedCollection} rather than replacing it because
-     * the two shapes coexist: ADR 0001 migrates one resource type at a time, so Architecture
-     * reads this way while patterns, flows, standards and interfaces still read the other.
-     * Note the failure mode if a migrated type is left on the old method — {@code getList}
-     * returns null for a header document, so the loop skips every document and the type
-     * silently returns no results at all, with nothing logged.</p>
+     * <p>This was one of two search paths while ADR 0001's rollout was part-done: the other
+     * read a namespace-wide array of entries and was retired once Interface — the last of the
+     * five namespaced types — moved to this shape. The failure mode it guarded against is
+     * worth remembering for any type still to migrate: leave one on an array-shaped read and
+     * {@code getList} returns null for a header document, so every document is skipped and
+     * the type silently returns no results at all, with nothing logged.</p>
      */
     private List<SearchResult> searchHeaderCollection(MongoCollection<Document> collection,
                                                       String idField,
@@ -107,41 +107,6 @@ public class MongoSearchStore implements SearchStore {
         return results;
     }
 
-    private List<SearchResult> searchNamespacedCollection(MongoCollection<Document> collection,
-                                                          String arrayField,
-                                                          String idField,
-                                                          String lowerQuery,
-                                                          Optional<Set<String>> readableNamespaces) {
-        List<SearchResult> results = new ArrayList<>();
-
-        for (Document namespaceDoc : collection.find()) {
-            String namespace = namespaceDoc.getString("namespace");
-            if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
-                continue;
-            }
-            List<Document> entries = namespaceDoc.getList(arrayField, Document.class);
-            if (entries == null) {
-                continue;
-            }
-            for (Document entry : entries) {
-                if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
-                    return results;
-                }
-                String name = entry.getString("name");
-                String description = entry.getString("description");
-                if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
-                    results.add(new SearchResult(
-                            namespace,
-                            entry.getInteger(idField),
-                            SearchTextMatcher.nullToEmpty(name),
-                            SearchTextMatcher.nullToEmpty(description)
-                    ));
-                }
-            }
-        }
-
-        return results;
-    }
 
     private List<SearchResult> searchControlCollection(String lowerQuery) {
         List<SearchResult> results = new ArrayList<>();

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -104,6 +104,14 @@ public class MongoSearchStore implements SearchStore {
                 // NullPointerException thrown out of search() — which builds every type's
                 // results eagerly, so one malformed document fails the whole request rather
                 // than one resource type. A resource with no id is not addressable anyway.
+                //
+                // Deliberately unlike the namespace listing, which renders the same malformed
+                // header as "<Type> null" rather than hiding it (see
+                // NitriteVersionDocumentStore.listSummariesPaged). The two differ because the
+                // outputs differ: a search hit is a link the caller is expected to follow, so
+                // one that cannot be addressed is worse than absent, whereas a listing row is
+                // informational and showing it is how an operator learns the bad header is
+                // there. Dropping it from both would hide the problem entirely.
                 continue;
             }
             String name = header.getString("name");

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -9,7 +9,7 @@ import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
 import org.finos.calm.store.util.MongoVersionDocumentStore;
-import org.finos.calm.store.util.NumericVersionOrder;
+import org.finos.calm.store.util.VersionScheme;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class MongoSearchStore implements SearchStore {
         this.controlCollection = database.getCollection("controls");
         this.adrCollection = database.getCollection("adrs");
         this.adrDocuments = new MongoVersionDocumentStore(adrCollection,
-                database.getCollection("adrVersions"), "adrId", "ADR", NumericVersionOrder.ASCENDING);
+                database.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -59,7 +59,7 @@ public class MongoSearchStore implements SearchStore {
         return new GroupedSearchResults(
                 searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(flowCollection, "flows", "flowId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -9,7 +9,6 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
@@ -19,6 +18,8 @@ import org.finos.calm.store.util.MongoVersionDocumentStore;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.MongoVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * MongoDB-backed implementation of {@link StandardStore}.
@@ -47,7 +48,6 @@ public class MongoStandardStore implements StandardStore {
     private static final String VERSION_COLLECTION = "standardVersions";
     private static final String ID_FIELD = "standardId";
     private static final String RESOURCE_LABEL = "Standard";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
@@ -77,7 +77,7 @@ public class MongoStandardStore implements StandardStore {
 
         int id = counterStore.getNextStandardSequenceValue();
         documentStore.createHeader(namespace, id, standardRequest.getName(), standardRequest.getDescription());
-        createInitialVersion(namespace, id, content);
+        documentStore.createFirstVersion(namespace, id, content);
 
         Standard createdStandard = new Standard(standardRequest);
         createdStandard.setId(id);
@@ -121,25 +121,6 @@ public class MongoStandardStore implements StandardStore {
         return standard;
     }
 
-    /**
-     * Writes the first version of a newly created standard, removing the header again if
-     * that fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, Document content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void requireNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -1,211 +1,156 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.bson.conversions.Bson;
 import org.finos.calm.domain.Standard;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
-import org.finos.calm.store.util.VersionKeySelector;
-import org.finos.calm.domain.exception.*;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StandardNotFoundException;
+import org.finos.calm.domain.exception.StandardVersionExistsException;
+import org.finos.calm.domain.exception.StandardVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.StandardStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link StandardStore}.
  *
- * <h2>Document model &amp; concurrency</h2>
- * Follows the same namespace-scoped document pattern as {@link MongoArchitectureStore}:
- * one document per namespace (enforced by a unique index on {@code standards.namespace}),
- * with an array of standard sub-documents. New standards are added via upsert + {@code $push},
- * and new versions use an atomic conditional update with {@code $elemMatch} /
- * {@code $exists: false} to prevent duplicate version creation under concurrency.
- * Unique standard IDs are generated atomically by {@link MongoCounterStore}.
+ * <h2>Document model</h2>
+ * One <em>header</em> document per standard in {@code standards}, and one <em>version</em>
+ * document per version in {@code standardVersions}. All document handling lives in
+ * {@link MongoVersionDocumentStore}.
  *
- * @see MongoCounterStore
+ * <p>Two things differ from the Pattern and Flow ports, both preserving Standard's own
+ * behaviour: version writes set name and description <em>unconditionally</em>, as Standard's
+ * old shape did (Architecture's behaviour, not Pattern's); and there is no update path at
+ * all, so nothing here upserts a version.</p>
+ *
+ * <p>Incidentally fixes a bug the old code carried a {@code FIXME} for: its
+ * {@code retrieveStandardVersions} looked up only the namespace and ignored
+ * {@code standardId}, which happened to work while a namespace held one standard. Existence
+ * is now checked against {@code (namespace, standardId)} like every other type.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoStandardStore.class)
 public class MongoStandardStore implements StandardStore {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final String HEADER_COLLECTION = "standards";
+    private static final String VERSION_COLLECTION = "standardVersions";
+    private static final String ID_FIELD = "standardId";
+    private static final String RESOURCE_LABEL = "Standard";
+    private static final String INITIAL_VERSION = "1.0.0";
+
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final MongoCollection<Document> standardCollection;
+    private final MongoVersionDocumentStore documentStore;
 
-    public MongoStandardStore(MongoDatabase database, MongoCounterStore mongoCounterStore, MongoNamespaceStore mongoNamespaceStore) {
-        this.counterStore = mongoCounterStore;
-        this.namespaceStore = mongoNamespaceStore;
-        this.standardCollection = database.getCollection("standards");
+    public MongoStandardStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
+        this.counterStore = counterStore;
+        this.namespaceStore = namespaceStore;
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
     }
 
     @Override
     public List<NamespaceResourceSummary> getStandardsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Document namespaceDocument = standardCollection.find(Filters.eq("namespace", namespace)).first();
-
-        if(namespaceDocument == null) {
-            return List.of();
-        }
-
-        List<Document> standards = namespaceDocument.getList("standards", Document.class);
-        List<NamespaceResourceSummary> namespaceStandardSummary = new ArrayList<>();
-
-        for (Document standard : standards) {
-            // Count versions from the already-in-memory sub-document (O(1), no extra query).
-            Object rawVersions = standard.get("versions");
-            int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.keySet() : null);
-            NamespaceResourceSummary standardSummary = new NamespaceResourceSummary(
-                    standard.getString("name"),
-                    standard.getString("description"),
-                    standard.getInteger("standardId"),
-                    versionCount
-            );
-
-            namespaceStandardSummary.add(standardSummary);
-        }
-
-        return namespaceStandardSummary;
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED);
     }
 
     @Override
     public Standard createStandardForNamespace(CreateStandardRequest standardRequest, String namespace) throws NamespaceNotFoundException {
-        Standard createdStandard = new Standard(standardRequest);
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+
+        Document content = Document.parse(standardRequest.getStandardJson());
 
         int id = counterStore.getNextStandardSequenceValue();
-        Document standardDocument = new Document("standardId", id)
-                .append("name", standardRequest.getName())
-                .append("description", standardRequest.getDescription())
-                .append("versions",
-                new Document("1-0-0", Document.parse(standardRequest.getStandardJson())));
+        documentStore.createHeader(namespace, id, standardRequest.getName(), standardRequest.getDescription());
+        createInitialVersion(namespace, id, content);
 
-        MongoUpsertPush.pushWithDuplicateRetry(standardCollection,
-                Filters.eq("namespace", namespace),
-                "standards", standardDocument);
-
+        Standard createdStandard = new Standard(standardRequest);
         createdStandard.setId(id);
-        createdStandard.setVersion("1.0.0");
-
+        createdStandard.setVersion(INITIAL_VERSION);
         return createdStandard;
     }
 
     @Override
     public List<String> getStandardVersions(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
-        Document result = retrieveStandardVersions(namespace);
-
-        List<Document> standards = result.getList("standards", Document.class);
-        for (Document standardDoc : standards) {
-            if (standardId.equals(standardDoc.getInteger("standardId"))) {
-                // Extract the versions map from the matching standard
-                Document versions = (Document) standardDoc.get("versions");
-                if (versions == null) {
-                    throw new StandardNotFoundException();
-                }
-                Set<String> versionKeys = versions.keySet();
-
-                //Convert from Mongo representation
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
-                }
-                return resourceVersions;  // Return the list of version keys
-            }
-        }
-
-        throw new StandardNotFoundException();
-
-    }
-
-    private Document retrieveStandardVersions(String namespace) throws NamespaceNotFoundException, StandardNotFoundException {
-        //FIXME there is a bug here where standardId is not used, which will be fine when one standard exists
-
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", namespace);
-        Bson projection = Projections.fields(Projections.include("standards"));
-
-        Document result = standardCollection.find(filter).projection(projection).first();
-
-        if (result == null) {
-            throw new StandardNotFoundException();
-        }
-
-        return result;
+        requireStandard(namespace, standardId);
+        return documentStore.listVersions(namespace, standardId);
     }
 
     @Override
     public String getStandardForVersion(String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionNotFoundException {
-        Document result = retrieveStandardVersions(namespace);
-        List<Document> standards = result.getList("standards", Document.class);
-        for (Document standardDoc : standards) {
-            if (standardId.equals(standardDoc.getInteger("standardId"))) {
-                Document versions = (Document) standardDoc.get("versions");
-                if (versions == null) {
-                    throw new StandardVersionNotFoundException();
-                }
-                Document versionDoc = (Document) versions.get(version.replace('.', '-'));
-                if(versionDoc == null) {
-                    throw new StandardVersionNotFoundException();
-                }
-                return versionDoc.toJson();
-            }
+        requireStandard(namespace, standardId);
+
+        Document content = documentStore.getVersion(namespace, standardId, version);
+        if (content == null) {
+            throw new StandardVersionNotFoundException();
         }
-        throw new StandardNotFoundException();
+        return content.toJson();
     }
 
     @Override
     public Standard createStandardForVersion(CreateStandardRequest standardRequest, String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionExistsException {
-        // Validates namespace and standard existence
-        getStandardVersions(namespace, standardId);
-        String mongoVersion = version.replace('.', '-');
+        requireStandard(namespace, standardId);
 
-        // Atomic conditional update: only succeeds if the version doesn't already exist
-        Document filter = new Document("namespace", namespace)
-                .append("standards", new Document("$elemMatch",
-                        new Document("standardId", standardId)
-                                .append("versions." + mongoVersion, new Document("$exists", false))));
-
-        Document update = new Document("$set", new Document()
-                .append("standards.$.name", standardRequest.getName())
-                .append("standards.$.description", standardRequest.getDescription())
-                .append("standards.$.versions." + mongoVersion, Document.parse(standardRequest.getStandardJson())));
-
-        try {
-            if (standardCollection.updateOne(filter, update).getMatchedCount() == 0) {
-                throw new StandardVersionExistsException();
-            }
-        } catch (MongoWriteException ex) {
-            log.error("Failed to write standard [namespace={}, id={}, version={}] to mongo",
-                    namespace, standardId, version, ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
+        Document content = Document.parse(standardRequest.getStandardJson());
+        if (!documentStore.createVersion(namespace, standardId, version, content)) {
+            throw new StandardVersionExistsException();
         }
+
+        // Unconditional, matching the old shape: Standard did not guard these on blank.
+        documentStore.updateHeaderDetails(namespace, standardId,
+                standardRequest.getName(), standardRequest.getDescription());
 
         Standard standard = new Standard(standardRequest);
         standard.setId(standardId);
         standard.setVersion(version);
         return standard;
+    }
+
+    /**
+     * Writes the first version of a newly created standard, removing the header again if
+     * that fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, Document content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireStandard(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
+        requireNamespace(namespace);
+        if (!documentStore.headerExists(namespace, standardId)) {
+            throw new StandardNotFoundException();
+        }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -9,7 +9,6 @@ import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
@@ -20,6 +19,8 @@ import org.finos.calm.store.util.MongoVersionDocumentStore;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.MongoVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * MongoDB-backed implementation of {@link TimelineStore}.
@@ -46,7 +47,6 @@ public class MongoTimelineStore implements TimelineStore {
     private static final String VERSION_COLLECTION = "timelineVersions";
     private static final String ID_FIELD = "timelineId";
     private static final String RESOURCE_LABEL = "Timeline";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
@@ -85,7 +85,7 @@ public class MongoTimelineStore implements TimelineStore {
 
         int id = counterStore.getNextTimelineSequenceValue();
         documentStore.createHeader(namespace, id, timelineRequest.getName(), timelineRequest.getDescription());
-        createInitialVersion(namespace, id, content);
+        documentStore.createFirstVersion(namespace, id, content);
 
         return new Timeline.TimelineBuilder()
                 .setId(id)
@@ -136,25 +136,6 @@ public class MongoTimelineStore implements TimelineStore {
         return timeline;
     }
 
-    /**
-     * Writes the first version of a newly created timeline, removing the header again if that
-     * fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, Document content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     /**
      * Applies the name and description that came with a version write, ignoring either that

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -1,107 +1,95 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.MongoWriteException;
-import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import org.bson.Document;
-import org.bson.conversions.Bson;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
-import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.store.TimelineStore;
-import org.finos.calm.store.util.MongoUpsertPush;
-import org.finos.calm.store.util.MongoWriteFailures;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
  * MongoDB-backed implementation of {@link TimelineStore}.
  *
- * <h2>Document model &amp; concurrency</h2>
- * Follows the same namespace-scoped document pattern as {@link MongoFlowStore} and
- * {@link MongoArchitectureStore}: one document per namespace (enforced by a unique index on
- * {@code timelines.namespace}), with an array of timeline sub-documents. New timelines are
- * added via upsert + {@code $push}, and new versions use an atomic conditional update with
- * {@code $elemMatch} / {@code $exists: false} to prevent duplicate version creation under
- * concurrency. Unique timeline IDs are generated atomically by {@link MongoCounterStore}.
+ * <h2>Document model</h2>
+ * One <em>header</em> document per timeline in {@code timelines}, and one <em>version</em> document
+ * per version in {@code timelineVersions}. All document handling lives in
+ * {@link MongoVersionDocumentStore}; this class only translates between that and the
+ * domain's objects and exceptions. See
+ * {@code calm-hub/decisions/0001-versioned-artefact-storage.md}.
  *
- * @see MongoCounterStore
+ * <p>Like Pattern and unlike Architecture, version writes update the header's name and
+ * description only when they are non-blank — Timeline's old shape guarded those fields.</p>
+ *
+ * <p>{@link TimelineStore} exposes no paged listing, so summaries are always fetched
+ * {@link PageRequest#UNPAGED}. The helper supports paging whenever the interface grows one.</p>
  */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
 @Typed(MongoTimelineStore.class)
 public class MongoTimelineStore implements TimelineStore {
-    private final MongoCollection<Document> timelineCollection;
+
+    private static final String HEADER_COLLECTION = "timelines";
+    private static final String VERSION_COLLECTION = "timelineVersions";
+    private static final String ID_FIELD = "timelineId";
+    private static final String RESOURCE_LABEL = "Timeline";
+    private static final String INITIAL_VERSION = "1.0.0";
+
     private final MongoCounterStore counterStore;
     private final MongoNamespaceStore namespaceStore;
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final MongoVersionDocumentStore documentStore;
 
     public MongoTimelineStore(MongoDatabase database, MongoCounterStore counterStore, MongoNamespaceStore namespaceStore) {
         this.counterStore = counterStore;
         this.namespaceStore = namespaceStore;
-        this.timelineCollection = database.getCollection("timelines");
+        this.documentStore = new MongoVersionDocumentStore(
+                database.getCollection(HEADER_COLLECTION),
+                database.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
     }
 
     @Override
     public List<NamespaceTimelineSummary> getTimelinesForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED).stream()
+                .map(MongoTimelineStore::toTimelineSummary)
+                .toList();
+    }
 
-        Document namespaceDocument = timelineCollection.find(Filters.eq("namespace", namespace)).first();
-
-        //protects from an unpopulated mongo collection
-        if (namespaceDocument == null || namespaceDocument.isEmpty()) {
-            return List.of();
-        }
-
-        List<Document> timelines = namespaceDocument.getList("timelines", Document.class);
-        List<NamespaceTimelineSummary> timelineSummaries = new ArrayList<>();
-
-        for (Document timeline : timelines) {
-            Integer timelineId = timeline.getInteger("timelineId");
-            String name = timeline.getString("name");
-            String description = timeline.getString("description");
-            if (name == null) name = "Timeline " + timelineId;
-            if (description == null) description = "";
-            timelineSummaries.add(new NamespaceTimelineSummary(name, description, timelineId));
-        }
-
-        return timelineSummaries;
+    /** Drops the version count, which {@link NamespaceTimelineSummary} does not carry. */
+    private static NamespaceTimelineSummary toTimelineSummary(NamespaceResourceSummary summary) {
+        return new NamespaceTimelineSummary(summary.getName(), summary.getDescription(), summary.getId());
     }
 
     @Override
     public Timeline createTimelineForNamespace(CreateTimelineRequest timelineRequest, String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+
+        // Parsed before the counter is drawn and before anything is written, so malformed
+        // JSON can't leave a header behind with no version to go with it.
+        Document content = Document.parse(timelineRequest.getTimelineJson());
 
         int id = counterStore.getNextTimelineSequenceValue();
-        Document timelineDocument = new Document("timelineId", id)
-                .append("name", timelineRequest.getName())
-                .append("description", timelineRequest.getDescription())
-                .append("versions",
-                        new Document("1-0-0", Document.parse(timelineRequest.getTimelineJson())));
-
-        MongoUpsertPush.pushWithDuplicateRetry(timelineCollection,
-                Filters.eq("namespace", namespace),
-                "timelines", timelineDocument);
+        documentStore.createHeader(namespace, id, timelineRequest.getName(), timelineRequest.getDescription());
+        createInitialVersion(namespace, id, content);
 
         return new Timeline.TimelineBuilder()
                 .setId(id)
-                .setVersion("1.0.0")
+                .setVersion(INITIAL_VERSION)
                 .setNamespace(namespace)
                 .setTimeline(timelineRequest.getTimelineJson())
                 .build();
@@ -109,145 +97,84 @@ public class MongoTimelineStore implements TimelineStore {
 
     @Override
     public List<String> getTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        Document result = retrieveTimelineVersions(timeline);
-
-        List<Document> timelines = result.getList("timelines", Document.class);
-        for (Document timelineDoc : timelines) {
-            if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
-                // Extract the versions map from the matching timeline
-                Document versions = (Document) timelineDoc.get("versions");
-                if (versions == null) {
-                    throw new TimelineNotFoundException();
-                }
-                Set<String> versionKeys = versions.keySet();
-
-                // Convert from Mongo representation
-                List<String> resourceVersions = new ArrayList<>();
-                for (String versionKey : versionKeys) {
-                    resourceVersions.add(versionKey.replace('-', '.'));
-                }
-                return resourceVersions;
-            }
-        }
-
-        throw new TimelineNotFoundException();
-    }
-
-    private Document retrieveTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        if (!namespaceStore.namespaceExists(timeline.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
-
-        Bson filter = new Document("namespace", timeline.getNamespace());
-        Bson projection = Projections.fields(Projections.include("timelines"));
-
-        Document result = timelineCollection.find(filter).projection(projection).first();
-
-        if (result == null) {
-            throw new TimelineNotFoundException();
-        }
-
-        return result;
-    }
-
-    private void verifyTimelineExists(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        Document result = retrieveTimelineVersions(timeline);
-        List<Document> timelines = result.getList("timelines", Document.class);
-        for (Document timelineDoc : timelines) {
-            if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
-                return;
-            }
-        }
-        throw new TimelineNotFoundException();
+        requireTimeline(timeline);
+        return documentStore.listVersions(timeline.getNamespace(), timeline.getId());
     }
 
     @Override
     public String getTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
-        Document result = retrieveTimelineVersions(timeline);
+        requireTimeline(timeline);
 
-        List<Document> timelines = result.getList("timelines", Document.class);
-        for (Document timelineDoc : timelines) {
-            if (timeline.getId() == timelineDoc.getInteger("timelineId")) {
-                // Retrieve the versions map from the matching timeline
-                Document versions = (Document) timelineDoc.get("versions");
-                if (versions == null) {
-                    throw new TimelineVersionNotFoundException();
-                }
-
-                // Return the timeline JSON blob for the specified version
-                Document versionDoc = (Document) versions.get(timeline.getMongoVersion());
-                log.info("Version [{}] found: {}", timeline.getMongoVersion(), versionDoc != null);
-                if (versionDoc == null) {
-                    throw new TimelineVersionNotFoundException();
-                }
-                return versionDoc.toJson();
-            }
+        Document content = documentStore.getVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion());
+        if (content == null) {
+            throw new TimelineVersionNotFoundException();
         }
-        // Timelines is empty, no version to find
-        throw new TimelineVersionNotFoundException();
+        return content.toJson();
     }
 
     @Override
     public Timeline createTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionExistsException {
-        // Validates namespace and timeline existence
-        getTimelineVersions(timeline);
+        requireTimeline(timeline);
 
-        // Atomic conditional update: only succeeds if the version doesn't already exist
-        Document filter = new Document("namespace", timeline.getNamespace())
-                .append("timelines", new Document("$elemMatch",
-                        new Document("timelineId", timeline.getId())
-                                .append("versions." + timeline.getMongoVersion(), new Document("$exists", false))));
-
-        Document update = new Document("$set", buildVersionSetFields(timeline));
-
-        if (timelineCollection.updateOne(filter, update).getMatchedCount() == 0) {
+        Document content = Document.parse(timeline.getTimelineJson());
+        if (!documentStore.createVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion(), content)) {
             throw new TimelineVersionExistsException();
         }
 
+        updateHeaderDetails(timeline);
         return timeline;
     }
 
     @Override
     public Timeline updateTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        if (!namespaceStore.namespaceExists(timeline.getNamespace())) {
-            throw new NamespaceNotFoundException();
-        }
-        writeTimelineToMongo(timeline);
+        requireTimeline(timeline);
+
+        Document content = Document.parse(timeline.getTimelineJson());
+        documentStore.upsertVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion(), content);
+
+        updateHeaderDetails(timeline);
         return timeline;
     }
 
-    private void writeTimelineToMongo(Timeline timeline) throws TimelineNotFoundException, NamespaceNotFoundException {
-        // Verifies the namespace AND the specific timeline entity exist, so any
-        // MongoWriteException from the update below is a genuine write failure, not a
-        // disguised not-found.
-        verifyTimelineExists(timeline);
-
-        Document filter = new Document("namespace", timeline.getNamespace())
-                .append("timelines.timelineId", timeline.getId());
-        Document update = new Document("$set", buildVersionSetFields(timeline));
-
+    /**
+     * Writes the first version of a newly created timeline, removing the header again if that
+     * fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, Document content) {
+        boolean created;
         try {
-            timelineCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (MongoWriteException ex) {
-            // Log identifying fields only, not the full timeline object — its toString()
-            // includes the entire (potentially near-16MB) timelineJson payload.
-            log.error("Failed to write timeline [namespace={}, id={}, version={}] to mongo",
-                    timeline.getNamespace(), timeline.getId(), timeline.getMongoVersion(), ex);
-            throw MongoWriteFailures.toStorageWriteException(ex);
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
         }
     }
 
-    private Document buildVersionSetFields(Timeline timeline) {
-        Document setFields = new Document("timelines.$.versions." + timeline.getMongoVersion(), Document.parse(timeline.getTimelineJson()));
-        // Defensive: the REST layer enforces @NotBlank on name/description via CreateTimelineRequest,
-        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-        if (timeline.getName() != null && !timeline.getName().isBlank()) {
-            setFields.append("timelines.$.name", timeline.getName());
-        }
-        if (timeline.getDescription() != null && !timeline.getDescription().isBlank()) {
-            setFields.append("timelines.$.description", timeline.getDescription());
-        }
-        return setFields;
+    /**
+     * Applies the name and description that came with a version write, ignoring either that
+     * is blank, and only after the version write succeeds.
+     */
+    private void updateHeaderDetails(Timeline timeline) {
+        documentStore.updatePresentHeaderDetails(timeline.getNamespace(), timeline.getId(),
+                timeline.getName(), timeline.getDescription());
     }
 
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireTimeline(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
+        requireNamespace(timeline.getNamespace());
+        if (!documentStore.headerExists(timeline.getNamespace(), timeline.getId())) {
+            throw new TimelineNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -88,6 +88,15 @@ public class NitriteAdrStore implements AdrStore {
         String title = "ADR " + adrId;
         String status = "unknown";
 
+        // A header carrying no adrId is malformed rather than missing, and
+        // listSummariesPaged deliberately renders it instead of failing — it sorts null ids
+        // last for exactly that reason. Resolving its latest revision would unbox this null
+        // and undo that tolerance, turning one bad document into a 500 for every ADR in the
+        // namespace. Render the placeholder and move on, which is what the row is worth.
+        if (adrId == null) {
+            return new NamespaceAdrSummary(title, status, null);
+        }
+
         String latest = documentStore.getLatestVersionContent(namespace, adrId);
         if (latest != null) {
             try {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -17,7 +17,7 @@ import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.AdrStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.util.NitriteVersionDocumentStore;
-import org.finos.calm.store.util.NumericVersionOrder;
+import org.finos.calm.store.util.VersionScheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +31,9 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  *
  * <p>Mirrors {@link org.finos.calm.store.mongo.MongoAdrStore}, including the two things that
  * make ADR different from every other versioned type — integer revisions, which need
- * {@link NumericVersionOrder}, and a summary built from the latest revision's content rather
- * than from the entity. See that class for why both matter.</p>
+ * {@link VersionScheme#NUMERIC} so they are ordered numerically and stored verbatim, and a
+ * summary built from the latest revision's content rather than from the entity. See that
+ * class for why both matter.</p>
  *
  * <p>As with the other Nitrite stores, revision content is held as a JSON string rather than
  * a parsed document.</p>
@@ -62,7 +63,7 @@ public class NitriteAdrStore implements AdrStore {
                 db.getCollection(VERSION_COLLECTION),
                 ID_FIELD,
                 RESOURCE_LABEL,
-                NumericVersionOrder.ASCENDING);
+                VersionScheme.NUMERIC);
         this.objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         LOG.info("NitriteAdrStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -7,32 +7,35 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.adr.Adr;
 import org.finos.calm.domain.adr.AdrMeta;
 import org.finos.calm.domain.adr.NamespaceAdrSummary;
 import org.finos.calm.domain.adr.Status;
 import org.finos.calm.domain.exception.*;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.AdrStore;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
+import org.finos.calm.store.util.NumericVersionOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the AdrStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link AdrStore}, used in standalone mode.
+ *
+ * <p>Mirrors {@link org.finos.calm.store.mongo.MongoAdrStore}, including the two things that
+ * make ADR different from every other versioned type — integer revisions, which need
+ * {@link NumericVersionOrder}, and a summary built from the latest revision's content rather
+ * than from the entity. See that class for why both matter.</p>
+ *
+ * <p>As with the other Nitrite stores, revision content is held as a JSON string rather than
+ * a parsed document.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -40,354 +43,230 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 public class NitriteAdrStore implements AdrStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteAdrStore.class);
-    private static final String COLLECTION_NAME = "adrs";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String ADR_ID_FIELD = "adrId";
-    private static final String ADRS_FIELD = "adrs";
-    private static final String REVISIONS_FIELD = "revisions";
+    private static final String HEADER_COLLECTION = "adrs";
+    private static final String VERSION_COLLECTION = "adrVersions";
+    private static final String ID_FIELD = "adrId";
+    private static final String RESOURCE_LABEL = "ADR";
 
-    private final NitriteCollection adrCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
+    private final NitriteVersionDocumentStore documentStore;
     private final ObjectMapper objectMapper;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     @Inject
     public NitriteAdrStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.adrCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL,
+                NumericVersionOrder.ASCENDING);
         this.objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-        LOG.info("NitriteAdrStore initialized with collection: {}", COLLECTION_NAME);
+        LOG.info("NitriteAdrStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
 
     @Override
     public List<NamespaceAdrSummary> getAdrsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving ADRs", namespace);
-            throw new NamespaceNotFoundException();
+        requireNamespace(namespace);
+
+        List<NamespaceAdrSummary> summaries = new ArrayList<>();
+        for (NamespaceResourceSummary header : documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED)) {
+            summaries.add(toAdrSummary(namespace, header.getId()));
         }
+        return summaries;
+    }
 
-        lock.readLock().lock();
-        try {
-            TypeSafeNitriteDocument<Document> namespaceDocument = new TypeSafeNitriteDocument<>(adrCollection.find(where(NAMESPACE_FIELD).eq(namespace)).firstOrNull(), Document.class);
-            List<Document> adrs = namespaceDocument.getList(ADRS_FIELD);
-            if (adrs == null || adrs.isEmpty()) {
-                return List.of();
-            }
+    /**
+     * Builds a summary from the latest revision's content, falling back to the same
+     * placeholders the old shape used when an ADR has no readable revision.
+     */
+    private NamespaceAdrSummary toAdrSummary(String namespace, Integer adrId) {
+        String title = "ADR " + adrId;
+        String status = "unknown";
 
-            List<NamespaceAdrSummary> summaries = new ArrayList<>();
-            for (Document adr : adrs) {
-                int adrId = adr.get(ADR_ID_FIELD, Integer.class);
-                String title = "ADR " + adrId;
-                String status = "unknown";
-
-                Document revisions = adr.get(REVISIONS_FIELD, Document.class);
-                if (revisions != null) {
-                    Set<String> fieldNames = revisions.getFields();
-                    if (!fieldNames.isEmpty()) {
-                        int latestRevision = fieldNames.stream()
-                                .map(Integer::parseInt)
-                                .mapToInt(i -> i)
-                                .max()
-                                .getAsInt();
-                        String adrStr = revisions.get(String.valueOf(latestRevision), String.class);
-                        if (adrStr != null) {
-                            try {
-                                Adr adrObj = objectMapper.readValue(adrStr, Adr.class);
-                                if (adrObj.getTitle() != null) title = adrObj.getTitle();
-                                if (adrObj.getStatus() != null) status = adrObj.getStatus().name();
-                            } catch (JsonProcessingException e) {
-                                LOG.warn("Could not parse ADR {} for summary, using fallback", adrId, e);
-                            }
-                        }
-                    }
+        String latest = documentStore.getLatestVersionContent(namespace, adrId);
+        if (latest != null) {
+            try {
+                Adr adr = objectMapper.readValue(latest, Adr.class);
+                if (adr.getTitle() != null) {
+                    title = adr.getTitle();
                 }
-
-                summaries.add(new NamespaceAdrSummary(title, status, adrId));
+                if (adr.getStatus() != null) {
+                    status = adr.getStatus().name();
+                }
+            } catch (JsonProcessingException e) {
+                // A summary listing must not fail because one ADR's stored content is
+                // unreadable — the placeholders above are exactly what the old shape showed.
+                LOG.warn("Could not parse the latest revision of ADR [{}] for its summary", adrId, e);
             }
-
-            LOG.debug("Retrieved {} ADRs for namespace '{}'", summaries.size(), namespace);
-            return summaries;
-        } finally {
-            lock.readLock().unlock();
         }
+        return new NamespaceAdrSummary(title, status, adrId);
     }
 
     @Override
     public AdrMeta createAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrParseException {
-        if (!namespaceStore.namespaceExists(adrMeta.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when creating ADR", adrMeta.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(adrMeta.getNamespace());
 
-        String adrStr;
-        try {
-            adrStr = objectMapper.writeValueAsString(adrMeta.getAdr());
-            // Validate JSON by attempting to parse it
-            org.bson.Document.parse(adrStr);
-        } catch (JsonProcessingException e) {
-            LOG.error("Could not write ADR Content to String", e);
-            throw new AdrParseException();
-        } catch (Exception e) {
-            LOG.error("Invalid JSON format for ADR: {}", e.getMessage());
-            throw new AdrParseException();
-        }
+        String content = toContent(adrMeta);
 
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextAdrSequenceValue();
-            Document adrDocument = Document.createDocument()
-                    .put(ADR_ID_FIELD, id)
-                    .put(REVISIONS_FIELD, Document.createDocument()
-                            .put(String.valueOf(adrMeta.getRevision()), adrStr));
+        int id = counterStore.getNextAdrSequenceValue();
+        // ADRs carry no name or description of their own — both live in the revision content.
+        documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
+        createFirstRevision(adrMeta, id, content);
 
-        Filter filter = where(NAMESPACE_FIELD).eq(adrMeta.getNamespace());
-        Document namespaceDoc = adrCollection.find(filter).firstOrNull();
-
-        if (namespaceDoc == null) {
-            // Create a new namespace document with the ADR
-            namespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, adrMeta.getNamespace())
-                    .put(ADRS_FIELD, List.of(adrDocument));
-            adrCollection.insert(namespaceDoc);
-        } else {
-            // Add the ADR to the existing namespace document
-            TypeSafeNitriteDocument<Document> tsNamespaceDoc = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class);
-            List<Document> adrs = tsNamespaceDoc.getList(ADRS_FIELD);
-            if (adrs == null) {
-                adrs = new ArrayList<>();
-            } else {
-                adrs = new ArrayList<>(adrs); // Make a mutable copy
-            }
-            adrs.add(adrDocument);
-            namespaceDoc.put(ADRS_FIELD, adrs);
-            adrCollection.update(filter, namespaceDoc);
-        }
-
-            LOG.info("Created ADR with ID {} for namespace '{}'", id, adrMeta.getNamespace());
-            return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        LOG.info("Created ADR with ID {} for namespace '{}'", id, adrMeta.getNamespace());
+        return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
     }
 
     @Override
     public AdrMeta getAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        lock.readLock().lock();
-        try {
-            Document adrDoc = retrieveAdrDoc(adrMeta);
-            return retrieveLatestRevision(adrMeta, adrDoc);
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireAdr(adrMeta);
+        return latestRevision(adrMeta);
     }
 
     @Override
     public List<Integer> getAdrRevisions(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document adrDoc = retrieveAdrDoc(adrMeta);
-            Document revisions = retrieveRevisionsDoc(adrDoc, adrMeta);
+        requireAdr(adrMeta);
 
-            List<Integer> revisionList = new ArrayList<>();
-            // In NitriteDB, we need to get the field names directly
-            Set<String> fieldNames = revisions.getFields();
-            for (String revision : fieldNames) {
-                revisionList.add(Integer.parseInt(revision));
-            }
-
-            LOG.debug("Retrieved {} revisions for ADR {} in namespace '{}'",
-                    revisionList.size(), adrMeta.getId(), adrMeta.getNamespace());
-            return revisionList;
-        } finally {
-            lock.readLock().unlock();
+        List<String> revisions = documentStore.listVersions(adrMeta.getNamespace(), adrMeta.getId());
+        if (revisions.isEmpty()) {
+            LOG.error("Could not find any revision of ADR [{}]", adrMeta.getId());
+            throw new AdrRevisionNotFoundException();
         }
+        return revisions.stream().map(Integer::parseInt).toList();
     }
 
     @Override
     public AdrMeta getAdrRevision(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException {
-        lock.readLock().lock();
-        try {
-            Document adrDoc = retrieveAdrDoc(adrMeta);
-            Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
+        requireAdr(adrMeta);
 
-            // Return the ADR JSON blob for the specified revision
-            String adrStr = revisionsDoc.get(String.valueOf(adrMeta.getRevision()), String.class);
-            LOG.info("Revision [{}] found: {}", adrMeta.getRevision(), adrStr != null);
-
-            if (adrStr == null) {
-                LOG.warn("Revision {} not found for ADR {} in namespace '{}'",
-                        adrMeta.getRevision(), adrMeta.getId(), adrMeta.getNamespace());
-                throw new AdrRevisionNotFoundException();
-            }
-
-            try {
-                return new AdrMeta.AdrMetaBuilder(adrMeta)
-                        .setAdr(objectMapper.readValue(adrStr, Adr.class))
-                        .build();
-            } catch (JsonProcessingException e) {
-                LOG.error("Could not parse stored ADR to ADR Content.", e);
-                throw new AdrParseException();
-            }
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    @Override
-    public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
-        lock.writeLock().lock();
-        try {
-            Document adrDoc = retrieveAdrDoc(adrMeta);
-            AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
-
-            int newRevision = latestRevision.getRevision() + 1;
-            AdrMeta newAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
-                    .setAdr(new Adr.AdrBuilder(adrMeta.getAdr())
-                            .setStatus(latestRevision.getAdr().getStatus())
-                            .setCreationDateTime(latestRevision.getAdr().getCreationDateTime())
-                            .build())
-                    .setRevision(newRevision)
-                    .build();
-
-            writeAdrToNitrite(newAdrMeta);
-            return newAdrMeta;
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    @Override
-    public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException {
-        lock.writeLock().lock();
-        try {
-            Document adrDoc = retrieveAdrDoc(adrMeta);
-            AdrMeta latestRevision = retrieveLatestRevision(adrMeta, adrDoc);
-
-            int newRevisionNum = latestRevision.getRevision() + 1;
-            AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latestRevision)
-                    .setRevision(newRevisionNum)
-                    .setAdr(new Adr.AdrBuilder(latestRevision.getAdr())
-                            .setStatus(status)
-                            .build())
-                    .build();
-
-            writeAdrToNitrite(newRevision);
-            return newRevision;
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    private List<Document> retrieveAdrsDocs(String namespace) throws NamespaceNotFoundException, AdrNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving ADR documents", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        TypeSafeNitriteDocument<Document> result = new TypeSafeNitriteDocument<>(adrCollection.find(filter).firstOrNull(), Document.class);
-
-        List<Document> adrs = result.getList(ADRS_FIELD);
-        if (adrs == null || adrs.isEmpty()) {
-            LOG.warn("Empty ADRs list for namespace '{}'", namespace);
-            throw new AdrNotFoundException();
-        }
-
-        return adrs;
-    }
-
-    private Document retrieveAdrDoc(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException {
-        List<Document> adrsDoc = retrieveAdrsDocs(adrMeta.getNamespace());
-
-        for (Document adrDoc : adrsDoc) {
-            Integer id = adrDoc.get(ADR_ID_FIELD, Integer.class);
-            if (id != null && id == adrMeta.getId()) {
-                return adrDoc;
-            }
-        }
-
-        LOG.warn("ADR with ID {} not found in namespace '{}'", adrMeta.getId(), adrMeta.getNamespace());
-        throw new AdrNotFoundException();
-    }
-
-    private Document retrieveRevisionsDoc(Document adrDoc, AdrMeta adrMeta) throws AdrRevisionNotFoundException {
-        Document revisionsDoc = adrDoc.get(REVISIONS_FIELD, Document.class);
-
-        if (revisionsDoc == null) {
-            LOG.error("Could not find revisions for ADR [{}]", adrMeta.getId());
+        String revision = documentStore.getVersion(
+                adrMeta.getNamespace(), adrMeta.getId(), String.valueOf(adrMeta.getRevision()));
+        if (revision == null) {
+            LOG.warn("Revision '{}' not found for ADR {} in namespace '{}'",
+                    adrMeta.getRevision(), adrMeta.getId(), adrMeta.getNamespace());
             throw new AdrRevisionNotFoundException();
         }
-
-        return revisionsDoc;
+        return new AdrMeta.AdrMetaBuilder(adrMeta).setAdr(toAdr(revision)).build();
     }
 
-    private AdrMeta retrieveLatestRevision(AdrMeta adrMeta, Document adrDoc) throws AdrRevisionNotFoundException, AdrParseException {
-        Document revisionsDoc = retrieveRevisionsDoc(adrDoc, adrMeta);
+    @Override
+    public AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
+        requireAdr(adrMeta);
+        AdrMeta latest = latestRevision(adrMeta);
 
-        Set<String> fieldNames = revisionsDoc.getFields();
-        int latestRevision = fieldNames.stream()
-                .map(Integer::parseInt)
-                .mapToInt(i -> i)
-                .max()
-                .orElseThrow(() -> {
-                    LOG.error("No revisions found for ADR [{}]", adrMeta.getId());
-                    return new AdrRevisionNotFoundException();
-                });
+        AdrMeta newAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
+                .setAdr(new Adr.AdrBuilder(adrMeta.getAdr())
+                        .setStatus(latest.getAdr().getStatus())
+                        .setCreationDateTime(latest.getAdr().getCreationDateTime())
+                        .build())
+                .setRevision(latest.getRevision() + 1)
+                .build();
 
-        // Return the ADR JSON blob for the specified revision
-        String adrStr = revisionsDoc.get(String.valueOf(latestRevision), String.class);
-        LOG.info("Resolved latest revision: [{}]", latestRevision);
+        writeRevision(newAdrMeta);
+        return newAdrMeta;
+    }
 
+    @Override
+    public AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
+        requireAdr(adrMeta);
+        AdrMeta latest = latestRevision(adrMeta);
+
+        AdrMeta newRevision = new AdrMeta.AdrMetaBuilder(latest)
+                .setRevision(latest.getRevision() + 1)
+                .setAdr(new Adr.AdrBuilder(latest.getAdr()).setStatus(status).build())
+                .build();
+
+        writeRevision(newRevision);
+        return newRevision;
+    }
+
+    private AdrMeta latestRevision(AdrMeta adrMeta) throws AdrRevisionNotFoundException, AdrParseException {
+        String latest = documentStore.getLatestVersion(adrMeta.getNamespace(), adrMeta.getId());
+        if (latest == null) {
+            LOG.error("Could not find the latest revision of ADR [{}]", adrMeta.getId());
+            throw new AdrRevisionNotFoundException();
+        }
+        String content = documentStore.getVersion(adrMeta.getNamespace(), adrMeta.getId(), latest);
+        if (content == null) {
+            LOG.error("Latest revision [{}] of ADR [{}] disappeared between resolving and reading it",
+                    latest, adrMeta.getId());
+            throw new AdrRevisionNotFoundException();
+        }
+        return new AdrMeta.AdrMetaBuilder()
+                .setNamespace(adrMeta.getNamespace())
+                .setId(adrMeta.getId())
+                .setRevision(Integer.parseInt(latest))
+                .setAdr(toAdr(content))
+                .build();
+    }
+
+    /**
+     * Writes the first revision of a newly created ADR, removing the header again if that
+     * fails — a header with no revisions cannot be removed through the API.
+     */
+    private void createFirstRevision(AdrMeta adrMeta, int id, String content) {
+        boolean created;
         try {
-            return new AdrMeta.AdrMetaBuilder()
-                    .setNamespace(adrMeta.getNamespace())
-                    .setId(adrMeta.getId())
-                    .setRevision(latestRevision)
-                    .setAdr(objectMapper.readValue(adrStr, Adr.class))
-                    .build();
+            created = documentStore.createVersion(
+                    adrMeta.getNamespace(), id, String.valueOf(adrMeta.getRevision()), content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(adrMeta.getNamespace(), id);
+            throw e;
+        }
+        if (!created) {
+            documentStore.deleteHeader(adrMeta.getNamespace(), id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Revision " + adrMeta.getRevision() + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + adrMeta.getNamespace()));
+        }
+    }
+
+    /**
+     * Writes a new revision, rejecting one that already exists — both callers compute
+     * {@code latest + 1}, so two concurrent writers can arrive at the same number.
+     */
+    private void writeRevision(AdrMeta adrMeta) throws AdrParseException, AdrRevisionExistsException {
+        String content = toContent(adrMeta);
+        if (!documentStore.createVersion(adrMeta.getNamespace(), adrMeta.getId(),
+                String.valueOf(adrMeta.getRevision()), content)) {
+            throw new AdrRevisionExistsException();
+        }
+    }
+
+    private String toContent(AdrMeta adrMeta) throws AdrParseException {
+        try {
+            return objectMapper.writeValueAsString(adrMeta.getAdr());
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not write ADR Content to String", e);
+            throw new AdrParseException();
+        }
+    }
+
+    private Adr toAdr(String content) throws AdrParseException {
+        try {
+            return objectMapper.readValue(content, Adr.class);
         } catch (JsonProcessingException e) {
             LOG.error("Could not parse stored ADR to ADR Content.", e);
             throw new AdrParseException();
         }
     }
 
-    private void writeAdrToNitrite(AdrMeta adrMeta) throws AdrPersistenceException, AdrParseException {
-        try {
-            String adrStr = objectMapper.writeValueAsString(adrMeta.getAdr());
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
 
-            Filter filter = where(NAMESPACE_FIELD).eq(adrMeta.getNamespace());
-            Document namespaceDoc = adrCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc != null) {
-                List<Document> adrs = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(ADRS_FIELD);
-                if (adrs != null) {
-                    // Create a mutable copy of the list
-                    adrs = new ArrayList<>(adrs);
-                    for (int i = 0; i < adrs.size(); i++) {
-                        Document adrDoc = adrs.get(i);
-                        if (adrDoc.get(ADR_ID_FIELD, Integer.class) == adrMeta.getId()) {
-                            Document revisionsDoc = adrDoc.get(REVISIONS_FIELD, Document.class);
-                            revisionsDoc.put(String.valueOf(adrMeta.getRevision()), adrStr);
-                            adrDoc.put(REVISIONS_FIELD, revisionsDoc);
-                            adrs.set(i, adrDoc);
-                            namespaceDoc.put(ADRS_FIELD, adrs);
-                            adrCollection.update(filter, namespaceDoc);
-                            LOG.info("Updated revision {} for ADR {} in namespace '{}'", 
-                                    adrMeta.getRevision(), adrMeta.getId(), adrMeta.getNamespace());
-                            return;
-                        }
-                    }
-                }
-            }
-
-            LOG.error("Failed to update ADR [{}] - namespace or ADR not found", adrMeta);
-            throw new AdrPersistenceException();
-        } catch (JsonProcessingException e) {
-            LOG.error("Could not write ADR Content to String", e);
-            throw new AdrParseException();
+    private void requireAdr(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException {
+        requireNamespace(adrMeta.getNamespace());
+        if (!documentStore.headerExists(adrMeta.getNamespace(), adrMeta.getId())) {
+            LOG.warn("ADR with ID {} not found in namespace '{}'", adrMeta.getId(), adrMeta.getNamespace());
+            throw new AdrNotFoundException();
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -80,6 +80,12 @@ public class NitriteAdrStore implements AdrStore {
         return summaries;
     }
 
+    @Override
+    public int countAdrsForNamespace(String namespace) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+        return documentStore.countHeaders(namespace);
+    }
+
     /**
      * Builds a summary from the latest revision's content, falling back to the same
      * placeholders the old shape used when an ADR has no readable revision.

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -96,7 +96,7 @@ public class NitriteAdrStore implements AdrStore {
 
         // A header carrying no adrId is malformed rather than missing, and
         // listSummariesPaged deliberately renders it instead of failing — it sorts null ids
-        // last for exactly that reason. Resolving its latest revision would unbox this null
+        // first for exactly that reason. Resolving its latest revision would unbox this null
         // and undo that tolerance, turning one bad document into a 500 for every ADR in the
         // namespace. Render the placeholder and move on, which is what the row is worth.
         if (adrId == null) {
@@ -131,7 +131,8 @@ public class NitriteAdrStore implements AdrStore {
         int id = counterStore.getNextAdrSequenceValue();
         // ADRs carry no name or description of their own — both live in the revision content.
         documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
-        createFirstRevision(adrMeta, id, content);
+        documentStore.createFirstVersion(adrMeta.getNamespace(), id,
+                String.valueOf(adrMeta.getRevision()), content);
 
         LOG.info("Created ADR with ID {} for namespace '{}'", id, adrMeta.getNamespace());
         return new AdrMeta.AdrMetaBuilder(adrMeta).setId(id).build();
@@ -220,26 +221,6 @@ public class NitriteAdrStore implements AdrStore {
                 .build();
     }
 
-    /**
-     * Writes the first revision of a newly created ADR, removing the header again if that
-     * fails — a header with no revisions cannot be removed through the API.
-     */
-    private void createFirstRevision(AdrMeta adrMeta, int id, String content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(
-                    adrMeta.getNamespace(), id, String.valueOf(adrMeta.getRevision()), content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(adrMeta.getNamespace(), id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(adrMeta.getNamespace(), id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Revision " + adrMeta.getRevision() + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + adrMeta.getNamespace()));
-        }
-    }
 
     /**
      * Writes a new revision, rejecting one that already exists — both callers compute
@@ -253,6 +234,13 @@ public class NitriteAdrStore implements AdrStore {
         }
     }
 
+    /**
+     * ADR has no {@code validate<Type>Json} guard like its siblings, and does not need one:
+     * they validate a user-supplied JSON <em>string</em>, whereas an ADR arrives as a typed
+     * {@code Adr} that Jackson serialises here. The old store parsed the serialiser's own
+     * output with {@code org.bson.Document.parse} as a second check; that could only fail
+     * for output Jackson itself produced, so it is not carried across.
+     */
     private String toContent(AdrMeta adrMeta) throws AdrParseException {
         try {
             return objectMapper.writeValueAsString(adrMeta.getAdr());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -5,35 +5,36 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.json.JsonParseException;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.Flow;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.FlowStore;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
-import org.finos.calm.store.util.VersionKeySelector;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the FlowStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link FlowStore}, used in standalone mode.
+ *
+ * <h2>Document model</h2>
+ * One <em>header</em> document per flow in {@code flows}, and one <em>version</em> document
+ * per version in {@code flowVersions}, mirroring {@link org.finos.calm.store.mongo.MongoFlowStore}.
+ * All document handling and locking live in {@link NitriteVersionDocumentStore}.
+ *
+ * <p>As with the other Nitrite stores, content is held as a JSON string rather than a parsed
+ * document, and JSON is validated up front — before the flow's existence is checked, where
+ * Mongo reports the missing flow first.</p>
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -41,317 +42,157 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 public class NitriteFlowStore implements FlowStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteFlowStore.class);
-    private static final String COLLECTION_NAME = "flows";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String FLOWS_FIELD = "flows";
-    private static final String FLOW_ID_FIELD = "flowId";
-    private static final String VERSIONS_FIELD = "versions";
-    private static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    private static final String HEADER_COLLECTION = "flows";
+    private static final String VERSION_COLLECTION = "flowVersions";
+    private static final String ID_FIELD = "flowId";
+    private static final String RESOURCE_LABEL = "Flow";
+    private static final String INITIAL_VERSION = "1.0.0";
 
-    private final NitriteCollection flowCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final NitriteVersionDocumentStore documentStore;
 
     @Inject
     public NitriteFlowStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.flowCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
-        LOG.info("NitriteFlowStore initialized with collection: {}", COLLECTION_NAME);
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
+        LOG.info("NitriteFlowStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
 
     @Override
     public List<NamespaceResourceSummary> getFlowsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving flows", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        lock.readLock().lock();
-        try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDoc = flowCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc == null) {
-                LOG.warn("No flows found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<Document> flows = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(FLOWS_FIELD);
-            if (flows == null || flows.isEmpty()) {
-                return List.of();
-            }
-
-            List<NamespaceResourceSummary> flowSummaries = new ArrayList<>();
-            for (Document flow : flows) {
-                Integer flowId = flow.get(FLOW_ID_FIELD, Integer.class);
-                String name = flow.get(NAME_FIELD, String.class);
-                String description = flow.get(DESCRIPTION_FIELD, String.class);
-                if (name == null) name = "Flow " + flowId;
-                if (description == null) description = "";
-                // Count versions from the already-in-memory sub-document (O(1), no extra query).
-                Object rawVersions = flow.get(VERSIONS_FIELD);
-                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-                flowSummaries.add(new NamespaceResourceSummary(name, description, flowId, versionCount));
-            }
-
-            return flowSummaries;
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED);
     }
 
     @Override
     public Flow createFlowForNamespace(CreateFlowRequest flowRequest, String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when creating flow", namespace);
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        validateFlowJson(flowRequest.getFlowJson());
 
-        // Validate JSON
-        try {
-            // Use org.bson.Document to validate JSON
-            org.bson.Document.parse(flowRequest.getFlowJson());
-        } catch (Exception e) {
-            LOG.error("Invalid JSON format for flow: {}", e.getMessage());
-            throw new JsonParseException(e.getMessage());
-        }
-
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextFlowSequenceValue();
-            Document flowDocument = Document.createDocument()
-                .put(FLOW_ID_FIELD, id)
-                .put(NAME_FIELD, flowRequest.getName())
-                .put(DESCRIPTION_FIELD, flowRequest.getDescription())
-                .put(VERSIONS_FIELD, Document.createDocument()
-                        .put("1-0-0", flowRequest.getFlowJson()));
-
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDoc = flowCollection.find(filter).firstOrNull();
-
-        if (namespaceDoc == null) {
-            // Create a new namespace document with the flow
-            namespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, namespace)
-                    .put(FLOWS_FIELD, List.of(flowDocument));
-            flowCollection.insert(namespaceDoc);
-        } else {
-            // Add the flow to the existing namespace document
-            List<Document> flows = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(FLOWS_FIELD);
-            if (flows == null) {
-                flows = new ArrayList<>();
-            } else {
-                flows = new ArrayList<>(flows); // Make a mutable copy
-            }
-            flows.add(flowDocument);
-            namespaceDoc.put(FLOWS_FIELD, flows);
-            flowCollection.update(filter, namespaceDoc);
-        }
+        int id = counterStore.getNextFlowSequenceValue();
+        documentStore.createHeader(namespace, id, flowRequest.getName(), flowRequest.getDescription());
+        createInitialVersion(namespace, id, flowRequest.getFlowJson());
 
         LOG.info("Created flow with ID {} for namespace '{}'", id, namespace);
-
-            return new Flow.FlowBuilder()
-                    .setId(id)
-                    .setVersion("1.0.0")
-                    .setNamespace(namespace)
-                    .setFlow(flowRequest.getFlowJson())
-                    .build();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        return new Flow.FlowBuilder()
+                .setId(id)
+                .setVersion(INITIAL_VERSION)
+                .setNamespace(namespace)
+                .setFlow(flowRequest.getFlowJson())
+                .build();
     }
 
     @Override
     public List<String> getFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveFlowVersions(flow);
-
-            List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
-            for (Document flowDoc : flows) {
-                if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
-                    // Extract the versions map from the matching flow
-                    Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
-
-                    // Convert from Nitrite representation
-                    List<String> resourceVersions = new ArrayList<>();
-                    if (versions != null) {
-                        Set<String> versionKeys = versions.getFields();
-                        for (String versionKey : versionKeys) {
-                            resourceVersions.add(versionKey.replace('-', '.'));
-                        }
-                    }
-                    return resourceVersions;  // Return the list of version keys
-                }
-            }
-
-            throw new FlowNotFoundException();
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    private Document retrieveFlowVersions(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        if (!namespaceStore.namespaceExists(flow.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when retrieving flow versions", flow.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
-        Filter filter = where(NAMESPACE_FIELD).eq(flow.getNamespace());
-        Document result = flowCollection.find(filter).firstOrNull();
-
-        if (result == null) {
-            LOG.warn("No flows found for namespace '{}'", flow.getNamespace());
-            throw new FlowNotFoundException();
-        }
-
-        return result;
+        requireFlow(flow);
+        return documentStore.listVersions(flow.getNamespace(), flow.getId());
     }
 
     @Override
     public String getFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveFlowVersions(flow);
+        requireFlow(flow);
 
-            List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
-            for (Document flowDoc : flows) {
-                if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
-                    // Retrieve the versions map from the matching flow
-                    Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
-
-                    // Return the flow JSON blob for the specified version
-                    String mongoVersion = flow.getMongoVersion();
-                    Object versionObj = versions.get(mongoVersion);
-                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj != null);
-
-                    if (versionObj == null) {
-                        LOG.warn("Version '{}' not found for flow {} in namespace '{}'",
-                                flow.getDotVersion(), flow.getId(), flow.getNamespace());
-                        throw new FlowVersionNotFoundException();
-                    }
-
-                    // In NitriteDB, we're storing the JSON as a string directly
-                    // No need to convert to JSON string
-                    return (String) versionObj;
-                }
-            }
-
-            // Flows is empty, no version to find
-            LOG.warn("Flow with ID {} not found in namespace '{}'", flow.getId(), flow.getNamespace());
+        String content = documentStore.getVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion());
+        if (content == null) {
+            LOG.warn("Version '{}' not found for flow {} in namespace '{}'",
+                    flow.getDotVersion(), flow.getId(), flow.getNamespace());
             throw new FlowVersionNotFoundException();
-        } finally {
-            lock.readLock().unlock();
         }
+        return content;
     }
 
     @Override
     public Flow createFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionExistsException {
-        if (!namespaceStore.namespaceExists(flow.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when creating flow version", flow.getNamespace());
-            throw new NamespaceNotFoundException();
+        requireNamespace(flow.getNamespace());
+        validateFlowJson(flow.getFlowJson());
+        requireFlowExists(flow);
+
+        if (!documentStore.createVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion(), flow.getFlowJson())) {
+            LOG.warn("Version '{}' already exists for flow {} in namespace '{}'",
+                    flow.getDotVersion(), flow.getId(), flow.getNamespace());
+            throw new FlowVersionExistsException();
         }
 
-        lock.writeLock().lock();
-        try {
-            if (versionExists(flow)) {
-                LOG.warn("Version '{}' already exists for flow {} in namespace '{}'",
-                        flow.getDotVersion(), flow.getId(), flow.getNamespace());
-                throw new FlowVersionExistsException();
-            }
-
-            writeFlowToNitrite(flow);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        updateHeaderDetails(flow);
         return flow;
     }
 
     @Override
     public Flow updateFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
-        if (!namespaceStore.namespaceExists(flow.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when updating flow version", flow.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(flow.getNamespace());
+        validateFlowJson(flow.getFlowJson());
+        requireFlowExists(flow);
 
-        lock.writeLock().lock();
-        try {
-            writeFlowToNitrite(flow);
-        } finally {
-            lock.writeLock().unlock();
-        }
-        LOG.info("Updated version '{}' for flow {} in namespace '{}'",
-                flow.getDotVersion(), flow.getId(), flow.getNamespace());
+        documentStore.upsertVersion(flow.getNamespace(), flow.getId(), flow.getDotVersion(), flow.getFlowJson());
+
+        updateHeaderDetails(flow);
         return flow;
     }
 
-    private void writeFlowToNitrite(Flow flow) throws FlowNotFoundException, NamespaceNotFoundException {
-        // First verify the flow exists
-        retrieveFlowVersions(flow);
-
-        // Find the namespace document
-        Filter filter = where(NAMESPACE_FIELD).eq(flow.getNamespace());
-        Document namespaceDoc = flowCollection.find(filter).firstOrNull();
-
-        if (namespaceDoc != null) {
-            List<Document> flows = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(FLOWS_FIELD);
-            if (flows != null) {
-                // Create a mutable copy of the list
-                flows = new ArrayList<>(flows);
-                boolean found = false;
-                for (int i = 0; i < flows.size(); i++) {
-                    Document flowDoc = flows.get(i);
-                    if (flowDoc.get(FLOW_ID_FIELD, Integer.class) == flow.getId()) {
-                        // Found the flow, update its version
-                        Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
-                        versions.put(flow.getMongoVersion(), flow.getFlowJson());
-                        flowDoc.put(VERSIONS_FIELD, versions);
-                        // Defensive: the REST layer enforces @NotBlank on name/description via CreateFlowRequest,
-                        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-                        if (flow.getName() != null && !flow.getName().isBlank()) {
-                            flowDoc.put(NAME_FIELD, flow.getName());
-                        }
-                        if (flow.getDescription() != null && !flow.getDescription().isBlank()) {
-                            flowDoc.put(DESCRIPTION_FIELD, flow.getDescription());
-                        }
-                        flows.set(i, flowDoc);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (found) {
-                    namespaceDoc.put(FLOWS_FIELD, flows);
-                    flowCollection.update(filter, namespaceDoc);
-                    return;
-                }
-            }
+    /**
+     * Validates that the supplied flow JSON is parseable, throwing {@link JsonParseException}
+     * if not so the REST layer can surface a 400.
+     */
+    private void validateFlowJson(String flowJson) {
+        if (flowJson == null) {
+            LOG.error("Flow JSON must not be null");
+            throw new JsonParseException("Flow JSON must not be null");
         }
-
-        LOG.warn("Flow with ID {} not found in namespace '{}'", flow.getId(), flow.getNamespace());
-        throw new FlowNotFoundException();
+        try {
+            org.bson.Document.parse(flowJson);
+        } catch (Exception e) {
+            LOG.error("Invalid JSON format for flow: {}", e.getMessage());
+            throw new JsonParseException(e.getMessage());
+        }
     }
 
-    private boolean versionExists(Flow flow) {
+    /**
+     * Writes the first version of a newly created flow, removing the header again if that
+     * fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, String content) {
+        boolean created;
         try {
-            Document result = retrieveFlowVersions(flow);
-
-            List<Document> flows = new TypeSafeNitriteDocument<>(result, Document.class).getList(FLOWS_FIELD);
-            for (Document flowDoc : flows) {
-                if (flow.getId() == flowDoc.get(FLOW_ID_FIELD, Integer.class)) {
-                    Document versions = flowDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions != null && versions.containsKey(flow.getMongoVersion())) {
-                        return true;  // The version already exists
-                    }
-                }
-            }
-        } catch (NamespaceNotFoundException | FlowNotFoundException e) {
-            return false;
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
         }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
+    }
 
-        return false;
+    private void updateHeaderDetails(Flow flow) {
+        documentStore.updatePresentHeaderDetails(flow.getNamespace(), flow.getId(),
+                flow.getName(), flow.getDescription());
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireFlowExists(Flow flow) throws FlowNotFoundException {
+        if (!documentStore.headerExists(flow.getNamespace(), flow.getId())) {
+            LOG.warn("Flow with ID {} not found in namespace '{}'", flow.getId(), flow.getNamespace());
+            throw new FlowNotFoundException();
+        }
+    }
+
+    private void requireFlow(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException {
+        requireNamespace(flow.getNamespace());
+        requireFlowExists(flow);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -11,7 +11,6 @@ import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.FlowStore;
@@ -23,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.NitriteVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * NitriteDB-backed implementation of {@link FlowStore}, used in standalone mode.
@@ -46,7 +47,6 @@ public class NitriteFlowStore implements FlowStore {
     private static final String VERSION_COLLECTION = "flowVersions";
     private static final String ID_FIELD = "flowId";
     private static final String RESOURCE_LABEL = "Flow";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
@@ -77,7 +77,7 @@ public class NitriteFlowStore implements FlowStore {
 
         int id = counterStore.getNextFlowSequenceValue();
         documentStore.createHeader(namespace, id, flowRequest.getName(), flowRequest.getDescription());
-        createInitialVersion(namespace, id, flowRequest.getFlowJson());
+        documentStore.createFirstVersion(namespace, id, flowRequest.getFlowJson());
 
         LOG.info("Created flow with ID {} for namespace '{}'", id, namespace);
         return new Flow.FlowBuilder()
@@ -152,25 +152,6 @@ public class NitriteFlowStore implements FlowStore {
         }
     }
 
-    /**
-     * Writes the first version of a newly created flow, removing the header again if that
-     * fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, String content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void updateHeaderDetails(Flow flow) {
         documentStore.updatePresentHeaderDetails(flow.getNamespace(), flow.getId(),

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
@@ -5,34 +5,32 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.json.JsonParseException;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.CalmInterface;
 import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.InterfaceStore;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the InterfaceStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link InterfaceStore}, used in standalone mode.
+ * Mirrors {@link org.finos.calm.store.mongo.MongoInterfaceStore}: content held as a JSON
+ * string, name and description set unconditionally on a version write, no update path, and
+ * the helper's summary mapped down to {@link NamespaceInterfaceSummary}, which carries no
+ * version count.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -40,284 +38,150 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 public class NitriteInterfaceStore implements InterfaceStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteInterfaceStore.class);
-    private static final String COLLECTION_NAME = "interfaces";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String INTERFACE_ID_FIELD = "interfaceId";
-    private static final String INTERFACES_FIELD = "interfaces";
-    private static final String VERSIONS_FIELD = "versions";
-    private static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    private static final String HEADER_COLLECTION = "interfaces";
+    private static final String VERSION_COLLECTION = "interfaceVersions";
+    private static final String ID_FIELD = "interfaceId";
+    private static final String RESOURCE_LABEL = "Interface";
+    private static final String INITIAL_VERSION = "1.0.0";
 
-    private final NitriteCollection interfaceCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final NitriteVersionDocumentStore documentStore;
 
     @Inject
     public NitriteInterfaceStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.interfaceCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
-        LOG.info("NitriteInterfaceStore initialized with collection: {}", COLLECTION_NAME);
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
+        LOG.info("NitriteInterfaceStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
 
     @Override
     public List<NamespaceInterfaceSummary> getInterfacesForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving interfaces", namespace);
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED).stream()
+                .map(NitriteInterfaceStore::toInterfaceSummary)
+                .toList();
+    }
 
-        lock.readLock().lock();
-        try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDocument = interfaceCollection.find(filter).firstOrNull();
-
-            if (namespaceDocument == null) {
-                LOG.debug("No interfaces found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
-            if (interfaces == null || interfaces.isEmpty()) {
-                LOG.debug("No interfaces found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<NamespaceInterfaceSummary> namespaceInterfaceSummary = new ArrayList<>();
-
-            for (Document interfaceDoc : interfaces) {
-                NamespaceInterfaceSummary summary = new NamespaceInterfaceSummary(
-                        interfaceDoc.get(NAME_FIELD, String.class),
-                        interfaceDoc.get(DESCRIPTION_FIELD, String.class),
-                        interfaceDoc.get(INTERFACE_ID_FIELD, Integer.class)
-                );
-                namespaceInterfaceSummary.add(summary);
-            }
-
-            LOG.debug("Retrieved {} interfaces for namespace '{}'", namespaceInterfaceSummary.size(), namespace);
-            return namespaceInterfaceSummary;
-        } finally {
-            lock.readLock().unlock();
-        }
+    /** Drops the version count, which {@link NamespaceInterfaceSummary} does not carry. */
+    private static NamespaceInterfaceSummary toInterfaceSummary(NamespaceResourceSummary summary) {
+        return new NamespaceInterfaceSummary(summary.getName(), summary.getDescription(), summary.getId());
     }
 
     @Override
     public CalmInterface createInterfaceForNamespace(CreateInterfaceRequest createInterfaceRequest, String namespace) throws NamespaceNotFoundException {
         CalmInterface createdInterface = new CalmInterface(createInterfaceRequest);
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when creating interface", namespace);
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        validateInterfaceJson(createInterfaceRequest.getInterfaceJson());
 
-        try {
-            org.bson.Document.parse(createInterfaceRequest.getInterfaceJson());
-        } catch (Exception e) {
-            LOG.error("Invalid JSON format for interface: {}", e.getMessage());
-            throw new JsonParseException(e.getMessage());
-        }
+        int id = counterStore.getNextInterfaceSequenceValue();
+        documentStore.createHeader(namespace, id, createInterfaceRequest.getName(), createInterfaceRequest.getDescription());
+        createInitialVersion(namespace, id, createInterfaceRequest.getInterfaceJson());
 
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextInterfaceSequenceValue();
-
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = interfaceCollection.find(filter).firstOrNull();
-
-        Document interfaceDocument = Document.createDocument()
-                .put(INTERFACE_ID_FIELD, id)
-                .put(NAME_FIELD, createInterfaceRequest.getName())
-                .put(DESCRIPTION_FIELD, createInterfaceRequest.getDescription())
-                .put(VERSIONS_FIELD, Document.createDocument().put("1-0-0", createInterfaceRequest.getInterfaceJson()));
-
-        if (namespaceDocument == null) {
-            // Create new namespace document with interface
-            Document newNamespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, namespace)
-                    .put(INTERFACES_FIELD, List.of(interfaceDocument));
-
-            interfaceCollection.insert(newNamespaceDoc);
-        } else {
-            // Update existing namespace document
-            List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
-            if (interfaces == null) {
-                interfaces = new ArrayList<>();
-            } else {
-                interfaces = new ArrayList<>(interfaces); // Create a mutable copy
-            }
-            interfaces.add(interfaceDocument);
-
-            namespaceDocument.put(INTERFACES_FIELD, interfaces);
-            interfaceCollection.update(filter, namespaceDocument);
-        }
-
-            createdInterface.setId(id);
-            createdInterface.setVersion("1.0.0");
-            createdInterface.setNamespace(namespace);
-            return createdInterface;
-        } finally {
-            lock.writeLock().unlock();
-        }
+        LOG.info("Created interface with ID {} for namespace '{}'", id, namespace);
+        createdInterface.setId(id);
+        createdInterface.setVersion(INITIAL_VERSION);
+        return createdInterface;
     }
 
     @Override
     public List<String> getInterfaceVersions(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving interface versions", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        lock.readLock().lock();
-        try {
-            Document interfaceDoc = findInterfaceDocument(namespace, interfaceId);
-            if (interfaceDoc == null) {
-                LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
-                throw new InterfaceNotFoundException();
-            }
-
-            Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new InterfaceNotFoundException();
-            }
-            Set<String> fieldNames = versions.getFields();
-            List<String> versionList = new ArrayList<>();
-            for (String fieldName : fieldNames) {
-                versionList.add(fieldName.replace('-', '.'));
-            }
-
-            LOG.debug("Retrieved {} versions for interface {} in namespace '{}'",
-                    versionList.size(), interfaceId, namespace);
-            return versionList;
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireInterface(namespace, interfaceId);
+        return documentStore.listVersions(namespace, interfaceId);
     }
 
     @Override
     public String getInterfaceForVersion(String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        requireInterface(namespace, interfaceId);
+
+        String content = documentStore.getVersion(namespace, interfaceId, version);
+        if (content == null) {
+            LOG.warn("Version '{}' not found for interface {} in namespace '{}'", version, interfaceId, namespace);
+            throw new InterfaceVersionNotFoundException();
         }
-
-        lock.readLock().lock();
-        try {
-            Document interfaceDocument = findInterfaceDocument(namespace, interfaceId);
-            if (interfaceDocument == null) {
-                LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
-                throw new InterfaceNotFoundException();
-            }
-
-            Document versions = interfaceDocument.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new InterfaceVersionNotFoundException();
-            }
-
-            String storedVersion = version.replace('.', '-');
-            Object versionObj = versions.get(storedVersion);
-
-            if (!(versionObj instanceof String)) {
-                LOG.warn("Version '{}' not found for interface {} in namespace '{}'",
-                        storedVersion, interfaceId, namespace);
-                throw new InterfaceVersionNotFoundException();
-            }
-
-            LOG.debug("Retrieved version '{}' for interface {} in namespace '{}'",
-                    storedVersion, interfaceId, namespace);
-
-            return (String) versionObj;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return content;
     }
 
     @Override
     public CalmInterface createInterfaceForVersion(CreateInterfaceRequest interfaceRequest, String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionExistsException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        requireNamespace(namespace);
+        validateInterfaceJson(interfaceRequest.getInterfaceJson());
+        requireInterfaceExists(namespace, interfaceId);
+
+        if (!documentStore.createVersion(namespace, interfaceId, version, interfaceRequest.getInterfaceJson())) {
+            LOG.warn("Version '{}' already exists for interface {} in namespace '{}'", version, interfaceId, namespace);
+            throw new InterfaceVersionExistsException();
         }
 
-        lock.writeLock().lock();
-        try {
-            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDocument = interfaceCollection.find(namespaceFilter).firstOrNull();
+        // Unconditional, matching the old shape.
+        documentStore.updateHeaderDetails(namespace, interfaceId,
+                interfaceRequest.getName(), interfaceRequest.getDescription());
 
-            if (namespaceDocument == null) {
-                LOG.warn("Namespace document for '{}' not found when creating interface version", namespace);
-                throw new InterfaceNotFoundException();
-            }
-
-            Document interfaceDoc = findInterfaceDocument(namespace, interfaceId);
-            if (interfaceDoc == null) {
-                LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
-                throw new InterfaceNotFoundException();
-            }
-
-            String mongoVersion = version.replace('.', '-');
-
-            Document versions = interfaceDoc.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new InterfaceNotFoundException();
-            }
-            if (versions.containsKey(mongoVersion)) {
-                LOG.warn("Version '{}' already exists for interface {} in namespace '{}'",
-                        mongoVersion, interfaceId, namespace);
-                throw new InterfaceVersionExistsException();
-            }
-
-            // Add the new version
-            versions.put(mongoVersion, interfaceRequest.getInterfaceJson());
-            interfaceDoc.put(VERSIONS_FIELD, versions);
-            interfaceDoc.put(NAME_FIELD, interfaceRequest.getName());
-            interfaceDoc.put(DESCRIPTION_FIELD, interfaceRequest.getDescription());
-
-            // Update the interface in the namespace document
-            List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
-            interfaces = new ArrayList<>(interfaces); // Create a mutable copy
-            for (int i = 0; i < interfaces.size(); i++) {
-                Document doc = interfaces.get(i);
-                if (doc.get(INTERFACE_ID_FIELD, Integer.class).equals(interfaceId)) {
-                    interfaces.set(i, interfaceDoc);
-                    break;
-                }
-            }
-
-            namespaceDocument.put(INTERFACES_FIELD, interfaces);
-            interfaceCollection.update(namespaceFilter, namespaceDocument);
-        } finally {
-            lock.writeLock().unlock();
-        }
-
-        LOG.info("Created version '{}' for interface {} in namespace '{}'",
-                version.replace('.', '-'), interfaceId, namespace);
-
+        LOG.info("Created version '{}' for interface {} in namespace '{}'", version, interfaceId, namespace);
         CalmInterface calmInterface = new CalmInterface(interfaceRequest);
-        calmInterface.setVersion(version);
         calmInterface.setId(interfaceId);
-        calmInterface.setNamespace(namespace);
+        calmInterface.setVersion(version);
         return calmInterface;
     }
 
-    private Document findInterfaceDocument(String namespace, Integer interfaceId) {
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = interfaceCollection.find(filter).firstOrNull();
-
-        if (namespaceDocument == null) {
-            return null;
+    /**
+     * Validates that the supplied interface JSON is parseable, throwing
+     * {@link JsonParseException} if not so the REST layer can surface a 400.
+     */
+    private void validateInterfaceJson(String interfaceJson) {
+        if (interfaceJson == null) {
+            LOG.error("Interface JSON must not be null");
+            throw new JsonParseException("Interface JSON must not be null");
         }
-
-        List<Document> interfaces = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(INTERFACES_FIELD);
-        if (interfaces == null) {
-            return null;
+        try {
+            org.bson.Document.parse(interfaceJson);
+        } catch (Exception e) {
+            LOG.error("Invalid JSON format for interface: {}", e.getMessage());
+            throw new JsonParseException(e.getMessage());
         }
+    }
 
-        for (Object iface : interfaces) {
-            if (iface instanceof Document interfaceDoc) {
-                Integer id = interfaceDoc.get(INTERFACE_ID_FIELD, Integer.class);
-                if (id != null && id.equals(interfaceId)) {
-                    return interfaceDoc;
-                }
-            }
+    /**
+     * Writes the first version of a newly created interface, removing the header again if
+     * that fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, String content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
         }
-        return null;
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireInterfaceExists(String namespace, Integer interfaceId) throws InterfaceNotFoundException {
+        if (!documentStore.headerExists(namespace, interfaceId)) {
+            LOG.warn("Interface with ID {} not found in namespace '{}'", interfaceId, namespace);
+            throw new InterfaceNotFoundException();
+        }
+    }
+
+    private void requireInterface(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
+        requireNamespace(namespace);
+        requireInterfaceExists(namespace, interfaceId);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
@@ -11,7 +11,6 @@ import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
@@ -24,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.NitriteVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * NitriteDB-backed implementation of {@link InterfaceStore}, used in standalone mode.
@@ -42,7 +43,6 @@ public class NitriteInterfaceStore implements InterfaceStore {
     private static final String VERSION_COLLECTION = "interfaceVersions";
     private static final String ID_FIELD = "interfaceId";
     private static final String RESOURCE_LABEL = "Interface";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
@@ -81,7 +81,7 @@ public class NitriteInterfaceStore implements InterfaceStore {
 
         int id = counterStore.getNextInterfaceSequenceValue();
         documentStore.createHeader(namespace, id, createInterfaceRequest.getName(), createInterfaceRequest.getDescription());
-        createInitialVersion(namespace, id, createInterfaceRequest.getInterfaceJson());
+        documentStore.createFirstVersion(namespace, id, createInterfaceRequest.getInterfaceJson());
 
         LOG.info("Created interface with ID {} for namespace '{}'", id, namespace);
         createdInterface.setId(id);
@@ -146,25 +146,6 @@ public class NitriteInterfaceStore implements InterfaceStore {
         }
     }
 
-    /**
-     * Writes the first version of a newly created interface, removing the header again if
-     * that fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, String content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void requireNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -220,17 +220,16 @@ public class NitriteSearchStore implements SearchStore {
     }
 
     /**
-     * @return the title from a stored ADR revision, or {@code null} if it cannot be read.
-     * Content is a JSON string in this backend, so the field has to be parsed out; a search
-     * must not fail because one ADR's content is unreadable.
-     */
-    /**
      * Reads an ADR revision's title with the same parser {@code NitriteAdrStore} uses.
      *
      * <p>Deliberately Jackson rather than {@code org.bson.Document.parse}: the two disagree
      * about what is readable, so a BSON-only parse here would show a title in the ADR
      * listing and a bare "ADR n" in search results for the same document. BSON also has no
      * business in the Nitrite path, which stores content as a plain JSON string.</p>
+     *
+     * @return the title from a stored ADR revision, or {@code null} if it cannot be read.
+     * Content is a JSON string in this backend, so the field has to be parsed out; a search
+     * must not fail because one ADR's content is unreadable.
      */
     private String titleOf(String content) {
         try {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -66,7 +66,7 @@ public class NitriteSearchStore implements SearchStore {
                 searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(standardCollection, "standardId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -11,7 +11,7 @@ import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
 import org.finos.calm.store.util.NitriteVersionDocumentStore;
-import org.finos.calm.store.util.NumericVersionOrder;
+import org.finos.calm.store.util.VersionScheme;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.slf4j.Logger;
@@ -59,7 +59,7 @@ public class NitriteSearchStore implements SearchStore {
         this.controlCollection = db.getCollection("controls");
         this.adrCollection = db.getCollection("adrs");
         this.adrDocuments = new NitriteVersionDocumentStore(adrCollection,
-                db.getCollection("adrVersions"), "adrId", "ADR", NumericVersionOrder.ASCENDING);
+                db.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
         LOG.info("NitriteSearchStore initialized");
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -49,6 +49,21 @@ public class NitriteSearchStore implements SearchStore {
     private final NitriteCollection interfaceCollection;
     private final NitriteCollection controlCollection;
     private final NitriteCollection adrCollection;
+    /**
+     * Read-only. Do not add a write path through this field.
+     *
+     * <p>This is a second {@link NitriteVersionDocumentStore} over the same two collections
+     * {@link NitriteAdrStore} uses, and the two carry independent
+     * {@link java.util.concurrent.locks.ReentrantReadWriteLock}s. Writes are safe there only
+     * because that store's lock serialises every writer; a write issued through this instance
+     * would take a different lock and so would not be serialised against them, reintroducing
+     * the duplicate-revision race the lock exists to prevent — {@code createVersion}'s
+     * check-then-act would no longer be atomic with respect to the other instance.</p>
+     *
+     * <p>Reads need no such coordination, which is why two instances are tolerable at all. If
+     * this ever needs to write, share {@code NitriteAdrStore}'s instance rather than widening
+     * this one.</p>
+     */
     private final NitriteVersionDocumentStore adrDocuments;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -109,6 +124,14 @@ public class NitriteSearchStore implements SearchStore {
                 // NullPointerException thrown out of search() — which builds every type's
                 // results eagerly, so one malformed document fails the whole request rather
                 // than one resource type. A resource with no id is not addressable anyway.
+                //
+                // Deliberately unlike the namespace listing, which renders the same malformed
+                // header as "<Type> null" rather than hiding it (see
+                // NitriteVersionDocumentStore.listSummariesPaged). The two differ because the
+                // outputs differ: a search hit is a link the caller is expected to follow, so
+                // one that cannot be addressed is worse than absent, whereas a listing row is
+                // informational and showing it is how an operator learns the bad header is
+                // there. Dropping it from both would hide the problem entirely.
                 continue;
             }
             String name = header.get("name", String.class);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -67,7 +67,7 @@ public class NitriteSearchStore implements SearchStore {
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(standardCollection, "standardId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(interfaceCollection, "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),
                 searchAdrCollection(lowerQuery, readableNamespaces)
         );
@@ -109,42 +109,6 @@ public class NitriteSearchStore implements SearchStore {
         return results;
     }
 
-    private List<SearchResult> searchNamespacedCollection(NitriteCollection collection,
-                                                          String arrayField,
-                                                          String idField,
-                                                          String lowerQuery,
-                                                          Optional<Set<String>> readableNamespaces) {
-        List<SearchResult> results = new ArrayList<>();
-
-        for (Document namespaceDoc : collection.find()) {
-            String namespace = namespaceDoc.get("namespace", String.class);
-            if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
-                continue;
-            }
-            TypeSafeNitriteDocument<Document> wrapper = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class);
-            List<Document> entries = wrapper.getList(arrayField);
-            if (entries == null) {
-                continue;
-            }
-            for (Document entry : entries) {
-                if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
-                    return results;
-                }
-                String name = entry.get("name", String.class);
-                String description = entry.get("description", String.class);
-                if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
-                    results.add(new SearchResult(
-                            namespace,
-                            entry.get(idField, Integer.class),
-                            SearchTextMatcher.nullToEmpty(name),
-                            SearchTextMatcher.nullToEmpty(description)
-                    ));
-                }
-            }
-        }
-
-        return results;
-    }
 
     private List<SearchResult> searchControlCollection(String lowerQuery) {
         List<SearchResult> results = new ArrayList<>();

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -1,5 +1,8 @@
 package org.finos.calm.store.nitrite;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
@@ -47,6 +50,7 @@ public class NitriteSearchStore implements SearchStore {
     private final NitriteCollection controlCollection;
     private final NitriteCollection adrCollection;
     private final NitriteVersionDocumentStore adrDocuments;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Inject
     public NitriteSearchStore(@StandaloneQualifier Nitrite db) {
@@ -79,10 +83,10 @@ public class NitriteSearchStore implements SearchStore {
 
     /**
      * Searches a collection in the header/version shape, where each document <em>is</em> one
-     * resource rather than a namespace-wide array of them. See
-     * {@code MongoSearchStore.searchHeaderCollection} for why both shapes have to be
-     * supported at once, and for the silent failure mode if a migrated type is left on the
-     * array-shaped method.
+     * resource rather than a namespace-wide array of them. The array-shaped path this once
+     * sat beside was retired when Interface, the last of the namespaced types, migrated —
+     * see {@code MongoSearchStore.searchHeaderCollection} for the silent failure mode it
+     * guarded against, which is worth remembering rather than the method itself.
      */
     private List<SearchResult> searchHeaderCollection(NitriteCollection collection,
                                                       String idField,
@@ -98,12 +102,21 @@ public class NitriteSearchStore implements SearchStore {
             if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
                 continue;
             }
+            Integer id = header.get(idField, Integer.class);
+            if (id == null) {
+                // Same reason the ADR branch below skips these: SearchResult takes a
+                // primitive id, so a header missing its id field unboxes to a
+                // NullPointerException thrown out of search() — which builds every type's
+                // results eagerly, so one malformed document fails the whole request rather
+                // than one resource type. A resource with no id is not addressable anyway.
+                continue;
+            }
             String name = header.get("name", String.class);
             String description = header.get("description", String.class);
             if (SearchTextMatcher.containsIgnoreCase(name, lowerQuery) || SearchTextMatcher.containsIgnoreCase(description, lowerQuery)) {
                 results.add(new SearchResult(
                         namespace,
-                        header.get(idField, Integer.class),
+                        id,
                         SearchTextMatcher.nullToEmpty(name),
                         SearchTextMatcher.nullToEmpty(description)
                 ));
@@ -188,10 +201,19 @@ public class NitriteSearchStore implements SearchStore {
      * Content is a JSON string in this backend, so the field has to be parsed out; a search
      * must not fail because one ADR's content is unreadable.
      */
+    /**
+     * Reads an ADR revision's title with the same parser {@code NitriteAdrStore} uses.
+     *
+     * <p>Deliberately Jackson rather than {@code org.bson.Document.parse}: the two disagree
+     * about what is readable, so a BSON-only parse here would show a title in the ADR
+     * listing and a bare "ADR n" in search results for the same document. BSON also has no
+     * business in the Nitrite path, which stores content as a plain JSON string.</p>
+     */
     private String titleOf(String content) {
         try {
-            return org.bson.Document.parse(content).getString("title");
-        } catch (RuntimeException e) {
+            JsonNode title = objectMapper.readTree(content).get("title");
+            return title == null || !title.isTextual() ? null : title.asText();
+        } catch (JsonProcessingException | RuntimeException e) {
             return null;
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -65,7 +65,7 @@ public class NitriteSearchStore implements SearchStore {
         return new GroupedSearchResults(
                 searchHeaderCollection(architectureCollection, "architectureId", lowerQuery, readableNamespaces),
                 searchHeaderCollection(patternCollection, "patternId", lowerQuery, readableNamespaces),
-                searchNamespacedCollection(flowCollection, "flows", "flowId", lowerQuery, readableNamespaces),
+                searchHeaderCollection(flowCollection, "flowId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(standardCollection, "standards", "standardId", lowerQuery, readableNamespaces),
                 searchNamespacedCollection(interfaceCollection, "interfaces", "interfaceId", lowerQuery, readableNamespaces),
                 searchControlCollection(lowerQuery),

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import io.quarkus.arc.lookup.LookupIfProperty;

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -144,7 +144,6 @@ public class NitriteSearchStore implements SearchStore {
         return results;
     }
 
-    @SuppressWarnings("unchecked")
     /**
      * ADR searches on the latest revision's title. See
      * {@code MongoSearchStore.searchAdrCollection} for why this goes through the helper.
@@ -161,6 +160,11 @@ public class NitriteSearchStore implements SearchStore {
                 continue;
             }
             Integer adrId = header.get("adrId", Integer.class);
+            if (adrId == null) {
+                // SearchResult takes a primitive id, and resolving the latest revision would
+                // unbox this too. An ADR with no id is not addressable, so it is not a result.
+                continue;
+            }
             String title = "ADR " + adrId;
 
             String latest = adrDocuments.getLatestVersionContent(namespace, adrId);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -10,6 +10,8 @@ import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
+import org.finos.calm.store.util.NumericVersionOrder;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.slf4j.Logger;
@@ -45,6 +47,7 @@ public class NitriteSearchStore implements SearchStore {
     private final NitriteCollection interfaceCollection;
     private final NitriteCollection controlCollection;
     private final NitriteCollection adrCollection;
+    private final NitriteVersionDocumentStore adrDocuments;
 
     @Inject
     public NitriteSearchStore(@StandaloneQualifier Nitrite db) {
@@ -55,6 +58,8 @@ public class NitriteSearchStore implements SearchStore {
         this.interfaceCollection = db.getCollection("interfaces");
         this.controlCollection = db.getCollection("controls");
         this.adrCollection = db.getCollection("adrs");
+        this.adrDocuments = new NitriteVersionDocumentStore(adrCollection,
+                db.getCollection("adrVersions"), "adrId", "ADR", NumericVersionOrder.ASCENDING);
         LOG.info("NitriteSearchStore initialized");
     }
 
@@ -141,48 +146,50 @@ public class NitriteSearchStore implements SearchStore {
     }
 
     @SuppressWarnings("unchecked")
+    /**
+     * ADR searches on the latest revision's title. See
+     * {@code MongoSearchStore.searchAdrCollection} for why this goes through the helper.
+     */
     private List<SearchResult> searchAdrCollection(String lowerQuery, Optional<Set<String>> readableNamespaces) {
         List<SearchResult> results = new ArrayList<>();
 
-        for (Document namespaceDoc : adrCollection.find()) {
-            String namespace = namespaceDoc.get("namespace", String.class);
+        for (Document header : adrCollection.find()) {
+            if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
+                return results;
+            }
+            String namespace = header.get("namespace", String.class);
             if (readableNamespaces.isPresent() && !readableNamespaces.get().contains(namespace)) {
                 continue;
             }
-            TypeSafeNitriteDocument<Document> wrapper = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class);
-            List<Document> adrs = wrapper.getList("adrs");
-            if (adrs == null) {
-                continue;
+            Integer adrId = header.get("adrId", Integer.class);
+            String title = "ADR " + adrId;
+
+            String latest = adrDocuments.getLatestVersionContent(namespace, adrId);
+            if (latest != null) {
+                String documentTitle = titleOf(latest);
+                if (documentTitle != null) {
+                    title = documentTitle;
+                }
             }
-            for (Document adr : adrs) {
-                if (results.size() >= SearchStore.MAX_RESULTS_PER_TYPE) {
-                    return results;
-                }
-                Integer adrId = adr.get("adrId", Integer.class);
-                String title = "ADR " + adrId;
 
-                Map<String, Object> revisions = (Map<String, Object>) adr.get("revisions");
-                if (revisions != null && !revisions.isEmpty()) {
-                    int latestRevision = revisions.keySet().stream()
-                            .map(Integer::parseInt)
-                            .mapToInt(i -> i)
-                            .max()
-                            .getAsInt();
-                    Object revObj = revisions.get(String.valueOf(latestRevision));
-                    if (revObj instanceof Document revisionDoc) {
-                        String docTitle = revisionDoc.get("title", String.class);
-                        if (docTitle != null) {
-                            title = docTitle;
-                        }
-                    }
-                }
-
-                if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {
-                    results.add(new SearchResult(namespace, adrId, title, ""));
-                }
+            if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {
+                results.add(new SearchResult(namespace, adrId, title, ""));
             }
         }
 
         return results;
+    }
+
+    /**
+     * @return the title from a stored ADR revision, or {@code null} if it cannot be read.
+     * Content is a JSON string in this backend, so the field has to be parsed out; a search
+     * must not fail because one ADR's content is unreadable.
+     */
+    private String titleOf(String content) {
+        try {
+            return org.bson.Document.parse(content).getString("title");
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
@@ -11,7 +11,6 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
@@ -23,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.NitriteVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * NitriteDB-backed implementation of {@link StandardStore}, used in standalone mode.
@@ -44,7 +45,6 @@ public class NitriteStandardStore implements StandardStore {
     private static final String VERSION_COLLECTION = "standardVersions";
     private static final String ID_FIELD = "standardId";
     private static final String RESOURCE_LABEL = "Standard";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
@@ -76,7 +76,7 @@ public class NitriteStandardStore implements StandardStore {
 
         int id = counterStore.getNextStandardSequenceValue();
         documentStore.createHeader(namespace, id, createStandardRequest.getName(), createStandardRequest.getDescription());
-        createInitialVersion(namespace, id, createStandardRequest.getStandardJson());
+        documentStore.createFirstVersion(namespace, id, createStandardRequest.getStandardJson());
 
         LOG.info("Created standard with ID {} for namespace '{}'", id, namespace);
         createdStandard.setId(id);
@@ -142,25 +142,6 @@ public class NitriteStandardStore implements StandardStore {
         }
     }
 
-    /**
-     * Writes the first version of a newly created standard, removing the header again if
-     * that fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, String content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void requireNamespace(String namespace) throws NamespaceNotFoundException {
         if (!namespaceStore.namespaceExists(namespace)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
@@ -5,35 +5,34 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.json.JsonParseException;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.StandardStore;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
-import org.finos.calm.store.util.VersionKeySelector;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the StandardStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link StandardStore}, used in standalone mode.
+ *
+ * <h2>Document model</h2>
+ * One <em>header</em> document per standard in {@code standards}, and one <em>version</em>
+ * document per version in {@code standardVersions}, mirroring
+ * {@link org.finos.calm.store.mongo.MongoStandardStore}. Content is held as a JSON string,
+ * and version writes set name and description unconditionally, both matching what this
+ * store did before.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -41,294 +40,144 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 public class NitriteStandardStore implements StandardStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteStandardStore.class);
-    private static final String COLLECTION_NAME = "standards";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String STANDARD_ID_FIELD = "standardId";
-    private static final String STANDARDS_FIELD = "standards";
-    private static final String VERSIONS_FIELD = "versions";
-    private static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    private static final String HEADER_COLLECTION = "standards";
+    private static final String VERSION_COLLECTION = "standardVersions";
+    private static final String ID_FIELD = "standardId";
+    private static final String RESOURCE_LABEL = "Standard";
+    private static final String INITIAL_VERSION = "1.0.0";
 
-    private final NitriteCollection standardCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final NitriteVersionDocumentStore documentStore;
 
     @Inject
     public NitriteStandardStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.standardCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
-        LOG.info("NitriteStandardStore initialized with collection: {}", COLLECTION_NAME);
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
+        LOG.info("NitriteStandardStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
-
 
     @Override
     public List<NamespaceResourceSummary> getStandardsForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving standards", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        lock.readLock().lock();
-        try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDocument = standardCollection.find(filter).firstOrNull();
-
-            // If no standards exist for this namespace yet
-            if (namespaceDocument == null) {
-                LOG.debug("No standards found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
-            if (standards == null || standards.isEmpty()) {
-                LOG.debug("No standards found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<NamespaceResourceSummary> namespaceStandardSummary = new ArrayList<>();
-
-            for (Document standard : standards) {
-                // Count versions from the already-in-memory sub-document (O(1), no extra query).
-                Object rawVersions = standard.get(VERSIONS_FIELD);
-                int versionCount = VersionKeySelector.versionCount(rawVersions instanceof Document d ? d.getFields() : null);
-                NamespaceResourceSummary summary = new NamespaceResourceSummary(
-                        standard.get(NAME_FIELD, String.class),
-                        standard.get(DESCRIPTION_FIELD, String.class),
-                        standard.get(STANDARD_ID_FIELD, Integer.class),
-                        versionCount
-                );
-                namespaceStandardSummary.add(summary);
-            }
-
-            LOG.debug("Retrieved {} standards for namespace '{}'", namespaceStandardSummary.size(), namespace);
-            return namespaceStandardSummary;
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED);
     }
 
     @Override
     public Standard createStandardForNamespace(CreateStandardRequest createStandardRequest, String namespace) throws NamespaceNotFoundException {
         Standard createdStandard = new Standard(createStandardRequest);
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when creating standard", namespace);
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        validateStandardJson(createStandardRequest.getStandardJson());
 
-        try {
-            // Validate JSON by attempting to parse it
-            org.bson.Document.parse(createStandardRequest.getStandardJson());
-        } catch (Exception e) {
-            LOG.error("Invalid JSON format for standard: {}", e.getMessage());
-            throw new JsonParseException(e.getMessage());
-        }
+        int id = counterStore.getNextStandardSequenceValue();
+        documentStore.createHeader(namespace, id, createStandardRequest.getName(), createStandardRequest.getDescription());
+        createInitialVersion(namespace, id, createStandardRequest.getStandardJson());
 
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextStandardSequenceValue();
-
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = standardCollection.find(filter).firstOrNull();
-
-        Document standardDocument = Document.createDocument()
-                .put(STANDARD_ID_FIELD, id)
-                .put(NAME_FIELD, createStandardRequest.getName())
-                .put(DESCRIPTION_FIELD, createStandardRequest.getDescription())
-                .put(VERSIONS_FIELD, Document.createDocument().put("1-0-0", createStandardRequest.getStandardJson()));
-
-        if (namespaceDocument == null) {
-            // Create new namespace document with standard
-            Document newNamespaceDoc = Document.createDocument()
-                    .put(NAMESPACE_FIELD, namespace)
-                    .put(STANDARDS_FIELD, List.of(standardDocument));
-
-            standardCollection.insert(newNamespaceDoc);
-        } else {
-            // Update existing namespace document
-            List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
-            if (standards == null) {
-                standards = new ArrayList<>();
-            } else {
-                standards = new ArrayList<>(standards); // Make a mutable copy
-            }
-            standards.add(standardDocument);
-
-            namespaceDocument.put(STANDARDS_FIELD, standards);
-            standardCollection.update(filter, namespaceDocument);
-        }
-
-            createdStandard.setId(id);
-            createdStandard.setVersion("1.0.0");
-            createdStandard.setNamespace(namespace);
-            return createdStandard;
-        } finally {
-            lock.writeLock().unlock();
-        }
+        LOG.info("Created standard with ID {} for namespace '{}'", id, namespace);
+        createdStandard.setId(id);
+        createdStandard.setVersion(INITIAL_VERSION);
+        return createdStandard;
     }
 
     @Override
     public List<String> getStandardVersions(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving standard versions", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
-        lock.readLock().lock();
-        try {
-            Document standardDoc = findStandardDocument(namespace, standardId);
-            if (standardDoc == null) {
-                LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
-                throw new StandardNotFoundException();
-            }
-
-            Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new StandardNotFoundException();
-            }
-            Set<String> fieldNames = versions.getFields();
-            List<String> versionList = new ArrayList<>();
-            for (String fieldName : fieldNames) {
-                versionList.add(fieldName.replace('-', '.'));
-            }
-
-            LOG.debug("Retrieved {} versions for standard {} in namespace '{}'",
-                    versionList.size(), standardId, namespace);
-            return versionList;
-        } finally {
-            lock.readLock().unlock();
-        }
+        requireStandard(namespace, standardId);
+        return documentStore.listVersions(namespace, standardId);
     }
 
     @Override
     public String getStandardForVersion(String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionNotFoundException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        requireStandard(namespace, standardId);
+
+        String content = documentStore.getVersion(namespace, standardId, version);
+        if (content == null) {
+            LOG.warn("Version '{}' not found for standard {} in namespace '{}'", version, standardId, namespace);
+            throw new StandardVersionNotFoundException();
         }
-
-        lock.readLock().lock();
-        try {
-            Document standardDocument = findStandardDocument(namespace, standardId);
-            if (standardDocument == null) {
-                LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
-                throw new StandardNotFoundException();
-            }
-
-            Document versions = standardDocument.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new StandardVersionNotFoundException();
-            }
-
-            String mongoVersion = version.replace('.', '-');
-            Object versionObj = versions.get(mongoVersion);
-
-            if (!(versionObj instanceof String)) {
-                LOG.warn("Version '{}' not found for standard {} in namespace '{}'",
-                        mongoVersion, standardId, namespace);
-                throw new StandardVersionNotFoundException();
-            }
-
-            LOG.debug("Retrieved version '{}' for standard {} in namespace '{}'",
-                    mongoVersion, standardId, namespace);
-
-            return (String) versionObj;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return content;
     }
 
     @Override
     public Standard createStandardForVersion(CreateStandardRequest standardRequest, String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionExistsException {
-        if(!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        requireNamespace(namespace);
+        validateStandardJson(standardRequest.getStandardJson());
+        requireStandardExists(namespace, standardId);
+
+        if (!documentStore.createVersion(namespace, standardId, version, standardRequest.getStandardJson())) {
+            LOG.warn("Version '{}' already exists for standard {} in namespace '{}'", version, standardId, namespace);
+            throw new StandardVersionExistsException();
         }
 
-        lock.writeLock().lock();
-        try {
-            Filter namespaceFilter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDocument = standardCollection.find(namespaceFilter).firstOrNull();
+        // Unconditional, matching the old shape: Standard did not guard these on blank.
+        documentStore.updateHeaderDetails(namespace, standardId,
+                standardRequest.getName(), standardRequest.getDescription());
 
-            if (namespaceDocument == null) {
-                LOG.warn("Namespace document for '{}' not found when creating standard version", namespace);
-                throw new StandardNotFoundException();
-            }
-
-            Document standardDoc = findStandardDocument(namespace, standardId);
-            if (standardDoc == null) {
-                LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
-                throw new StandardNotFoundException();
-            }
-
-            String mongoVersion = version.replace('.','-');
-
-            Document versions = standardDoc.get(VERSIONS_FIELD, Document.class);
-            if (versions == null) {
-                throw new StandardNotFoundException();
-            }
-            if (versions.containsKey(mongoVersion)) {
-                LOG.warn("Version '{}' already exists for standard {} in namespace '{}'",
-                        mongoVersion, standardId, namespace);
-                throw new StandardVersionExistsException();
-            }
-
-            // Add the new version
-            versions.put(mongoVersion, standardRequest.getStandardJson());
-            standardDoc.put(VERSIONS_FIELD, versions);
-            standardDoc.put(NAME_FIELD, standardRequest.getName());
-            standardDoc.put(DESCRIPTION_FIELD, standardRequest.getDescription());
-
-            // Update the standard in the namespace document
-            List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
-            // Create a mutable copy of the list
-            standards = new ArrayList<>(standards);
-            for (int i = 0; i < standards.size(); i++) {
-                Document doc = standards.get(i);
-                if (doc.get(STANDARD_ID_FIELD, Integer.class).equals(standardId)) {
-                    standards.set(i, standardDoc);
-                    break;
-                }
-            }
-
-            namespaceDocument.put(STANDARDS_FIELD, standards);
-            standardCollection.update(namespaceFilter, namespaceDocument);
-        } finally {
-            lock.writeLock().unlock();
-        }
-
-        LOG.info("Created version '{}' for standard {} in namespace '{}'",
-                version.replace('.','-'), standardId, namespace);
-
+        LOG.info("Created version '{}' for standard {} in namespace '{}'", version, standardId, namespace);
         Standard standard = new Standard(standardRequest);
         standard.setVersion(version);
         standard.setId(standardId);
         standard.setNamespace(namespace);
         return standard;
-
     }
 
-    private Document findStandardDocument(String namespace, Integer standardId) {
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-        Document namespaceDocument = standardCollection.find(filter).firstOrNull();
-
-        if (namespaceDocument == null) {
-            return null;
+    /**
+     * Validates that the supplied standard JSON is parseable, throwing
+     * {@link JsonParseException} if not so the REST layer can surface a 400.
+     */
+    private void validateStandardJson(String standardJson) {
+        if (standardJson == null) {
+            LOG.error("Standard JSON must not be null");
+            throw new JsonParseException("Standard JSON must not be null");
         }
-
-        List<Document> standards = new TypeSafeNitriteDocument<>(namespaceDocument, Document.class).getList(STANDARDS_FIELD);
-        if (standards == null) {
-            return null;
+        try {
+            org.bson.Document.parse(standardJson);
+        } catch (Exception e) {
+            LOG.error("Invalid JSON format for standard: {}", e.getMessage());
+            throw new JsonParseException(e.getMessage());
         }
+    }
 
-        for (Object standard : standards) {
-            if (standard instanceof Document standardDoc) {
-                Integer id = standardDoc.get(STANDARD_ID_FIELD, Integer.class);
-                if (id != null && id.equals(standardId)) {
-                    return standardDoc;
-                }
-            }
+    /**
+     * Writes the first version of a newly created standard, removing the header again if
+     * that fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, String content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
+            throw e;
         }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
+    }
 
-        return null;
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
+
+    private void requireStandardExists(String namespace, Integer standardId) throws StandardNotFoundException {
+        if (!documentStore.headerExists(namespace, standardId)) {
+            LOG.warn("Standard with ID {} not found in namespace '{}'", standardId, namespace);
+            throw new StandardNotFoundException();
+        }
+    }
+
+    private void requireStandard(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
+        requireNamespace(namespace);
+        requireStandardExists(namespace, standardId);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -11,7 +11,6 @@ import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
@@ -24,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
+
+import static org.finos.calm.store.util.NitriteVersionDocumentStore.INITIAL_VERSION;
 
 /**
  * NitriteDB-backed implementation of {@link TimelineStore}, used in standalone mode.
@@ -47,7 +48,6 @@ public class NitriteTimelineStore implements TimelineStore {
     private static final String VERSION_COLLECTION = "timelineVersions";
     private static final String ID_FIELD = "timelineId";
     private static final String RESOURCE_LABEL = "Timeline";
-    private static final String INITIAL_VERSION = "1.0.0";
 
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
@@ -85,7 +85,7 @@ public class NitriteTimelineStore implements TimelineStore {
 
         int id = counterStore.getNextTimelineSequenceValue();
         documentStore.createHeader(namespace, id, timelineRequest.getName(), timelineRequest.getDescription());
-        createInitialVersion(namespace, id, timelineRequest.getTimelineJson());
+        documentStore.createFirstVersion(namespace, id, timelineRequest.getTimelineJson());
 
         LOG.info("Created timeline with ID {} for namespace '{}'", id, namespace);
         return new Timeline.TimelineBuilder()
@@ -160,25 +160,6 @@ public class NitriteTimelineStore implements TimelineStore {
         }
     }
 
-    /**
-     * Writes the first version of a newly created timeline, removing the header again if that
-     * fails — a header with no versions cannot be removed through the API.
-     */
-    private void createInitialVersion(String namespace, int id, String content) {
-        boolean created;
-        try {
-            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
-        } catch (RuntimeException e) {
-            documentStore.deleteHeader(namespace, id);
-            throw e;
-        }
-        if (!created) {
-            documentStore.deleteHeader(namespace, id);
-            throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
-                            + ID_FIELD + " " + id + " in namespace " + namespace));
-        }
-    }
 
     private void updateHeaderDetails(Timeline timeline) {
         documentStore.updatePresentHeaderDetails(timeline.getNamespace(), timeline.getId(),

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -153,10 +153,15 @@ public class NitriteTimelineStore implements TimelineStore {
             throw new JsonParseException("Timeline JSON must not be null");
         }
         try {
+            // Use org.bson.Document to validate JSON
             org.bson.Document.parse(timelineJson);
-        } catch (Exception e) {
+        } catch (JsonParseException e) {
+            // Rethrow the original so the parse failure's stack trace is preserved for
+            // observability. Flow, Standard and Interface wrap instead — that is a real
+            // pre-existing difference between the types, not an inconsistency to tidy, and
+            // this port exists to preserve each one's behaviour rather than pick a winner.
             LOG.error("Invalid JSON format for timeline: {}", e.getMessage());
-            throw new JsonParseException(e.getMessage());
+            throw e;
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -5,288 +5,147 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.json.JsonParseException;
 import org.dizitart.no2.Nitrite;
-import org.dizitart.no2.collection.Document;
-import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
-import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.store.TimelineStore;
-import org.finos.calm.store.util.TypeSafeNitriteDocument;
+import org.finos.calm.store.PageRequest;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.dizitart.no2.filters.FluentFilter.where;
+import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * Implementation of the TimelineStore interface using NitriteDB.
- * This implementation is used when the application is running in standalone mode.
+ * NitriteDB-backed implementation of {@link TimelineStore}, used in standalone mode.
+ *
+ * <h2>Document model</h2>
+ * One <em>header</em> document per timeline in {@code timelines}, and one <em>version</em> document
+ * per version in {@code timelineVersions}, mirroring {@link org.finos.calm.store.mongo.MongoTimelineStore}.
+ * All document handling and locking live in {@link NitriteVersionDocumentStore}.
+ *
+ * <p>As with the other Nitrite stores, content is held as a JSON string rather than a parsed
+ * document, and JSON is validated up front — before the timeline's existence is checked, where
+ * Mongo reports the missing timeline first.</p>
  */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
 @Typed(NitriteTimelineStore.class)
 public class NitriteTimelineStore implements TimelineStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(NitriteTimelineStore.class);
-    private static final String COLLECTION_NAME = "timelines";
-    private static final String NAMESPACE_FIELD = "namespace";
-    private static final String TIMELINES_FIELD = "timelines";
-    private static final String TIMELINE_ID_FIELD = "timelineId";
-    private static final String VERSIONS_FIELD = "versions";
-    private static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    private static final String HEADER_COLLECTION = "timelines";
+    private static final String VERSION_COLLECTION = "timelineVersions";
+    private static final String ID_FIELD = "timelineId";
+    private static final String RESOURCE_LABEL = "Timeline";
+    private static final String INITIAL_VERSION = "1.0.0";
 
-    private final NitriteCollection timelineCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final NitriteCounterStore counterStore;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final NitriteVersionDocumentStore documentStore;
 
     @Inject
     public NitriteTimelineStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore, NitriteCounterStore counterStore) {
-        this.timelineCollection = db.getCollection(COLLECTION_NAME);
         this.namespaceStore = namespaceStore;
         this.counterStore = counterStore;
-        LOG.info("NitriteTimelineStore initialized with collection: {}", COLLECTION_NAME);
+        this.documentStore = new NitriteVersionDocumentStore(
+                db.getCollection(HEADER_COLLECTION),
+                db.getCollection(VERSION_COLLECTION),
+                ID_FIELD,
+                RESOURCE_LABEL);
+        LOG.info("NitriteTimelineStore initialized with collections: {} / {}", HEADER_COLLECTION, VERSION_COLLECTION);
     }
 
     @Override
     public List<NamespaceTimelineSummary> getTimelinesForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when retrieving timelines", namespace);
-            throw new NamespaceNotFoundException();
-        }
+        requireNamespace(namespace);
+        return documentStore.listSummariesPaged(namespace, PageRequest.UNPAGED).stream()
+                .map(NitriteTimelineStore::toTimelineSummary)
+                .toList();
+    }
 
-        lock.readLock().lock();
-        try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDoc = timelineCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc == null) {
-                LOG.warn("No timelines found for namespace '{}'", namespace);
-                return List.of();
-            }
-
-            List<Document> timelines = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(TIMELINES_FIELD);
-            if (timelines == null || timelines.isEmpty()) {
-                return List.of();
-            }
-
-            List<NamespaceTimelineSummary> timelineSummaries = new ArrayList<>();
-            for (Document timeline : timelines) {
-                Integer timelineId = timeline.get(TIMELINE_ID_FIELD, Integer.class);
-                String name = timeline.get(NAME_FIELD, String.class);
-                String description = timeline.get(DESCRIPTION_FIELD, String.class);
-                if (name == null) name = "Timeline " + timelineId;
-                if (description == null) description = "";
-                timelineSummaries.add(new NamespaceTimelineSummary(name, description, timelineId));
-            }
-
-            return timelineSummaries;
-        } finally {
-            lock.readLock().unlock();
-        }
+    /** Drops the version count, which {@link NamespaceTimelineSummary} does not carry. */
+    private static NamespaceTimelineSummary toTimelineSummary(NamespaceResourceSummary summary) {
+        return new NamespaceTimelineSummary(summary.getName(), summary.getDescription(), summary.getId());
     }
 
     @Override
     public Timeline createTimelineForNamespace(CreateTimelineRequest timelineRequest, String namespace) throws NamespaceNotFoundException {
-        if (!namespaceStore.namespaceExists(namespace)) {
-            LOG.warn("Namespace '{}' not found when creating timeline", namespace);
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(namespace);
         validateTimelineJson(timelineRequest.getTimelineJson());
 
-        lock.writeLock().lock();
-        try {
-            int id = counterStore.getNextTimelineSequenceValue();
-            Document timelineDocument = Document.createDocument()
-                    .put(TIMELINE_ID_FIELD, id)
-                    .put(NAME_FIELD, timelineRequest.getName())
-                    .put(DESCRIPTION_FIELD, timelineRequest.getDescription())
-                    .put(VERSIONS_FIELD, Document.createDocument()
-                            .put("1-0-0", timelineRequest.getTimelineJson()));
+        int id = counterStore.getNextTimelineSequenceValue();
+        documentStore.createHeader(namespace, id, timelineRequest.getName(), timelineRequest.getDescription());
+        createInitialVersion(namespace, id, timelineRequest.getTimelineJson());
 
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace);
-            Document namespaceDoc = timelineCollection.find(filter).firstOrNull();
-
-            if (namespaceDoc == null) {
-                // Create a new namespace document with the timeline
-                namespaceDoc = Document.createDocument()
-                        .put(NAMESPACE_FIELD, namespace)
-                        .put(TIMELINES_FIELD, List.of(timelineDocument));
-                timelineCollection.insert(namespaceDoc);
-            } else {
-                // Add the timeline to the existing namespace document
-                List<Document> timelines = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(TIMELINES_FIELD);
-                if (timelines == null) {
-                    timelines = new ArrayList<>();
-                } else {
-                    timelines = new ArrayList<>(timelines); // Make a mutable copy
-                }
-                timelines.add(timelineDocument);
-                namespaceDoc.put(TIMELINES_FIELD, timelines);
-                timelineCollection.update(filter, namespaceDoc);
-            }
-
-            LOG.info("Created timeline with ID {} for namespace '{}'", id, namespace);
-
-            return new Timeline.TimelineBuilder()
-                    .setId(id)
-                    .setVersion("1.0.0")
-                    .setNamespace(namespace)
-                    .setTimeline(timelineRequest.getTimelineJson())
-                    .build();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        LOG.info("Created timeline with ID {} for namespace '{}'", id, namespace);
+        return new Timeline.TimelineBuilder()
+                .setId(id)
+                .setVersion(INITIAL_VERSION)
+                .setNamespace(namespace)
+                .setTimeline(timelineRequest.getTimelineJson())
+                .build();
     }
 
     @Override
     public List<String> getTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveTimelineVersions(timeline);
-
-            List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
-            for (Document timelineDoc : timelines) {
-                if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
-                    // Extract the versions map from the matching timeline
-                    Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions == null) {
-                        throw new TimelineNotFoundException();
-                    }
-
-                    // Convert from Nitrite representation
-                    List<String> resourceVersions = new ArrayList<>();
-                    Set<String> versionKeys = versions.getFields();
-                    for (String versionKey : versionKeys) {
-                        resourceVersions.add(versionKey.replace('-', '.'));
-                    }
-                    return resourceVersions;
-                }
-            }
-
-            throw new TimelineNotFoundException();
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    private Document retrieveTimelineVersions(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        if (!namespaceStore.namespaceExists(timeline.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when retrieving timeline versions", timeline.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
-        Filter filter = where(NAMESPACE_FIELD).eq(timeline.getNamespace());
-        Document result = timelineCollection.find(filter).firstOrNull();
-
-        if (result == null) {
-            LOG.warn("No timelines found for namespace '{}'", timeline.getNamespace());
-            throw new TimelineNotFoundException();
-        }
-
-        return result;
+        requireTimeline(timeline);
+        return documentStore.listVersions(timeline.getNamespace(), timeline.getId());
     }
 
     @Override
     public String getTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
-        lock.readLock().lock();
-        try {
-            Document result = retrieveTimelineVersions(timeline);
+        requireTimeline(timeline);
 
-            List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
-            for (Document timelineDoc : timelines) {
-                if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
-                    // Retrieve the versions map from the matching timeline
-                    Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions == null) {
-                        throw new TimelineVersionNotFoundException();
-                    }
-
-                    // Return the timeline JSON blob for the specified version
-                    String mongoVersion = timeline.getMongoVersion();
-                    Object versionObj = versions.get(mongoVersion);
-                    LOG.info("Version [{}] found: {}", mongoVersion, versionObj instanceof String);
-
-                    if (!(versionObj instanceof String)) {
-                        LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",
-                                timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
-                        throw new TimelineVersionNotFoundException();
-                    }
-
-                    return (String) versionObj;
-                }
-            }
-
-            // Timelines is empty, no version to find
-            LOG.warn("Timeline with ID {} not found in namespace '{}'", timeline.getId(), timeline.getNamespace());
+        String content = documentStore.getVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion());
+        if (content == null) {
+            LOG.warn("Version '{}' not found for timeline {} in namespace '{}'",
+                    timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
             throw new TimelineVersionNotFoundException();
-        } finally {
-            lock.readLock().unlock();
         }
+        return content;
     }
 
     @Override
     public Timeline createTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionExistsException {
-        if (!namespaceStore.namespaceExists(timeline.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when creating timeline version", timeline.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(timeline.getNamespace());
         validateTimelineJson(timeline.getTimelineJson());
+        requireTimelineExists(timeline);
 
-        lock.writeLock().lock();
-        try {
-            if (versionExists(timeline)) {
-                LOG.warn("Version '{}' already exists for timeline {} in namespace '{}'",
-                        timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
-                throw new TimelineVersionExistsException();
-            }
-
-            writeTimelineToNitrite(timeline);
-        } finally {
-            lock.writeLock().unlock();
+        if (!documentStore.createVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion(), timeline.getTimelineJson())) {
+            LOG.warn("Version '{}' already exists for timeline {} in namespace '{}'",
+                    timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
+            throw new TimelineVersionExistsException();
         }
+
+        updateHeaderDetails(timeline);
         return timeline;
     }
 
     @Override
     public Timeline updateTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
-        if (!namespaceStore.namespaceExists(timeline.getNamespace())) {
-            LOG.warn("Namespace '{}' not found when updating timeline version", timeline.getNamespace());
-            throw new NamespaceNotFoundException();
-        }
-
+        requireNamespace(timeline.getNamespace());
         validateTimelineJson(timeline.getTimelineJson());
+        requireTimelineExists(timeline);
 
-        lock.writeLock().lock();
-        try {
-            writeTimelineToNitrite(timeline);
-        } finally {
-            lock.writeLock().unlock();
-        }
-        LOG.info("Updated version '{}' for timeline {} in namespace '{}'",
-                timeline.getDotVersion(), timeline.getId(), timeline.getNamespace());
+        documentStore.upsertVersion(timeline.getNamespace(), timeline.getId(), timeline.getDotVersion(), timeline.getTimelineJson());
+
+        updateHeaderDetails(timeline);
         return timeline;
     }
 
     /**
-     * Validates that the supplied timeline JSON is parseable, throwing {@link JsonParseException} if not so the
-     * REST layer can surface a 400. Validation runs immediately after the namespace check, before any existence or
-     * version checks, so a malformed payload is rejected consistently regardless of the operation.
-     *
-     * @param timelineJson the raw timeline JSON to validate
+     * Validates that the supplied timeline JSON is parseable, throwing {@link JsonParseException}
+     * if not so the REST layer can surface a 400.
      */
     private void validateTimelineJson(String timelineJson) {
         if (timelineJson == null) {
@@ -294,82 +153,54 @@ public class NitriteTimelineStore implements TimelineStore {
             throw new JsonParseException("Timeline JSON must not be null");
         }
         try {
-            // Use org.bson.Document to validate JSON
             org.bson.Document.parse(timelineJson);
-        } catch (JsonParseException e) {
-            // Rethrow the original so the parse failure's stack trace is preserved for observability
+        } catch (Exception e) {
             LOG.error("Invalid JSON format for timeline: {}", e.getMessage());
+            throw new JsonParseException(e.getMessage());
+        }
+    }
+
+    /**
+     * Writes the first version of a newly created timeline, removing the header again if that
+     * fails — a header with no versions cannot be removed through the API.
+     */
+    private void createInitialVersion(String namespace, int id, String content) {
+        boolean created;
+        try {
+            created = documentStore.createVersion(namespace, id, INITIAL_VERSION, content);
+        } catch (RuntimeException e) {
+            documentStore.deleteHeader(namespace, id);
             throw e;
         }
+        if (!created) {
+            documentStore.deleteHeader(namespace, id);
+            throw StorageWriteException.writeFailed(new IllegalStateException(
+                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                            + ID_FIELD + " " + id + " in namespace " + namespace));
+        }
     }
 
-    private void writeTimelineToNitrite(Timeline timeline) throws TimelineNotFoundException, NamespaceNotFoundException {
-        // First verify the timeline exists
-        retrieveTimelineVersions(timeline);
-
-        // Find the namespace document
-        Filter filter = where(NAMESPACE_FIELD).eq(timeline.getNamespace());
-        Document namespaceDoc = timelineCollection.find(filter).firstOrNull();
-
-        if (namespaceDoc != null) {
-            List<Document> timelines = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class).getList(TIMELINES_FIELD);
-            if (timelines != null) {
-                // Create a mutable copy of the list
-                timelines = new ArrayList<>(timelines);
-                boolean found = false;
-                for (int i = 0; i < timelines.size(); i++) {
-                    Document timelineDoc = timelines.get(i);
-                    if (timelineDoc.get(TIMELINE_ID_FIELD, Integer.class) == timeline.getId()) {
-                        // Found the timeline, update its version
-                        Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                        if (versions == null) {
-                            throw new TimelineNotFoundException();
-                        }
-                        versions.put(timeline.getMongoVersion(), timeline.getTimelineJson());
-                        timelineDoc.put(VERSIONS_FIELD, versions);
-                        // Defensive: the REST layer enforces @NotBlank on name/description via CreateTimelineRequest,
-                        // so these guards are only reachable by non-REST callers (e.g. direct store usage in tests).
-                        if (timeline.getName() != null && !timeline.getName().isBlank()) {
-                            timelineDoc.put(NAME_FIELD, timeline.getName());
-                        }
-                        if (timeline.getDescription() != null && !timeline.getDescription().isBlank()) {
-                            timelineDoc.put(DESCRIPTION_FIELD, timeline.getDescription());
-                        }
-                        timelines.set(i, timelineDoc);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (found) {
-                    namespaceDoc.put(TIMELINES_FIELD, timelines);
-                    timelineCollection.update(filter, namespaceDoc);
-                    return;
-                }
-            }
-        }
-
-        LOG.warn("Timeline with ID {} not found in namespace '{}'", timeline.getId(), timeline.getNamespace());
-        throw new TimelineNotFoundException();
+    private void updateHeaderDetails(Timeline timeline) {
+        documentStore.updatePresentHeaderDetails(timeline.getNamespace(), timeline.getId(),
+                timeline.getName(), timeline.getDescription());
     }
 
-    private boolean versionExists(Timeline timeline) {
-        try {
-            Document result = retrieveTimelineVersions(timeline);
-
-            List<Document> timelines = new TypeSafeNitriteDocument<>(result, Document.class).getList(TIMELINES_FIELD);
-            for (Document timelineDoc : timelines) {
-                if (timeline.getId() == timelineDoc.get(TIMELINE_ID_FIELD, Integer.class)) {
-                    Document versions = timelineDoc.get(VERSIONS_FIELD, Document.class);
-                    if (versions != null && versions.containsKey(timeline.getMongoVersion())) {
-                        return true;  // The version already exists
-                    }
-                }
-            }
-        } catch (NamespaceNotFoundException | TimelineNotFoundException e) {
-            return false;
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
         }
+    }
 
-        return false;
+    private void requireTimelineExists(Timeline timeline) throws TimelineNotFoundException {
+        if (!documentStore.headerExists(timeline.getNamespace(), timeline.getId())) {
+            LOG.warn("Timeline with ID {} not found in namespace '{}'", timeline.getId(), timeline.getNamespace());
+            throw new TimelineNotFoundException();
+        }
+    }
+
+    private void requireTimeline(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException {
+        requireNamespace(timeline.getNamespace());
+        requireTimelineExists(timeline);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/producer/TimelineStoreProducer.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/producer/TimelineStoreProducer.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.finos.calm.store.TimelineStore;
 import org.finos.calm.store.mongo.MongoTimelineStore;
 import org.finos.calm.store.nitrite.NitriteTimelineStore;
+import jakarta.enterprise.inject.Instance;
 
 /**
  * Producer for TimelineStore implementations.
@@ -20,10 +21,10 @@ public class TimelineStoreProducer {
     String databaseMode;
 
     @Inject
-    MongoTimelineStore mongoTimelineStore;
+    Instance<MongoTimelineStore> mongoTimelineStore;
 
     @Inject
-    NitriteTimelineStore standaloneTimelineStore;
+    Instance<NitriteTimelineStore> standaloneTimelineStore;
 
     /**
      * Produces the appropriate TimelineStore implementation based on the configured database mode.
@@ -34,9 +35,9 @@ public class TimelineStoreProducer {
     @ApplicationScoped
     public TimelineStore produceTimelineStore() {
         if ("standalone".equals(databaseMode)) {
-            return standaloneTimelineStore;
+            return standaloneTimelineStore.get();
         } else {
-            return mongoTimelineStore;
+            return mongoTimelineStore.get();
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -80,6 +81,7 @@ public class MongoVersionDocumentStore {
     private final MongoCollection<Document> versionCollection;
     private final String idField;
     private final String resourceLabel;
+    private final Comparator<String> versionOrder;
 
     /**
      * @param headerCollection  the existing per-type collection, now holding headers
@@ -94,10 +96,25 @@ public class MongoVersionDocumentStore {
                                      MongoCollection<Document> versionCollection,
                                      String idField,
                                      String resourceLabel) {
+        this(headerCollection, versionCollection, idField, resourceLabel, SemanticVersionOrder.ASCENDING);
+    }
+
+    /**
+     * @param versionOrder how this type's versions rank. Every type but ADR uses
+     *                     {@link SemanticVersionOrder}; ADR's revisions are integers, which
+     *                     that comparator would order {@code 1, 10, 2} — see
+     *                     {@link NumericVersionOrder}.
+     */
+    public MongoVersionDocumentStore(MongoCollection<Document> headerCollection,
+                                     MongoCollection<Document> versionCollection,
+                                     String idField,
+                                     String resourceLabel,
+                                     Comparator<String> versionOrder) {
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
         this.idField = idField;
         this.resourceLabel = resourceLabel;
+        this.versionOrder = versionOrder;
     }
 
     /**
@@ -339,7 +356,7 @@ public class MongoVersionDocumentStore {
     }
 
     /**
-     * @return every version of one resource, ordered by {@link SemanticVersionOrder}.
+     * @return every version of one resource, ordered by this store's version comparator.
      * Empty means "no versions written" — <em>not</em> "no such resource"; ask
      * {@link #headerExists} to tell those apart. Sorted in memory rather than by the
      * database because semantic ordering isn't expressible as a Mongo sort, which is
@@ -350,8 +367,35 @@ public class MongoVersionDocumentStore {
         versionCollection.find(headerFilter(namespace, resourceId))
                 .projection(Projections.include(VERSION_FIELD))
                 .forEach(document -> versions.add(document.getString(VERSION_FIELD)));
-        versions.sort(SemanticVersionOrder.ASCENDING);
+        versions.sort(versionOrder);
         return versions;
+    }
+
+    /**
+     * @return the highest-ranking version of one resource, or {@code null} if it has none.
+     *
+     * <p>Resolved by listing and ranking in memory rather than by a database sort, because
+     * the ordering is type-specific and not expressible as a Mongo sort — the stored values
+     * are strings, so the database would rank {@code 10} below {@code 2}. Only the version
+     * field is projected, so the cost is bounded by the number of versions, not their
+     * content.</p>
+     *
+     * <p>Exists for ADR, whose summary and read paths are defined in terms of the latest
+     * revision. ADR 0001 decided against caching a latest-version pointer on the header, so
+     * this recomputes it; that decision is unchanged.</p>
+     */
+    public String getLatestVersion(String namespace, int resourceId) {
+        List<String> versions = listVersions(namespace, resourceId);
+        return versions.isEmpty() ? null : versions.get(versions.size() - 1);
+    }
+
+    /**
+     * @return the content of the highest-ranking version, or {@code null} if the resource has
+     * no versions. Two reads: one to rank the versions, one to fetch the winner's content.
+     */
+    public Document getLatestVersionContent(String namespace, int resourceId) {
+        String latest = getLatestVersion(namespace, resourceId);
+        return latest == null ? null : getVersion(namespace, resourceId, latest);
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -398,6 +398,22 @@ public class MongoVersionDocumentStore {
     }
 
     /**
+     * @return how many resources of this type exist in a namespace.
+     *
+     * <p>Counts header documents and nothing else. Every other type's summary is built
+     * entirely from its header, so a caller wanting only a count can size the summary list
+     * for free — but ADR's summary carries the latest revision's title and status, which
+     * costs two further reads and a parse per resource. Callers that want a number rather
+     * than a list should not pay that, and this is how they avoid it.</p>
+     *
+     * <p>{@code namespace} is the prefix of the unique {@code (namespace, id)} index the
+     * migration creates, so this is answered from the index without fetching documents.</p>
+     */
+    public int countHeaders(String namespace) {
+        return (int) headerCollection.countDocuments(Filters.eq(NAMESPACE_FIELD, namespace));
+    }
+
+    /**
      * Lists resource summaries for a namespace, applying the paging window at the
      * database with {@code skip}/{@code limit}.
      *

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -81,7 +81,7 @@ public class MongoVersionDocumentStore {
     private final MongoCollection<Document> versionCollection;
     private final String idField;
     private final String resourceLabel;
-    private final Comparator<String> versionOrder;
+    private final VersionScheme versionScheme;
 
     /**
      * @param headerCollection  the existing per-type collection, now holding headers
@@ -96,25 +96,25 @@ public class MongoVersionDocumentStore {
                                      MongoCollection<Document> versionCollection,
                                      String idField,
                                      String resourceLabel) {
-        this(headerCollection, versionCollection, idField, resourceLabel, SemanticVersionOrder.ASCENDING);
+        this(headerCollection, versionCollection, idField, resourceLabel, VersionScheme.SEMANTIC);
     }
 
     /**
-     * @param versionOrder how this type's versions rank. Every type but ADR uses
-     *                     {@link SemanticVersionOrder}; ADR's revisions are integers, which
-     *                     that comparator would order {@code 1, 10, 2} — see
-     *                     {@link NumericVersionOrder}.
+     * @param versionScheme how this type spells and ranks its versions. Every type but
+     *                      ADR uses {@link VersionScheme#SEMANTIC}; ADR's revisions are
+     *                      integers, which must be stored verbatim and ordered numerically
+     *                      — see {@link VersionScheme}.
      */
     public MongoVersionDocumentStore(MongoCollection<Document> headerCollection,
                                      MongoCollection<Document> versionCollection,
                                      String idField,
                                      String resourceLabel,
-                                     Comparator<String> versionOrder) {
+                                     VersionScheme versionScheme) {
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
         this.idField = idField;
         this.resourceLabel = resourceLabel;
-        this.versionOrder = versionOrder;
+        this.versionScheme = versionScheme;
     }
 
     /**
@@ -215,7 +215,7 @@ public class MongoVersionDocumentStore {
      * which domain exception that means. Never overwrites.
      */
     public boolean createVersion(String namespace, int resourceId, String version, Document content) {
-        String canonicalVersion = CanonicalVersion.of(version);
+        String canonicalVersion = versionScheme.canonicalise(version);
         Document versionDocument = new Document(NAMESPACE_FIELD, namespace)
                 .append(idField, resourceId)
                 .append(VERSION_FIELD, canonicalVersion)
@@ -251,7 +251,7 @@ public class MongoVersionDocumentStore {
     public void upsertVersion(String namespace, int resourceId, String version, Document content) {
         // Canonical before the filter is built, so an upsert-insert derives its stored
         // version field from the canonical form via the filter's equality conditions.
-        String canonicalVersion = CanonicalVersion.of(version);
+        String canonicalVersion = versionScheme.canonicalise(version);
         Bson update = Updates.combine(
                 Updates.set(CONTENT_FIELD, content),
                 Updates.setOnInsert(METADATA_FIELD, new Document()));
@@ -351,7 +351,7 @@ public class MongoVersionDocumentStore {
      */
     public Document getVersion(String namespace, int resourceId, String version) {
         Document versionDocument = versionCollection
-                .find(versionFilter(namespace, resourceId, CanonicalVersion.of(version))).first();
+                .find(versionFilter(namespace, resourceId, versionScheme.canonicalise(version))).first();
         return versionDocument == null ? null : versionDocument.get(CONTENT_FIELD, Document.class);
     }
 
@@ -367,7 +367,7 @@ public class MongoVersionDocumentStore {
         versionCollection.find(headerFilter(namespace, resourceId))
                 .projection(Projections.include(VERSION_FIELD))
                 .forEach(document -> versions.add(document.getString(VERSION_FIELD)));
-        versions.sort(versionOrder);
+        versions.sort(versionScheme.order());
         return versions;
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -192,9 +192,18 @@ public class MongoVersionDocumentStore {
      * database — reporting success would return 201 for content that was never stored.</p>
      */
     public void createFirstVersion(String namespace, int resourceId, Document content) {
+        createFirstVersion(namespace, resourceId, INITIAL_VERSION, content);
+    }
+
+    /**
+     * As {@link #createFirstVersion(String, int, Document)}, for a type whose first version is not
+     * {@code 1.0.0}. ADR numbers its revisions from an integer supplied by the caller, so it
+     * needs the same compensation with a different version string — not a second copy of it.
+     */
+    public void createFirstVersion(String namespace, int resourceId, String version, Document content) {
         boolean created;
         try {
-            created = createVersion(namespace, resourceId, INITIAL_VERSION, content);
+            created = createVersion(namespace, resourceId, version, content);
         } catch (RuntimeException e) {
             deleteHeader(namespace, resourceId);
             throw e;
@@ -202,7 +211,7 @@ public class MongoVersionDocumentStore {
         if (!created) {
             deleteHeader(namespace, resourceId);
             throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                    "Version " + version + " already exists for newly allocated "
                             + idField + " " + resourceId + " in namespace " + namespace));
         }
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /**

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -72,7 +72,7 @@ public class NitriteVersionDocumentStore {
     private final NitriteCollection versionCollection;
     private final String idField;
     private final String resourceLabel;
-    private final Comparator<String> versionOrder;
+    private final VersionScheme versionScheme;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
@@ -86,24 +86,23 @@ public class NitriteVersionDocumentStore {
                                        NitriteCollection versionCollection,
                                        String idField,
                                        String resourceLabel) {
-        this(headerCollection, versionCollection, idField, resourceLabel, SemanticVersionOrder.ASCENDING);
+        this(headerCollection, versionCollection, idField, resourceLabel, VersionScheme.SEMANTIC);
     }
 
     /**
-     * @param versionOrder how this type's versions rank. See
-     *                     {@link MongoVersionDocumentStore} for why ADR needs
-     *                     {@link NumericVersionOrder} rather than the semantic one.
+     * @param versionScheme how this type spells and ranks its versions. See
+     *                      {@link VersionScheme}.
      */
     public NitriteVersionDocumentStore(NitriteCollection headerCollection,
                                        NitriteCollection versionCollection,
                                        String idField,
                                        String resourceLabel,
-                                       Comparator<String> versionOrder) {
+                                       VersionScheme versionScheme) {
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
         this.idField = idField;
         this.resourceLabel = resourceLabel;
-        this.versionOrder = versionOrder;
+        this.versionScheme = versionScheme;
     }
 
     /**
@@ -189,7 +188,7 @@ public class NitriteVersionDocumentStore {
      * @return {@code false} if that version is already present. Never overwrites.
      */
     public boolean createVersion(String namespace, int resourceId, String version, String content) {
-        String canonicalVersion = CanonicalVersion.of(version);
+        String canonicalVersion = versionScheme.canonicalise(version);
         lock.writeLock().lock();
         try {
             if (versionCollection.find(versionFilter(namespace, resourceId, canonicalVersion)).firstOrNull() != null) {
@@ -218,7 +217,7 @@ public class NitriteVersionDocumentStore {
      * as well as overwrite.</p>
      */
     public void upsertVersion(String namespace, int resourceId, String version, String content) {
-        String canonicalVersion = CanonicalVersion.of(version);
+        String canonicalVersion = versionScheme.canonicalise(version);
         lock.writeLock().lock();
         try {
             Filter filter = versionFilter(namespace, resourceId, canonicalVersion);
@@ -313,7 +312,7 @@ public class NitriteVersionDocumentStore {
         lock.readLock().lock();
         try {
             Document versionDocument = versionCollection
-                    .find(versionFilter(namespace, resourceId, CanonicalVersion.of(version))).firstOrNull();
+                    .find(versionFilter(namespace, resourceId, versionScheme.canonicalise(version))).firstOrNull();
             if (versionDocument == null) {
                 return null;
             }
@@ -336,7 +335,7 @@ public class NitriteVersionDocumentStore {
             for (Document versionDocument : versionCollection.find(headerFilter(namespace, resourceId))) {
                 versions.add(versionDocument.get(VERSION_FIELD, String.class));
             }
-            versions.sort(versionOrder);
+            versions.sort(versionScheme.order());
             return versions;
         } finally {
             lock.readLock().unlock();

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -413,6 +413,11 @@ public class NitriteVersionDocumentStore {
             // renders it ("<Type> null"), which is the honest representation of a malformed
             // header.
             //
+            // Rendered here but skipped by search (MongoSearchStore/NitriteSearchStore), on
+            // purpose: a search hit is a link the caller is expected to follow, so an
+            // unaddressable one is worse than absent, while a listing row is informational and
+            // showing it is how an operator finds out the bad header exists at all.
+            //
             // Nulls first, not last, so the two backends put it in the same place: BSON's
             // sort order ranks Null below every number, so Mongo's ascending sort returns it
             // first. Under paging the difference is visible — nulls last would surface the

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -72,6 +72,7 @@ public class NitriteVersionDocumentStore {
     private final NitriteCollection versionCollection;
     private final String idField;
     private final String resourceLabel;
+    private final Comparator<String> versionOrder;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
@@ -85,10 +86,24 @@ public class NitriteVersionDocumentStore {
                                        NitriteCollection versionCollection,
                                        String idField,
                                        String resourceLabel) {
+        this(headerCollection, versionCollection, idField, resourceLabel, SemanticVersionOrder.ASCENDING);
+    }
+
+    /**
+     * @param versionOrder how this type's versions rank. See
+     *                     {@link MongoVersionDocumentStore} for why ADR needs
+     *                     {@link NumericVersionOrder} rather than the semantic one.
+     */
+    public NitriteVersionDocumentStore(NitriteCollection headerCollection,
+                                       NitriteCollection versionCollection,
+                                       String idField,
+                                       String resourceLabel,
+                                       Comparator<String> versionOrder) {
         this.headerCollection = headerCollection;
         this.versionCollection = versionCollection;
         this.idField = idField;
         this.resourceLabel = resourceLabel;
+        this.versionOrder = versionOrder;
     }
 
     /**
@@ -310,7 +325,7 @@ public class NitriteVersionDocumentStore {
     }
 
     /**
-     * @return every version of one resource, ordered by {@link SemanticVersionOrder}.
+     * @return every version of one resource, ordered by this store's version comparator.
      * Empty means "no versions written" — <em>not</em> "no such resource"; ask
      * {@link #headerExists} to tell those apart.
      */
@@ -321,11 +336,29 @@ public class NitriteVersionDocumentStore {
             for (Document versionDocument : versionCollection.find(headerFilter(namespace, resourceId))) {
                 versions.add(versionDocument.get(VERSION_FIELD, String.class));
             }
-            versions.sort(SemanticVersionOrder.ASCENDING);
+            versions.sort(versionOrder);
             return versions;
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    /**
+     * @return the highest-ranking version of one resource, or {@code null} if it has none.
+     * See {@link MongoVersionDocumentStore#getLatestVersion} for why this ranks in memory.
+     */
+    public String getLatestVersion(String namespace, int resourceId) {
+        List<String> versions = listVersions(namespace, resourceId);
+        return versions.isEmpty() ? null : versions.get(versions.size() - 1);
+    }
+
+    /**
+     * @return the content of the highest-ranking version, or {@code null} if the resource has
+     * no versions.
+     */
+    public String getLatestVersionContent(String namespace, int resourceId) {
+        String latest = getLatestVersion(namespace, resourceId);
+        return latest == null ? null : getVersion(namespace, resourceId, latest);
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -32,7 +32,12 @@ import static org.dizitart.no2.filters.FluentFilter.where;
  *       write fail. {@link #createVersion} therefore checks before writing, holding
  *       the write lock across both — which is genuinely safe, rather than a
  *       check-then-act race, because Nitrite is a single-process embedded store and
- *       this lock serialises every write through it. The Mongo helper can instead
+ *       this lock serialises every write through it. Note the lock is per <em>instance</em>,
+ *       so that holds only while one instance owns writes to a given collection pair. It
+ *       does today; {@code NitriteSearchStore} constructs a second instance over
+ *       {@code adrs}/{@code adrVersions} but only reads through it. Adding a write path
+ *       through a second instance would silently drop the guarantee, since there is no
+ *       database constraint underneath to catch it. The Mongo helper can instead
  *       write optimistically and translate a {@code DUPLICATE_KEY} error, because
  *       there a shared database arbitrates between separate application instances.</li>
  *   <li><b>Content is stored as a JSON string</b>, not a parsed document, matching
@@ -163,9 +168,18 @@ public class NitriteVersionDocumentStore {
      * allocated and is not yet visible to any other caller.</p>
      */
     public void createFirstVersion(String namespace, int resourceId, String content) {
+        createFirstVersion(namespace, resourceId, INITIAL_VERSION, content);
+    }
+
+    /**
+     * As {@link #createFirstVersion(String, int, String)}, for a type whose first version is not
+     * {@code 1.0.0}. ADR numbers its revisions from an integer supplied by the caller, so it
+     * needs the same compensation with a different version string — not a second copy of it.
+     */
+    public void createFirstVersion(String namespace, int resourceId, String version, String content) {
         boolean created;
         try {
-            created = createVersion(namespace, resourceId, INITIAL_VERSION, content);
+            created = createVersion(namespace, resourceId, version, content);
         } catch (RuntimeException e) {
             deleteHeader(namespace, resourceId);
             throw e;
@@ -173,7 +187,7 @@ public class NitriteVersionDocumentStore {
         if (!created) {
             deleteHeader(namespace, resourceId);
             throw StorageWriteException.writeFailed(new IllegalStateException(
-                    "Version " + INITIAL_VERSION + " already exists for newly allocated "
+                    "Version " + version + " already exists for newly allocated "
                             + idField + " " + resourceId + " in namespace " + namespace));
         }
     }
@@ -395,11 +409,16 @@ public class NitriteVersionDocumentStore {
             // Null-safe because the id is read straight off the stored header and a header
             // missing its id field yields a null one. Comparing with Integer.compare unboxes,
             // so a single such document would NPE the whole listing into a 500 — where Mongo,
-            // which sorts database-side, returns 200 with that row included. Sorting nulls
-            // last keeps the two backends agreeing; toSummary already renders the row itself
-            // ("<Type> null"), which is the honest representation of a malformed header.
+            // which sorts database-side, returns 200 with that row included. toSummary
+            // renders it ("<Type> null"), which is the honest representation of a malformed
+            // header.
+            //
+            // Nulls first, not last, so the two backends put it in the same place: BSON's
+            // sort order ranks Null below every number, so Mongo's ascending sort returns it
+            // first. Under paging the difference is visible — nulls last would surface the
+            // row on page 1 here and on the final page there, for the same data.
             summaries.sort(Comparator.comparing(NamespaceResourceSummary::getId,
-                    Comparator.nullsLast(Comparator.naturalOrder())));
+                    Comparator.nullsFirst(Comparator.naturalOrder())));
             return page.apply(summaries);
         } finally {
             lock.readLock().unlock();

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -361,6 +361,23 @@ public class NitriteVersionDocumentStore {
     }
 
     /**
+     * @return how many resources of this type exist in a namespace. See
+     * {@link MongoVersionDocumentStore#countHeaders} for why this exists.
+     *
+     * <p>A scan rather than an index count — CalmHub creates no Nitrite indexes — but it
+     * reads only the small header documents, where sizing an ADR summary list would read
+     * and parse every ADR's latest revision content.</p>
+     */
+    public int countHeaders(String namespace) {
+        lock.readLock().lock();
+        try {
+            return (int) headerCollection.find(where(NAMESPACE_FIELD).eq(namespace)).size();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
      * Lists resource summaries for a namespace.
      *
      * <p>Nitrite has no server-side paging equivalent, so the window is applied in

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NumericVersionOrder.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NumericVersionOrder.java
@@ -42,12 +42,20 @@ public final class NumericVersionOrder {
         return leftValue == null ? -1 : 1;
     }
 
+    /**
+     * Deliberately does not trim. Every consumer of a revision string parses it with a plain
+     * {@code Integer.parseInt} — {@code getAdrRevisions} and the latest-revision read on both
+     * backends — and those reject surrounding whitespace. Accepting it here would rank a key
+     * like {@code " 2 "} as a real revision, so it could sort as the latest and then throw
+     * when the caller parsed it, which is the opposite of what ranking unparseable values
+     * first is for.
+     */
     private static Integer parseOrNull(String version) {
         if (version == null) {
             return null;
         }
         try {
-            return Integer.valueOf(version.trim());
+            return Integer.valueOf(version);
         } catch (NumberFormatException e) {
             return null;
         }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NumericVersionOrder.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NumericVersionOrder.java
@@ -1,0 +1,59 @@
+package org.finos.calm.store.util;
+
+import java.util.Comparator;
+
+/**
+ * Orders versions that are plain integers, for resource types whose history is a revision
+ * number rather than a semantic version — ADR is the only one.
+ *
+ * <h2>Why {@link SemanticVersionOrder} cannot be used</h2>
+ * It parses each value as {@code major.minor.patch} and maps anything unparseable to
+ * {@code 0.0.0}, falling back to a plain string comparison to keep the order total. Every ADR
+ * revision is unparseable by that rule, so the whole set collapses to the string tiebreak and
+ * sorts {@code 1, 10, 2} — which would make "latest revision" mean revision 2 once an ADR
+ * reached double figures, silently returning stale content from every read that resolves the
+ * latest.
+ *
+ * <h2>Malformed input</h2>
+ * Anything that isn't an integer sorts before everything that is, and ties are broken by
+ * string comparison so the order stays total. Nothing in the current write path can produce
+ * such a value — revisions come from {@code latest + 1} — but a comparator that threw would
+ * turn one bad stored key into a failure of every listing for that resource.
+ */
+public final class NumericVersionOrder {
+
+    /** Ascending: {@code 1}, {@code 2}, {@code 10}. */
+    public static final Comparator<String> ASCENDING = NumericVersionOrder::compare;
+
+    private NumericVersionOrder() {
+    }
+
+    private static int compare(String left, String right) {
+        Integer leftValue = parseOrNull(left);
+        Integer rightValue = parseOrNull(right);
+
+        if (leftValue != null && rightValue != null) {
+            return Integer.compare(leftValue, rightValue);
+        }
+        if (leftValue == null && rightValue == null) {
+            return orEmpty(left).compareTo(orEmpty(right));
+        }
+        // Unparseable values sort first, so a stray key can never be mistaken for the latest.
+        return leftValue == null ? -1 : 1;
+    }
+
+    private static Integer parseOrNull(String version) {
+        if (version == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(version.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String orEmpty(String version) {
+        return version == null ? "" : version;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/VersionKeySelector.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/VersionKeySelector.java
@@ -3,13 +3,23 @@ package org.finos.calm.store.util;
 import java.util.Comparator;
 import java.util.Set;
 
+/**
+ * Picks the latest of a set of dash-encoded version keys.
+ *
+ * <p>All that remains of this class after the ADR 0001 storage redesign: its
+ * {@code versionCount} method lost every caller once the seven versioned types moved to the
+ * header/version shape, where the count is a stored field rather than the size of a loaded
+ * map, and was deleted. {@link #latestVersionKey} survives because
+ * {@code MongoControlStore} and {@code NitriteControlStore} still use it, and Control keeps
+ * the old shape and its dash-encoded keys deliberately (ADR 0004).</p>
+ *
+ * <p>Do not reach for this from a migrated type. It splits on {@code "-"}, so it only
+ * understands the old encoding; {@code SemanticVersionOrder} and {@code NumericVersionOrder}
+ * are what rank versions in the new shape. This class retires with Control.</p>
+ */
 public final class VersionKeySelector {
 
     private VersionKeySelector() {
-    }
-
-    public static int versionCount(Set<String> keys) {
-        return keys == null ? 0 : keys.size();
     }
 
     public static String latestVersionKey(Set<String> keys) {

--- a/calm-hub/src/main/java/org/finos/calm/store/util/VersionScheme.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/VersionScheme.java
@@ -1,0 +1,65 @@
+package org.finos.calm.store.util;
+
+import java.util.Comparator;
+import java.util.function.UnaryOperator;
+
+/**
+ * How a resource type spells and ranks its versions. Every version-store helper holds one,
+ * and every version string entering or leaving a helper passes through it.
+ *
+ * <h2>Why these two things are one type</h2>
+ * They are not independent, and treating them as independent has already caused a bug.
+ * Ordering was made pluggable when ADR arrived, because {@link SemanticVersionOrder} ranks
+ * integer revisions {@code 1, 10, 2}; canonicalisation was left hard-wired to
+ * {@link CanonicalVersion}. Nothing then forced the pair to agree, and for ADR they did not:
+ *
+ * <ul>
+ *   <li>{@code VERSION_REGEX} makes both separators optional, so {@code "100"} is one of the
+ *       six accepted spellings of {@code 1.0.0}. ADR revision 100 was therefore stored as
+ *       {@code "1.0.0"} — revisions 1–99 are unaffected, which is exactly why no test caught
+ *       it.</li>
+ *   <li>{@code "1.0.0"} is not parseable as an integer, and {@link NumericVersionOrder} sorts
+ *       unparseable values <em>first</em>. So revision 100 sorted below revision 99, and the
+ *       "latest revision" read — which every ADR read goes through — silently returned
+ *       revision 99's content while 100 existed. That is the precise failure
+ *       {@code NumericVersionOrder} was introduced to prevent, arriving through a different
+ *       door.</li>
+ *   <li>{@code MongoAdrStore.getAdrRevisions} then calls {@code Integer.parseInt} on the
+ *       stored strings, so listing revisions threw rather than returning a wrong answer.</li>
+ * </ul>
+ *
+ * Bundling them makes the mismatch unrepresentable: a caller picks a scheme, not a comparator
+ * and separately a spelling rule it has to remember to match.
+ */
+public enum VersionScheme {
+
+    /**
+     * Semantic versions, for every type but ADR. Folds the several accepted spellings of one
+     * version onto {@code major.minor.patch} so each logical version is one stored document.
+     */
+    SEMANTIC(CanonicalVersion::of, SemanticVersionOrder.ASCENDING),
+
+    /**
+     * Integer revisions, for ADR. Stored verbatim: there is nothing to fold, since one
+     * revision has exactly one spelling, and rewriting them is what corrupted them.
+     */
+    NUMERIC(UnaryOperator.identity(), NumericVersionOrder.ASCENDING);
+
+    private final UnaryOperator<String> canonicaliser;
+    private final Comparator<String> order;
+
+    VersionScheme(UnaryOperator<String> canonicaliser, Comparator<String> order) {
+        this.canonicaliser = canonicaliser;
+        this.order = order;
+    }
+
+    /** @return the form this version is stored and queried under. {@code null} passes through. */
+    public String canonicalise(String version) {
+        return canonicaliser.apply(version);
+    }
+
+    /** @return ascending order, so the last element of a sorted list is the latest. */
+    public Comparator<String> order() {
+        return order;
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestAdrToolsShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/mcp/tools/TestAdrToolsShould.java
@@ -11,6 +11,7 @@ import org.finos.calm.domain.exception.AdrPersistenceException;
 import org.finos.calm.domain.exception.AdrRevisionExistsException;
 import org.finos.calm.domain.exception.AdrRevisionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.AdrStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -634,6 +635,21 @@ class TestAdrToolsShould {
 
         assertThat(result.isError(), is(true));
         assertThat(text(result), containsString("concurrently updated"));
+    }
+
+    @Test
+    void return_error_rather_than_propagating_an_unchecked_write_failure_on_status_update() throws Exception {
+        // StorageWriteException is unchecked, so it is not in updateAdrStatus's throws clause
+        // and none of the catch blocks above name it. Without a generic catch it escapes the
+        // @Tool method entirely instead of becoming an error response — the five sibling
+        // methods in AdrTools have always ended with one; this one did not.
+        when(adrStore.updateAdrStatus(any(AdrMeta.class), any(Status.class)))
+                .thenThrow(StorageWriteException.writeFailed(new RuntimeException("mongo down")));
+
+        ToolResponse result = adrTools.updateAdrStatus("finos", 1, "accepted");
+
+        assertThat(result.isError(), is(true));
+        assertThat(text(result), containsString("Failed to update status"));
     }
 
     @ParameterizedTest

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrVersionSplitStepShould.java
@@ -1,0 +1,142 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Adr-specific wiring only. The fan-out itself is {@link MongoVersionSplitMigration},
+ * exercised in depth by {@code TestMongoArchitectureVersionSplitStepShould} — repeating
+ * those cases here would test the same code twice under a different name. What matters for
+ * this class is that it targets the right collections, at the right schema version, and
+ * still honours the database-mode gate.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoAdrVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoAdrVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("adrs")).thenReturn(headers);
+        when(database.getCollection("adrVersions")).thenReturn(versions);
+
+        step = new MongoAdrVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+            if (filter.contains("adrs")) {
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+            when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+            return iterable;
+        });
+    }
+
+    @Test
+    void run_at_schema_version_eight() {
+        // One past Timeline. A new step rather than an edit to that one, because a
+        // committed step is immutable — a deployment already past 3 never re-runs it.
+        assertThat(step.fromVersion(), is(8));
+    }
+
+    @Test
+    void swap_the_adr_indexes_rather_than_the_architecture_ones() {
+        step.apply();
+
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("adrId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("adrId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_adr_headers_and_versions() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("adrs", List.of(new Document("adrId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("revisions", new Document("1-0-0", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(headerCaptor.getValue().getInteger("adrId"), is(1));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+
+        verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+
+    @Test
+    void transition_indexes_without_fanning_anything_out() {
+        // The entry point integration-test infrastructure uses to bring a database's
+        // indexes to the new shape when it has no old-shape data to migrate.
+        step.transitionIndexes();
+
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("adrId", 1)), any());
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrVersionSplitStepShould.java
@@ -104,7 +104,7 @@ class TestMongoAdrVersionSplitStepShould {
                 .append("adrs", List.of(new Document("adrId", 1)
                         .append("name", "Sample")
                         .append("description", "A description")
-                        .append("revisions", new Document("1-0-0", new Document("nodes", List.of())))))));
+                        .append("revisions", new Document("1", new Document("nodes", List.of())))))));
 
         step.apply();
 
@@ -115,9 +115,28 @@ class TestMongoAdrVersionSplitStepShould {
 
         ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
         verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
-        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+        // An integer revision, which is the only kind ADR has — the old fixture used a
+        // semantic key copied from the architecture test, a shape ADR never stored.
+        assertThat(versionCaptor.getValue().getString("version"), is("1"));
 
         verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void migrate_a_three_digit_revision_without_rewriting_it() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("adrs", List.of(new Document("adrId", 1)
+                        .append("revisions", new Document("100", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        // VERSION_REGEX also reads "100" as a spelling of 1.0.0. Canonicalising here wrote
+        // the corruption permanently into the migrated data, where it sorts below revision
+        // 99 and cannot be Integer.parseInt by the ADR store.
+        assertThat(versionCaptor.getValue().getString("version"), is("100"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoFlowVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoFlowVersionSplitStepShould.java
@@ -1,0 +1,142 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Flow-specific wiring only. The fan-out itself is {@link MongoVersionSplitMigration},
+ * exercised in depth by {@code TestMongoArchitectureVersionSplitStepShould} — repeating
+ * those cases here would test the same code twice under a different name. What matters for
+ * this class is that it targets the right collections, at the right schema version, and
+ * still honours the database-mode gate.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoFlowVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoFlowVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("flows")).thenReturn(headers);
+        when(database.getCollection("flowVersions")).thenReturn(versions);
+
+        step = new MongoFlowVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+            if (filter.contains("flows")) {
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+            when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+            return iterable;
+        });
+    }
+
+    @Test
+    void run_at_schema_version_four() {
+        // One past Pattern's. A new step rather than an edit to that one, because a
+        // committed step is immutable — a deployment already past 3 never re-runs it.
+        assertThat(step.fromVersion(), is(4));
+    }
+
+    @Test
+    void swap_the_flow_indexes_rather_than_the_architecture_ones() {
+        step.apply();
+
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("flowId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("flowId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_flow_headers_and_versions() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("flows", List.of(new Document("flowId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("versions", new Document("1-0-0", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(headerCaptor.getValue().getInteger("flowId"), is(1));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+
+        verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+
+    @Test
+    void transition_indexes_without_fanning_anything_out() {
+        // The entry point integration-test infrastructure uses to bring a database's
+        // indexes to the new shape when it has no old-shape data to migrate.
+        step.transitionIndexes();
+
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("flowId", 1)), any());
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoInterfaceVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoInterfaceVersionSplitStepShould.java
@@ -1,0 +1,142 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Interface-specific wiring only. The fan-out itself is {@link MongoVersionSplitMigration},
+ * exercised in depth by {@code TestMongoArchitectureVersionSplitStepShould} — repeating
+ * those cases here would test the same code twice under a different name. What matters for
+ * this class is that it targets the right collections, at the right schema version, and
+ * still honours the database-mode gate.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoInterfaceVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoInterfaceVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("interfaces")).thenReturn(headers);
+        when(database.getCollection("interfaceVersions")).thenReturn(versions);
+
+        step = new MongoInterfaceVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+            if (filter.contains("interfaces")) {
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+            when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+            return iterable;
+        });
+    }
+
+    @Test
+    void run_at_schema_version_six() {
+        // One past Standard. A new step rather than an edit to that one, because a
+        // committed step is immutable — a deployment already past 3 never re-runs it.
+        assertThat(step.fromVersion(), is(6));
+    }
+
+    @Test
+    void swap_the_interface_indexes_rather_than_the_architecture_ones() {
+        step.apply();
+
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("interfaceId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("interfaceId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_interface_headers_and_versions() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("interfaces", List.of(new Document("interfaceId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("versions", new Document("1-0-0", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(headerCaptor.getValue().getInteger("interfaceId"), is(1));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+
+        verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+
+    @Test
+    void transition_indexes_without_fanning_anything_out() {
+        // The entry point integration-test infrastructure uses to bring a database's
+        // indexes to the new shape when it has no old-shape data to migrate.
+        step.transitionIndexes();
+
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("interfaceId", 1)), any());
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoStandardVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoStandardVersionSplitStepShould.java
@@ -1,0 +1,142 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Standard-specific wiring only. The fan-out itself is {@link MongoVersionSplitMigration},
+ * exercised in depth by {@code TestMongoArchitectureVersionSplitStepShould} — repeating
+ * those cases here would test the same code twice under a different name. What matters for
+ * this class is that it targets the right collections, at the right schema version, and
+ * still honours the database-mode gate.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoStandardVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoStandardVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("standards")).thenReturn(headers);
+        when(database.getCollection("standardVersions")).thenReturn(versions);
+
+        step = new MongoStandardVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+            if (filter.contains("standards")) {
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+            when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+            return iterable;
+        });
+    }
+
+    @Test
+    void run_at_schema_version_five() {
+        // One past Flow. A new step rather than an edit to that one, because a
+        // committed step is immutable — a deployment already past 3 never re-runs it.
+        assertThat(step.fromVersion(), is(5));
+    }
+
+    @Test
+    void swap_the_standard_indexes_rather_than_the_architecture_ones() {
+        step.apply();
+
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("standardId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("standardId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_standard_headers_and_versions() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("standards", List.of(new Document("standardId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("versions", new Document("1-0-0", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(headerCaptor.getValue().getInteger("standardId"), is(1));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+
+        verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+
+    @Test
+    void transition_indexes_without_fanning_anything_out() {
+        // The entry point integration-test infrastructure uses to bring a database's
+        // indexes to the new shape when it has no old-shape data to migrate.
+        step.transitionIndexes();
+
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("standardId", 1)), any());
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoTimelineVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoTimelineVersionSplitStepShould.java
@@ -1,0 +1,142 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Timeline-specific wiring only. The fan-out itself is {@link MongoVersionSplitMigration},
+ * exercised in depth by {@code TestMongoArchitectureVersionSplitStepShould} — repeating
+ * those cases here would test the same code twice under a different name. What matters for
+ * this class is that it targets the right collections, at the right schema version, and
+ * still honours the database-mode gate.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoTimelineVersionSplitStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoCollection<Document> headers;
+    private MongoCollection<Document> versions;
+    private MongoTimelineVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        headers = mock(DocumentMongoCollection.class);
+        versions = mock(DocumentMongoCollection.class);
+        when(database.getCollection("timelines")).thenReturn(headers);
+        when(database.getCollection("timelineVersions")).thenReturn(versions);
+
+        step = new MongoTimelineVersionSplitStep(database);
+        step.databaseMode = "mongo";
+        stubOldDocuments(List.of());
+    }
+
+    private void stubOldDocuments(List<Document> documents) {
+        when(headers.find(any(Bson.class))).thenAnswer(invocation -> {
+            String filter = ((Bson) invocation.getArgument(0)).toBsonDocument().toJson();
+            FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+            when(iterable.projection(any())).thenReturn(iterable);
+            if (filter.contains("timelines")) {
+                doAnswer(scan -> {
+                    Consumer<Document> consumer = scan.getArgument(0);
+                    documents.forEach(consumer);
+                    return null;
+                }).when(iterable).forEach(any());
+                return iterable;
+            }
+            when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+            return iterable;
+        });
+    }
+
+    @Test
+    void run_at_schema_version_seven() {
+        // One past Interface. A new step rather than an edit to that one, because a
+        // committed step is immutable — a deployment already past 3 never re-runs it.
+        assertThat(step.fromVersion(), is(7));
+    }
+
+    @Test
+    void swap_the_timeline_indexes_rather_than_the_architecture_ones() {
+        step.apply();
+
+        verify(headers).dropIndex("namespace_1");
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("timelineId", 1)), any());
+        verify(versions).createIndex(
+                eq(new Document("namespace", 1).append("timelineId", 1).append("version", 1)), any());
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_timeline_headers_and_versions() {
+        stubOldDocuments(List.of(new Document("_id", "abc")
+                .append("namespace", "finos")
+                .append("timelines", List.of(new Document("timelineId", 1)
+                        .append("name", "Sample")
+                        .append("description", "A description")
+                        .append("versions", new Document("1-0-0", new Document("nodes", List.of())))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).replaceOne(any(Bson.class), headerCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(headerCaptor.getValue().getInteger("timelineId"), is(1));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).replaceOne(any(Bson.class), versionCaptor.capture(), any(ReplaceOptions.class));
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+
+        verify(headers).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void skip_the_whole_step_when_not_running_against_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headers, never()).dropIndex(anyString());
+        verify(headers, never()).createIndex(any(Bson.class), any());
+    }
+
+    @Test
+    void transition_indexes_without_fanning_anything_out() {
+        // The entry point integration-test infrastructure uses to bring a database's
+        // indexes to the new shape when it has no old-shape data to migrate.
+        step.transitionIndexes();
+
+        verify(headers).createIndex(eq(new Document("namespace", 1).append("timelineId", 1)), any());
+        verify(headers, never()).deleteOne(any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrVersionSplitStepShould.java
@@ -73,7 +73,7 @@ class TestNitriteAdrVersionSplitStepShould {
                 .put("adrs", List.of(Document.createDocument()
                         .put("adrId", 1)
                         .put("name", "Sample")
-                        .put("revisions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+                        .put("revisions", Document.createDocument().put("1", "{\"nodes\":[]}"))))));
 
         step.apply();
 
@@ -84,8 +84,27 @@ class TestNitriteAdrVersionSplitStepShould {
 
         ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
         verify(versions).insert(versionCaptor.capture());
-        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // An integer revision, the only kind ADR has — the old fixture used a semantic
+        // key copied from the architecture test, a shape ADR never stored.
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1"));
         // Content stays a JSON string in this backend.
         assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+
+    @Test
+    void migrate_a_three_digit_revision_without_rewriting_it() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("adrs", List.of(Document.createDocument()
+                        .put("adrId", 1)
+                        .put("revisions", Document.createDocument().put("100", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        // See the Mongo twin: "100" is also an accepted spelling of 1.0.0, and canonicalising
+        // it here wrote the corruption permanently into the migrated data.
+        assertThat(versionCaptor.getValue().get("version", String.class), is("100"));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrVersionSplitStepShould.java
@@ -1,0 +1,91 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.collection.NitriteId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Adr-specific wiring only — the fan-out is {@link NitriteVersionSplitMigration},
+ * exercised in depth by {@code TestNitriteArchitectureVersionSplitStepShould}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteAdrVersionSplitStepShould {
+
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteAdrVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("adrs")).thenReturn(headers);
+        when(db.getCollection("adrVersions")).thenReturn(versions);
+
+        step = new NitriteAdrVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(headers.getById(any(NitriteId.class))).thenAnswer(invocation -> {
+            NitriteId id = invocation.getArgument(0);
+            return documents.stream()
+                    .filter(document -> id.equals(document.getId()))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+    @Test
+    void run_at_schema_version_eight() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(8));
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_adr_headers_and_versions() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("adrs", List.of(Document.createDocument()
+                        .put("adrId", 1)
+                        .put("name", "Sample")
+                        .put("revisions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("adrId", Integer.class), is(1));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend.
+        assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteFlowVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteFlowVersionSplitStepShould.java
@@ -1,0 +1,91 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.collection.NitriteId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Flow-specific wiring only — the fan-out is {@link NitriteVersionSplitMigration},
+ * exercised in depth by {@code TestNitriteArchitectureVersionSplitStepShould}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteFlowVersionSplitStepShould {
+
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteFlowVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("flows")).thenReturn(headers);
+        when(db.getCollection("flowVersions")).thenReturn(versions);
+
+        step = new NitriteFlowVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(headers.getById(any(NitriteId.class))).thenAnswer(invocation -> {
+            NitriteId id = invocation.getArgument(0);
+            return documents.stream()
+                    .filter(document -> id.equals(document.getId()))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+    @Test
+    void run_at_schema_version_four() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(4));
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_flow_headers_and_versions() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("flows", List.of(Document.createDocument()
+                        .put("flowId", 1)
+                        .put("name", "Sample")
+                        .put("versions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("flowId", Integer.class), is(1));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend.
+        assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteInterfaceVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteInterfaceVersionSplitStepShould.java
@@ -1,0 +1,91 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.collection.NitriteId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Interface-specific wiring only — the fan-out is {@link NitriteVersionSplitMigration},
+ * exercised in depth by {@code TestNitriteArchitectureVersionSplitStepShould}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteInterfaceVersionSplitStepShould {
+
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteInterfaceVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("interfaces")).thenReturn(headers);
+        when(db.getCollection("interfaceVersions")).thenReturn(versions);
+
+        step = new NitriteInterfaceVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(headers.getById(any(NitriteId.class))).thenAnswer(invocation -> {
+            NitriteId id = invocation.getArgument(0);
+            return documents.stream()
+                    .filter(document -> id.equals(document.getId()))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+    @Test
+    void run_at_schema_version_six() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(6));
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_interface_headers_and_versions() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("interfaces", List.of(Document.createDocument()
+                        .put("interfaceId", 1)
+                        .put("name", "Sample")
+                        .put("versions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("interfaceId", Integer.class), is(1));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend.
+        assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteStandardVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteStandardVersionSplitStepShould.java
@@ -1,0 +1,91 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.collection.NitriteId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Standard-specific wiring only — the fan-out is {@link NitriteVersionSplitMigration},
+ * exercised in depth by {@code TestNitriteArchitectureVersionSplitStepShould}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteStandardVersionSplitStepShould {
+
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteStandardVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("standards")).thenReturn(headers);
+        when(db.getCollection("standardVersions")).thenReturn(versions);
+
+        step = new NitriteStandardVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(headers.getById(any(NitriteId.class))).thenAnswer(invocation -> {
+            NitriteId id = invocation.getArgument(0);
+            return documents.stream()
+                    .filter(document -> id.equals(document.getId()))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+    @Test
+    void run_at_schema_version_five() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(5));
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_standard_headers_and_versions() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("standards", List.of(Document.createDocument()
+                        .put("standardId", 1)
+                        .put("name", "Sample")
+                        .put("versions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("standardId", Integer.class), is(1));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend.
+        assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteTimelineVersionSplitStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteTimelineVersionSplitStepShould.java
@@ -1,0 +1,91 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.collection.NitriteId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Timeline-specific wiring only — the fan-out is {@link NitriteVersionSplitMigration},
+ * exercised in depth by {@code TestNitriteArchitectureVersionSplitStepShould}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteTimelineVersionSplitStepShould {
+
+    private NitriteCollection headers;
+    private NitriteCollection versions;
+    private NitriteTimelineVersionSplitStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headers = mock(NitriteCollection.class);
+        versions = mock(NitriteCollection.class);
+        when(db.getCollection("timelines")).thenReturn(headers);
+        when(db.getCollection("timelineVersions")).thenReturn(versions);
+
+        step = new NitriteTimelineVersionSplitStep(db);
+        stubCollectionContents(List.of());
+    }
+
+    private void stubCollectionContents(List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headers.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(headers.getById(any(NitriteId.class))).thenAnswer(invocation -> {
+            NitriteId id = invocation.getArgument(0);
+            return documents.stream()
+                    .filter(document -> id.equals(document.getId()))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+    @Test
+    void run_at_schema_version_seven() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(7));
+    }
+
+    @Test
+    void fan_a_namespace_document_out_into_timeline_headers_and_versions() {
+        stubCollectionContents(List.of(Document.createDocument()
+                .put("namespace", "finos")
+                .put("timelines", List.of(Document.createDocument()
+                        .put("timelineId", 1)
+                        .put("name", "Sample")
+                        .put("versions", Document.createDocument().put("1-0-0", "{\"nodes\":[]}"))))));
+
+        step.apply();
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headers).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("timelineId", Integer.class), is(1));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(1));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versions).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend.
+        assertThat(versionCaptor.getValue().get("content", String.class), is("{\"nodes\":[]}"));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/services/TestCountsServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestCountsServiceShould.java
@@ -99,10 +99,10 @@ class TestCountsServiceShould {
                         new NamespaceResourceSummary("f3", "desc", 3, 0)));
         when(mockStandardStore.getStandardsForNamespace(NAMESPACE))
                 .thenReturn(List.of(new NamespaceResourceSummary("s1", "desc", 1, 0)));
-        when(mockAdrStore.getAdrsForNamespace(NAMESPACE))
-                .thenReturn(List.of(
-                        new NamespaceAdrSummary("adr1", "draft", 1),
-                        new NamespaceAdrSummary("adr2", "accepted", 2)));
+        // ADR is counted rather than listed: its summary carries the latest revision's title
+        // and status, so building the list costs two reads and a parse per ADR for a number
+        // that discards all of it.
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE)).thenReturn(2);
         when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE))
                 .thenReturn(List.of(new NamespaceInterfaceSummary("i1", "desc", 1)));
 
@@ -132,7 +132,7 @@ class TestCountsServiceShould {
                 .thenThrow(new NamespaceNotFoundException());
         when(mockStandardStore.getStandardsForNamespace(NAMESPACE))
                 .thenThrow(new NamespaceNotFoundException());
-        when(mockAdrStore.getAdrsForNamespace(NAMESPACE))
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE))
                 .thenThrow(new NamespaceNotFoundException());
         when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE))
                 .thenThrow(new NamespaceNotFoundException());
@@ -275,7 +275,7 @@ class TestCountsServiceShould {
         when(mockPatternStore.getPatternsForNamespace(NAMESPACE)).thenReturn(List.of());
         when(mockFlowStore.getFlowsForNamespace(NAMESPACE)).thenReturn(List.of());
         when(mockStandardStore.getStandardsForNamespace(NAMESPACE)).thenReturn(List.of());
-        when(mockAdrStore.getAdrsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE)).thenReturn(0);
         when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE)).thenReturn(List.of());
 
         service.getNamespaceCounts(ALL_ACCESS);
@@ -308,7 +308,7 @@ class TestCountsServiceShould {
         when(mockPatternStore.getPatternsForNamespace(NAMESPACE)).thenReturn(List.of());
         when(mockFlowStore.getFlowsForNamespace(NAMESPACE)).thenReturn(List.of());
         when(mockStandardStore.getStandardsForNamespace(NAMESPACE)).thenReturn(List.of());
-        when(mockAdrStore.getAdrsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE)).thenReturn(0);
         when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE)).thenReturn(List.of());
 
         List<NamespaceCounts> result = service.getNamespaceCounts(ALL_ACCESS);

--- a/calm-hub/src/test/java/org/finos/calm/services/TestCountsServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestCountsServiceShould.java
@@ -1,7 +1,6 @@
 package org.finos.calm.services;
 
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
-import org.finos.calm.domain.adr.NamespaceAdrSummary;
 import org.finos.calm.domain.controls.ControlDetail;
 import org.finos.calm.domain.controls.DomainControlCount;
 import org.finos.calm.domain.exception.DomainNotFoundException;
@@ -316,6 +315,44 @@ class TestCountsServiceShould {
         // A store-level failure is counted as zero rather than 500-ing the whole endpoint.
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getArchitectures(), is(0));
+    }
+
+    @Test
+    void count_adrs_as_zero_when_the_adr_store_throws_at_runtime() throws Exception {
+        when(mockNamespaceStore.getNamespaces())
+                .thenReturn(List.of(new NamespaceInfo(NAMESPACE, "FINOS namespace")));
+        when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockPatternStore.getPatternsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockFlowStore.getFlowsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockStandardStore.getStandardsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE))
+                .thenThrow(new RuntimeException("store unavailable"));
+        when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE)).thenReturn(List.of());
+
+        List<NamespaceCounts> result = service.getNamespaceCounts(ALL_ACCESS);
+
+        // ADR counts through its own path now, so it needs its own proof that a store
+        // failure is an undercount rather than a 500 for the whole endpoint.
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getAdrs(), is(0));
+    }
+
+    @Test
+    void count_adrs_as_zero_when_the_namespace_is_missing_from_the_adr_store() throws Exception {
+        when(mockNamespaceStore.getNamespaces())
+                .thenReturn(List.of(new NamespaceInfo(NAMESPACE, "FINOS namespace")));
+        when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockPatternStore.getPatternsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockFlowStore.getFlowsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockStandardStore.getStandardsForNamespace(NAMESPACE)).thenReturn(List.of());
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE))
+                .thenThrow(new NamespaceNotFoundException());
+        when(mockInterfaceStore.getInterfacesForNamespace(NAMESPACE)).thenReturn(List.of());
+
+        List<NamespaceCounts> result = service.getNamespaceCounts(ALL_ACCESS);
+
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getAdrs(), is(0));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
@@ -64,7 +64,7 @@ class TestNamespaceContentServiceShould {
         verify(mockPatternStore).getPatternsForNamespace(NAMESPACE);
         verify(mockFlowStore).getFlowsForNamespace(NAMESPACE);
         verify(mockStandardStore).getStandardsForNamespace(NAMESPACE);
-        verify(mockAdrStore).getAdrsForNamespace(NAMESPACE);
+        verify(mockAdrStore).countAdrsForNamespace(NAMESPACE);
         verify(mockInterfaceStore).getInterfacesForNamespace(NAMESPACE);
         verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
         verify(mockDecoratorStore).getDecoratorsForNamespace(NAMESPACE, null, null);

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
@@ -93,6 +93,33 @@ class TestNamespaceContentServiceShould {
     }
 
     @Test
+    void return_true_when_only_the_adr_store_has_content() throws Exception {
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE)).thenReturn(3);
+
+        // ADR is checked by count rather than by listing, so its true path needs its own
+        // cover — this gates an irreversible namespace delete.
+        assertThat(service.hasContent(NAMESPACE), is(true));
+    }
+
+    @Test
+    void treat_namespace_not_found_from_the_adr_store_as_empty() throws Exception {
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE))
+                .thenThrow(new NamespaceNotFoundException());
+
+        assertThat(service.hasContent(NAMESPACE), is(false));
+    }
+
+    @Test
+    void propagate_a_runtime_failure_from_the_adr_store_instead_of_treating_it_as_empty() throws Exception {
+        when(mockAdrStore.countAdrsForNamespace(NAMESPACE))
+                .thenThrow(new RuntimeException("store unavailable"));
+
+        // Deliberately unlike CountsService: reporting "no content" for content that was
+        // never confirmed absent would let the delete proceed.
+        assertThrows(RuntimeException.class, () -> service.hasContent(NAMESPACE));
+    }
+
+    @Test
     void treat_namespace_not_found_from_a_store_as_empty() throws Exception {
         when(mockArchitectureStore.getArchitecturesForNamespace(NAMESPACE))
                 .thenThrow(new NamespaceNotFoundException());

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -1,6 +1,5 @@
 package org.finos.calm.store.mongo;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mongodb.MongoWriteException;
@@ -9,10 +8,6 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -23,21 +18,35 @@ import org.finos.calm.domain.adr.Adr;
 import org.finos.calm.domain.adr.AdrMeta;
 import org.finos.calm.domain.adr.NamespaceAdrSummary;
 import org.finos.calm.domain.adr.Status;
-import org.finos.calm.domain.exception.*;
+import org.finos.calm.domain.exception.AdrNotFoundException;
+import org.finos.calm.domain.exception.AdrRevisionExistsException;
+import org.finos.calm.domain.exception.AdrRevisionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for ADR on the header/version shape. ADR is the one type whose history is
+ * an integer revision rather than a semantic version, and whose summary comes from the latest
+ * revision's content rather than from the entity — both are pinned here.
+ */
 @QuarkusTest
 public class TestMongoAdrStoreShould {
 
@@ -50,576 +59,287 @@ public class TestMongoAdrStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private ObjectMapper objectMapper;
-
-    private final String NAMESPACE = "finos";
-    private final AdrMeta simpleAdrMeta = new AdrMeta.AdrMetaBuilder()
-            .setNamespace(NAMESPACE)
-            .setId(42)
-            .setRevision(2)
-            .setAdr(new Adr.AdrBuilder()
-                    .setTitle("My ADR")
-                    .setStatus(Status.superseded)
-                    .setCreationDateTime(LocalDateTime.now())
-                    .setUpdateDateTime(LocalDateTime.now())
-                    .build())
-            .build();
-    private MongoCollection<Document> adrCollection;
-    private MongoAdrStore mongoAdrStore;
-
-    @BeforeEach
-    void setup() {
-        adrCollection = Mockito.mock(DocumentMongoCollection.class);
-
-        when(mongoDatabase.getCollection("adrs")).thenReturn(adrCollection);
-        mongoAdrStore = new MongoAdrStore(mongoDatabase, counterStore, namespaceStore);
-
-        this.objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-    }
-
-    @Test
-    void get_adrs_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(adrCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("adrs", Document.class))
-                .thenReturn(new ArrayList<>());
-
-        assertThat(mongoAdrStore.getAdrsForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_adrs_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(adrCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        assertThat(mongoAdrStore.getAdrsForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_adrs_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.getAdrsForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void get_adrs_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(adrCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        Document rev1 = new Document("title", "First ADR").append("status", "draft");
-        Document doc1 = new Document("adrId", 1001)
-                .append("revisions", new Document("1", rev1));
-        Document rev2 = new Document("title", "Second ADR").append("status", "accepted");
-        Document doc2 = new Document("adrId", 1002)
-                .append("revisions", new Document("1", rev2));
-
-        when(documentMock.getList("adrs", Document.class))
-                .thenReturn(Arrays.asList(doc1, doc2));
-
-        List<NamespaceAdrSummary> summaries = mongoAdrStore.getAdrsForNamespace(NAMESPACE);
-
-        assertThat(summaries.size(), is(2));
-        assertThat(summaries.get(0).getTitle(), is("First ADR"));
-        assertThat(summaries.get(0).getStatus(), is("draft"));
-        assertThat(summaries.get(0).getId(), is(1001));
-        assertThat(summaries.get(1).getTitle(), is("Second ADR"));
-        assertThat(summaries.get(1).getStatus(), is("accepted"));
-        assertThat(summaries.get(1).getId(), is(1002));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    private FindIterable<Document> setupInvalidAdr() {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        //Return the same find iterable as the projection unboxes, then return null
-        when(adrCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        return findIterable;
-    }
-
-    private void mockSetupAdrDocumentWithRevisions() throws JsonProcessingException {
-        Document mainDocument = setupAdrRevisionDocument();
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(adrCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_an_adr() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(namespace).build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.createAdrForNamespace(adrMeta));
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_created_adr_when_parameters_are_valid() throws NamespaceNotFoundException, JsonProcessingException, AdrParseException {
-        String validNamespace = NAMESPACE;
-        int sequenceNumber = 42;
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextAdrSequenceValue()).thenReturn(sequenceNumber);
-        AdrMeta adrMetaToCreate = new AdrMeta.AdrMetaBuilder()
-                .setAdr(new Adr.AdrBuilder().build())
-                .setNamespace(validNamespace)
-                .setRevision(1)
-                .build();
-
-        AdrMeta adrMeta = mongoAdrStore.createAdrForNamespace(adrMetaToCreate);
-
-        AdrMeta expectedAdrMeta = new AdrMeta.AdrMetaBuilder()
-                .setAdr(new Adr.AdrBuilder().build())
-                .setNamespace(validNamespace)
-                .setRevision(1)
-                .setId(sequenceNumber)
-                .build();
-
-        assertThat(adrMeta, is(expectedAdrMeta));
-        Document expectedDoc = new Document("adrId", adrMeta.getId()).append("revisions",
-                new Document("1", Document.parse(objectMapper.writeValueAsString(adrMeta.getAdr()))));
-
-        verify(adrCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("adrs", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException, AdrParseException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextAdrSequenceValue()).thenReturn(42);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-        AdrMeta adrMetaToCreate = new AdrMeta.AdrMetaBuilder()
-                .setAdr(new Adr.AdrBuilder().build())
-                .setNamespace(NAMESPACE)
-                .setRevision(1)
-                .build();
-
-        mongoAdrStore.createAdrForNamespace(adrMetaToCreate);
-
-        verify(adrCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_an_adr() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextAdrSequenceValue()).thenReturn(42);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-        AdrMeta adrMetaToCreate = new AdrMeta.AdrMetaBuilder()
-                .setAdr(new Adr.AdrBuilder().build())
-                .setNamespace(NAMESPACE)
-                .setRevision(1)
-                .build();
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoAdrStore.createAdrForNamespace(adrMetaToCreate));
-    }
-
-    @Test
-    void get_adr_revisions_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace("does-not-exist").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.getAdrRevisions(adrMeta));
-
-        verify(namespaceStore).namespaceExists(adrMeta.getNamespace());
-    }
-
-    private void mockSetupAdrDocumentWithNoRevisions() {
-        Document mainDocument = setupAdrWithNoRevisions();
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(adrCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    @Test
-    void get_adr_revisions_for_invalid_adr_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidAdr();
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE).build();
-
-        assertThrows(AdrNotFoundException.class,
-                () -> mongoAdrStore.getAdrRevisions(adrMeta));
-
-        verify(adrCollection).find(new Document("namespace", adrMeta.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("adrs")));
-    }
-
-    @Test
-    void get_adr_revisions_for_valid_adr_returns_list_of_revisions() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE).setId(42).build();
-        List<Integer> adrRevisions = mongoAdrStore.getAdrRevisions(adrMeta);
-
-        assertThat(adrRevisions, is(List.of(1)));
-    }
-
-    @Test
-    void get_adr_revision_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace("does-not-exist").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.getAdrRevision(adrMeta));
-
-        verify(namespaceStore).namespaceExists(adrMeta.getNamespace());
-    }
-
-    @Test
-    void throw_an_exception_for_an_invalid_adr_when_retrieving_adr_revision() {
-        FindIterable<Document> findIterable = setupInvalidAdr();
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE).build();
-
-        assertThrows(AdrNotFoundException.class,
-                () -> mongoAdrStore.getAdrRevision(adrMeta));
-
-        verify(adrCollection).find(new Document("namespace", adrMeta.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("adrs")));
-    }
-
-    @Test
-    void return_an_adr_revision() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException, JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE)
-                .setId(42).setRevision(1).build();
-
-        AdrMeta adrMetaRevision = mongoAdrStore.getAdrRevision(adrMeta);
-        AdrMeta expectedAdrRevisionMeta = new AdrMeta.AdrMetaBuilder(simpleAdrMeta).setRevision(1).build();
-        assertThat(adrMetaRevision, is(expectedAdrRevisionMeta));
-    }
-
-    private Document setupAdrWithNoRevisions() {
-        //Set up an ADR document with 1 ADR with No Revisions
-        return new Document("namespace", NAMESPACE)
-                .append("adrs", List.of(new Document("adrId", 42)));
-    }
-
-    private Document setupAdrRevisionDocument() throws JsonProcessingException {
-        //Set up an ADR document with 2 ADRs in (one with a valid revision)
-        Map<String, Document> revisionMap = new HashMap<>();
-        revisionMap.put("1", Document.parse(objectMapper.writeValueAsString(simpleAdrMeta.getAdr())));
-        Document targetStoredAdr = new Document("adrId", 42)
-                .append("revisions", new Document(revisionMap));
-
-        Document paddingAdr = new Document("adrId", 0);
-
-        return new Document("namespace", NAMESPACE)
-                .append("adrs", Arrays.asList(paddingAdr, targetStoredAdr));
-    }
-
-    @Test
-    void throw_an_exception_when_revision_of_adr_does_not_exist() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE)
-                .setId(42).setRevision(9).build();
-
-        assertThrows(AdrRevisionNotFoundException.class,
-                () -> mongoAdrStore.getAdrRevision(adrMeta));
-    }
-
-    @Test
-    void throw_an_exception_when_no_revision_exists_when_getting_adr()  {
-        mockSetupAdrDocumentWithNoRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE)
-                .setId(42).setRevision(1).build();
-
-        assertThrows(AdrRevisionNotFoundException.class,
-                () -> mongoAdrStore.getAdr(adrMeta));
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoAdrStore store;
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private static final String NAMESPACE = "finos";
+    private static final int ADR_ID = 42;
+
+    @BeforeEach
+    void setup() {
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
+
+        when(mongoDatabase.getCollection("adrs")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("adrVersions")).thenReturn(versionCollection);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new MongoAdrStore(mongoDatabase, counterStore, namespaceStore);
+    }
+
+    private void stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    private void adrExists() {
+        stubFind(headerCollection, List.of(new Document("adrId", ADR_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void adrDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static Adr adr(String title, Status status) {
+        return new Adr.AdrBuilder().setTitle(title).setStatus(status).build();
+    }
+
+    private Document contentOf(String title, Status status) throws Exception {
+        return Document.parse(objectMapper.writeValueAsString(adr(title, status)));
+    }
+
+    private static AdrMeta adrMeta(int revision, Adr adr) {
+        return new AdrMeta.AdrMetaBuilder()
+                .setNamespace(NAMESPACE).setId(ADR_ID).setRevision(revision).setAdr(adr).build();
+    }
+
+    /** Version documents as listVersions sees them, plus the content getVersion returns. */
+    private void stubRevisions(List<String> revisions, Document latestContent) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(versionCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(latestContent == null ? null : new Document("content", latestContent));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            revisions.forEach(revision -> consumer.accept(new Document("version", revision)));
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    // --- getAdrsForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_adrs_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getAdrsForNamespace(NAMESPACE));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_adr_when_retrieving_adr() {
-        FindIterable<Document> findIterable = setupInvalidAdr();
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE).setId(7).build();
+    void return_an_empty_list_when_a_namespace_has_no_adrs() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        assertThrows(AdrNotFoundException.class,
-                () -> mongoAdrStore.getAdr(adrMeta));
-
-        verify(adrCollection).find(new Document("namespace", adrMeta.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("adrs")));
+        assertThat(store.getAdrsForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void get_adr_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace("does-not-exist").build();
+    void build_the_summary_from_the_latest_revisions_title_and_status() throws Exception {
+        stubFind(headerCollection, List.of(new Document("adrId", ADR_ID)));
+        stubRevisions(List.of("1", "2"), contentOf("Use Event Sourcing", Status.accepted));
 
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.getAdr(adrMeta));
-
-        verify(namespaceStore).namespaceExists(adrMeta.getNamespace());
+        // Unlike every other type, none of this comes off the header — ADR has no name or
+        // description of its own.
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("Use Event Sourcing", "accepted", ADR_ID)));
     }
 
     @Test
-    void return_the_latest_adr_revision() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrParseException {
-        mockSetupAdrDocumentWithRevisions();
+    void fall_back_to_placeholders_when_an_adr_has_no_readable_revision() throws Exception {
+        stubFind(headerCollection, List.of(new Document("adrId", 7)));
+        stubRevisions(List.of(), null);
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder().setNamespace(NAMESPACE)
-                .setId(42).build();
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("ADR 7", "unknown", 7)));
+    }
 
-        AdrMeta latestAdrMeta = mongoAdrStore.getAdr(adrMeta);
-        AdrMeta expectedAdrMeta = new AdrMeta.AdrMetaBuilder(simpleAdrMeta).setRevision(1).build();
-        assertThat(latestAdrMeta, is(expectedAdrMeta));
+    // --- createAdrForNamespace ---
+
+    @Test
+    void create_a_header_and_the_first_revision() throws Exception {
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        AdrMeta created = store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft)));
+
+        assertThat(created.getId(), is(99));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        // Stored as the revision number, not a semantic version.
+        assertThat(versionCaptor.getValue().getString("version"), is("1"));
     }
 
     @Test
-    void throw_an_exception_when_update_adr_with_a_namespace_that_doesnt_exists() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
+    void remove_the_header_again_when_the_first_revision_write_fails() {
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
+        assertThrows(RuntimeException.class,
+                () -> store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft))));
 
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
 
-        verify(namespaceStore, times(1)).namespaceExists(adrMeta.getNamespace());
+    // --- getAdr / getAdrRevisions / getAdrRevision ---
+
+    @Test
+    void throw_an_adr_exception_when_the_adr_is_missing() {
+        adrDoesNotExist();
+
+        assertThrows(AdrNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
     }
 
     @Test
-    void throw_an_exception_when_updating_an_adr_that_doesnt_exist() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
+    void resolve_the_latest_revision_numerically_rather_than_lexicographically() throws Exception {
+        adrExists();
+        stubRevisions(List.of("2", "10"), contentOf("Latest", Status.accepted));
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(22)
-                .build();
-
-        assertThrows(AdrNotFoundException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+        // The whole reason ADR needed NumericVersionOrder: a string sort would call 2 the
+        // latest, so every read resolving "latest" would return stale content.
+        assertThat(store.getAdr(adrMeta(1, null)).getRevision(), is(10));
     }
 
     @Test
-    void throw_an_exception_when_updating_an_adr_but_no_revisions_exist() {
-        mockSetupAdrDocumentWithNoRevisions();
+    void throw_a_revision_exception_when_an_adr_has_no_revisions() {
+        adrExists();
+        stubRevisions(List.of(), null);
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setAdr(new Adr.AdrBuilder().build())
-                .build();
-
-        assertThrows(AdrRevisionNotFoundException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
     }
 
     @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_when_updating_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
+    void list_revisions_as_ascending_integers() throws Exception {
+        adrExists();
+        stubRevisions(List.of("10", "2", "1"), contentOf("t", Status.draft));
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setAdr(new Adr.AdrBuilder().build())
-                .build();
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
-        assertThat(exception.isCapacityExceeded(), is(false));
+        assertThat(store.getAdrRevisions(adrMeta(1, null)), contains(1, 2, 10));
     }
 
     @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_an_adr_hits_the_document_size_limit() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenThrow(new MongoWriteException(new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of()));
+    void throw_a_revision_exception_when_listing_revisions_of_an_adr_with_none() {
+        adrExists();
+        stubRevisions(List.of(), null);
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setAdr(new Adr.AdrBuilder().build())
-                .build();
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
-        assertThat(exception.isCapacityExceeded(), is(true));
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdrRevisions(adrMeta(1, null)));
     }
 
     @Test
-    void throw_an_exception_when_a_concurrent_writer_already_created_the_same_adr_revision() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        UpdateResult conflictingResult = mock(UpdateResult.class);
-        when(conflictingResult.getMatchedCount()).thenReturn(0L);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(conflictingResult);
+    void return_a_specific_revision() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1"), contentOf("Specific", Status.proposed));
 
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setAdr(new Adr.AdrBuilder().build())
-                .build();
+        assertThat(store.getAdrRevision(adrMeta(1, null)).getAdr().getTitle(), is("Specific"));
+    }
 
+    @Test
+    void throw_a_revision_exception_when_the_requested_revision_is_missing() {
+        adrExists();
+        stubRevisions(List.of("1"), null);
+
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdrRevision(adrMeta(9, null)));
+    }
+
+    @Test
+    void report_a_parse_failure_when_stored_content_is_not_a_readable_adr() {
+        adrExists();
+        stubRevisions(List.of("1"), new Document("not-an-adr", true).append("title", 42));
+
+        assertThrows(org.finos.calm.domain.exception.AdrParseException.class,
+                () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    void report_a_missing_revision_when_the_latest_disappears_between_resolving_and_reading() {
+        adrExists();
+        // listVersions sees revision 1, but the content read comes back empty — the document
+        // was removed in between. Reporting "no revision" is honest; returning null is not.
+        stubRevisions(List.of("1"), null);
+
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    void remove_the_header_when_the_first_revision_already_exists_for_a_fresh_id() {
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        // A revision present for an id the counter just issued is a storage inconsistency,
+        // not a normal "already exists".
+        assertThrows(org.finos.calm.domain.exception.StorageWriteException.class,
+                () -> store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft))));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    // --- updateAdrForNamespace / updateAdrStatus ---
+
+    @Test
+    void write_the_next_revision_when_updating_an_adr() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1", "2"), contentOf("Existing", Status.accepted));
+
+        AdrMeta updated = store.updateAdrForNamespace(adrMeta(1, adr("Rewritten", Status.draft)));
+
+        assertThat(updated.getRevision(), is(3));
+        // Status and creation time come from the stored latest revision, not the request.
+        assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(captor.capture());
+        assertThat(captor.getValue().getString("version"), is("3"));
+    }
+
+    @Test
+    void write_the_next_revision_when_updating_status() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1"), contentOf("Existing", Status.draft));
+
+        AdrMeta updated = store.updateAdrStatus(adrMeta(1, null), Status.accepted);
+
+        assertThat(updated.getRevision(), is(2));
+        assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+    }
+
+    @Test
+    void report_the_revision_already_exists_when_two_writers_race() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1"), contentOf("Existing", Status.draft));
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        // Both update paths compute latest + 1, so two concurrent writers land on the same
+        // number. The loser must be told, not silently overwrite the winner.
         assertThrows(AdrRevisionExistsException.class,
-                () -> mongoAdrStore.updateAdrForNamespace(adrMeta));
-    }
-
-    @Test
-    void return_successfully_when_correctly_updating_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
-        mockSetupAdrDocumentWithRevisions();
-        UpdateResult successfulResult = mock(UpdateResult.class);
-        when(successfulResult.getMatchedCount()).thenReturn(1L);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(successfulResult);
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .setRevision(2)
-                .setAdr(new Adr.AdrBuilder().build())
-                .build();
-
-        mongoAdrStore.updateAdrForNamespace(adrMeta);
-
-        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class));
-    }
-
-    @Test
-    void throw_an_exception_when_updating_status_with_a_namespace_that_doesnt_exists() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted));
-
-        verify(namespaceStore, times(1)).namespaceExists(adrMeta.getNamespace());
-    }
-
-    @Test
-    void throw_an_exception_when_updating_the_status_of_an_adr_that_doesnt_exist() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(22)
-                .build();
-
-        assertThrows(AdrNotFoundException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted));
-    }
-
-    @Test
-    void throw_an_exception_when_updating_the_status_of_an_adr_but_no_revisions_exist() {
-        mockSetupAdrDocumentWithNoRevisions();
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        assertThrows(AdrRevisionNotFoundException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_when_updating_the_status_of_an_adr_but_mongo_cannot_write_update() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenThrow(new MongoWriteException(new WriteError(1, "error", new BsonDocument()), new ServerAddress(), List.of()));
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.proposed));
-        assertThat(exception.isCapacityExceeded(), is(false));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_the_status_of_an_adr_hits_the_document_size_limit() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenThrow(new MongoWriteException(new WriteError(10334, "object to insert too large", new BsonDocument()), new ServerAddress(), List.of()));
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.proposed));
-        assertThat(exception.isCapacityExceeded(), is(true));
-    }
-
-    @Test
-    void throw_an_exception_when_a_concurrent_writer_already_created_the_same_status_revision() throws JsonProcessingException {
-        mockSetupAdrDocumentWithRevisions();
-        UpdateResult conflictingResult = mock(UpdateResult.class);
-        when(conflictingResult.getMatchedCount()).thenReturn(0L);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(conflictingResult);
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        assertThrows(AdrRevisionExistsException.class,
-                () -> mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted));
-    }
-
-    @Test
-    void return_successfully_when_correctly_updating_the_status_of_an_adr() throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, JsonProcessingException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException {
-        mockSetupAdrDocumentWithRevisions();
-        UpdateResult successfulResult = mock(UpdateResult.class);
-        when(successfulResult.getMatchedCount()).thenReturn(1L);
-        when(adrCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(successfulResult);
-
-        AdrMeta adrMeta = new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(42)
-                .build();
-
-        mongoAdrStore.updateAdrStatus(adrMeta, Status.accepted);
-
-        verify(adrCollection, times(1)).updateOne(any(Bson.class), any(Bson.class));
+                () -> store.updateAdrStatus(adrMeta(1, null), Status.accepted));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -176,6 +176,17 @@ public class TestMongoAdrStoreShould {
                 contains(new NamespaceAdrSummary("ADR 7", "unknown", 7)));
     }
 
+    @Test
+    void render_a_header_with_no_id_rather_than_failing_the_whole_listing() throws Exception {
+        stubFind(headerCollection, List.of(new Document("adrId", null)));
+
+        // listSummariesPaged sorts null ids last precisely so one malformed header does not
+        // fail the listing. Resolving its latest revision unboxes the null into the helper's
+        // int parameter, which would turn that tolerance back into a 500 for the namespace.
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("ADR null", "unknown", null)));
+    }
+
     // --- createAdrForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -40,6 +40,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -185,6 +186,23 @@ public class TestMongoAdrStoreShould {
         // int parameter, which would turn that tolerance back into a 500 for the namespace.
         assertThat(store.getAdrsForNamespace(NAMESPACE),
                 contains(new NamespaceAdrSummary("ADR null", "unknown", null)));
+    }
+
+    @Test
+    void count_adrs_without_resolving_any_revision() throws Exception {
+        when(headerCollection.countDocuments(any(Bson.class))).thenReturn(4L);
+
+        assertThat(store.countAdrsForNamespace(NAMESPACE), is(4));
+        // The whole point: sizing getAdrsForNamespace would read and parse every ADR's
+        // latest revision to produce this number.
+        verifyNoInteractions(versionCollection);
+    }
+
+    @Test
+    void throw_a_namespace_exception_when_counting_adrs_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.countAdrsForNamespace(NAMESPACE));
     }
 
     // --- createAdrForNamespace ---

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -227,6 +227,28 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
+    void resolve_a_three_digit_revision_as_the_latest() throws Exception {
+        adrExists();
+        stubRevisions(List.of("99", "100"), contentOf("Latest", Status.accepted));
+
+        // Revision 100 is the first that VERSION_REGEX also reads as a spelling of 1.0.0.
+        // While the helper canonicalised it, it was stored as "1.0.0", which
+        // NumericVersionOrder sorts below "99" — so this returned revision 99's content
+        // while 100 existed, with no error anywhere.
+        assertThat(store.getAdr(adrMeta(1, null)).getRevision(), is(100));
+    }
+
+    @Test
+    void list_three_digit_revisions_without_failing_to_parse_them() throws Exception {
+        adrExists();
+        stubRevisions(List.of("99", "100"), null);
+
+        // getAdrRevisions maps these through Integer.parseInt; a canonicalised "1.0.0"
+        // threw NumberFormatException straight out of the store.
+        assertThat(store.getAdrRevisions(adrMeta(1, null)), contains(99, 100));
+    }
+
+    @Test
     void throw_a_revision_exception_when_an_adr_has_no_revisions() {
         adrExists();
         stubRevisions(List.of(), null);

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
@@ -6,10 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -18,26 +15,42 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Flow;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestMongoVersionDocumentStoreShould}; what this class pins is the glue — which
+ * domain exception each missing thing produces, and Flow's blank-guarding of
+ * name/description, which is where it deliberately differs from Architecture.
+ */
 @QuarkusTest
 public class TestMongoFlowStoreShould {
 
@@ -50,410 +63,351 @@ public class TestMongoFlowStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private MongoCollection<Document> flowCollection;
-    private MongoFlowStore mongoFlowStore;
-    private final String NAMESPACE = "finos";
-
-    private final String validJson = "{\"test\": \"test\"}";
-
-    @BeforeEach
-    void setup() {
-        flowCollection = Mockito.mock(DocumentMongoCollection.class);
-
-        when(mongoDatabase.getCollection("flows")).thenReturn(flowCollection);
-        mongoFlowStore = new MongoFlowStore(mongoDatabase, counterStore, namespaceStore);
-    }
-
-    @Test
-    void get_flows_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(flowCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("flows", Document.class))
-                .thenReturn(new ArrayList<>());
-
-        assertThat(mongoFlowStore.getFlowsForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_flows_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(flowCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        assertThat(mongoFlowStore.getFlowsForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_flow_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.getFlowsForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void get_flow_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(flowCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        Document doc1 = new Document("flowId", 1001).append("name", "Flow One").append("description", "First flow")
-                .append("versions", new Document("1-0-0", new Document()).append("2-0-0", new Document()));
-        Document doc2 = new Document("flowId", 1002).append("name", "Flow Two").append("description", "Second flow")
-                .append("versions", new Document("1-0-0", new Document()));
-
-        when(documentMock.getList("flows", Document.class))
-                .thenReturn(Arrays.asList(doc1, doc2));
-
-        List<NamespaceResourceSummary> flows = mongoFlowStore.getFlowsForNamespace(NAMESPACE);
-
-        assertThat(flows.size(), is(2));
-        assertThat(flows.get(0).getName(), is("Flow One"));
-        assertThat(flows.get(0).getDescription(), is("First flow"));
-        assertThat(flows.get(0).getId(), is(1001));
-        assertThat(flows.get(0).getVersionCount(), is(2));
-        assertThat(flows.get(1).getName(), is("Flow Two"));
-        assertThat(flows.get(1).getDescription(), is("Second flow"));
-        assertThat(flows.get(1).getId(), is(1002));
-        assertThat(flows.get(1).getVersionCount(), is(1));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_flow_for_namespace_returns_fallback_for_legacy_documents() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(flowCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        // Legacy document without name or description
-        Document legacyDoc = new Document("flowId", 77);
-
-        when(documentMock.getList("flows", Document.class))
-                .thenReturn(List.of(legacyDoc));
-
-        List<NamespaceResourceSummary> flows = mongoFlowStore.getFlowsForNamespace(NAMESPACE);
-
-        assertThat(flows.size(), is(1));
-        assertThat(flows.get(0).getName(), is("Flow 77"));
-        assertThat(flows.get(0).getDescription(), is(""));
-        assertThat(flows.get(0).getId(), is(77));
-        // Legacy document carries no versions sub-document → count guards to 0.
-        assertThat(flows.get(0).getVersionCount(), is(0));
-    }
-
-    private FindIterable<Document> setupInvalidFlow() {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        //Return the same find iterable as the projection unboxes, then return null
-        when(flowCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-
-        return findIterable;
-    }
-
-    private void mockSetupFlowDocumentWithVersions() {
-        Document mainDocument = setupFlowVersionDocument();
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(flowCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_an_flow() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        CreateFlowRequest request = new CreateFlowRequest("name", "desc", validJson);
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.createFlowForNamespace(request, namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_a_json_parse_exception_when_an_invalid_json_object_is_presented() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextFlowSequenceValue()).thenReturn(42);
-        CreateFlowRequest request = new CreateFlowRequest("name", "desc", "Invalid JSON");
-
-        assertThrows(JsonParseException.class,
-                () -> mongoFlowStore.createFlowForNamespace(request, NAMESPACE));
-    }
-
-    @Test
-    void return_created_flow_when_parameters_are_valid() throws NamespaceNotFoundException {
-        String validNamespace = NAMESPACE;
-        int sequenceNumber = 42;
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextFlowSequenceValue()).thenReturn(sequenceNumber);
-        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", validJson);
-
-        Flow flow = mongoFlowStore.createFlowForNamespace(request, validNamespace);
-
-        Flow expectedFlow = new Flow.FlowBuilder().setFlow(validJson)
-                .setNamespace(validNamespace)
-                .setVersion("1.0.0")
-                .setId(sequenceNumber)
-                .build();
-
-        assertThat(flow, is(expectedFlow));
-        Document expectedDoc = new Document("flowId", flow.getId())
-                .append("name", "Test Flow")
-                .append("description", "A test")
-                .append("versions",
-                new Document("1-0-0", Document.parse(flow.getFlowJson())));
-
-        verify(flowCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("flows", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextFlowSequenceValue()).thenReturn(42);
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", validJson);
-
-        mongoFlowStore.createFlowForNamespace(request, NAMESPACE);
-
-        verify(flowCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_a_flow() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextFlowSequenceValue()).thenReturn(42);
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", validJson);
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoFlowStore.createFlowForNamespace(request, NAMESPACE));
-    }
-
-    @Test
-    void get_flow_version_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        Flow flow = new Flow.FlowBuilder().setNamespace("does-not-exist").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.getFlowVersions(flow));
-
-        verify(namespaceStore).namespaceExists(flow.getNamespace());
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoFlowStore store;
+
+    private static final String NAMESPACE = "finos";
+    private static final int FLOW_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
+
+    @BeforeEach
+    void setup() {
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
+
+        when(mongoDatabase.getCollection("flows")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("flowVersions")).thenReturn(versionCollection);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new MongoFlowStore(mongoDatabase, counterStore, namespaceStore);
+    }
+
+    private FindIterable<Document> stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+        return iterable;
+    }
+
+    private void flowExists() {
+        stubFind(headerCollection, List.of(new Document("flowId", FLOW_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void flowDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static Flow flow(String version, String name, String description) {
+        return new Flow.FlowBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(FLOW_ID)
+                .setVersion(version)
+                .setName(name)
+                .setDescription(description)
+                .setFlow(VALID_JSON)
+                .build();
+    }
+
+    private static Flow flow(String version) {
+        return flow(version, "flow-name", "flow-description");
+    }
+
+    private static CreateFlowRequest createRequest() {
+        return new CreateFlowRequest("flow-name", "flow-description", VALID_JSON);
+    }
+
+    // --- getFlowsForNamespace ---
+
     @Test
-    void get_flow_version_for_invalid_pattern_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidFlow();
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE).build();
+    void throw_a_namespace_exception_when_listing_flows_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        assertThrows(FlowNotFoundException.class,
-                () -> mongoFlowStore.getFlowVersions(flow));
-
-        verify(flowCollection).find(new Document("namespace", flow.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("flows")));
+        assertThrows(NamespaceNotFoundException.class, () -> store.getFlowsForNamespace(NAMESPACE));
     }
 
     @Test
-    void get_flow_versions_for_valid_flow_returns_list_of_versions() throws FlowNotFoundException, NamespaceNotFoundException {
-        mockSetupFlowDocumentWithVersions();
+    void return_an_empty_list_when_a_namespace_has_no_flows() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE).setId(42).build();
-        List<String> flowVersions = mongoFlowStore.getFlowVersions(flow);
-
-        assertThat(flowVersions, is(List.of("1.0.0")));
+        assertThat(store.getFlowsForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_namespace_when_retrieving_flow_for_version() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        Flow flow = new Flow.FlowBuilder().setNamespace("does-not-exist").build();
+    void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                new Document("flowId", 1).append("name", "First").append("description", "d1")
+                        .append("versionCount", 2),
+                new Document("flowId", 2).append("name", "Second").append("description", "d2")
+                        .append("versionCount", 0)));
+
+        assertThat(store.getFlowsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
+    }
+
+    @Test
+    void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(new Document("flowId", 7)));
+
+        assertThat(store.getFlowsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("Flow 7", "", 7, 0)));
+    }
+
+
+    // --- createFlowForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_creating_a_flow_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.getFlowVersions(flow));
-
-        verify(namespaceStore).namespaceExists(flow.getNamespace());
+                () -> store.createFlowForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_flow_when_retrieving_flow_for_version() {
-        FindIterable<Document> findIterable = setupInvalidFlow();
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE).build();
+    void reject_invalid_json_before_drawing_an_id_or_writing_anything() {
+        CreateFlowRequest invalid = new CreateFlowRequest("n", "d", "{invalid json}");
 
-        assertThrows(FlowNotFoundException.class,
-                () -> mongoFlowStore.getFlowForVersion(flow));
+        assertThrows(JsonParseException.class, () -> store.createFlowForNamespace(invalid, NAMESPACE));
 
-        verify(flowCollection).find(new Document("namespace", flow.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("flows")));
+        verify(counterStore, never()).getNextFlowSequenceValue();
+        verify(headerCollection, never()).insertOne(any(Document.class));
     }
 
     @Test
-    void return_an_flow_for_a_given_version() throws FlowNotFoundException, FlowVersionNotFoundException, NamespaceNotFoundException {
-        mockSetupFlowDocumentWithVersions();
+    void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(counterStore.getNextFlowSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
 
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").build();
+        Flow created = store.createFlowForNamespace(createRequest(), NAMESPACE);
 
-        String flowForVersion = mongoFlowStore.getFlowForVersion(flow);
-        assertThat(flowForVersion, is(validJson));
-    }
+        assertThat(created.getId(), is(99));
+        // Dot-separated on both backends now; Nitrite used to return "1-0-0" here.
+        assertThat(created.getDotVersion(), is("1.0.0"));
 
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().getInteger("flowId"), is(99));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(0));
 
-    private Document setupFlowVersionDocument() {
-        //Set up an flow document with 2 flows in (one with a valid version)
-        Map<String, Document> versionMap = new HashMap<>();
-        versionMap.put("1-0-0", Document.parse(validJson));
-        Document targetStoredFlow = new Document("flowId", 42)
-                .append("versions", new Document(versionMap));
-
-        Document paddingFlow = new Document("flowId", 0);
-
-        return new Document("namespace", NAMESPACE)
-                .append("flows", Arrays.asList(paddingFlow, targetStoredFlow));
-    }
-
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
     }
 
     @Test
-    void throw_an_exception_when_flow_for_given_version_does_not_exist()  {
-        mockSetupFlowDocumentWithVersions();
+    void remove_the_header_again_when_the_first_version_write_fails() {
+        when(counterStore.getNextFlowSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
 
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
+        assertThrows(StorageWriteException.class,
+                () -> store.createFlowForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    // --- getFlowVersions ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_versions_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getFlowVersions(flow(null)));
+    }
+
+    @Test
+    void throw_a_flow_exception_when_listing_versions_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class, () -> store.getFlowVersions(flow(null)));
+    }
+
+    @Test
+    void list_versions_in_semantic_order() throws NamespaceNotFoundException, FlowNotFoundException {
+        stubFind(headerCollection, List.of(new Document("flowId", FLOW_ID)));
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.getFlowVersions(flow(null)), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void return_no_versions_rather_than_not_found_for_a_flow_with_none() throws NamespaceNotFoundException, FlowNotFoundException {
+        stubFind(headerCollection, List.of(new Document("flowId", FLOW_ID)));
+        stubFind(versionCollection, List.of());
+
+        // ADR 0003: the header proves the flow exists, so an empty version list is an
+        // answer rather than evidence of a missing flow.
+        assertThat(store.getFlowVersions(flow(null)), is(empty()));
+    }
+
+    // --- getFlowForVersion ---
+
+    @Test
+    void throw_a_flow_exception_when_getting_a_version_of_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class, () -> store.getFlowForVersion(flow("1.0.0")));
+    }
+
+    @Test
+    void throw_a_version_exception_when_the_version_is_not_stored() {
+        stubFind(headerCollection, List.of(new Document("flowId", FLOW_ID)));
+        stubFind(versionCollection, List.of());
 
         assertThrows(FlowVersionNotFoundException.class,
-                () -> mongoFlowStore.getFlowForVersion(flow));
+                () -> store.getFlowForVersion(flow("9.0.0")));
     }
 
     @Test
-    void throw_an_exception_when_create_or_update_flow_for_version_with_a_namespace_that_doesnt_exists() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
+    void return_the_content_of_a_stored_version() throws Exception {
+        stubFind(headerCollection, List.of(new Document("flowId", FLOW_ID)));
+        stubFind(versionCollection, List.of(new Document("content", new Document("test", "test"))));
 
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
+        assertThat(store.getFlowForVersion(flow("1.0.0")), containsString("\"test\""));
+    }
 
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.createFlowForVersion(flow));
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoFlowStore.updateFlowForVersion(flow));
+    // --- createFlowForVersion ---
 
-        verify(namespaceStore, times(2)).namespaceExists(flow.getNamespace());
+    @Test
+    void throw_a_flow_exception_when_creating_a_version_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class,
+                () -> store.createFlowForVersion(flow("1.0.1")));
     }
 
     @Test
-    void throw_an_exception_when_create_on_a_version_that_exists() {
-        mockSetupFlowDocumentWithVersions();
-
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(0, 0L, null));
-
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").setFlow(validJson).build();
+    void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        flowExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
         assertThrows(FlowVersionExistsException.class,
-                () -> mongoFlowStore.createFlowForVersion(flow));
+                () -> store.createFlowForVersion(flow("1.0.1")));
     }
 
     @Test
-    void throw_a_flow_not_found_exception_when_creating_or_updating_a_version_for_a_missing_flow() {
-        mockSetupFlowDocumentWithVersions();
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(50).setVersion("1.0.1")
-                .setFlow(validJson).build();
+    void not_rename_the_flow_when_the_version_already_exists() {
+        flowExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
-        assertThrows(FlowNotFoundException.class,
-                () -> mongoFlowStore.createFlowForVersion(flow));
-        assertThrows(FlowNotFoundException.class,
-                () -> mongoFlowStore.updateFlowForVersion(flow));
+        assertThrows(FlowVersionExistsException.class,
+                () -> store.createFlowForVersion(flow("1.0.1")));
 
-        // The entity-existence pre-check catches the missing flow before any write is
-        // attempted, so no update is ever sent to Mongo (either overload).
-        verify(flowCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(flowCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class));
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
-        mockSetupFlowDocumentWithVersions();
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setFlow(validJson).build();
+    void write_the_version_and_then_the_header_details() throws Exception {
+        flowExists();
 
-        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+        store.createFlowForVersion(flow("1.0.1"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.1"));
+        // Two header writes: the versionCount increment and the name/description update.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void leave_the_stored_name_alone_when_a_version_write_carries_none() throws Exception {
+        flowExists();
+
+        store.createFlowForVersion(flow("1.0.1", null, null));
+
+        // Where Architecture overwrites unconditionally — wiping the display name, bugs.md
+        // #2 — Flow's old shape guarded these fields, so only the count write happens.
+        verify(headerCollection, Mockito.times(1)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void update_only_the_details_that_are_present() throws Exception {
+        flowExists();
+
+        store.createFlowForVersion(flow("1.0.1", "Renamed", "  "));
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), updateCaptor.capture());
+        String detailsUpdate = updateCaptor.getAllValues().get(1).toBsonDocument().toJson();
+        assertThat(detailsUpdate, containsString("Renamed"));
+        assertThat(detailsUpdate, not(containsString("description")));
+    }
+
+    // --- updateFlowForVersion ---
+
+    @Test
+    void throw_a_flow_exception_when_updating_a_version_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class,
+                () -> store.updateFlowForVersion(flow("1.0.1")));
+    }
+
+    @Test
+    void force_write_a_version_on_update() throws Exception {
+        flowExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        store.updateFlowForVersion(flow("1.0.1"));
+
+        verify(versionCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        // Replacing an existing version doesn't move the count, so the only header write
+        // here is the name/description update.
+        verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void report_capacity_exceeded_when_a_version_write_hits_the_document_size_limit() {
+        flowExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10334, "object to insert too large"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoFlowStore.updateFlowForVersion(flow));
+                () -> store.updateFlowForVersion(flow("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
-        mockSetupFlowDocumentWithVersions();
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setFlow(validJson).build();
-
-        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+    void report_a_plain_write_failure_for_other_version_write_errors() {
+        flowExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10107, "not master"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoFlowStore.updateFlowForVersion(flow));
+                () -> store.updateFlowForVersion(flow("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
-    }
-
-    @Test
-    void accept_the_creation_or_update_of_a_valid_version() throws FlowNotFoundException, NamespaceNotFoundException, FlowVersionExistsException {
-        mockSetupFlowDocumentWithVersions();
-
-        when(flowCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
-
-        Flow flow = new Flow.FlowBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setFlow(validJson).build();
-
-        mongoFlowStore.updateFlowForVersion(flow);
-        mongoFlowStore.createFlowForVersion(flow);
-
-        verify(flowCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(flowCollection).updateOne(any(Bson.class), any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -6,39 +6,49 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.bson.json.JsonParseException;
 import org.finos.calm.domain.CalmInterface;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestMongoVersionDocumentStoreShould}. Interface differs from Pattern and Flow in two
+ * ways this class pins: version writes set name/description unconditionally, and there is no
+ * update path at all.
+ */
 @QuarkusTest
 public class TestMongoInterfaceStoreShould {
 
@@ -51,362 +61,235 @@ public class TestMongoInterfaceStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private MongoCollection<Document> interfaceCollection;
-
-    private MongoInterfaceStore mongoInterfaceStore;
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
-    }
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoInterfaceStore store;
+
+    private static final String NAMESPACE = "finos";
+    private static final int INTERFACE_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
 
     @BeforeEach
     void setup() {
-        interfaceCollection = Mockito.mock(DocumentMongoCollection.class);
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
 
-        when(mongoDatabase.getCollection("interfaces")).thenReturn(interfaceCollection);
-        mongoInterfaceStore = new MongoInterfaceStore(mongoDatabase, counterStore, namespaceStore);
-    }
-
-    @Test
-    void get_interface_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(mongoDatabase.getCollection("interfaces")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("interfaceVersions")).thenReturn(versionCollection);
         when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("interfaces", Document.class))
-                .thenReturn(new ArrayList<>());
 
-        assertThat(mongoInterfaceStore.getInterfacesForNamespace("finos"), is(empty()));
-        verify(namespaceStore).namespaceExists("finos");
+        store = new MongoInterfaceStore(mongoDatabase, counterStore, namespaceStore);
+    }
+
+    private void stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    private void interfaceExists() {
+        stubFind(headerCollection, List.of(new Document("interfaceId", INTERFACE_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void interfaceDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static CreateInterfaceRequest createRequest() {
+        return new CreateInterfaceRequest("interface-name", "interface-description", VALID_JSON);
+    }
+
+    // --- getInterfacesForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_interfaces_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getInterfacesForNamespace(NAMESPACE));
     }
 
     @Test
-    void get_interface_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
+    void return_an_empty_list_when_a_namespace_has_no_interfaces() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        assertThat(mongoInterfaceStore.getInterfacesForNamespace("finos"), is(empty()));
-        verify(namespaceStore).namespaceExists("finos");
+        assertThat(store.getInterfacesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void get_interface_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
+    void return_a_summary_per_header_document_without_a_version_count() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                new Document("interfaceId", 1).append("name", "First").append("description", "d1")
+                        .append("versionCount", 2),
+                new Document("interfaceId", 2).append("name", "Second").append("description", "d2")
+                        .append("versionCount", 0)));
+
+        assertThat(store.getInterfacesForNamespace(NAMESPACE), contains(
+                new NamespaceInterfaceSummary("First", "d1", 1),
+                new NamespaceInterfaceSummary("Second", "d2", 2)));
+    }
+
+    // --- createInterfaceForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_creating_a_interface_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfacesForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
+                () -> store.createInterfaceForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    void get_interface_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
+    void reject_invalid_json_before_drawing_an_id_or_writing_anything() {
+        CreateInterfaceRequest invalid = new CreateInterfaceRequest("n", "d", "{invalid json}");
 
-        Map<String, Object> interfaceDetailMap = new HashMap<>();
-        interfaceDetailMap.put("interfaceId", 55);
-        interfaceDetailMap.put("name", "Test Interface");
-        interfaceDetailMap.put("description", "Test Description");
+        assertThrows(JsonParseException.class, () -> store.createInterfaceForNamespace(invalid, NAMESPACE));
 
-        Document doc = new Document(interfaceDetailMap);
-
-        when(documentMock.getList("interfaces", Document.class))
-                .thenReturn(List.of(doc));
-
-        List<NamespaceInterfaceSummary> interfaces = mongoInterfaceStore.getInterfacesForNamespace("finos");
-
-        assertThat(interfaces.size(), is(1));
-        assertThat(interfaces.getFirst().getName(), is("Test Interface"));
-        assertThat(interfaces.getFirst().getDescription(), is("Test Description"));
-        assertThat(interfaces.getFirst().getId(), is(55));
-
-        verify(namespaceStore).namespaceExists("finos");
-    }
-
-    private DocumentFindIterable setupInvalidInterface() {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        return findIterable;
-    }
-
-    private void mockSetupInterfaceDocumentWithVersions() {
-        Document mainDocument = setupInterfaceVersionDocument();
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    private void mockSetupInterfaceDocumentWithoutVersions() {
-        Document interfaceWithNoVersions = new Document("namespace", "finos")
-                .append("interfaces", List.of(new Document("interfaceId", 42)));
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(interfaceCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(interfaceWithNoVersions);
+        verify(counterStore, never()).getNextInterfaceSequenceValue();
+        verify(headerCollection, never()).insertOne(any(Document.class));
     }
 
     @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_interface() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        CreateInterfaceRequest createInterfaceRequest = new CreateInterfaceRequest();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoInterfaceStore.createInterfaceForNamespace(createInterfaceRequest, namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_created_interface_when_parameters_are_valid() throws NamespaceNotFoundException {
-        String validNamespace = "finos";
-        int sequenceNumber = 42;
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(sequenceNumber);
-
-        CreateInterfaceRequest interfaceToCreate = new CreateInterfaceRequest(
-                "test",
-                "Test Interface",
-                "{}"
-        );
-
-        CalmInterface createdInterface = mongoInterfaceStore.createInterfaceForNamespace(interfaceToCreate, validNamespace);
-
-        CalmInterface expectedInterface = new CalmInterface(interfaceToCreate);
-        expectedInterface.setVersion("1.0.0");
-        expectedInterface.setId(sequenceNumber);
-
-        assertThat(createdInterface, is(expectedInterface));
-
-        Document expectedDoc = new Document("interfaceId", sequenceNumber)
-                .append("name", interfaceToCreate.getName())
-                .append("description", interfaceToCreate.getDescription())
-                .append("versions", new Document("1-0-0", Document.parse(interfaceToCreate.getInterfaceJson())));
-
-        verify(interfaceCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("interfaces", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(42);
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-        CreateInterfaceRequest interfaceToCreate = new CreateInterfaceRequest("test", "Test Interface", "{}");
-
-        mongoInterfaceStore.createInterfaceForNamespace(interfaceToCreate, "finos");
-
-        verify(interfaceCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_an_interface() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(42);
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-        CreateInterfaceRequest interfaceToCreate = new CreateInterfaceRequest("test", "Test Interface", "{}");
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoInterfaceStore.createInterfaceForNamespace(interfaceToCreate, "finos"));
-    }
-
-    @Test
-    void get_interface_versions_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceVersions("does-not-exist", 5));
-
-        verify(namespaceStore).namespaceExists("does-not-exist");
-    }
-
-    @Test
-    void get_interface_versions_for_invalid_interface_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidInterface();
-
-        assertThrows(InterfaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceVersions("finos", 5));
-
-        verify(interfaceCollection).find(new Document("namespace", "finos"));
-        verify(findIterable).projection(Projections.fields(Projections.include("interfaces")));
-    }
-
-    @Test
-    void get_interface_versions_for_interface_returns_list_of_versions() throws InterfaceNotFoundException, NamespaceNotFoundException {
-        mockSetupInterfaceDocumentWithVersions();
-
-        List<String> interfaceVersions = mongoInterfaceStore.getInterfaceVersions("finos", 42);
-
-        assertThat(interfaceVersions, is(List.of("1.0.0")));
-    }
-
-    @Test
-    void throw_interface_not_found_when_versions_document_is_missing_on_get_versions() {
-        mockSetupInterfaceDocumentWithoutVersions();
-
-        assertThrows(InterfaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceVersions("finos", 42));
-    }
-
-    @Test
-    void throw_interface_version_not_found_when_versions_document_is_missing_on_get_for_version() {
-        mockSetupInterfaceDocumentWithoutVersions();
-
-        assertThrows(InterfaceVersionNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceForVersion("finos", 42, "1.0.0"));
-    }
-
-    @Test
-    void throw_an_exception_for_an_invalid_namespace_when_retrieving_interface_for_version() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String invalidNamespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceForVersion(invalidNamespace, null, null));
-
-        verify(namespaceStore).namespaceExists(invalidNamespace);
-    }
-
-    @Test
-    void throw_an_exception_for_an_invalid_interface_when_retrieving_interface_for_version() {
-        FindIterable<Document> findIterable = setupInvalidInterface();
-        String validNamespace = "finos";
-
-        assertThrows(InterfaceNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceForVersion(validNamespace, 1, null));
-
-        verify(interfaceCollection).find(new Document("namespace", validNamespace));
-        verify(findIterable).projection(Projections.fields(Projections.include("interfaces")));
-    }
-
-    @Test
-    void return_an_interface_for_a_given_version() throws InterfaceNotFoundException, InterfaceVersionNotFoundException, NamespaceNotFoundException {
-        mockSetupInterfaceDocumentWithVersions();
-
-        String interfaceForVersion = mongoInterfaceStore.getInterfaceForVersion("finos", 42, "1.0.0");
-        assertThat(interfaceForVersion, is("{}"));
-    }
-
-    private Document setupInterfaceVersionDocument() {
-        Map<String, Document> versionMap = new HashMap<>();
-        versionMap.put("1-0-0", Document.parse("{}"));
-        Document targetStoredInterface = new Document("interfaceId", 42)
-                .append("versions", new Document(versionMap));
-
-        Document paddingInterface = new Document("interfaceId", 0);
-
-        return new Document("namespace", "finos")
-                .append("interfaces", Arrays.asList(paddingInterface, targetStoredInterface));
-    }
-
-    @Test
-    void throw_an_exception_when_interface_for_given_version_does_not_exist() {
-        mockSetupInterfaceDocumentWithVersions();
-
-        assertThrows(InterfaceVersionNotFoundException.class,
-                () -> mongoInterfaceStore.getInterfaceForVersion("finos", 42, "9.0.0"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_interface_for_version_when_a_namespace_doesnt_exist() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> mongoInterfaceStore.createInterfaceForVersion(interfaceToStore(), "finos", 42, "9.0.0"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_interface_for_version_when_an_interface_doesnt_exist() {
-        mockSetupInterfaceDocumentWithVersions();
-        CreateInterfaceRequest interfaceRequest = interfaceToStore();
-
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class))).thenThrow(mongoWriteException);
-
-        assertThrows(InterfaceNotFoundException.class, () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 50, "1.0.1"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_interface_for_version_when_a_version_already_exists() {
-        mockSetupInterfaceDocumentWithVersions();
-        CreateInterfaceRequest interfaceRequest = interfaceToStore();
-
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(0, 0L, null));
-
-        assertThrows(InterfaceVersionExistsException.class, () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.0"));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_creating_a_version_hits_the_document_size_limit() {
-        mockSetupInterfaceDocumentWithVersions();
-        CreateInterfaceRequest interfaceRequest = interfaceToStore();
-
-        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1"));
-        assertThat(exception.isCapacityExceeded(), is(true));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_creating_a_version() {
-        mockSetupInterfaceDocumentWithVersions();
-        CreateInterfaceRequest interfaceRequest = interfaceToStore();
-
-        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1"));
-        assertThat(exception.isCapacityExceeded(), is(false));
-    }
-
-    @Test
-    void accept_the_creation_of_a_valid_version() throws InterfaceVersionExistsException, InterfaceNotFoundException, NamespaceNotFoundException {
-        mockSetupInterfaceDocumentWithVersions();
-        CreateInterfaceRequest interfaceRequest = interfaceToStore();
-
-        when(interfaceCollection.updateOne(any(Bson.class), any(Bson.class)))
+    void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenReturn(UpdateResult.acknowledged(1, 1L, null));
 
-        mongoInterfaceStore.createInterfaceForVersion(interfaceRequest, "finos", 42, "1.0.1");
+        CalmInterface created = store.createInterfaceForNamespace(createRequest(), NAMESPACE);
 
-        verify(interfaceCollection).updateOne(any(Bson.class), any(Bson.class));
+        assertThat(created.getId(), is(99));
+        assertThat(created.getVersion(), is("1.0.0"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
     }
 
-    private CreateInterfaceRequest interfaceToStore() {
-        return new CreateInterfaceRequest("Second Version", "Second Description", "{}");
+    @Test
+    void remove_the_header_again_when_the_first_version_write_fails() {
+        when(counterStore.getNextInterfaceSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createInterfaceForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    // --- getInterfaceVersions ---
+
+    @Test
+    void throw_a_interface_exception_when_listing_versions_for_a_missing_interface() {
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class, () -> store.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
+    }
+
+    @Test
+    void list_versions_in_semantic_order() throws NamespaceNotFoundException, InterfaceNotFoundException {
+        stubFind(headerCollection, List.of(new Document("interfaceId", INTERFACE_ID)));
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.getInterfaceVersions(NAMESPACE, INTERFACE_ID), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void check_existence_against_the_interface_id_not_just_the_namespace() throws Exception {
+        // The old store carried a FIXME: it looked up only the namespace and ignored the id,
+        // which happened to work while a namespace held a single interface.
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class,
+                () -> store.getInterfaceVersions(NAMESPACE, 999));
+    }
+
+    // --- getInterfaceForVersion ---
+
+    @Test
+    void throw_a_version_exception_when_the_version_is_not_stored() {
+        stubFind(headerCollection, List.of(new Document("interfaceId", INTERFACE_ID)));
+        stubFind(versionCollection, List.of());
+
+        assertThrows(InterfaceVersionNotFoundException.class,
+                () -> store.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "9.0.0"));
+    }
+
+    @Test
+    void return_the_content_of_a_stored_version() throws Exception {
+        stubFind(headerCollection, List.of(new Document("interfaceId", INTERFACE_ID)));
+        stubFind(versionCollection, List.of(new Document("content", new Document("test", "test"))));
+
+        assertThat(store.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"), containsString("\"test\""));
+    }
+
+    // --- createInterfaceForVersion ---
+
+    @Test
+    void throw_a_interface_exception_when_creating_a_version_for_a_missing_interface() {
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class,
+                () -> store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1"));
+    }
+
+    @Test
+    void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        interfaceExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(InterfaceVersionExistsException.class,
+                () -> store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1"));
+    }
+
+    @Test
+    void write_the_version_and_then_the_header_details() throws Exception {
+        interfaceExists();
+
+        store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1");
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.1"));
+        // Two header writes: the versionCount increment and the name/description update.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void overwrite_the_header_details_even_when_blank() throws Exception {
+        interfaceExists();
+
+        store.createInterfaceForVersion(new CreateInterfaceRequest(null, null, VALID_JSON),
+                NAMESPACE, INTERFACE_ID, "1.0.1");
+
+        // Interface's old shape $set both fields unconditionally, unlike Pattern and Flow
+        // which guarded them. Preserved rather than harmonised — see the store's javadoc.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -217,6 +217,17 @@ class TestMongoSearchStoreShould {
     }
 
     @Test
+    void skip_an_adr_header_with_no_id_rather_than_failing_the_search() {
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", null)));
+
+        // SearchResult takes a primitive id and resolving the latest revision unboxes too, so
+        // one id-less header would 500 the entire /search request — every type, not just ADR.
+        assertEquals(0, searchStore.search("event").getAdrs().size());
+    }
+
+    @Test
     void search_adr_by_latest_revision_title() {
         // ADR reads its title from the latest revision's content, so the fixture needs a
         // header and a revision document rather than one namespace-wide document.

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -143,17 +143,24 @@ class TestMongoSearchStoreShould {
                 .append("name", "Demo Pattern")
                 .append("description", "demo");
 
-        // A flow, still in the array shape, alongside two header-shaped types — the point
-        // being that both paths run in the same search while the rollout is part-done.
         Document flowDoc = new Document("namespace", "finos")
-                .append("flows", List.of(new Document("flowId", 3)
-                        .append("name", "Demo Flow")
+                .append("flowId", 3)
+                .append("name", "Demo Flow")
+                .append("description", "demo");
+
+        // A standard, still in the array shape, alongside three header-shaped types — the
+        // point being that both paths run in the same search while the rollout is part-done.
+        // This fixture moves to another unmigrated type each time one migrates.
+        Document standardDoc = new Document("namespace", "finos")
+                .append("standards", List.of(new Document("standardId", 4)
+                        .append("name", "Demo Standard")
                         .append("description", "demo")));
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(patternCollection, List.of(patternDoc));
         mockCollectionFind(flowCollection, List.of(flowDoc));
-        mockEmptyCollections(standardCollection, interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(standardCollection, List.of(standardDoc));
+        mockEmptyCollections(interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("demo");
 
@@ -162,6 +169,8 @@ class TestMongoSearchStoreShould {
         assertEquals("Demo Pattern", results.getPatterns().get(0).getName());
         assertEquals(1, results.getFlows().size());
         assertEquals("Demo Flow", results.getFlows().get(0).getName());
+        assertEquals(1, results.getStandards().size());
+        assertEquals("Demo Standard", results.getStandards().get(0).getName());
     }
 
     @Test
@@ -223,19 +232,19 @@ class TestMongoSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
-        // Uses a flow: only the array-shaped types can have a null entries array at all, so
-        // this covers the branch where it still exists. It moves to another unmigrated type
-        // each time one migrates — it was on architectures, then patterns.
+        // Uses a standard: only the array-shaped types can have a null entries array at all,
+        // so this covers the branch where it still exists. It moves to another unmigrated
+        // type each time one migrates — architectures, then patterns, then flows.
         Document namespaceDoc = new Document("namespace", "finos")
-                .append("flows", null);
+                .append("standards", null);
 
-        mockCollectionFind(flowCollection, List.of(namespaceDoc));
-        mockEmptyCollections(architectureCollection, patternCollection, standardCollection,
+        mockCollectionFind(standardCollection, List.of(namespaceDoc));
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
 
-        assertTrue(results.getFlows().isEmpty());
+        assertTrue(results.getStandards().isEmpty());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -72,11 +72,6 @@ class TestMongoSearchStoreShould {
     }
 
     /**
-     * Architecture has moved to the header/version shape, so each of its documents is one
-     * architecture rather than a namespace-wide array of them. The other namespaced types
-     * still use the array shape, which is why both fixtures appear in this class.
-     */
-    /**
      * Stubs the adrVersions collection the ADR search reads through: the revision list that
      * ranks them, and the winning revision's content.
      */

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +52,9 @@ class TestMongoSearchStoreShould {
     @Mock
     private MongoCollection<Document> adrCollection;
 
+    @Mock
+    private MongoCollection<Document> adrVersionCollection;
+
     private MongoSearchStore searchStore;
 
     @BeforeEach
@@ -62,6 +67,7 @@ class TestMongoSearchStoreShould {
         when(database.getCollection("interfaces")).thenReturn(interfaceCollection);
         when(database.getCollection("controls")).thenReturn(controlCollection);
         when(database.getCollection("adrs")).thenReturn(adrCollection);
+        when(database.getCollection("adrVersions")).thenReturn(adrVersionCollection);
         searchStore = new MongoSearchStore(database);
     }
 
@@ -70,6 +76,24 @@ class TestMongoSearchStoreShould {
      * architecture rather than a namespace-wide array of them. The other namespaced types
      * still use the array shape, which is why both fixtures appear in this class.
      */
+    /**
+     * Stubs the adrVersions collection the ADR search reads through: the revision list that
+     * ranks them, and the winning revision's content.
+     */
+    @SuppressWarnings("unchecked")
+    private void mockAdrRevisions(List<String> revisions, Document latestContent) {
+        FindIterable<Document> findIterable = mock(FindIterable.class);
+        when(adrVersionCollection.find(any(org.bson.conversions.Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any())).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(
+                latestContent == null ? null : new Document("content", latestContent));
+        doAnswer(invocation -> {
+            java.util.function.Consumer<Document> consumer = invocation.getArgument(0);
+            revisions.forEach(revision -> consumer.accept(new Document("version", revision)));
+            return null;
+        }).when(findIterable).forEach(any());
+    }
+
     private static Document architectureHeader(int id, String name, String description) {
         return architectureHeader("finos", id, name, description);
     }
@@ -194,15 +218,12 @@ class TestMongoSearchStoreShould {
 
     @Test
     void search_adr_by_latest_revision_title() {
-        Document revisionDoc = new Document("title", "Use Event Sourcing");
-        Document adrEntry = new Document("adrId", 1)
-                .append("revisions", new Document("1", revisionDoc));
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("adrs", List.of(adrEntry));
-
+        // ADR reads its title from the latest revision's content, so the fixture needs a
+        // header and a revision document rather than one namespace-wide document.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(namespaceDoc));
+        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", 1)));
+        mockAdrRevisions(List.of("1"), new Document("title", "Use Event Sourcing"));
 
         GroupedSearchResults results = searchStore.search("event");
 
@@ -212,16 +233,11 @@ class TestMongoSearchStoreShould {
 
     @Test
     void search_adr_uses_latest_revision_when_multiple_exist() {
-        Document revisionDoc1 = new Document("title", "Old Title");
-        Document revisionDoc2 = new Document("title", "New Title");
-        Document adrEntry = new Document("adrId", 1)
-                .append("revisions", new Document("1", revisionDoc1).append("2", revisionDoc2));
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("adrs", List.of(adrEntry));
-
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(namespaceDoc));
+        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", 1)));
+        // Two revisions; the search must read the later one's title.
+        mockAdrRevisions(List.of("1", "2"), new Document("title", "New Title"));
 
         GroupedSearchResults results = searchStore.search("New");
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -148,19 +148,19 @@ class TestMongoSearchStoreShould {
                 .append("name", "Demo Flow")
                 .append("description", "demo");
 
-        // A standard, still in the array shape, alongside three header-shaped types — the
+        // An interface, still in the array shape, alongside four header-shaped types — the
         // point being that both paths run in the same search while the rollout is part-done.
         // This fixture moves to another unmigrated type each time one migrates.
-        Document standardDoc = new Document("namespace", "finos")
-                .append("standards", List.of(new Document("standardId", 4)
-                        .append("name", "Demo Standard")
+        Document interfaceDoc = new Document("namespace", "finos")
+                .append("interfaces", List.of(new Document("interfaceId", 5)
+                        .append("name", "Demo Interface")
                         .append("description", "demo")));
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(patternCollection, List.of(patternDoc));
         mockCollectionFind(flowCollection, List.of(flowDoc));
-        mockCollectionFind(standardCollection, List.of(standardDoc));
-        mockEmptyCollections(interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(interfaceCollection, List.of(interfaceDoc));
+        mockEmptyCollections(standardCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("demo");
 
@@ -169,8 +169,8 @@ class TestMongoSearchStoreShould {
         assertEquals("Demo Pattern", results.getPatterns().get(0).getName());
         assertEquals(1, results.getFlows().size());
         assertEquals("Demo Flow", results.getFlows().get(0).getName());
-        assertEquals(1, results.getStandards().size());
-        assertEquals("Demo Standard", results.getStandards().get(0).getName());
+        assertEquals(1, results.getInterfaces().size());
+        assertEquals("Demo Interface", results.getInterfaces().get(0).getName());
     }
 
     @Test
@@ -232,19 +232,19 @@ class TestMongoSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
-        // Uses a standard: only the array-shaped types can have a null entries array at all,
-        // so this covers the branch where it still exists. It moves to another unmigrated
-        // type each time one migrates — architectures, then patterns, then flows.
+        // Uses an interface: only the array-shaped types can have a null entries array at
+        // all, so this covers the branch where it still exists. It moves to another
+        // unmigrated type each time one migrates — architectures, patterns, flows, standards.
         Document namespaceDoc = new Document("namespace", "finos")
-                .append("standards", null);
+                .append("interfaces", null);
 
-        mockCollectionFind(standardCollection, List.of(namespaceDoc));
+        mockCollectionFind(interfaceCollection, List.of(namespaceDoc));
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
-                interfaceCollection, controlCollection, adrCollection);
+                standardCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
 
-        assertTrue(results.getStandards().isEmpty());
+        assertTrue(results.getInterfaces().isEmpty());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -148,13 +148,12 @@ class TestMongoSearchStoreShould {
                 .append("name", "Demo Flow")
                 .append("description", "demo");
 
-        // An interface, still in the array shape, alongside four header-shaped types — the
-        // point being that both paths run in the same search while the rollout is part-done.
-        // This fixture moves to another unmigrated type each time one migrates.
+        // Every namespaced type now reads the header shape — the array-shaped path was
+        // retired with Interface, its last caller.
         Document interfaceDoc = new Document("namespace", "finos")
-                .append("interfaces", List.of(new Document("interfaceId", 5)
-                        .append("name", "Demo Interface")
-                        .append("description", "demo")));
+                .append("interfaceId", 5)
+                .append("name", "Demo Interface")
+                .append("description", "demo");
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(patternCollection, List.of(patternDoc));
@@ -230,22 +229,6 @@ class TestMongoSearchStoreShould {
         assertEquals("New Title", results.getAdrs().get(0).getName());
     }
 
-    @Test
-    void handle_null_entries_array_gracefully() {
-        // Uses an interface: only the array-shaped types can have a null entries array at
-        // all, so this covers the branch where it still exists. It moves to another
-        // unmigrated type each time one migrates — architectures, patterns, flows, standards.
-        Document namespaceDoc = new Document("namespace", "finos")
-                .append("interfaces", null);
-
-        mockCollectionFind(interfaceCollection, List.of(namespaceDoc));
-        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
-                standardCollection, controlCollection, adrCollection);
-
-        GroupedSearchResults results = searchStore.search("test");
-
-        assertTrue(results.getInterfaces().isEmpty());
-    }
 
     @Test
     void handle_empty_collections_gracefully() {

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -217,6 +217,19 @@ class TestMongoSearchStoreShould {
     }
 
     @Test
+    void skip_a_header_with_no_id_rather_than_failing_the_search() {
+        mockEmptyCollections(patternCollection, flowCollection, standardCollection,
+                interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(architectureCollection, List.of(
+                new Document("namespace", "finos").append("name", "event thing").append("description", "d")));
+
+        // No architectureId. SearchResult takes a primitive id, so unboxing would throw out
+        // of search() — which builds every type's results eagerly, failing the whole request
+        // rather than one type.
+        assertEquals(0, searchStore.search("event").getArchitectures().size());
+    }
+
+    @Test
     void skip_an_adr_header_with_no_id_rather_than_failing_the_search() {
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -6,10 +6,6 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -20,26 +16,39 @@ import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestMongoVersionDocumentStoreShould}. Standard differs from Pattern and Flow in two
+ * ways this class pins: version writes set name/description unconditionally, and there is no
+ * update path at all.
+ */
 @QuarkusTest
 public class TestMongoStandardStoreShould {
 
@@ -52,390 +61,235 @@ public class TestMongoStandardStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private MongoCollection<Document> standardCollection;
-
-    private MongoStandardStore mongoStandardStore;
-
-    @BeforeEach
-    void setup() {
-        standardCollection = Mockito.mock(DocumentMongoCollection.class);
-
-        when(mongoDatabase.getCollection("standards")).thenReturn(standardCollection);
-        mongoStandardStore = new MongoStandardStore(mongoDatabase, counterStore, namespaceStore);
-    }
-
-    @Test
-    void get_standard_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(standardCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("standards", Document.class))
-                .thenReturn(new ArrayList<>());
-
-        assertThat(mongoStandardStore.getStandardsForNamespace("finos"), is(empty()));
-        verify(namespaceStore).namespaceExists("finos");
-    }
-
-    @Test
-    void get_standard_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(standardCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        assertThat(mongoStandardStore.getStandardsForNamespace("finos"), is(empty()));
-        verify(namespaceStore).namespaceExists("finos");
-    }
-
-    @Test
-    void get_standard_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoStandardStore.getStandardsForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void get_standard_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(standardCollection.find(eq(Filters.eq("namespace", "finos"))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        Map<String, Object> standardDetailMap = new HashMap<>();
-        standardDetailMap.put("standardId", 55);
-        standardDetailMap.put("name", "Test Standard");
-        standardDetailMap.put("description", "Test Description");
-        standardDetailMap.put("versions", new Document("1-0-0", new Document()).append("2-0-0", new Document()));
-
-        Document doc = new Document(standardDetailMap);
-        // Second standard without a versions sub-document exercises the null-guard → 0.
-        Document docNoVersions = new Document("standardId", 56)
-                .append("name", "No Versions")
-                .append("description", "");
-
-        when(documentMock.getList("standards", Document.class))
-                .thenReturn(List.of(doc, docNoVersions));
-
-        List<NamespaceResourceSummary> standards = mongoStandardStore.getStandardsForNamespace("finos");
-
-        assertThat(standards.size(), is(2));
-        assertThat(standards.getFirst().getName(), is("Test Standard"));
-        assertThat(standards.getFirst().getDescription(), is("Test Description"));
-        assertThat(standards.getFirst().getId(), is(55));
-        assertThat(standards.getFirst().getVersionCount(), is(2));
-        assertThat(standards.get(1).getVersionCount(), is(0));
-
-        verify(namespaceStore).namespaceExists("finos");
-    }
-
-    private DocumentFindIterable setupInvalidStandard() {
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        //Return the same find iterable as the projection unboxes, then return null
-        when(standardCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-
-        return findIterable;
-    }
-
-    private void mockSetupStandardDocumentWithVersions() {
-        Document mainDocument = setupStandardVersionDocument();
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(standardCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    private void mockSetupStandardDocumentWithoutVersions() {
-        Document standardWithNoVersions = new Document("namespace", "finos")
-                .append("standards", List.of(new Document("standardId", 42)));
-        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(standardCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(standardWithNoVersions);
-    }
-
-    @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_standard() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        CreateStandardRequest createStandardRequest = new CreateStandardRequest();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoStandardStore.createStandardForNamespace(createStandardRequest, namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_a_json_parse_exception_when_an_invalid_json_object_is_presented_when_creating_standard() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextStandardSequenceValue()).thenReturn(42);
-
-        CreateStandardRequest createStandardRequest = new CreateStandardRequest();
-        createStandardRequest.setStandardJson("invalid JSON");
-
-        assertThrows(JsonParseException.class,
-                () -> mongoStandardStore.createStandardForNamespace(createStandardRequest, "finos"));
-    }
-
-    @Test
-    void return_created_standard_when_parameters_are_valid() throws NamespaceNotFoundException {
-        String validNamespace = "finos";
-        int sequenceNumber = 42;
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextStandardSequenceValue()).thenReturn(sequenceNumber);
-
-        CreateStandardRequest standardToCreate = new CreateStandardRequest(
-                "test",
-                "Test Standard",
-                "{}"
-        );
-
-        standardToCreate.setStandardJson("{}");
-        standardToCreate.setDescription("Test Standard");
-        standardToCreate.setName("test");
-
-        Standard createdStandard = mongoStandardStore.createStandardForNamespace(standardToCreate, validNamespace);
-
-        //Update the id from the standard
-        Standard standard = new Standard(standardToCreate);
-        standard.setVersion("1.0.0");
-        standard.setId(sequenceNumber);
-
-        assertThat(createdStandard, is(standard));
-
-        Document expectedDoc = new Document("standardId", sequenceNumber)
-                .append("name", standardToCreate.getName())
-                .append("description", standardToCreate.getDescription())
-                .append("versions", new Document("1-0-0", Document.parse(standardToCreate.getStandardJson())));
-
-        verify(standardCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("standards", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextStandardSequenceValue()).thenReturn(42);
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-        CreateStandardRequest standardToCreate = new CreateStandardRequest("test", "Test Standard", "{}");
-
-        mongoStandardStore.createStandardForNamespace(standardToCreate, "finos");
-
-        verify(standardCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_a_standard() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextStandardSequenceValue()).thenReturn(42);
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-        CreateStandardRequest standardToCreate = new CreateStandardRequest("test", "Test Standard", "{}");
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoStandardStore.createStandardForNamespace(standardToCreate, "finos"));
-    }
-
-    @Test
-    void get_standard_versions_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoStandardStore.getStandardVersions("does-not-exist", 5));
-
-        verify(namespaceStore).namespaceExists("does-not-exist");
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoStandardStore store;
+
+    private static final String NAMESPACE = "finos";
+    private static final int STANDARD_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
+
+    @BeforeEach
+    void setup() {
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
+
+        when(mongoDatabase.getCollection("standards")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("standardVersions")).thenReturn(versionCollection);
+        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new MongoStandardStore(mongoDatabase, counterStore, namespaceStore);
+    }
+
+    private void stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    private void standardExists() {
+        stubFind(headerCollection, List.of(new Document("standardId", STANDARD_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void standardDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static CreateStandardRequest createRequest() {
+        return new CreateStandardRequest("standard-name", "standard-description", VALID_JSON);
+    }
+
+    // --- getStandardsForNamespace ---
+
     @Test
-    void get_standard_versions_for_invalid_standard_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidStandard();
+    void throw_a_namespace_exception_when_listing_standards_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        assertThrows(StandardNotFoundException.class,
-                () -> mongoStandardStore.getStandardVersions("finos", 5));
-
-        verify(standardCollection).find(new Document("namespace", "finos"));
-        verify(findIterable).projection(Projections.fields(Projections.include("standards")));
+        assertThrows(NamespaceNotFoundException.class, () -> store.getStandardsForNamespace(NAMESPACE));
     }
 
     @Test
-    void get_standard_versions_for_standard_returns_list_of_versions() throws StandardNotFoundException, NamespaceNotFoundException {
-        mockSetupStandardDocumentWithVersions();
+    void return_an_empty_list_when_a_namespace_has_no_standards() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        List<String> standardVersions = mongoStandardStore.getStandardVersions("finos", 42);
-
-        assertThat(standardVersions, is(List.of("1.0.0")));
+        assertThat(store.getStandardsForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void throw_standard_not_found_when_versions_document_is_missing_on_get_versions() {
-        mockSetupStandardDocumentWithoutVersions();
+    void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                new Document("standardId", 1).append("name", "First").append("description", "d1")
+                        .append("versionCount", 2),
+                new Document("standardId", 2).append("name", "Second").append("description", "d2")
+                        .append("versionCount", 0)));
 
-        assertThrows(StandardNotFoundException.class,
-                () -> mongoStandardStore.getStandardVersions("finos", 42));
+        assertThat(store.getStandardsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
     }
 
-    @Test
-    void throw_standard_version_not_found_when_versions_document_is_missing_on_get_for_version() {
-        mockSetupStandardDocumentWithoutVersions();
-
-        assertThrows(StandardVersionNotFoundException.class,
-                () -> mongoStandardStore.getStandardForVersion("finos", 42, "1.0.0"));
-    }
+    // --- createStandardForNamespace ---
 
     @Test
-    void throw_an_exception_for_an_invalid_namespace_when_retrieving_standard_for_version() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String invalidNamespace = "does-not-exist";
+    void throw_a_namespace_exception_when_creating_a_standard_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> mongoStandardStore.getStandardForVersion(invalidNamespace, null, null));
-
-        verify(namespaceStore).namespaceExists(invalidNamespace);
+                () -> store.createStandardForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_standard_when_retrieving_standard_for_version() {
-        FindIterable<Document> findIterable = setupInvalidStandard();
-        String validNamespace = "finos";
+    void reject_invalid_json_before_drawing_an_id_or_writing_anything() {
+        CreateStandardRequest invalid = new CreateStandardRequest("n", "d", "{invalid json}");
 
-        assertThrows(StandardNotFoundException.class,
-                () -> mongoStandardStore.getStandardForVersion(validNamespace, 1, null));
+        assertThrows(JsonParseException.class, () -> store.createStandardForNamespace(invalid, NAMESPACE));
 
-        verify(standardCollection).find(new Document("namespace", validNamespace));
-        verify(findIterable).projection(Projections.fields(Projections.include("standards")));
+        verify(counterStore, never()).getNextStandardSequenceValue();
+        verify(headerCollection, never()).insertOne(any(Document.class));
     }
 
     @Test
-    void return_a_standard_for_a_given_version() throws StandardNotFoundException, StandardVersionNotFoundException, NamespaceNotFoundException {
-        mockSetupStandardDocumentWithVersions();
-
-        String standardForVersion = mongoStandardStore.getStandardForVersion("finos", 42, "1.0.0");
-        assertThat(standardForVersion, is("{}"));
-    }
-
-
-    private Document setupStandardVersionDocument() {
-        //Set up a standard document with 2 standards in (one with a valid version)
-        Map<String, Document> versionMap = new HashMap<>();
-        versionMap.put("1-0-0", Document.parse("{}"));
-        Document targetStoredStandard = new Document("standardId", 42)
-                .append("versions", new Document(versionMap));
-
-        Document paddingStandard = new Document("standardId", 0);
-
-        return new Document("namespace", "finos")
-                .append("standards", Arrays.asList(paddingStandard, targetStoredStandard));
-    }
-
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
-    }
-
-    @Test
-    void throw_an_exception_when_standard_for_given_version_does_not_exist() {
-        mockSetupStandardDocumentWithVersions();
-
-        assertThrows(StandardVersionNotFoundException.class,
-                () -> mongoStandardStore.getStandardForVersion("finos", 42, "9.0.0"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_standard_for_version_when_a_namespace_doesnt_exist() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> mongoStandardStore.createStandardForVersion(standardToStore(), "finos", 42, "9.0.0"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_standard_for_version_when_a_standard_doesnt_exist() {
-        mockSetupStandardDocumentWithVersions();
-        CreateStandardRequest standard = standardToStore();
-
-        WriteError writeError = new WriteError(2, "The positional operator did not find the match needed from the query", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class))).thenThrow(mongoWriteException);
-
-        assertThrows(StandardNotFoundException.class, () -> mongoStandardStore.createStandardForVersion(standard, "finos", 50, "1.0.1"));
-    }
-
-    @Test
-    void throw_an_exception_for_create_standard_for_version_when_a_version_already_exists() {
-        mockSetupStandardDocumentWithVersions();
-        CreateStandardRequest standard = standardToStore();
-
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(0, 0L, null));
-
-        assertThrows(StandardVersionExistsException.class, () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.0"));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_creating_a_version_hits_the_document_size_limit() {
-        mockSetupStandardDocumentWithVersions();
-        CreateStandardRequest standard = standardToStore();
-
-        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1"));
-        assertThat(exception.isCapacityExceeded(), is(true));
-    }
-
-    @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_creating_a_version() {
-        mockSetupStandardDocumentWithVersions();
-        CreateStandardRequest standard = standardToStore();
-
-        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class))).thenThrow(mongoWriteException);
-
-        StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1"));
-        assertThat(exception.isCapacityExceeded(), is(false));
-    }
-
-    @Test
-    void accept_the_creation_of_a_valid_version() throws StandardVersionExistsException, StandardNotFoundException, NamespaceNotFoundException {
-        mockSetupStandardDocumentWithVersions();
-        CreateStandardRequest standard = standardToStore();
-
-        when(standardCollection.updateOne(any(Bson.class), any(Bson.class)))
+    void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(counterStore.getNextStandardSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenReturn(UpdateResult.acknowledged(1, 1L, null));
 
-        mongoStandardStore.createStandardForVersion(standard, "finos", 42, "1.0.1");
+        Standard created = store.createStandardForNamespace(createRequest(), NAMESPACE);
 
-        verify(standardCollection).updateOne(any(Bson.class), any(Bson.class));
+        assertThat(created.getId(), is(99));
+        assertThat(created.getVersion(), is("1.0.0"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
     }
 
-    private CreateStandardRequest standardToStore() {
-        return new CreateStandardRequest("Second Version", "Second Description", "{}");
+    @Test
+    void remove_the_header_again_when_the_first_version_write_fails() {
+        when(counterStore.getNextStandardSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createStandardForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    // --- getStandardVersions ---
+
+    @Test
+    void throw_a_standard_exception_when_listing_versions_for_a_missing_standard() {
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class, () -> store.getStandardVersions(NAMESPACE, STANDARD_ID));
+    }
+
+    @Test
+    void list_versions_in_semantic_order() throws NamespaceNotFoundException, StandardNotFoundException {
+        stubFind(headerCollection, List.of(new Document("standardId", STANDARD_ID)));
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.getStandardVersions(NAMESPACE, STANDARD_ID), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void check_existence_against_the_standard_id_not_just_the_namespace() throws Exception {
+        // The old store carried a FIXME: it looked up only the namespace and ignored the id,
+        // which happened to work while a namespace held a single standard.
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class,
+                () -> store.getStandardVersions(NAMESPACE, 999));
+    }
+
+    // --- getStandardForVersion ---
+
+    @Test
+    void throw_a_version_exception_when_the_version_is_not_stored() {
+        stubFind(headerCollection, List.of(new Document("standardId", STANDARD_ID)));
+        stubFind(versionCollection, List.of());
+
+        assertThrows(StandardVersionNotFoundException.class,
+                () -> store.getStandardForVersion(NAMESPACE, STANDARD_ID, "9.0.0"));
+    }
+
+    @Test
+    void return_the_content_of_a_stored_version() throws Exception {
+        stubFind(headerCollection, List.of(new Document("standardId", STANDARD_ID)));
+        stubFind(versionCollection, List.of(new Document("content", new Document("test", "test"))));
+
+        assertThat(store.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"), containsString("\"test\""));
+    }
+
+    // --- createStandardForVersion ---
+
+    @Test
+    void throw_a_standard_exception_when_creating_a_version_for_a_missing_standard() {
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class,
+                () -> store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1"));
+    }
+
+    @Test
+    void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        standardExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(StandardVersionExistsException.class,
+                () -> store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1"));
+    }
+
+    @Test
+    void write_the_version_and_then_the_header_details() throws Exception {
+        standardExists();
+
+        store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1");
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.1"));
+        // Two header writes: the versionCount increment and the name/description update.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void overwrite_the_header_details_even_when_blank() throws Exception {
+        standardExists();
+
+        store.createStandardForVersion(new CreateStandardRequest(null, null, VALID_JSON),
+                NAMESPACE, STANDARD_ID, "1.0.1");
+
+        // Standard's old shape $set both fields unconditionally, unlike Pattern and Flow
+        // which guarded them. Preserved rather than harmonised — see the store's javadoc.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -6,10 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -17,27 +14,43 @@ import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonParseException;
+import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
-import org.finos.calm.domain.timeline.Timeline;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestMongoVersionDocumentStoreShould}; what this class pins is the glue — which
+ * domain exception each missing thing produces, and Timeline's blank-guarding of
+ * name/description, which is where it deliberately differs from Architecture.
+ */
 @QuarkusTest
 public class TestMongoTimelineStoreShould {
 
@@ -50,421 +63,351 @@ public class TestMongoTimelineStoreShould {
     @InjectMock
     MongoNamespaceStore namespaceStore;
 
-    private MongoCollection<Document> timelineCollection;
-    private MongoTimelineStore mongoTimelineStore;
-    private final String NAMESPACE = "finos";
-
-    private final String validJson = "{\"test\": \"test\"}";
-
-    @BeforeEach
-    void setup() {
-        timelineCollection = Mockito.mock(DocumentMongoCollection.class);
-
-        when(mongoDatabase.getCollection("timelines")).thenReturn(timelineCollection);
-        mongoTimelineStore = new MongoTimelineStore(mongoDatabase, counterStore, namespaceStore);
-    }
-
-    @Test
-    void get_timelines_for_namespace_returns_empty_list_when_none_exist() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-        when(documentMock.getList("timelines", Document.class))
-                .thenReturn(new ArrayList<>());
-
-        assertThat(mongoTimelineStore.getTimelinesForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_timelines_for_namespace_returns_empty_list_when_mongo_collection_not_created() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        assertThat(mongoTimelineStore.getTimelinesForNamespace(NAMESPACE), is(empty()));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_timeline_for_namespace_that_doesnt_exist_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoTimelineStore.getTimelinesForNamespace(namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void get_timeline_for_namespace_returns_values() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        Document doc1 = new Document("timelineId", 1001).append("name", "Timeline One").append("description", "First timeline");
-        Document doc2 = new Document("timelineId", 1002).append("name", "Timeline Two").append("description", "Second timeline");
-
-        when(documentMock.getList("timelines", Document.class))
-                .thenReturn(Arrays.asList(doc1, doc2));
-
-        List<NamespaceTimelineSummary> timelines = mongoTimelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(timelines.size(), is(2));
-        assertThat(timelines.get(0).getName(), is("Timeline One"));
-        assertThat(timelines.get(0).getDescription(), is("First timeline"));
-        assertThat(timelines.get(0).getId(), is(1001));
-        assertThat(timelines.get(1).getName(), is("Timeline Two"));
-        assertThat(timelines.get(1).getDescription(), is("Second timeline"));
-        assertThat(timelines.get(1).getId(), is(1002));
-        verify(namespaceStore).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    void get_timeline_for_namespace_returns_fallback_for_legacy_documents() throws NamespaceNotFoundException {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(eq(Filters.eq("namespace", NAMESPACE))))
-                .thenReturn(findIterable);
-        Document documentMock = Mockito.mock(Document.class);
-        when(findIterable.first()).thenReturn(documentMock);
-
-        // Legacy document without name or description
-        Document legacyDoc = new Document("timelineId", 77);
-
-        when(documentMock.getList("timelines", Document.class))
-                .thenReturn(List.of(legacyDoc));
-
-        List<NamespaceTimelineSummary> timelines = mongoTimelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(timelines.size(), is(1));
-        assertThat(timelines.get(0).getName(), is("Timeline 77"));
-        assertThat(timelines.get(0).getDescription(), is(""));
-        assertThat(timelines.get(0).getId(), is(77));
-    }
-
-    private FindIterable<Document> setupInvalidTimeline() {
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(null);
-
-        return findIterable;
-    }
-
-    private void mockSetupTimelineDocumentWithVersions() {
-        Document mainDocument = setupTimelineVersionDocument();
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(any(Bson.class)))
-                .thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(mainDocument);
-    }
-
-    @Test
-    void return_a_namespace_exception_when_namespace_does_not_exist_when_creating_a_timeline() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        String namespace = "does-not-exist";
-        CreateTimelineRequest request = new CreateTimelineRequest("name", "desc", validJson);
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoTimelineStore.createTimelineForNamespace(request, namespace));
-
-        verify(namespaceStore).namespaceExists(namespace);
-    }
-
-    @Test
-    void return_a_json_parse_exception_when_an_invalid_json_object_is_presented() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextTimelineSequenceValue()).thenReturn(42);
-        CreateTimelineRequest request = new CreateTimelineRequest("name", "desc", "Invalid JSON");
-
-        assertThrows(JsonParseException.class,
-                () -> mongoTimelineStore.createTimelineForNamespace(request, NAMESPACE));
-    }
-
-    @Test
-    void return_created_timeline_when_parameters_are_valid() throws NamespaceNotFoundException {
-        String validNamespace = NAMESPACE;
-        int sequenceNumber = 42;
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextTimelineSequenceValue()).thenReturn(sequenceNumber);
-        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", validJson);
-
-        Timeline timeline = mongoTimelineStore.createTimelineForNamespace(request, validNamespace);
-
-        Timeline expectedTimeline = new Timeline.TimelineBuilder().setTimeline(validJson)
-                .setNamespace(validNamespace)
-                .setVersion("1.0.0")
-                .setId(sequenceNumber)
-                .build();
-
-        assertThat(timeline, is(expectedTimeline));
-        Document expectedDoc = new Document("timelineId", timeline.getId())
-                .append("name", "Test Timeline")
-                .append("description", "A test")
-                .append("versions",
-                        new Document("1-0-0", Document.parse(timeline.getTimelineJson())));
-
-        verify(timelineCollection).updateOne(
-                eq(Filters.eq("namespace", validNamespace)),
-                eq(Updates.push("timelines", expectedDoc)),
-                any(UpdateOptions.class));
-    }
-
-    @Test
-    void retry_and_succeed_when_a_concurrent_request_wins_the_first_create_race() throws NamespaceNotFoundException {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextTimelineSequenceValue()).thenReturn(42);
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
-                .thenReturn(null);
-        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", validJson);
-
-        mongoTimelineStore.createTimelineForNamespace(request, NAMESPACE);
-
-        verify(timelineCollection, times(2)).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-    }
-
-    @Test
-    void propagate_non_duplicate_key_errors_when_creating_a_timeline() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(counterStore.getNextTimelineSequenceValue()).thenReturn(42);
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
-        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", validJson);
-
-        assertThrows(MongoWriteException.class,
-                () -> mongoTimelineStore.createTimelineForNamespace(request, NAMESPACE));
-    }
-
-    @Test
-    void get_timeline_version_for_invalid_namespace_throws_exception() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace("does-not-exist").build();
-
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineVersions(timeline));
-
-        verify(namespaceStore).namespaceExists(timeline.getNamespace());
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
     }
 
     private interface DocumentFindIterable extends FindIterable<Document> {
     }
 
-    @Test
-    void get_timeline_version_for_invalid_timeline_throws_exception() {
-        FindIterable<Document> findIterable = setupInvalidTimeline();
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).build();
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoTimelineStore store;
 
-        assertThrows(TimelineNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineVersions(timeline));
+    private static final String NAMESPACE = "finos";
+    private static final int TIMELINE_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
 
-        verify(timelineCollection).find(new Document("namespace", timeline.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("timelines")));
-    }
+    @BeforeEach
+    void setup() {
+        headerCollection = Mockito.mock(DocumentMongoCollection.class);
+        versionCollection = Mockito.mock(DocumentMongoCollection.class);
 
-    @Test
-    void throw_timeline_not_found_when_versions_document_is_missing_on_get_versions() {
-        Document timelineWithNoVersions = new Document("namespace", NAMESPACE)
-                .append("timelines", List.of(new Document("timelineId", 42)));
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
+        when(mongoDatabase.getCollection("timelines")).thenReturn(headerCollection);
+        when(mongoDatabase.getCollection("timelineVersions")).thenReturn(versionCollection);
         when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(timelineWithNoVersions);
 
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(42).build();
+        store = new MongoTimelineStore(mongoDatabase, counterStore, namespaceStore);
+    }
 
-        assertThrows(TimelineNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineVersions(timeline));
+    private FindIterable<Document> stubFind(MongoCollection<Document> collection, List<Document> documents) {
+        FindIterable<Document> iterable = Mockito.mock(DocumentFindIterable.class);
+        when(collection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.sort(any())).thenReturn(iterable);
+        when(iterable.skip(anyInt())).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+        return iterable;
+    }
+
+    private void timelineExists() {
+        stubFind(headerCollection, List.of(new Document("timelineId", TIMELINE_ID)));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+    }
+
+    private void timelineDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static MongoWriteException writeError(int code, String message) {
+        return new MongoWriteException(new WriteError(code, message, new BsonDocument()), new ServerAddress(), List.of());
+    }
+
+    private static Timeline timeline(String version, String name, String description) {
+        return new Timeline.TimelineBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(TIMELINE_ID)
+                .setVersion(version)
+                .setName(name)
+                .setDescription(description)
+                .setTimeline(VALID_JSON)
+                .build();
+    }
+
+    private static Timeline timeline(String version) {
+        return timeline(version, "timeline-name", "timeline-description");
+    }
+
+    private static CreateTimelineRequest createRequest() {
+        return new CreateTimelineRequest("timeline-name", "timeline-description", VALID_JSON);
+    }
+
+    // --- getTimelinesForNamespace ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_timelines_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getTimelinesForNamespace(NAMESPACE));
     }
 
     @Test
-    void throw_timeline_version_not_found_when_versions_document_is_missing_on_get_for_version() {
-        Document timelineWithNoVersions = new Document("namespace", NAMESPACE)
-                .append("timelines", List.of(new Document("timelineId", 42)));
-        FindIterable<Document> findIterable = Mockito.mock(DocumentFindIterable.class);
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(true);
-        when(timelineCollection.find(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.projection(any(Bson.class))).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(timelineWithNoVersions);
+    void return_an_empty_list_when_a_namespace_has_no_timelines() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(42).setVersion("1.0.0").build();
-
-        assertThrows(TimelineVersionNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineForVersion(timeline));
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    void get_timeline_versions_for_valid_timeline_returns_list_of_versions() throws TimelineNotFoundException, NamespaceNotFoundException {
-        mockSetupTimelineDocumentWithVersions();
+    void return_a_summary_per_header_document_without_a_version_count() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                new Document("timelineId", 1).append("name", "First").append("description", "d1")
+                        .append("versionCount", 2),
+                new Document("timelineId", 2).append("name", "Second").append("description", "d2")
+                        .append("versionCount", 0)));
 
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(42).build();
-        List<String> timelineVersions = mongoTimelineStore.getTimelineVersions(timeline);
-
-        assertThat(timelineVersions, is(List.of("1.0.0")));
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), contains(
+                new NamespaceTimelineSummary("First", "d1", 1),
+                new NamespaceTimelineSummary("Second", "d2", 2)));
     }
 
     @Test
-    void throw_an_exception_for_an_invalid_timeline_when_retrieving_timeline_for_version() {
-        FindIterable<Document> findIterable = setupInvalidTimeline();
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).build();
+    void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(new Document("timelineId", 7)));
 
-        assertThrows(TimelineNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineForVersion(timeline));
-
-        verify(timelineCollection).find(new Document("namespace", timeline.getNamespace()));
-        verify(findIterable).projection(Projections.fields(Projections.include("timelines")));
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), contains(
+                new NamespaceTimelineSummary("Timeline 7", "", 7)));
     }
+
+
+    // --- createTimelineForNamespace ---
 
     @Test
-    void return_a_timeline_for_a_given_version() throws TimelineNotFoundException, TimelineVersionNotFoundException, NamespaceNotFoundException {
-        mockSetupTimelineDocumentWithVersions();
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").build();
-
-        String timelineForVersion = mongoTimelineStore.getTimelineForVersion(timeline);
-        assertThat(timelineForVersion, is(validJson));
-    }
-
-    private Document setupTimelineVersionDocument() {
-        Map<String, Document> versionMap = new HashMap<>();
-        versionMap.put("1-0-0", Document.parse(validJson));
-        Document targetStoredTimeline = new Document("timelineId", 42)
-                .append("versions", new Document(versionMap));
-
-        Document paddingTimeline = new Document("timelineId", 0);
-
-        return new Document("namespace", NAMESPACE)
-                .append("timelines", Arrays.asList(paddingTimeline, targetStoredTimeline));
-    }
-
-    private interface DocumentMongoCollection extends MongoCollection<Document> {
-    }
-
-    @Test
-    void throw_an_exception_when_timeline_for_given_version_does_not_exist() {
-        mockSetupTimelineDocumentWithVersions();
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
-
-        assertThrows(TimelineVersionNotFoundException.class,
-                () -> mongoTimelineStore.getTimelineForVersion(timeline));
-    }
-
-    @Test
-    void throw_an_exception_when_create_or_update_timeline_for_version_with_a_namespace_that_doesnt_exist() {
-        when(namespaceStore.namespaceExists(anyString())).thenReturn(false);
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("9.0.0").build();
+    void throw_a_namespace_exception_when_creating_a_timeline_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> mongoTimelineStore.createTimelineForVersion(timeline));
-        assertThrows(NamespaceNotFoundException.class,
-                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
-
-        verify(namespaceStore, times(2)).namespaceExists(timeline.getNamespace());
+                () -> store.createTimelineForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    void throw_an_exception_when_create_on_a_version_that_exists() {
-        mockSetupTimelineDocumentWithVersions();
+    void reject_invalid_json_before_drawing_an_id_or_writing_anything() {
+        CreateTimelineRequest invalid = new CreateTimelineRequest("n", "d", "{invalid json}");
 
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(0, 0L, null));
+        assertThrows(JsonParseException.class, () -> store.createTimelineForNamespace(invalid, NAMESPACE));
 
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.0").setTimeline(validJson).build();
+        verify(counterStore, never()).getNextTimelineSequenceValue();
+        verify(headerCollection, never()).insertOne(any(Document.class));
+    }
+
+    @Test
+    void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(counterStore.getNextTimelineSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        Timeline created = store.createTimelineForNamespace(createRequest(), NAMESPACE);
+
+        assertThat(created.getId(), is(99));
+        // Dot-separated on both backends now; Nitrite used to return "1-0-0" here.
+        assertThat(created.getDotVersion(), is("1.0.0"));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().getInteger("timelineId"), is(99));
+        assertThat(headerCaptor.getValue().getInteger("versionCount"), is(0));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.0"));
+    }
+
+    @Test
+    void remove_the_header_again_when_the_first_version_write_fails() {
+        when(counterStore.getNextTimelineSequenceValue()).thenReturn(99);
+        doAnswer(invocation -> {
+            throw writeError(10334, "object to insert too large");
+        }).when(versionCollection).insertOne(any(Document.class));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createTimelineForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    // --- getTimelineVersions ---
+
+    @Test
+    void throw_a_namespace_exception_when_listing_versions_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getTimelineVersions(timeline(null)));
+    }
+
+    @Test
+    void throw_a_timeline_exception_when_listing_versions_for_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class, () -> store.getTimelineVersions(timeline(null)));
+    }
+
+    @Test
+    void list_versions_in_semantic_order() throws NamespaceNotFoundException, TimelineNotFoundException {
+        stubFind(headerCollection, List.of(new Document("timelineId", TIMELINE_ID)));
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0"),
+                new Document("version", "1.0.0")));
+
+        assertThat(store.getTimelineVersions(timeline(null)), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    void return_no_versions_rather_than_not_found_for_a_timeline_with_none() throws NamespaceNotFoundException, TimelineNotFoundException {
+        stubFind(headerCollection, List.of(new Document("timelineId", TIMELINE_ID)));
+        stubFind(versionCollection, List.of());
+
+        // ADR 0003: the header proves the timeline exists, so an empty version list is an
+        // answer rather than evidence of a missing timeline.
+        assertThat(store.getTimelineVersions(timeline(null)), is(empty()));
+    }
+
+    // --- getTimelineForVersion ---
+
+    @Test
+    void throw_a_timeline_exception_when_getting_a_version_of_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class, () -> store.getTimelineForVersion(timeline("1.0.0")));
+    }
+
+    @Test
+    void throw_a_version_exception_when_the_version_is_not_stored() {
+        stubFind(headerCollection, List.of(new Document("timelineId", TIMELINE_ID)));
+        stubFind(versionCollection, List.of());
+
+        assertThrows(TimelineVersionNotFoundException.class,
+                () -> store.getTimelineForVersion(timeline("9.0.0")));
+    }
+
+    @Test
+    void return_the_content_of_a_stored_version() throws Exception {
+        stubFind(headerCollection, List.of(new Document("timelineId", TIMELINE_ID)));
+        stubFind(versionCollection, List.of(new Document("content", new Document("test", "test"))));
+
+        assertThat(store.getTimelineForVersion(timeline("1.0.0")), containsString("\"test\""));
+    }
+
+    // --- createTimelineForVersion ---
+
+    @Test
+    void throw_a_timeline_exception_when_creating_a_version_for_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class,
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
+    }
+
+    @Test
+    void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        timelineExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
         assertThrows(TimelineVersionExistsException.class,
-                () -> mongoTimelineStore.createTimelineForVersion(timeline));
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
     }
 
     @Test
-    void throw_a_timeline_not_found_exception_when_creating_or_updating_a_version_for_a_missing_timeline() {
-        mockSetupTimelineDocumentWithVersions();
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(50).setVersion("1.0.1")
-                .setTimeline(validJson).build();
+    void not_rename_the_timeline_when_the_version_already_exists() {
+        timelineExists();
+        doAnswer(invocation -> {
+            throw writeError(11000, "duplicate key");
+        }).when(versionCollection).insertOne(any(Document.class));
 
-        assertThrows(TimelineNotFoundException.class,
-                () -> mongoTimelineStore.createTimelineForVersion(timeline));
-        assertThrows(TimelineNotFoundException.class,
-                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+        assertThrows(TimelineVersionExistsException.class,
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
 
-        // The entity-existence pre-check catches the missing timeline before any write is
-        // attempted, so no update is ever sent to Mongo (either overload).
-        verify(timelineCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(timelineCollection, never())
-                .updateOne(any(Bson.class), any(Bson.class));
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test
-    void throw_a_storage_write_exception_with_capacity_exceeded_when_updating_a_version_hits_the_document_size_limit() {
-        mockSetupTimelineDocumentWithVersions();
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setTimeline(validJson).build();
+    void write_the_version_and_then_the_header_details() throws Exception {
+        timelineExists();
 
-        WriteError writeError = new WriteError(10334, "object to insert too large", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+        store.createTimelineForVersion(timeline("1.0.1"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().getString("version"), is("1.0.1"));
+        // Two header writes: the versionCount increment and the name/description update.
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void leave_the_stored_name_alone_when_a_version_write_carries_none() throws Exception {
+        timelineExists();
+
+        store.createTimelineForVersion(timeline("1.0.1", null, null));
+
+        // Where Architecture overwrites unconditionally — wiping the display name, bugs.md
+        // #2 — Timeline's old shape guarded these fields, so only the count write happens.
+        verify(headerCollection, Mockito.times(1)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void update_only_the_details_that_are_present() throws Exception {
+        timelineExists();
+
+        store.createTimelineForVersion(timeline("1.0.1", "Renamed", "  "));
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), updateCaptor.capture());
+        String detailsUpdate = updateCaptor.getAllValues().get(1).toBsonDocument().toJson();
+        assertThat(detailsUpdate, containsString("Renamed"));
+        assertThat(detailsUpdate, not(containsString("description")));
+    }
+
+    // --- updateTimelineForVersion ---
+
+    @Test
+    void throw_a_timeline_exception_when_updating_a_version_for_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class,
+                () -> store.updateTimelineForVersion(timeline("1.0.1")));
+    }
+
+    @Test
+    void force_write_a_version_on_update() throws Exception {
+        timelineExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        store.updateTimelineForVersion(timeline("1.0.1"));
+
+        verify(versionCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
+        // Replacing an existing version doesn't move the count, so the only header write
+        // here is the name/description update.
+        verify(headerCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void report_capacity_exceeded_when_a_version_write_hits_the_document_size_limit() {
+        timelineExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10334, "object to insert too large"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+                () -> store.updateTimelineForVersion(timeline("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(true));
     }
 
     @Test
-    void throw_a_storage_write_exception_without_capacity_exceeded_for_other_write_failures_when_updating_a_version() {
-        mockSetupTimelineDocumentWithVersions();
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setTimeline(validJson).build();
-
-        WriteError writeError = new WriteError(2, "some other error", new BsonDocument());
-        MongoWriteException mongoWriteException = new MongoWriteException(writeError, new ServerAddress(), Set.of("label"));
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
-                .thenThrow(mongoWriteException);
+    void report_a_plain_write_failure_for_other_version_write_errors() {
+        timelineExists();
+        when(versionCollection.updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class)))
+                .thenThrow(writeError(10107, "not master"));
 
         StorageWriteException exception = assertThrows(StorageWriteException.class,
-                () -> mongoTimelineStore.updateTimelineForVersion(timeline));
+                () -> store.updateTimelineForVersion(timeline("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
-    }
-
-    @Test
-    void accept_the_creation_or_update_of_a_valid_version() throws TimelineNotFoundException, NamespaceNotFoundException, TimelineVersionExistsException {
-        mockSetupTimelineDocumentWithVersions();
-
-        when(timelineCollection.updateOne(any(Bson.class), any(Bson.class)))
-                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE)
-                .setId(42).setVersion("1.0.1")
-                .setTimeline(validJson).build();
-
-        mongoTimelineStore.updateTimelineForVersion(timeline);
-        mongoTimelineStore.createTimelineForVersion(timeline);
-
-        verify(timelineCollection).updateOne(any(Bson.class), any(Bson.class), any(UpdateOptions.class));
-        verify(timelineCollection).updateOne(any(Bson.class), any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
@@ -166,6 +166,16 @@ public class TestNitriteAdrStoreShould {
                 contains(new NamespaceAdrSummary("ADR 7", "unknown", 7)));
     }
 
+    @Test
+    public void render_a_header_with_no_id_rather_than_failing_the_whole_listing() throws Exception {
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", null)));
+
+        // The helper sorts null ids last so one malformed header does not fail the listing;
+        // resolving its latest revision unboxes that null into an int parameter.
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("ADR null", "unknown", null)));
+    }
+
     // --- createAdrForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -80,6 +81,7 @@ public class TestNitriteAdrStoreShould {
         when(collection.find(any(Filter.class))).thenReturn(cursor);
         when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
         when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(cursor.size()).thenReturn((long) documents.size());
         when(collection.find()).thenReturn(cursor);
     }
 
@@ -174,6 +176,23 @@ public class TestNitriteAdrStoreShould {
         // resolving its latest revision unboxes that null into an int parameter.
         assertThat(store.getAdrsForNamespace(NAMESPACE),
                 contains(new NamespaceAdrSummary("ADR null", "unknown", null)));
+    }
+
+    @Test
+    public void count_adrs_without_resolving_any_revision() throws Exception {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("adrId", 1),
+                Document.createDocument().put("adrId", 2)));
+
+        assertThat(store.countAdrsForNamespace(NAMESPACE), is(2));
+        verifyNoInteractions(versionCollection);
+    }
+
+    @Test
+    public void throw_a_namespace_exception_when_counting_adrs_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.countAdrsForNamespace(NAMESPACE));
     }
 
     // --- createAdrForNamespace ---

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
@@ -1,6 +1,5 @@
 package org.finos.calm.store.nitrite;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.dizitart.no2.Nitrite;
@@ -8,39 +7,47 @@ import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
-import org.finos.calm.domain.adr.*;
+import org.finos.calm.domain.adr.Adr;
+import org.finos.calm.domain.adr.AdrMeta;
 import org.finos.calm.domain.adr.NamespaceAdrSummary;
-import org.finos.calm.domain.exception.*;
+import org.finos.calm.domain.adr.Status;
+import org.finos.calm.domain.exception.AdrNotFoundException;
+import org.finos.calm.domain.exception.AdrRevisionExistsException;
+import org.finos.calm.domain.exception.AdrRevisionNotFoundException;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for ADR on the header/version shape. Mirrors the Mongo class: integer
+ * revisions and a summary built from the latest revision's content, with content held as a
+ * JSON string in this backend.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteAdrStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -48,515 +55,250 @@ public class TestNitriteAdrStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteAdrStore adrStore;
-
-    private ObjectMapper objectMapper;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteAdrStore store;
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     private static final String NAMESPACE = "finos";
     private static final int ADR_ID = 42;
-    private static final int REVISION = 1;
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        adrStore = new NitriteAdrStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("adrs")).thenReturn(headerCollection);
+        when(mockDb.getCollection("adrVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteAdrStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
-    @Test
-    public void testGetAdrsForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> adrStore.getAdrsForNamespace(NAMESPACE));
-    }
-
-    @Test
-    public void testGetAdrsForNamespace_whenNamespaceExistsButNoAdrs_returnsEmptyList() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
         DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceAdrSummary> result = assertDoesNotThrow(() -> adrStore.getAdrsForNamespace(NAMESPACE));
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
     }
 
-    @Test
-    public void testGetAdr_retrievesLatestRevision() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-
-        // Act
-        AdrMeta result = adrStore.getAdr(adrMeta);
-
-        // Assert
-        assertThat(result.getRevision(), is(REVISION));
-        assertThat(result.getId(), is(ADR_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getAdr().getTitle(), is("Sample ADR"));
+    private void adrExists() {
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", ADR_ID)));
     }
 
-    @Test
-    public void testGetAdrRevisions_returnsAllRevisions() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-
-        // Act
-        List<Integer> revisions = adrStore.getAdrRevisions(adrMeta);
-
-        // Assert
-        assertThat(revisions.size(), is(1));
-        assertThat(revisions, hasItem(REVISION));
+    private void adrDoesNotExist() {
+        stubFind(headerCollection, List.of());
     }
 
-    @Test
-    public void testGetAdrRevision_returnsSpecificRevision() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-
-        // Act
-        AdrMeta result = adrStore.getAdrRevision(adrMeta);
-
-        // Assert
-        assertThat(result.getRevision(), is(REVISION));
-        assertThat(result.getId(), is(ADR_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getAdr().getTitle(), is("Sample ADR"));
+    private static Adr adr(String title, Status status) {
+        return new Adr.AdrBuilder().setTitle(title).setStatus(status).build();
     }
 
-    @Test
-    public void testRetrieveAdrDoc_whenAdrDoesNotExist_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a document for the namespace with empty ADRs list
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(AdrNotFoundException.class, () -> adrStore.getAdr(adrMeta));
+    private String contentOf(String title, Status status) throws Exception {
+        return objectMapper.writeValueAsString(adr(title, status));
     }
 
-    @Test
-    public void testRetrieveRevisionsDoc_whenRevisionsNotFound_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a document for the ADR without revisions
-        Document adrDoc = Document.createDocument()
-                .put("adrId", ADR_ID);
-
-        List<Document> adrs = new ArrayList<>();
-        adrs.add(adrDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", adrs);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(AdrRevisionNotFoundException.class, () -> adrStore.getAdr(adrMeta));
-    }
-
-    @Test
-    public void testWriteAdrToNitrite_whenAdrNotFound_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create an empty namespace document
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(AdrNotFoundException.class, () -> {
-            // We need to access a private method, so we'll call a public method that uses it
-            adrStore.updateAdrStatus(adrMeta, Status.accepted);
-        });
-    }
-
-    @Test
-    public void testGetAdrRevision_whenRevisionNotFound_throwsException() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        AdrMeta wrongRevisionAdrMeta = new AdrMeta.AdrMetaBuilder(adrMeta)
-                .setRevision(999) // Non-existent revision
-                .build();
-
-        setupMockForExistingAdr(adrMeta);
-
-        // Act & Assert
-        assertThrows(AdrRevisionNotFoundException.class, () -> adrStore.getAdrRevision(wrongRevisionAdrMeta));
-    }
-
-    @Test
-    public void testGetAdrRevisions_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> adrStore.getAdrRevisions(adrMeta));
-    }
-
-    @Test
-    public void testWriteAdrToNitriteWithPersistenceException() {
-        // This test demonstrates a scenario that would lead to AdrPersistenceException
-        // We're testing the exception type directly rather than through the implementation
-        // to ensure we have coverage of the exception type
-        AdrPersistenceException exception = new AdrPersistenceException();
-        assertThat(exception, is(notNullValue()));
-    }
-
-    @Test
-    public void testGetAdrRevision_whenJsonProcessingExceptionOccurs_throwsAdrParseException() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-
-        // Create a spy on the object mapper to throw an exception
-        ObjectMapper spyMapper = spy(new ObjectMapper());
-        doThrow(new JsonProcessingException("Test exception") {}).when(spyMapper).readValue(anyString(), eq(Adr.class));
-
-        // Use reflection to replace the objectMapper in adrStore with our spy
-        Field mapperField = NitriteAdrStore.class.getDeclaredField("objectMapper");
-        mapperField.setAccessible(true);
-        mapperField.set(adrStore, spyMapper);
-
-        // Act & Assert
-        assertThrows(AdrParseException.class, () -> adrStore.getAdrRevision(adrMeta));
-    }
-
-    @Test
-    public void testCreateAdrForNamespace_whenJsonProcessingExceptionOccurs_throwsAdrParseException() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        lenient().when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a spy on the object mapper to throw an exception
-        ObjectMapper spyMapper = spy(new ObjectMapper());
-        doThrow(new JsonProcessingException("Test exception") {}).when(spyMapper).writeValueAsString(any(Adr.class));
-
-        // Use reflection to replace the objectMapper in adrStore with our spy
-        Field mapperField = NitriteAdrStore.class.getDeclaredField("objectMapper");
-        mapperField.setAccessible(true);
-        mapperField.set(adrStore, spyMapper);
-
-        // Act & Assert
-        assertThrows(AdrParseException.class, () -> adrStore.createAdrForNamespace(adrMeta));
-    }
-
-    @Test
-    public void testCreateAdrForNamespace_whenInvalidJsonFormat_throwsAdrParseException() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        lenient().when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a spy on the object mapper to return invalid JSON
-        ObjectMapper spyMapper = spy(new ObjectMapper());
-        doReturn("invalid json").when(spyMapper).writeValueAsString(any(Adr.class));
-
-        // Use reflection to replace the objectMapper in adrStore with our spy
-        Field mapperField = NitriteAdrStore.class.getDeclaredField("objectMapper");
-        mapperField.setAccessible(true);
-        mapperField.set(adrStore, spyMapper);
-
-        // Act & Assert
-        assertThrows(AdrParseException.class, () -> adrStore.createAdrForNamespace(adrMeta));
-    }
-
-    @Test
-    public void testGetAdrsForNamespace_whenEmptyAdrsList_returnsEmptyList() throws Exception {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a document with an empty adrs list
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceAdrSummary> result = adrStore.getAdrsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
-    }
-
-    @Test
-    public void testGetAdrsForNamespace_whenNullAdrsList_returnsEmptyList() throws Exception {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a document with a null adrs list
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceAdrSummary> result = adrStore.getAdrsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.isEmpty(), is(true));
-    }
-
-    @Test
-    public void testCreateAdrForNamespace_whenNamespaceDocumentExists_addsAdrToExistingDocument() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(ADR_ID);
-
-        // Create an existing namespace document with an empty adrs list
-        List<Document> existingAdrs = new ArrayList<>();
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", existingAdrs);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        AdrMeta result = adrStore.createAdrForNamespace(adrMeta);
-
-        // Assert
-        assertThat(result.getId(), is(ADR_ID));
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testRetrieveLatestRevision_getsMaxRevision() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-
-        // Create a document with multiple revisions
-        String adrStr = objectMapper.writeValueAsString(adrMeta.getAdr());
-        Document revisionsDoc = Document.createDocument()
-                .put("1", adrStr)
-                .put("2", adrStr);
-
-        Document adrDoc = Document.createDocument()
-                .put("adrId", ADR_ID)
-                .put("revisions", revisionsDoc);
-
-        // Act & Assert - Using reflection to access private method
-        Method retrieveLatestRevisionMethod = NitriteAdrStore.class.getDeclaredMethod(
-                "retrieveLatestRevision", AdrMeta.class, Document.class);
-        retrieveLatestRevisionMethod.setAccessible(true);
-
-        AdrMeta result = (AdrMeta) retrieveLatestRevisionMethod.invoke(adrStore, adrMeta, adrDoc);
-
-        // Assert
-        assertThat(result.getRevision(), is(2)); // Should get the highest revision number
-    }
-
-    @Test
-    public void testGetAdrsForNamespace_whenAdrsExist_returnsAdrSummaries() throws NamespaceNotFoundException, JsonProcessingException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Adr adr1Obj = new Adr.AdrBuilder()
-                .setTitle("First ADR")
-                .setStatus(Status.draft)
-                .setCreationDateTime(LocalDateTime.now())
-                .setUpdateDateTime(LocalDateTime.now())
-                .build();
-        Adr adr2Obj = new Adr.AdrBuilder()
-                .setTitle("Second ADR")
-                .setStatus(Status.accepted)
-                .setCreationDateTime(LocalDateTime.now())
-                .setUpdateDateTime(LocalDateTime.now())
-                .build();
-
-        Document adr1 = Document.createDocument()
-                .put("adrId", 1)
-                .put("revisions", Document.createDocument()
-                        .put("1", objectMapper.writeValueAsString(adr1Obj)));
-        Document adr2 = Document.createDocument()
-                .put("adrId", 2)
-                .put("revisions", Document.createDocument()
-                        .put("1", objectMapper.writeValueAsString(adr2Obj)));
-        List<Document> adrs = Arrays.asList(adr1, adr2);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", adrs);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceAdrSummary> result = adrStore.getAdrsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result.size(), is(2));
-        assertThat(result.get(0).getTitle(), is("First ADR"));
-        assertThat(result.get(0).getStatus(), is("draft"));
-        assertThat(result.get(0).getId(), is(1));
-        assertThat(result.get(1).getTitle(), is("Second ADR"));
-        assertThat(result.get(1).getStatus(), is("accepted"));
-        assertThat(result.get(1).getId(), is(2));
-    }
-
-    @Test
-    public void testCreateAdrForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> adrStore.createAdrForNamespace(adrMeta));
-    }
-
-    @Test
-    public void testCreateAdrForNamespace_whenNamespaceExists_createsAdr() throws NamespaceNotFoundException, AdrParseException {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(ADR_ID);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null); // No existing namespace document
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        AdrMeta result = adrStore.createAdrForNamespace(adrMeta);
-
-        // Assert
-        assertThat(result.getId(), is(ADR_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        verify(mockCollection).insert(any(Document.class));
-    }
-
-    @Test
-    public void testGetAdr_whenAdrDoesNotExist_throwsException() {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null); // No namespace document
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(AdrNotFoundException.class, () -> adrStore.getAdr(adrMeta));
-    }
-
-    @Test
-    public void testUpdateAdrForNamespace_updatesExistingAdr() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-
-        // Act
-        AdrMeta result = adrStore.updateAdrForNamespace(adrMeta);
-
-        // Assert
-        assertThat(result.getRevision(), is(REVISION + 1)); // Revision should be incremented
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testUpdateAdrStatus_updatesStatus() throws Exception {
-        // Arrange
-        AdrMeta adrMeta = createSampleAdrMeta();
-        setupMockForExistingAdr(adrMeta);
-        Status newStatus = Status.accepted;
-
-        // Act
-        AdrMeta result = adrStore.updateAdrStatus(adrMeta, newStatus);
-
-        // Assert
-        assertThat(result.getRevision(), is(REVISION + 1)); // Revision should be incremented
-        assertThat(result.getAdr().getStatus(), is(newStatus));
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
-
-    private AdrMeta createSampleAdrMeta() {
-        Option option1 = new Option("Option 1", "Description", List.of("Pro 1"), List.of("Con 1"));
-
-        Adr adr = new Adr.AdrBuilder()
-                .setTitle("Sample ADR")
-                .setStatus(Status.proposed)
-                .setCreationDateTime(LocalDateTime.now())
-                .setUpdateDateTime(LocalDateTime.now())
-                .setContextAndProblemStatement("This is a sample ADR")
-                .setDecisionDrivers(Arrays.asList("Driver 1", "Driver 2"))
-                .setConsideredOptions(Collections.singletonList(option1))
-                .setDecisionOutcome(new Decision(option1, "Justification"))
-                .setLinks(Collections.singletonList(
-                        new Link("Link 1", "http://example.com")
-                ))
-                .build();
-
+    private static AdrMeta adrMeta(int revision, Adr adr) {
         return new AdrMeta.AdrMetaBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(ADR_ID)
-                .setRevision(REVISION)
-                .setAdr(adr)
-                .build();
+                .setNamespace(NAMESPACE).setId(ADR_ID).setRevision(revision).setAdr(adr).build();
     }
 
-    private void setupMockForExistingAdr(AdrMeta adrMeta) throws JsonProcessingException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a string for the ADR revision
-        String adrStr = objectMapper.writeValueAsString(adrMeta.getAdr());
-
-        // Create a document for the revisions
-        Document revisionsDoc = Document.createDocument()
-                .put(String.valueOf(REVISION), adrStr);
-
-        // Create a document for the ADR
-        Document adrDoc = Document.createDocument()
-                .put("adrId", ADR_ID)
-                .put("revisions", revisionsDoc);
-
-        // Create a list of ADRs
-        List<Document> adrs = new ArrayList<>();
-        adrs.add(adrDoc);
-
-        // Create a document for the namespace
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("adrs", adrs);
-
-        // Set up the mock cursor
+    /**
+     * Stubs an update: the latest revision reads back, then the existence check that
+     * {@code createVersion} performs before inserting finds nothing, because the revision
+     * being written is new. A single always-returns-content stub would make that check see
+     * the existing revision and refuse the write — this backend inserts by check-then-insert,
+     * where Mongo inserts optimistically and translates a duplicate-key error.
+     */
+    private void stubRevisionsForUpdate(List<String> revisions, String latestContent) {
         DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(versionCollection.find(any(Filter.class))).thenReturn(cursor);
+        java.util.concurrent.atomic.AtomicBoolean firstRead = new java.util.concurrent.atomic.AtomicBoolean(true);
+        when(cursor.firstOrNull()).thenAnswer(invocation ->
+                firstRead.getAndSet(false) ? Document.createDocument().put("content", latestContent) : null);
+        when(cursor.iterator()).thenAnswer(invocation ->
+                revisions.stream().map(r -> Document.createDocument().put("version", r)).iterator());
+    }
+
+    /** Revision documents as listVersions sees them, plus the content getVersion returns. */
+    private void stubRevisions(List<String> revisions, String latestContent) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(versionCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(
+                latestContent == null ? null : Document.createDocument().put("content", latestContent));
+        when(cursor.iterator()).thenAnswer(invocation ->
+                revisions.stream().map(r -> Document.createDocument().put("version", r)).iterator());
+    }
+
+    // --- getAdrsForNamespace ---
+
+    @Test
+    public void throw_a_namespace_exception_when_listing_adrs_for_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.getAdrsForNamespace(NAMESPACE));
+    }
+
+    @Test
+    public void return_an_empty_list_when_a_namespace_has_no_adrs() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
+
+        assertThat(store.getAdrsForNamespace(NAMESPACE), is(empty()));
+    }
+
+    @Test
+    public void build_the_summary_from_the_latest_revisions_title_and_status() throws Exception {
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", ADR_ID)));
+        stubRevisions(List.of("1", "2"), contentOf("Use Event Sourcing", Status.accepted));
+
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("Use Event Sourcing", "accepted", ADR_ID)));
+    }
+
+    @Test
+    public void fall_back_to_placeholders_rather_than_failing_on_unreadable_content() throws Exception {
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", 7)));
+        stubRevisions(List.of("1"), "{not valid json");
+
+        // A listing must not fail because one ADR's stored content is unreadable.
+        assertThat(store.getAdrsForNamespace(NAMESPACE),
+                contains(new NamespaceAdrSummary("ADR 7", "unknown", 7)));
+    }
+
+    // --- createAdrForNamespace ---
+
+    @Test
+    public void create_a_header_and_the_first_revision() throws Exception {
+        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", 99).put("versionCount", 0)));
+        stubRevisions(List.of(), null);
+
+        AdrMeta created = store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft)));
+
+        assertThat(created.getId(), is(99));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("version", String.class), is("1"));
+    }
+
+    // --- reads ---
+
+    @Test
+    public void throw_an_adr_exception_when_the_adr_is_missing() {
+        adrDoesNotExist();
+
+        assertThrows(AdrNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    public void resolve_the_latest_revision_numerically_rather_than_lexicographically() throws Exception {
+        adrExists();
+        stubRevisions(List.of("2", "10"), contentOf("Latest", Status.accepted));
+
+        assertThat(store.getAdr(adrMeta(1, null)).getRevision(), is(10));
+    }
+
+    @Test
+    public void throw_a_revision_exception_when_an_adr_has_no_revisions() {
+        adrExists();
+        stubRevisions(List.of(), null);
+
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    public void list_revisions_as_ascending_integers() throws Exception {
+        adrExists();
+        stubRevisions(List.of("10", "2", "1"), contentOf("t", Status.draft));
+
+        assertThat(store.getAdrRevisions(adrMeta(1, null)), contains(1, 2, 10));
+    }
+
+    @Test
+    public void return_a_specific_revision() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1"), contentOf("Specific", Status.proposed));
+
+        assertThat(store.getAdrRevision(adrMeta(1, null)).getAdr().getTitle(), is("Specific"));
+    }
+
+    @Test
+    public void throw_a_revision_exception_when_the_requested_revision_is_missing() {
+        adrExists();
+        stubRevisions(List.of("1"), null);
+
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdrRevision(adrMeta(9, null)));
+    }
+
+    @Test
+    public void report_a_parse_failure_when_stored_content_is_not_a_readable_adr() {
+        adrExists();
+        stubRevisions(List.of("1"), "{\"title\": 42, \"status\": \"nonsense\"}");
+
+        assertThrows(org.finos.calm.domain.exception.AdrParseException.class,
+                () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    public void report_a_missing_revision_when_the_latest_disappears_between_resolving_and_reading() {
+        adrExists();
+        stubRevisions(List.of("1"), null);
+
+        assertThrows(AdrRevisionNotFoundException.class, () -> store.getAdr(adrMeta(1, null)));
+    }
+
+    @Test
+    public void remove_the_header_when_the_first_revision_already_exists_for_a_fresh_id() throws Exception {
+        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubRevisions(List.of("1"), contentOf("Existing", Status.draft));
+
+        assertThrows(org.finos.calm.domain.exception.StorageWriteException.class,
+                () -> store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft))));
+
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    // --- updates ---
+
+    @Test
+    public void write_the_next_revision_when_updating_an_adr() throws Exception {
+        adrExists();
+        stubRevisionsForUpdate(List.of("1", "2"), contentOf("Existing", Status.accepted));
+
+        AdrMeta updated = store.updateAdrForNamespace(adrMeta(1, adr("Rewritten", Status.draft)));
+
+        assertThat(updated.getRevision(), is(3));
+        // Status comes from the stored latest revision, not the request.
+        assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+    }
+
+    @Test
+    public void write_the_next_revision_when_updating_status() throws Exception {
+        adrExists();
+        stubRevisionsForUpdate(List.of("1"), contentOf("Existing", Status.draft));
+
+        AdrMeta updated = store.updateAdrStatus(adrMeta(1, null), Status.accepted);
+
+        assertThat(updated.getRevision(), is(2));
+        assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+    }
+
+    @Test
+    public void report_the_revision_already_exists_when_two_writers_race() throws Exception {
+        adrExists();
+        // The revision the update computes is already present, so createVersion refuses it.
+        stubRevisions(List.of("1"), contentOf("Existing", Status.draft));
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(versionCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(
+                Document.createDocument().put("content", contentOf("Existing", Status.draft)));
+        when(cursor.iterator()).thenAnswer(invocation ->
+                List.of(Document.createDocument().put("version", "1")).iterator());
+
+        assertThrows(AdrRevisionExistsException.class,
+                () -> store.updateAdrStatus(adrMeta(1, null), Status.accepted));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteFlowStoreShould.java
@@ -4,39 +4,53 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
+import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Flow;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestNitriteVersionDocumentStoreShould}; what this class pins is the glue — the
+ * domain exceptions, the JSON validation this backend does and Mongo doesn't, and Flow's
+ * blank-guarding of name/description.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteFlowStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -44,567 +58,333 @@ public class TestNitriteFlowStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteFlowStore flowStore;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteFlowStore store;
 
     private static final String NAMESPACE = "finos";
     private static final int FLOW_ID = 42;
-    private static final String VERSION = "1.0.0";
     private static final String VALID_JSON = "{\"test\": \"test\"}";
+    private static final String FLOW_NAME = "flow-name";
+    private static final String FLOW_DESCRIPTION = "flow description";
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        flowStore = new NitriteFlowStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("flows")).thenReturn(headerCollection);
+        when(mockDb.getCollection("flowVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteFlowStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
-    @Test
-    public void testGetFlowsForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.getFlowsForNamespace(NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowsForNamespace_whenNamespaceExistsButNoFlows_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
         DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = flowStore.getFlowsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, is(empty()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
     }
 
-    @Test
-    public void testGetFlowsForNamespace_whenNamespaceDocumentExists_butNoFlowsField_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = flowStore.getFlowsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, is(empty()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowsForNamespace_whenFlowsExist_returnsFlowSummaries() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document flow1 = Document.createDocument().put("flowId", 1001).put("name", "Flow One").put("description", "First")
-                .put("versions", Document.createDocument().put("1-0-0", "{}").put("2-0-0", "{}"));
-        Document flow2 = Document.createDocument().put("flowId", 1002).put("name", "Flow Two").put("description", "Second")
-                .put("versions", Document.createDocument().put("1-0-0", "{}"));
-        List<Document> flows = Arrays.asList(flow1, flow2);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = flowStore.getFlowsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, hasSize(2));
-        assertThat(result.get(0).getId(), is(1001));
-        assertThat(result.get(0).getName(), is("Flow One"));
-        assertThat(result.get(0).getDescription(), is("First"));
-        assertThat(result.get(0).getVersionCount(), is(2));
-        assertThat(result.get(1).getId(), is(1002));
-        assertThat(result.get(1).getName(), is("Flow Two"));
-        assertThat(result.get(1).getDescription(), is("Second"));
-        assertThat(result.get(1).getVersionCount(), is(1));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowsForNamespace_whenLegacyDocumentsMissingNameAndDescription_returnsFallbacks() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document legacyDoc = Document.createDocument().put("flowId", 77);
-        List<Document> flows = List.of(legacyDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceResourceSummary> result = flowStore.getFlowsForNamespace(NAMESPACE);
-
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getId(), is(77));
-        assertThat(result.get(0).getName(), is("Flow 77"));
-        assertThat(result.get(0).getDescription(), is(""));
-        // Legacy document carries no versions sub-document → count guards to 0.
-        assertThat(result.get(0).getVersionCount(), is(0));
-    }
-
-    @Test
-    public void testCreateFlowForNamespace_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        
-        CreateFlowRequest request = new CreateFlowRequest("name", "desc", VALID_JSON);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.createFlowForNamespace(request, NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testCreateFlowForNamespace_whenInvalidJson_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        CreateFlowRequest request = new CreateFlowRequest("name", "desc", "Invalid JSON");
-
-        // Act & Assert
-        assertThrows(Exception.class, () -> flowStore.createFlowForNamespace(request, NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testCreateFlowForNamespace_whenNamespaceDocumentDoesNotExist_createsNewDocument() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextFlowSequenceValue()).thenReturn(FLOW_ID);
-        
-        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", VALID_JSON);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Flow result = flowStore.createFlowForNamespace(request, NAMESPACE);
-
-        // Assert
-        assertThat(result.getId(), is(FLOW_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getFlowJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextFlowSequenceValue();
-        verify(mockCollection).insert(any(Document.class));
-    }
-
-    @Test
-    public void testCreateFlowForNamespace_whenNamespaceDocumentExists_updatesExistingDocument() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextFlowSequenceValue()).thenReturn(FLOW_ID);
-        
-        CreateFlowRequest request = new CreateFlowRequest("Test Flow", "A test", VALID_JSON);
-        
-        Document existingFlow = Document.createDocument().put("flowId", 1001);
-        List<Document> flows = new ArrayList<>();
-        flows.add(existingFlow);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Flow result = flowStore.createFlowForNamespace(request, NAMESPACE);
-
-        // Assert
-        assertThat(result.getId(), is(FLOW_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getFlowJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextFlowSequenceValue();
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testGetFlowVersions_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .build();
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.getFlowVersions(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowVersions_whenFlowDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", new ArrayList<>());
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .build();
-
-        // Act & Assert
-        assertThrows(FlowNotFoundException.class, () -> flowStore.getFlowVersions(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowVersions_whenFlowExists_returnsVersions() throws NamespaceNotFoundException, FlowNotFoundException {
-        // This test is challenging because we can't easily mock Document.getFields()
-        // We'll skip the detailed verification and just verify the method calls
-        
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        // Create a mock document structure
-        Document namespaceDoc = mock(Document.class);
-        List<Document> flows = new ArrayList<>();
-        Document flowDoc = mock(Document.class);
-        Document versions = mock(Document.class);
-        
-        flows.add(flowDoc);
-        
-        // Setup the mocks
-        when(flowDoc.get("flowId", Integer.class)).thenReturn(FLOW_ID);
-        when(flowDoc.get("versions", Document.class)).thenReturn(versions);
-        when(namespaceDoc.get("flows", List.class)).thenReturn(flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        // Return empty list to simplify test
-        when(versions.getFields()).thenReturn(java.util.Collections.emptySet());
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .build();
-
-        // Act
-        List<String> result = flowStore.getFlowVersions(flow);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(versions).getFields();
-    }
-
-    @Test
-    public void testGetFlowForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.getFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowForVersion_whenFlowDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", new ArrayList<>());
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act & Assert
-        assertThrows(FlowVersionNotFoundException.class, () -> flowStore.getFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testGetFlowForVersion_whenVersionDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON);
-        
-        Document flowDoc = Document.createDocument()
+    private void flowExists() {
+        stubFind(headerCollection, List.of(Document.createDocument()
                 .put("flowId", FLOW_ID)
-                .put("versions", versions);
-        
-        List<Document> flows = new ArrayList<>();
-        flows.add(flowDoc);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act & Assert
-        assertThrows(FlowVersionNotFoundException.class, () -> flowStore.getFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+                .put("versionCount", 1)));
     }
 
-    @Test
-    public void testGetFlowForVersion_whenVersionExists_returnsFlowJson() throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-        
-        Document flowDoc = Document.createDocument()
-                .put("flowId", FLOW_ID)
-                .put("versions", versions);
-        
-        List<Document> flows = new ArrayList<>();
-        flows.add(flowDoc);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .build();
-
-        // Act
-        String result = flowStore.getFlowForVersion(flow);
-
-        // Assert
-        assertThat(result, is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    private void flowDoesNotExist() {
+        stubFind(headerCollection, List.of());
     }
 
+    private static Flow flow(String version, String name, String description) {
+        return new Flow.FlowBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(FLOW_ID)
+                .setVersion(version)
+                .setName(name)
+                .setDescription(description)
+                .setFlow(VALID_JSON)
+                .build();
+    }
+
+    private static Flow flow(String version) {
+        return flow(version, FLOW_NAME, FLOW_DESCRIPTION);
+    }
+
+    private static CreateFlowRequest createRequest() {
+        return new CreateFlowRequest(FLOW_NAME, FLOW_DESCRIPTION, VALID_JSON);
+    }
+
+    // --- getFlowsForNamespace ---
+
     @Test
-    public void testCreateFlowForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void throw_a_namespace_exception_when_listing_flows_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .setFlow(VALID_JSON)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.createFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class, () -> store.getFlowsForNamespace(NAMESPACE));
     }
 
     @Test
-    public void testCreateFlowForVersion_whenVersionExists_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-        
-        Document flowDoc = Document.createDocument()
-                .put("flowId", FLOW_ID)
-                .put("versions", versions);
-        
-        List<Document> flows = new ArrayList<>();
-        flows.add(flowDoc);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .setFlow(VALID_JSON)
-                .build();
+    public void return_an_empty_list_when_a_namespace_has_no_flows() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        // Act & Assert
-        assertThrows(FlowVersionExistsException.class, () -> flowStore.createFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getFlowsForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    public void testCreateFlowForVersion_whenVersionDoesNotExist_createsVersion() throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionExistsException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON); // Different version
-        
-        Document flowDoc = Document.createDocument()
-                .put("flowId", FLOW_ID)
-                .put("versions", versions);
-        
-        List<Document> flows = new ArrayList<>();
-        flows.add(flowDoc);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION) // 1.0.0
-                .setFlow(VALID_JSON)
-                .build();
+    public void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("flowId", 1).put("name", "First")
+                        .put("description", "d1").put("versionCount", 2),
+                Document.createDocument().put("flowId", 2).put("name", "Second")
+                        .put("description", "d2").put("versionCount", 0)));
 
-        // Act
-        Flow result = flowStore.createFlowForVersion(flow);
-
-        // Assert
-        assertThat(result, is(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        assertThat(store.getFlowsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
     }
 
     @Test
-    public void testUpdateFlowForVersion_whenNamespaceDoesNotExist_throwsException() {
-        // Arrange
+    public void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(Document.createDocument().put("flowId", 7)));
+
+        assertThat(store.getFlowsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("Flow 7", "", 7, 0)));
+    }
+
+
+    // --- createFlowForNamespace ---
+
+    @Test
+    public void throw_a_namespace_exception_when_creating_a_flow_in_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .setFlow(VALID_JSON)
-                .build();
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> flowStore.updateFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.createFlowForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    public void testUpdateFlowForVersion_whenFlowDoesNotExist_throwsException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", new ArrayList<>());
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .setFlow(VALID_JSON)
-                .build();
+    public void reject_invalid_json_when_creating_a_flow() {
+        CreateFlowRequest invalid = new CreateFlowRequest("n", "d", "{invalid json}");
 
-        // Act & Assert
-        assertThrows(FlowNotFoundException.class, () -> flowStore.updateFlowForVersion(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(JsonParseException.class, () -> store.createFlowForNamespace(invalid, NAMESPACE));
+        verify(headerCollection, never()).insert(any(Document.class));
     }
 
     @Test
-    public void testUpdateFlowForVersion_whenValidParameters_returnsUpdatedFlow() throws NamespaceNotFoundException, FlowNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-        
-        Document flowDoc = Document.createDocument()
-                .put("flowId", FLOW_ID)
-                .put("versions", versions);
-        
-        List<Document> flows = new ArrayList<>();
-        flows.add(flowDoc);
-        
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("flows", flows);
-        
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-        
-        Flow flow = new Flow.FlowBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(FLOW_ID)
-                .setVersion(VERSION)
-                .setFlow(VALID_JSON)
-                .build();
+    public void reject_null_json_when_creating_a_flow() {
+        CreateFlowRequest noJson = new CreateFlowRequest("n", "d", null);
 
-        // Act
-        Flow result = flowStore.updateFlowForVersion(flow);
+        // This backend validates up front; Mongo would NPE inside Document.parse instead.
+        assertThrows(JsonParseException.class, () -> store.createFlowForNamespace(noJson, NAMESPACE));
+    }
 
-        // Assert
-        assertThat(result, is(flow));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+    @Test
+    public void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextFlowSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("flowId", 99).put("versionCount", 0)));
+        stubFind(versionCollection, List.of());
+
+        Flow created = store.createFlowForNamespace(createRequest(), NAMESPACE);
+
+        assertThat(created.getId(), is(99));
+        // Was "1-0-0" before this port, so the Location header differed by backend for the
+        // same operation. Now dot-separated on both, matching what is actually stored.
+        assertThat(created.getDotVersion(), is("1.0.0"));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("flowId", Integer.class), is(99));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(0));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend rather than a parsed document.
+        assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
+    }
+
+    @Test
+    public void remove_the_header_again_when_the_first_version_write_fails() {
+        when(mockCounterStore.getNextFlowSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of());
+        when(versionCollection.insert(any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
+
+        assertThrows(NitriteException.class,
+                () -> store.createFlowForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    @Test
+    public void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(mockCounterStore.getNextFlowSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.0")));
+
+        assertThrows(StorageWriteException.class,
+                () -> store.createFlowForNamespace(createRequest(), NAMESPACE));
+
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    // --- getFlowVersions ---
+
+    @Test
+    public void throw_a_flow_exception_when_listing_versions_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class, () -> store.getFlowVersions(flow(null)));
+    }
+
+    @Test
+    public void list_versions_in_semantic_order() throws NamespaceNotFoundException, FlowNotFoundException {
+        flowExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.10.0"),
+                Document.createDocument().put("version", "1.9.0"),
+                Document.createDocument().put("version", "1.0.0")));
+
+        assertThat(store.getFlowVersions(flow(null)), contains("1.0.0", "1.9.0", "1.10.0"));
+    }
+
+    @Test
+    public void return_no_versions_rather_than_not_found_for_a_flow_with_none() throws NamespaceNotFoundException, FlowNotFoundException {
+        flowExists();
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getFlowVersions(flow(null)), is(empty()));
+    }
+
+    // --- getFlowForVersion ---
+
+    @Test
+    public void throw_a_flow_exception_when_getting_a_version_of_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class, () -> store.getFlowForVersion(flow("1.0.0")));
+    }
+
+    @Test
+    public void throw_a_version_exception_when_the_version_is_not_stored() {
+        flowExists();
+        stubFind(versionCollection, List.of());
+
+        assertThrows(FlowVersionNotFoundException.class,
+                () -> store.getFlowForVersion(flow("9.0.0")));
+    }
+
+    @Test
+    public void return_the_content_of_a_stored_version() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("content", VALID_JSON)));
+
+        assertThat(store.getFlowForVersion(flow("1.0.0")), is(VALID_JSON));
+    }
+
+    // --- createFlowForVersion ---
+
+    @Test
+    public void reject_invalid_json_before_checking_the_flow_exists() {
+        flowDoesNotExist();
+        Flow invalid = new Flow.FlowBuilder()
+                .setNamespace(NAMESPACE).setId(FLOW_ID).setVersion("1.0.1")
+                .setFlow("{invalid json}").build();
+
+        // Deliberate divergence from Mongo, which reports the missing flow first.
+        assertThrows(JsonParseException.class, () -> store.createFlowForVersion(invalid));
+    }
+
+    @Test
+    public void throw_a_flow_exception_when_creating_a_version_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class,
+                () -> store.createFlowForVersion(flow("1.0.1")));
+    }
+
+    @Test
+    public void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        flowExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
+
+        assertThrows(FlowVersionExistsException.class,
+                () -> store.createFlowForVersion(flow("1.0.1")));
+    }
+
+    @Test
+    public void not_rename_the_flow_when_the_version_already_exists() {
+        flowExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
+
+        assertThrows(FlowVersionExistsException.class,
+                () -> store.createFlowForVersion(flow("1.0.1")));
+
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void write_the_version_and_then_the_header_details() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of());
+
+        store.createFlowForVersion(flow("1.0.1"));
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.1"));
+        // Two header writes: the versionCount increment, then the name/description update.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void leave_the_stored_name_alone_when_a_version_write_carries_none() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of());
+
+        store.createFlowForVersion(flow("1.0.1", null, null));
+
+        // Flow guards these fields where Architecture overwrites them, so only the
+        // versionCount write happens here.
+        verify(headerCollection, times(1)).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- updateFlowForVersion ---
+
+    @Test
+    public void throw_a_flow_exception_when_updating_a_version_for_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class,
+                () -> store.updateFlowForVersion(flow("1.0.1")));
+    }
+
+    @Test
+    public void replace_the_content_of_an_existing_version_on_update() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of(Document.createDocument()
+                .put("version", "1.0.1").put("content", "{\"old\":true}")));
+
+        store.updateFlowForVersion(flow("1.0.1"));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("content", String.class), is(VALID_JSON));
+    }
+
+    @Test
+    public void create_the_version_when_updating_one_that_does_not_exist() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of());
+
+        // Preserves the known create-on-PUT behaviour (bugs.md #1) rather than changing it.
+        store.updateFlowForVersion(flow("2.0.0"));
+
+        verify(versionCollection).insert(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
@@ -4,37 +4,51 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
+import org.bson.json.JsonParseException;
 import org.finos.calm.domain.CalmInterface;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
-import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.util.*;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestNitriteVersionDocumentStoreShould}. Interface sets name/description
+ * unconditionally on a version write and has no update path — both pinned here.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteInterfaceStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -42,414 +56,209 @@ public class TestNitriteInterfaceStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteInterfaceStore interfaceStore;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteInterfaceStore store;
 
-    private final String NAMESPACE = "finos";
-    private final String INTERFACE_JSON = "{\"type\":\"object\",\"properties\":{\"port\":{\"type\":\"integer\"}}}";
-    private final int INTERFACE_ID = 42;
+    private static final String NAMESPACE = "finos";
+    private static final int INTERFACE_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        interfaceStore = new NitriteInterfaceStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("interfaces")).thenReturn(headerCollection);
+        when(mockDb.getCollection("interfaceVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteInterfaceStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
+    }
+
+    private void interfaceExists() {
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("interfaceId", INTERFACE_ID).put("versionCount", 1)));
+    }
+
+    private void interfaceDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static CreateInterfaceRequest createRequest() {
+        return new CreateInterfaceRequest("interface-name", "interface-description", VALID_JSON);
+    }
+
+    // --- getInterfacesForNamespace ---
+
     @Test
-    public void testGetInterfacesForNamespace_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
+    public void throw_a_namespace_exception_when_listing_interfaces_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        assertThrows(NamespaceNotFoundException.class, () -> interfaceStore.getInterfacesForNamespace(NAMESPACE));
+        assertThrows(NamespaceNotFoundException.class, () -> store.getInterfacesForNamespace(NAMESPACE));
     }
 
     @Test
-    public void testGetInterfacesForNamespace_whenNoInterfaces_returnsEmptyList() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_an_empty_list_when_a_namespace_has_no_interfaces() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        List<NamespaceInterfaceSummary> result = interfaceStore.getInterfacesForNamespace(NAMESPACE);
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        assertThat(store.getInterfacesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    public void testGetInterfacesForNamespace_whenNamespaceExistsButInterfacesArrayIsNull_returnsEmptyList() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_a_summary_per_header_document_without_a_version_count() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("interfaceId", 1).put("name", "First")
+                        .put("description", "d1").put("versionCount", 2),
+                Document.createDocument().put("interfaceId", 2).put("name", "Second")
+                        .put("description", "d2").put("versionCount", 0)));
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", null);
+        assertThat(store.getInterfacesForNamespace(NAMESPACE), contains(
+                new NamespaceInterfaceSummary("First", "d1", 1),
+                new NamespaceInterfaceSummary("Second", "d2", 2)));
+    }
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+    // --- createInterfaceForNamespace ---
 
-        List<NamespaceInterfaceSummary> result = interfaceStore.getInterfacesForNamespace(NAMESPACE);
+    @Test
+    public void reject_invalid_json_when_creating_a_interface() {
+        CreateInterfaceRequest invalid = new CreateInterfaceRequest("n", "d", "{invalid json}");
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        assertThrows(JsonParseException.class, () -> store.createInterfaceForNamespace(invalid, NAMESPACE));
+        verify(headerCollection, org.mockito.Mockito.never()).insert(any(Document.class));
     }
 
     @Test
-    public void testGetInterfacesForNamespace_whenNamespaceExistsButInterfacesArrayIsEmpty_returnsEmptyList() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextInterfaceSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("interfaceId", 99).put("versionCount", 0)));
+        stubFind(versionCollection, List.of());
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", Collections.emptyList());
+        CalmInterface created = store.createInterfaceForNamespace(createRequest(), NAMESPACE);
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        assertThat(created.getId(), is(99));
+        assertThat(created.getVersion(), is("1.0.0"));
 
-        List<NamespaceInterfaceSummary> result = interfaceStore.getInterfacesForNamespace(NAMESPACE);
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
     }
 
     @Test
-    public void testGetInterfacesForNamespace_whenInterfacesExist_returnsInterfaces() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void remove_the_header_again_when_the_first_version_write_fails() {
+        when(mockCounterStore.getNextInterfaceSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of());
+        when(versionCollection.insert(any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
 
-        Map<String, Object> fullInterface = new HashMap<>();
-        fullInterface.put("interfaceId", 2);
-        fullInterface.put("name", "Test Name");
-        fullInterface.put("description", "Test Description");
+        assertThrows(NitriteException.class,
+                () -> store.createInterfaceForNamespace(createRequest(), NAMESPACE));
 
-        Document interfaceDoc1 = Document.createDocument("interfaceId", 1);
-        Document interfaceDoc2 = Document.createDocument(fullInterface);
-        List<Document> interfaces = Arrays.asList(interfaceDoc1, interfaceDoc2);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", interfaces);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceInterfaceSummary> result = interfaceStore.getInterfacesForNamespace(NAMESPACE);
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.size(), is(2));
-        assertThat(result.getFirst().getId(), is(1));
-        assertThat(result.get(1).getId(), is(2));
-        assertThat(result.get(1).getDescription(), is("Test Description"));
-        assertThat(result.get(1).getName(), is("Test Name"));
+        verify(headerCollection).remove(any(Filter.class));
     }
 
     @Test
-    public void testCreateInterfaceForNamespace_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        CreateInterfaceRequest interfaceRequest = new CreateInterfaceRequest();
-        interfaceRequest.setInterfaceJson(INTERFACE_JSON);
+    public void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(mockCounterStore.getNextInterfaceSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.0")));
 
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+        assertThrows(StorageWriteException.class,
+                () -> store.createInterfaceForNamespace(createRequest(), NAMESPACE));
 
-        assertThrows(NamespaceNotFoundException.class, () -> interfaceStore.createInterfaceForNamespace(interfaceRequest, NAMESPACE));
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    // --- getInterfaceVersions / getInterfaceForVersion ---
+
+    @Test
+    public void throw_a_interface_exception_when_listing_versions_for_a_missing_interface() {
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class, () -> store.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
     }
 
     @Test
-    public void testCreateInterfaceForNamespace_whenNamespaceExists_createsInterface() throws NamespaceNotFoundException {
-        CreateInterfaceRequest interfaceRequest = new CreateInterfaceRequest();
-        interfaceRequest.setInterfaceJson(INTERFACE_JSON);
+    public void list_versions_in_semantic_order() throws NamespaceNotFoundException, InterfaceNotFoundException {
+        interfaceExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.10.0"),
+                Document.createDocument().put("version", "1.9.0"),
+                Document.createDocument().put("version", "1.0.0")));
 
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextInterfaceSequenceValue()).thenReturn(INTERFACE_ID);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        CalmInterface result = interfaceStore.createInterfaceForNamespace(interfaceRequest, NAMESPACE);
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getId(), is(INTERFACE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getInterfaceJson(), is(INTERFACE_JSON));
-        assertThat(result.getVersion(), is("1.0.0"));
-
-        verify(mockCollection).insert(any(Document.class));
+        assertThat(store.getInterfaceVersions(NAMESPACE, INTERFACE_ID), contains("1.0.0", "1.9.0", "1.10.0"));
     }
 
     @Test
-    public void testGetInterfaceVersions_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void throw_a_version_exception_when_the_version_is_not_stored() {
+        interfaceExists();
+        stubFind(versionCollection, List.of());
 
-        assertThrows(NamespaceNotFoundException.class, () -> interfaceStore.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
+        assertThrows(InterfaceVersionNotFoundException.class,
+                () -> store.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "9.0.0"));
     }
 
     @Test
-    public void testGetInterfaceVersions_whenInterfaceDoesNotExist_throwsInterfaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mock(DocumentCursor.class));
+    public void return_the_content_of_a_stored_version() throws Exception {
+        interfaceExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("content", VALID_JSON)));
 
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
+        assertThat(store.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"), is(VALID_JSON));
+    }
+
+    // --- createInterfaceForVersion ---
+
+    @Test
+    public void throw_a_interface_exception_when_creating_a_version_for_a_missing_interface() {
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class,
+                () -> store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1"));
     }
 
     @Test
-    public void testGetInterfaceVersions_whenVersionsExist_returnsVersionsList() throws NamespaceNotFoundException, InterfaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        interfaceExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
 
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.getFields()).thenReturn(new HashSet<>(Arrays.asList("1-0-0", "1-1-0")));
-
-        Document interfaceDoc = mock(Document.class);
-        when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(interfaceDoc.get("interfaceId", Integer.class)).thenReturn(INTERFACE_ID);
-
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("interfaces"), any())).thenReturn(Collections.singletonList(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<String> result = interfaceStore.getInterfaceVersions(NAMESPACE, INTERFACE_ID);
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.size(), is(2));
-        assertThat(result, hasItem("1.0.0"));
-        assertThat(result, hasItem("1.1.0"));
+        assertThrows(InterfaceVersionExistsException.class,
+                () -> store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1"));
     }
 
     @Test
-    public void testGetInterfaceForVersion_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void write_the_version_and_then_the_header_details() throws Exception {
+        interfaceExists();
+        stubFind(versionCollection, List.of());
 
-        assertThrows(NamespaceNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
+        store.createInterfaceForVersion(createRequest(), NAMESPACE, INTERFACE_ID, "1.0.1");
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.1"));
+        // Two header writes: the versionCount increment, then the name/description update.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
 
     @Test
-    public void testGetInterfaceForVersion_whenInterfaceDoesNotExist_throwsInterfaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testGetInterfaceForVersion_whenVersionDoesNotExist_throwsInterfaceVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0")).thenReturn(null);
-
-        Document interfaceDoc = mock(Document.class);
-        when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(interfaceDoc.get("interfaceId", Integer.class)).thenReturn(INTERFACE_ID);
-
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("interfaces"), any())).thenReturn(Collections.singletonList(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceVersionNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "2.0.0"));
-    }
-
-    @Test
-    public void testGetInterfaceForVersion_whenVersionExists_returnsInterface() throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0")).thenReturn("{}");
-
-        Document interfaceDoc = mock(Document.class);
-        when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(interfaceDoc.get("interfaceId", Integer.class)).thenReturn(INTERFACE_ID);
-
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("interfaces"), any())).thenReturn(Collections.singletonList(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        String result = interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "2.0.0");
-
-        assertThat(result, equalTo("{}"));
-    }
-
-    @Test
-    public void testGetInterfaceVersions_whenVersionsDocumentIsNull_throwsInterfaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document interfaceDoc = Document.createDocument()
-                .put("interfaceId", INTERFACE_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", List.of(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.getInterfaceVersions(NAMESPACE, INTERFACE_ID));
-    }
-
-    @Test
-    public void testGetInterfaceForVersion_whenVersionsDocumentIsNull_throwsInterfaceVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document interfaceDoc = Document.createDocument()
-                .put("interfaceId", INTERFACE_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", List.of(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceVersionNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testGetInterfaceForVersion_whenVersionObjIsNotAString_throwsInterfaceVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("1-0-0", 12345);
-
-        Document interfaceDoc = Document.createDocument()
-                .put("interfaceId", INTERFACE_ID)
-                .put("versions", versions);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", List.of(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceVersionNotFoundException.class, () -> interfaceStore.getInterfaceForVersion(NAMESPACE, INTERFACE_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenVersionsDocumentIsNull_throwsInterfaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document interfaceDoc = Document.createDocument()
-                .put("interfaceId", INTERFACE_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("interfaces", List.of(interfaceDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.createInterfaceForVersion(getInterfaceToPersist(), NAMESPACE, INTERFACE_ID, "1.0.1"));
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        CreateInterfaceRequest interfaceRequest = getInterfaceToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> interfaceStore.createInterfaceForVersion(interfaceRequest, NAMESPACE, null, null));
-    }
-
-    private CreateInterfaceRequest getInterfaceToPersist() {
-        return new CreateInterfaceRequest("Test", "Test Description", INTERFACE_JSON);
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenNamespaceDocumentDoesNotExist_throwsInterfaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.createInterfaceForVersion(getInterfaceToPersist(), NAMESPACE, null, null));
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenInterfaceDoesNotExist_throwsInterfaceNotFoundException() {
-        CreateInterfaceRequest interfaceRequest = getInterfaceToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document namespaceDoc = mock(Document.class);
-
-        DocumentCursor namespaceCursor = mock(DocumentCursor.class);
-        when(namespaceCursor.firstOrNull()).thenReturn(namespaceDoc);
-
-        DocumentCursor interfaceCursor = mock(DocumentCursor.class);
-        when(interfaceCursor.firstOrNull()).thenReturn(null);
-
-        when(mockCollection.find(any(Filter.class))).thenReturn(namespaceCursor, interfaceCursor);
-
-        assertThrows(InterfaceNotFoundException.class, () -> interfaceStore.createInterfaceForVersion(interfaceRequest, NAMESPACE, INTERFACE_ID, null));
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenVersionAlreadyExists_throwsInterfaceVersionExistsException() {
-        CreateInterfaceRequest interfaceRequest = getInterfaceToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.containsKey(anyString())).thenReturn(true);
-
-        Document interfaceDoc = mock(Document.class);
-        when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(interfaceDoc.get("interfaceId", Integer.class)).thenReturn(INTERFACE_ID);
-
-        List<Document> interfaces = Collections.singletonList(interfaceDoc);
-
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("interfaces"), any())).thenReturn(interfaces);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(InterfaceVersionExistsException.class, () -> interfaceStore.createInterfaceForVersion(interfaceRequest, NAMESPACE, INTERFACE_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testCreateInterfaceForVersion_whenSuccess_returnsInterface() throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionExistsException {
-        CreateInterfaceRequest createInterfaceRequest = getInterfaceToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.containsKey(anyString())).thenReturn(false);
-
-        Document interfaceDoc = mock(Document.class);
-        when(interfaceDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(interfaceDoc.get("interfaceId", Integer.class)).thenReturn(INTERFACE_ID);
-
-        List<Document> interfaces = new ArrayList<>();
-        interfaces.add(interfaceDoc);
-
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("interfaces"), any())).thenReturn(interfaces);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        CalmInterface result = interfaceStore.createInterfaceForVersion(createInterfaceRequest, NAMESPACE, INTERFACE_ID, "1.0.0");
-
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getId(), is(INTERFACE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getVersion(), is("1.0.0"));
+    public void overwrite_the_header_details_even_when_blank() throws Exception {
+        interfaceExists();
+        stubFind(versionCollection, List.of());
+
+        store.createInterfaceForVersion(new CreateInterfaceRequest(null, null, VALID_JSON),
+                NAMESPACE, INTERFACE_ID, "1.0.1");
+
+        // Unconditional, unlike Pattern and Flow — Interface's old shape did not guard these.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -207,14 +207,13 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
-        // Uses a flow: only the array-shaped types can have a null entries array at all, so
-        // this covers the branch where it still exists. It moves to another unmigrated type
-        // each time one migrates — it was on architectures, then patterns.
+        // Uses a standard: only the array-shaped types can have a null entries array at all,
+        // so this covers the branch where it still exists. Moves as each type migrates.
         Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("flows", null);
+                .put("standards", null);
 
-        mockCollectionFind(flowCollection, List.of(namespaceDoc));
-        mockEmptyCollections(architectureCollection, patternCollection, standardCollection,
+        mockCollectionFind(standardCollection, List.of(namespaceDoc));
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
@@ -240,21 +239,28 @@ class TestNitriteSearchStoreShould {
     void return_results_from_multiple_collections() {
         Document archDoc = architectureHeader(1, "Demo Architecture", "demo");
 
-        Document flowEntry = Document.createDocument("flowId", 3)
+        Document flowDoc = Document.createDocument("namespace", "finos")
+                .put("flowId", 3)
                 .put("name", "Demo Flow")
                 .put("description", "demo");
-        Document flowDoc = Document.createDocument("namespace", "finos")
-                .put("flows", List.of(flowEntry));
+
+        // A standard, still array-shaped, so both search paths run in one search while the
+        // rollout is part-done. Moves to another unmigrated type as each one migrates.
+        Document standardDoc = Document.createDocument("namespace", "finos")
+                .put("standards", List.of(Document.createDocument("standardId", 4)
+                        .put("name", "Demo Standard")
+                        .put("description", "demo")));
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(flowCollection, List.of(flowDoc));
-        mockEmptyCollections(patternCollection, standardCollection,
-                interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(standardCollection, List.of(standardDoc));
+        mockEmptyCollections(patternCollection, interfaceCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("demo");
 
         assertEquals(1, results.getArchitectures().size());
         assertEquals(1, results.getFlows().size());
+        assertEquals(1, results.getStandards().size());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -4,6 +4,7 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
@@ -22,6 +23,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +53,9 @@ class TestNitriteSearchStoreShould {
     @Mock
     private NitriteCollection adrCollection;
 
+    @Mock
+    private NitriteCollection adrVersionCollection;
+
     private NitriteSearchStore searchStore;
 
     @BeforeEach
@@ -63,6 +68,7 @@ class TestNitriteSearchStoreShould {
         when(db.getCollection("interfaces")).thenReturn(interfaceCollection);
         when(db.getCollection("controls")).thenReturn(controlCollection);
         when(db.getCollection("adrs")).thenReturn(adrCollection);
+        when(db.getCollection("adrVersions")).thenReturn(adrVersionCollection);
         searchStore = new NitriteSearchStore(db);
     }
 
@@ -71,6 +77,16 @@ class TestNitriteSearchStoreShould {
      * architecture rather than a namespace-wide array of them. The other namespaced types
      * still use the array shape, which is why both fixtures appear in this class.
      */
+    /** Stubs the adrVersions collection: the revision list, and the latest revision's content. */
+    private void mockAdrRevisions(List<String> revisions, String latestContent) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(adrVersionCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(
+                latestContent == null ? null : Document.createDocument("content", latestContent));
+        when(cursor.iterator()).thenAnswer(invocation ->
+                revisions.stream().map(r -> Document.createDocument("version", r)).iterator());
+    }
+
     private static Document architectureHeader(int id, String name, String description) {
         return architectureHeader("finos", id, name, description);
     }
@@ -154,15 +170,12 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void search_adr_by_latest_revision_title() {
-        Document revisionDoc = Document.createDocument("title", "Use Event Sourcing");
-        Document adrEntry = Document.createDocument("adrId", 1)
-                .put("revisions", Map.of("1", revisionDoc));
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("adrs", List.of(adrEntry));
-
+        // ADR reads its title from the latest revision's content, held here as a JSON string.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(namespaceDoc));
+        mockCollectionFind(adrCollection, List.of(
+                Document.createDocument("namespace", "finos").put("adrId", 1)));
+        mockAdrRevisions(List.of("1"), "{\"title\": \"Use Event Sourcing\"}");
 
         GroupedSearchResults results = searchStore.search("event");
 
@@ -172,16 +185,12 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void search_adr_uses_latest_revision_when_multiple_exist() {
-        Document revisionDoc1 = Document.createDocument("title", "Old Title");
-        Document revisionDoc2 = Document.createDocument("title", "New Title");
-        Document adrEntry = Document.createDocument("adrId", 1)
-                .put("revisions", Map.of("1", revisionDoc1, "2", revisionDoc2));
-        Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("adrs", List.of(adrEntry));
-
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(namespaceDoc));
+        mockCollectionFind(adrCollection, List.of(
+                Document.createDocument("namespace", "finos").put("adrId", 1)));
+        // Two revisions; the search must read the later one's title.
+        mockAdrRevisions(List.of("1", "2"), "{\"title\": \"New Title\"}");
 
         GroupedSearchResults results = searchStore.search("New");
 
@@ -338,21 +347,13 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void filter_adrs_by_readable_namespaces() {
-        Document allowedRev = Document.createDocument("title", "Allowed ADR");
-        Document allowedAdr = Document.createDocument("adrId", 1)
-                .put("revisions", Map.of("1", allowedRev));
-        Document allowedNs = Document.createDocument("namespace", "finos")
-                .put("adrs", List.of(allowedAdr));
-
-        Document forbiddenRev = Document.createDocument("title", "Forbidden ADR");
-        Document forbiddenAdr = Document.createDocument("adrId", 2)
-                .put("revisions", Map.of("1", forbiddenRev));
-        Document forbiddenNs = Document.createDocument("namespace", "secret-ns")
-                .put("adrs", List.of(forbiddenAdr));
-
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(allowedNs, forbiddenNs));
+        mockCollectionFind(adrCollection, List.of(
+                Document.createDocument("namespace", "finos").put("adrId", 1),
+                Document.createDocument("namespace", "secret-ns").put("adrId", 2)));
+        // Both resolve to the same stubbed title; the filter is what decides the result.
+        mockAdrRevisions(List.of("1"), "{\"title\": \"Allowed ADR\"}");
 
         GroupedSearchResults results = searchStore.search("ADR",
                 Optional.of(Set.of("finos")));

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -199,7 +199,7 @@ class TestNitriteSearchStoreShould {
         assertTrue(results.getArchitectures().isEmpty());
         assertTrue(results.getPatterns().isEmpty());
         assertTrue(results.getFlows().isEmpty());
-        assertTrue(results.getStandards().isEmpty());
+        assertTrue(results.getInterfaces().isEmpty());
         assertTrue(results.getInterfaces().isEmpty());
         assertTrue(results.getControls().isEmpty());
         assertTrue(results.getAdrs().isEmpty());
@@ -207,14 +207,14 @@ class TestNitriteSearchStoreShould {
 
     @Test
     void handle_null_entries_array_gracefully() {
-        // Uses a standard: only the array-shaped types can have a null entries array at all,
-        // so this covers the branch where it still exists. Moves as each type migrates.
+        // Uses an interface: only the array-shaped types can have a null entries array at
+        // all, so this covers the branch where it still exists. Moves as each type migrates.
         Document namespaceDoc = Document.createDocument("namespace", "finos")
-                .put("standards", null);
+                .put("interfaces", null);
 
-        mockCollectionFind(standardCollection, List.of(namespaceDoc));
+        mockCollectionFind(interfaceCollection, List.of(namespaceDoc));
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
-                interfaceCollection, controlCollection, adrCollection);
+                standardCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("test");
 
@@ -244,23 +244,23 @@ class TestNitriteSearchStoreShould {
                 .put("name", "Demo Flow")
                 .put("description", "demo");
 
-        // A standard, still array-shaped, so both search paths run in one search while the
+        // An interface, still array-shaped, so both search paths run in one search while the
         // rollout is part-done. Moves to another unmigrated type as each one migrates.
-        Document standardDoc = Document.createDocument("namespace", "finos")
-                .put("standards", List.of(Document.createDocument("standardId", 4)
-                        .put("name", "Demo Standard")
+        Document interfaceDoc = Document.createDocument("namespace", "finos")
+                .put("interfaces", List.of(Document.createDocument("interfaceId", 5)
+                        .put("name", "Demo Interface")
                         .put("description", "demo")));
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(flowCollection, List.of(flowDoc));
-        mockCollectionFind(standardCollection, List.of(standardDoc));
-        mockEmptyCollections(patternCollection, interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(interfaceCollection, List.of(interfaceDoc));
+        mockEmptyCollections(patternCollection, standardCollection, controlCollection, adrCollection);
 
         GroupedSearchResults results = searchStore.search("demo");
 
         assertEquals(1, results.getArchitectures().size());
         assertEquals(1, results.getFlows().size());
-        assertEquals(1, results.getStandards().size());
+        assertEquals(1, results.getInterfaces().size());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -244,12 +244,12 @@ class TestNitriteSearchStoreShould {
                 .put("name", "Demo Flow")
                 .put("description", "demo");
 
-        // An interface, still array-shaped, so both search paths run in one search while the
-        // rollout is part-done. Moves to another unmigrated type as each one migrates.
+        // Every namespaced type now reads the header shape — the array-shaped path was
+        // retired with Interface, its last caller.
         Document interfaceDoc = Document.createDocument("namespace", "finos")
-                .put("interfaces", List.of(Document.createDocument("interfaceId", 5)
-                        .put("name", "Demo Interface")
-                        .put("description", "demo")));
+                .put("interfaceId", 5)
+                .put("name", "Demo Interface")
+                .put("description", "demo");
 
         mockCollectionFind(architectureCollection, List.of(archDoc));
         mockCollectionFind(flowCollection, List.of(flowDoc));

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -208,7 +208,7 @@ class TestNitriteSearchStoreShould {
         assertTrue(results.getArchitectures().isEmpty());
         assertTrue(results.getPatterns().isEmpty());
         assertTrue(results.getFlows().isEmpty());
-        assertTrue(results.getInterfaces().isEmpty());
+        assertTrue(results.getStandards().isEmpty());
         assertTrue(results.getInterfaces().isEmpty());
         assertTrue(results.getControls().isEmpty());
         assertTrue(results.getAdrs().isEmpty());

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -168,6 +168,18 @@ class TestNitriteSearchStoreShould {
     }
 
     @Test
+    void skip_an_adr_header_with_no_id_rather_than_failing_the_search() {
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+        mockCollectionFind(adrCollection, List.of(
+                Document.createDocument("namespace", "finos").put("adrId", null)));
+
+        // See the Mongo twin: unboxing an absent adrId would 500 the whole /search request,
+        // for every resource type rather than just ADR.
+        assertEquals(0, searchStore.search("event").getAdrs().size());
+    }
+
+    @Test
     void search_adr_by_latest_revision_title() {
         // ADR reads its title from the latest revision's content, held here as a JSON string.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -71,11 +71,6 @@ class TestNitriteSearchStoreShould {
         searchStore = new NitriteSearchStore(db);
     }
 
-    /**
-     * Architecture has moved to the header/version shape, so each of its documents is one
-     * architecture rather than a namespace-wide array of them. The other namespaced types
-     * still use the array shape, which is why both fixtures appear in this class.
-     */
     /** Stubs the adrVersions collection: the revision list, and the latest revision's content. */
     private void mockAdrRevisions(List<String> revisions, String latestContent) {
         DocumentCursor cursor = mock(DocumentCursor.class);

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -168,6 +168,17 @@ class TestNitriteSearchStoreShould {
     }
 
     @Test
+    void skip_a_header_with_no_id_rather_than_failing_the_search() {
+        mockEmptyCollections(patternCollection, flowCollection, standardCollection,
+                interfaceCollection, controlCollection, adrCollection);
+        mockCollectionFind(architectureCollection, List.of(
+                Document.createDocument("namespace", "finos").put("name", "event thing").put("description", "d")));
+
+        // See the Mongo twin: one id-less header would 500 the entire /search request.
+        assertEquals(0, searchStore.search("event").getArchitectures().size());
+    }
+
+    @Test
     void skip_an_adr_header_with_no_id_rather_than_failing_the_search() {
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -16,7 +16,6 @@ import org.mockito.MockitoAnnotations;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
@@ -4,37 +4,51 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
+import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
 import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.util.*;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestNitriteVersionDocumentStoreShould}. Standard sets name/description
+ * unconditionally on a version write and has no update path — both pinned here.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteStandardStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -42,506 +56,209 @@ public class TestNitriteStandardStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteStandardStore standardStore;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteStandardStore store;
 
-    private final String NAMESPACE = "finos";
-    private final String STANDARD_JSON = "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}";
-    // Default version used in tests
-    private final int STANDARD_ID = 42;
+    private static final String NAMESPACE = "finos";
+    private static final int STANDARD_ID = 42;
+    private static final String VALID_JSON = "{\"test\": \"test\"}";
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        standardStore = new NitriteStandardStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("standards")).thenReturn(headerCollection);
+        when(mockDb.getCollection("standardVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteStandardStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
+    }
+
+    private void standardExists() {
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("standardId", STANDARD_ID).put("versionCount", 1)));
+    }
+
+    private void standardDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static CreateStandardRequest createRequest() {
+        return new CreateStandardRequest("standard-name", "standard-description", VALID_JSON);
+    }
+
+    // --- getStandardsForNamespace ---
+
     @Test
-    public void testGetStandardsForNamespace_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        // Arrange
+    public void throw_a_namespace_exception_when_listing_standards_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> standardStore.getStandardsForNamespace(NAMESPACE));
+        assertThrows(NamespaceNotFoundException.class, () -> store.getStandardsForNamespace(NAMESPACE));
     }
 
     @Test
-    public void testGetStandardsForNamespace_whenNoStandards_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_an_empty_list_when_a_namespace_has_no_standards() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        // Mock cursor to return null for firstOrNull() (no namespace document found)
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = standardStore.getStandardsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        assertThat(store.getStandardsForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    public void testGetStandardsForNamespace_whenNamespaceExistsButStandardsArrayIsNull_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_a_summary_per_header_document() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("standardId", 1).put("name", "First")
+                        .put("description", "d1").put("versionCount", 2),
+                Document.createDocument().put("standardId", 2).put("name", "Second")
+                        .put("description", "d2").put("versionCount", 0)));
 
-        // Create namespace document with null standards array
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", null);
+        assertThat(store.getStandardsForNamespace(NAMESPACE), contains(
+                new NamespaceResourceSummary("First", "d1", 1, 2),
+                new NamespaceResourceSummary("Second", "d2", 2, 0)));
+    }
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+    // --- createStandardForNamespace ---
 
-        // Act
-        List<NamespaceResourceSummary> result = standardStore.getStandardsForNamespace(NAMESPACE);
+    @Test
+    public void reject_invalid_json_when_creating_a_standard() {
+        CreateStandardRequest invalid = new CreateStandardRequest("n", "d", "{invalid json}");
 
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        assertThrows(JsonParseException.class, () -> store.createStandardForNamespace(invalid, NAMESPACE));
+        verify(headerCollection, org.mockito.Mockito.never()).insert(any(Document.class));
     }
 
     @Test
-    public void testGetStandardsForNamespace_whenNamespaceExistsButStandardsArrayIsEmpty_returnsEmptyList() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextStandardSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("standardId", 99).put("versionCount", 0)));
+        stubFind(versionCollection, List.of());
 
-        // Create namespace document with empty standards array
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", Collections.emptyList());
+        Standard created = store.createStandardForNamespace(createRequest(), NAMESPACE);
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        assertThat(created.getId(), is(99));
+        assertThat(created.getVersion(), is("1.0.0"));
 
-        // Act
-        List<NamespaceResourceSummary> result = standardStore.getStandardsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.isEmpty(), is(true));
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
     }
 
     @Test
-    public void testGetStandardsForNamespace_whenStandardsExist_returnsStandards() throws NamespaceNotFoundException {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void remove_the_header_again_when_the_first_version_write_fails() {
+        when(mockCounterStore.getNextStandardSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of());
+        when(versionCollection.insert(any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
 
-        Map<String, Object> fullStandard = new HashMap<>();
-        fullStandard.put("standardId", 2);
-        fullStandard.put("name", "Test Name");
-        fullStandard.put("description", "Test Description");
-        fullStandard.put("versions", Document.createDocument().put("1-0-0", "{}").put("2-0-0", "{}"));
+        assertThrows(NitriteException.class,
+                () -> store.createStandardForNamespace(createRequest(), NAMESPACE));
 
-        // standardDoc1 carries no versions sub-document → count guards to 0;
-        // standardDoc2 carries two versions → count is 2.
-        Document standardDoc1 = Document.createDocument("standardId", 1);
-        Document standardDoc2 = Document.createDocument(fullStandard);
-        List<Document> standards = Arrays.asList(standardDoc1, standardDoc2);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", standards);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        List<NamespaceResourceSummary> result = standardStore.getStandardsForNamespace(NAMESPACE);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.size(), is(2));
-        assertThat(result.getFirst().getId(), is(1));
-        assertThat(result.getFirst().getVersionCount(), is(0));
-        assertThat(result.get(1).getId(), is(2));
-        assertThat(result.get(1).getDescription(), is("Test Description"));
-        assertThat(result.get(1).getName(), is("Test Name"));
-        assertThat(result.get(1).getVersionCount(), is(2));
+        verify(headerCollection).remove(any(Filter.class));
     }
 
     @Test
-    public void testCreateStandardForNamespace_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        // Arrange
-        CreateStandardRequest standard = new CreateStandardRequest();
-        standard.setStandardJson(STANDARD_JSON);
+    public void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(mockCounterStore.getNextStandardSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.0")));
 
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+        assertThrows(StorageWriteException.class,
+                () -> store.createStandardForNamespace(createRequest(), NAMESPACE));
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> standardStore.createStandardForNamespace(standard, NAMESPACE));
+        verify(headerCollection).remove(any(Filter.class));
+    }
+
+    // --- getStandardVersions / getStandardForVersion ---
+
+    @Test
+    public void throw_a_standard_exception_when_listing_versions_for_a_missing_standard() {
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class, () -> store.getStandardVersions(NAMESPACE, STANDARD_ID));
     }
 
     @Test
-    public void testCreateStandardForNamespace_whenNamespaceExists_createsStandard() throws NamespaceNotFoundException {
-        // Arrange
-        CreateStandardRequest standard = new CreateStandardRequest();
-        standard.setStandardJson(STANDARD_JSON);
+    public void list_versions_in_semantic_order() throws NamespaceNotFoundException, StandardNotFoundException {
+        standardExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.10.0"),
+                Document.createDocument().put("version", "1.9.0"),
+                Document.createDocument().put("version", "1.0.0")));
 
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextStandardSequenceValue()).thenReturn(STANDARD_ID);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Standard result = standardStore.createStandardForNamespace(standard, NAMESPACE);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getId(), is(STANDARD_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getStandardJson(), is(STANDARD_JSON));
-        assertThat(result.getVersion(), is("1.0.0"));
-
-        verify(mockCollection).insert(any(Document.class));
+        assertThat(store.getStandardVersions(NAMESPACE, STANDARD_ID), contains("1.0.0", "1.9.0", "1.10.0"));
     }
 
     @Test
-    public void testGetStandardVersions_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void throw_a_version_exception_when_the_version_is_not_stored() {
+        standardExists();
+        stubFind(versionCollection, List.of());
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> standardStore.getStandardVersions(NAMESPACE, STANDARD_ID));
+        assertThrows(StandardVersionNotFoundException.class,
+                () -> store.getStandardForVersion(NAMESPACE, STANDARD_ID, "9.0.0"));
     }
 
     @Test
-    public void testGetStandardVersions_whenStandardDoesNotExist_throwsStandardNotFoundException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mock(DocumentCursor.class));
+    public void return_the_content_of_a_stored_version() throws Exception {
+        standardExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("content", VALID_JSON)));
 
-        // Act & Assert
-        assertThrows(StandardNotFoundException.class, () -> standardStore.getStandardVersions(NAMESPACE, STANDARD_ID));
+        assertThat(store.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"), is(VALID_JSON));
+    }
+
+    // --- createStandardForVersion ---
+
+    @Test
+    public void throw_a_standard_exception_when_creating_a_version_for_a_missing_standard() {
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class,
+                () -> store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1"));
     }
 
     @Test
-    public void testGetStandardVersions_whenVersionsExist_returnsVersionsList() throws NamespaceNotFoundException, StandardNotFoundException {
-        // Arrange
+    public void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        standardExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
 
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Mock the versionsDoc with the fields we need
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.getFields()).thenReturn(new HashSet<>(Arrays.asList("1-0-0", "1-1-0")));
-
-        // Mock the standard document
-        Document standardDoc = mock(Document.class);
-        when(standardDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(standardDoc.get("standardId", Integer.class)).thenReturn(STANDARD_ID);
-
-        // Create the namespace document with the standard
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("standards"), any())).thenReturn(Collections.singletonList(standardDoc));
-
-        // Set up the cursor mock
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Set up the namespace store mock
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Act
-        List<String> result = standardStore.getStandardVersions(NAMESPACE, STANDARD_ID);
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.size(), is(2));
-        assertThat(result, hasItem("1.0.0"));
-        assertThat(result, hasItem("1.1.0"));
+        assertThrows(StandardVersionExistsException.class,
+                () -> store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1"));
     }
 
     @Test
-    public void testGetStandardForVersion_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void write_the_version_and_then_the_header_details() throws Exception {
+        standardExists();
+        stubFind(versionCollection, List.of());
 
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
+        store.createStandardForVersion(createRequest(), NAMESPACE, STANDARD_ID, "1.0.1");
+
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.1"));
+        // Two header writes: the versionCount increment, then the name/description update.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
 
     @Test
-    public void testGetStandardForVersion_whenStandardDoesNotExist_throwsStandardNotFoundException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a mock cursor that returns null for firstOrNull()
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        // Act & Assert
-        assertThrows(StandardNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testGetStandardForVersion_whenVersionDoesNotExist_throwsStandardVersionNotFoundException() {
-        // Arrange
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Mock the versionsDoc with the fields we need
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0")).thenReturn(null); // Version not found
-
-        // Mock the standard document
-        Document standardDoc = mock(Document.class);
-        when(standardDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(standardDoc.get("standardId", Integer.class)).thenReturn(STANDARD_ID);
-
-        // Create the namespace document with the standard
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("standards"), any())).thenReturn(Collections.singletonList(standardDoc));
-
-        // Set up the cursor mock
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(StandardVersionNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "2.0.0"));
-    }
-
-    @Test
-    public void testGetStandardForVersion_whenVersionExists_returnsStandard() throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Standard expectedStandard = new Standard();
-        expectedStandard.setId(STANDARD_ID);
-        expectedStandard.setName("Test Standard");
-        expectedStandard.setDescription("Test Description");
-        expectedStandard.setNamespace(NAMESPACE);
-        expectedStandard.setId(STANDARD_ID);
-        expectedStandard.setVersion("2.0.0");
-        expectedStandard.setStandardJson("{}");
-
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.get("2-0-0")).thenReturn("{}");
-
-        // Mock the standard document
-        Document standardDoc = mock(Document.class);
-        when(standardDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(standardDoc.get("standardId", Integer.class)).thenReturn(STANDARD_ID);
-
-        // Create the namespace document with the standard
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("standards"), any())).thenReturn(Collections.singletonList(standardDoc));
-
-        // Set up the cursor mock
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        String standard = standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, expectedStandard.getVersion());
-
-        // Assert
-        assertThat(standard, equalTo("{}"));
-    }
-
-    @Test
-    public void testGetStandardVersions_whenVersionsDocumentIsNull_throwsStandardNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document standardDoc = Document.createDocument()
-                .put("standardId", STANDARD_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", List.of(standardDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(StandardNotFoundException.class, () -> standardStore.getStandardVersions(NAMESPACE, STANDARD_ID));
-    }
-
-    @Test
-    public void testGetStandardForVersion_whenVersionsDocumentIsNull_throwsStandardVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document standardDoc = Document.createDocument()
-                .put("standardId", STANDARD_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", List.of(standardDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(StandardVersionNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testGetStandardForVersion_whenVersionObjIsNotAString_throwsStandardVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("1-0-0", 12345);
-
-        Document standardDoc = Document.createDocument()
-                .put("standardId", STANDARD_ID)
-                .put("versions", versions);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", List.of(standardDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(StandardVersionNotFoundException.class, () -> standardStore.getStandardForVersion(NAMESPACE, STANDARD_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenVersionsDocumentIsNull_throwsStandardNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document standardDoc = Document.createDocument()
-                .put("standardId", STANDARD_ID);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("standards", List.of(standardDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        assertThrows(StandardNotFoundException.class, () -> standardStore.createStandardForVersion(getStandardToPersist(), NAMESPACE, STANDARD_ID, "1.0.1"));
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenNamespaceDoesNotExist_throwsNamespaceNotFoundException() {
-        // Arrange
-        CreateStandardRequest standard = getStandardToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        // Act & Assert
-        assertThrows(NamespaceNotFoundException.class, () -> standardStore.createStandardForVersion(standard, NAMESPACE, null, null));
-    }
-
-    private CreateStandardRequest getStandardToPersist() {
-        return new CreateStandardRequest("Test", "Test Description", STANDARD_JSON);
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenNamespaceDocumentDoesNotExist_throwsStandardNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Create a mock cursor that returns null for firstOrNull()
-        DocumentCursor mockCursor = mock(DocumentCursor.class);
-        when(mockCursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
-
-        // Act & Assert
-        assertThrows(StandardNotFoundException.class, () -> standardStore.createStandardForVersion(getStandardToPersist(), NAMESPACE, null, null));
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenStandardDoesNotExist_throwsStandardNotFoundException() {
-        // Arrange
-        CreateStandardRequest standard = getStandardToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Mock the namespace document
-        Document namespaceDoc = mock(Document.class);
-
-        // Set up the cursor mock for namespace document
-        DocumentCursor namespaceCursor = mock(DocumentCursor.class);
-        when(namespaceCursor.firstOrNull()).thenReturn(namespaceDoc);
-
-        // Set up the cursor mock for pattern document (not found)
-        DocumentCursor standardCursor = mock(DocumentCursor.class);
-        when(standardCursor.firstOrNull()).thenReturn(null);
-
-        // Set up the collection mock to return different cursors based on the filter
-        when(mockCollection.find(any(Filter.class))).thenReturn(namespaceCursor, standardCursor);
-
-        // Act & Assert
-        assertThrows(StandardNotFoundException.class, () -> standardStore.createStandardForVersion(standard, NAMESPACE, STANDARD_ID, null));
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenVersionAlreadyExists_throwsStandardVersionExistsException() {
-        // Arrange
-        CreateStandardRequest standard = getStandardToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Mock the versionsDoc with the fields we need
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.containsKey(anyString())).thenReturn(true); // Version already exists
-
-        // Mock the standard document
-        Document standardDoc = mock(Document.class);
-        when(standardDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(standardDoc.get("standardId", Integer.class)).thenReturn(STANDARD_ID);
-
-        // Create a list of standards with document
-        List<Document> standards = Collections.singletonList(standardDoc);
-
-        // Mock the namespace document
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("standards"), any())).thenReturn(standards);
-
-        // Set up the cursor mock
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act & Assert
-        assertThrows(StandardVersionExistsException.class, () -> standardStore.createStandardForVersion(standard, NAMESPACE, STANDARD_ID, "1.0.0"));
-    }
-
-    @Test
-    public void testCreateStandardForVersion_whenSuccess_returnsStandard() throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionExistsException {
-        // Arrange
-        CreateStandardRequest createStandardRequest = getStandardToPersist();
-
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        // Mock the versionsDoc with the fields we need
-        Document versionsDoc = mock(Document.class);
-        when(versionsDoc.containsKey(anyString())).thenReturn(false); // Version doesn't exist yet
-
-        // Mock the standard document
-        Document standardDoc = mock(Document.class);
-        when(standardDoc.get(eq("versions"), any())).thenReturn(versionsDoc);
-        when(standardDoc.get("standardId", Integer.class)).thenReturn(STANDARD_ID);
-
-        // Create a list of standards with our standards document
-        List<Document> standards = new ArrayList<>();
-        standards.add(standardDoc);
-
-        // Mock the namespace document
-        Document namespaceDoc = mock(Document.class);
-        when(namespaceDoc.get(eq("standards"), any())).thenReturn(standards);
-
-        // Set up the cursor mock
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        // Act
-        Standard result = standardStore.createStandardForVersion(createStandardRequest, NAMESPACE, STANDARD_ID, "1.0.0");
-
-        // Assert
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getId(), is(STANDARD_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getVersion(), is("1.0.0"));
+    public void overwrite_the_header_details_even_when_blank() throws Exception {
+        standardExists();
+        stubFind(versionCollection, List.of());
+
+        store.createStandardForVersion(new CreateStandardRequest(null, null, VALID_JSON),
+                NAMESPACE, STANDARD_ID, "1.0.1");
+
+        // Unconditional, unlike Pattern and Flow — Standard's old shape did not guard these.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
@@ -4,40 +4,53 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.exceptions.NitriteException;
 import org.dizitart.no2.filters.Filter;
 import org.bson.json.JsonParseException;
+import org.finos.calm.domain.timeline.Timeline;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.TimelineNotFoundException;
 import org.finos.calm.domain.exception.TimelineVersionExistsException;
 import org.finos.calm.domain.exception.TimelineVersionNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.timeline.CreateTimelineRequest;
 import org.finos.calm.domain.timeline.NamespaceTimelineSummary;
-import org.finos.calm.domain.timeline.Timeline;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Store-level tests for the header/version shape. Document mechanics are covered by
+ * {@code TestNitriteVersionDocumentStoreShould}; what this class pins is the glue — the
+ * domain exceptions, the JSON validation this backend does and Mongo doesn't, and Timeline's
+ * blank-guarding of name/description.
+ */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestNitriteTimelineStoreShould {
 
     @Mock
     private Nitrite mockDb;
-
-    @Mock
-    private NitriteCollection mockCollection;
 
     @Mock
     private NitriteNamespaceStore mockNamespaceStore;
@@ -45,631 +58,333 @@ public class TestNitriteTimelineStoreShould {
     @Mock
     private NitriteCounterStore mockCounterStore;
 
-    private NitriteTimelineStore timelineStore;
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteTimelineStore store;
 
     private static final String NAMESPACE = "finos";
     private static final int TIMELINE_ID = 42;
-    private static final String VERSION = "1.0.0";
     private static final String VALID_JSON = "{\"test\": \"test\"}";
+    private static final String TIMELINE_NAME = "timeline-name";
+    private static final String TIMELINE_DESCRIPTION = "timeline description";
 
     @BeforeEach
     public void setup() {
-        when(mockDb.getCollection(anyString())).thenReturn(mockCollection);
-        timelineStore = new NitriteTimelineStore(mockDb, mockNamespaceStore, mockCounterStore);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+
+        when(mockDb.getCollection("timelines")).thenReturn(headerCollection);
+        when(mockDb.getCollection("timelineVersions")).thenReturn(versionCollection);
+        when(mockNamespaceStore.namespaceExists(anyString())).thenReturn(true);
+
+        store = new NitriteTimelineStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 
+    private void stubFind(NitriteCollection collection, List<Document> documents) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(collection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
+        when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(collection.find()).thenReturn(cursor);
+    }
+
+    private void timelineExists() {
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("timelineId", TIMELINE_ID)
+                .put("versionCount", 1)));
+    }
+
+    private void timelineDoesNotExist() {
+        stubFind(headerCollection, List.of());
+    }
+
+    private static Timeline timeline(String version, String name, String description) {
+        return new Timeline.TimelineBuilder()
+                .setNamespace(NAMESPACE)
+                .setId(TIMELINE_ID)
+                .setVersion(version)
+                .setName(name)
+                .setDescription(description)
+                .setTimeline(VALID_JSON)
+                .build();
+    }
+
+    private static Timeline timeline(String version) {
+        return timeline(version, TIMELINE_NAME, TIMELINE_DESCRIPTION);
+    }
+
+    private static CreateTimelineRequest createRequest() {
+        return new CreateTimelineRequest(TIMELINE_NAME, TIMELINE_DESCRIPTION, VALID_JSON);
+    }
+
+    // --- getTimelinesForNamespace ---
+
     @Test
-    public void testGetTimelinesForNamespace_whenNamespaceDoesNotExist_throwsException() {
+    public void throw_a_namespace_exception_when_listing_timelines_for_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.getTimelinesForNamespace(NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class, () -> store.getTimelinesForNamespace(NAMESPACE));
     }
 
     @Test
-    public void testGetTimelinesForNamespace_whenNamespaceExistsButNoTimelines_returnsEmptyList() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+    public void return_an_empty_list_when_a_namespace_has_no_timelines() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of());
 
-        List<NamespaceTimelineSummary> result = timelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(result, is(empty()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), is(empty()));
     }
 
     @Test
-    public void testGetTimelinesForNamespace_whenNamespaceDocumentExists_butNoTimelinesField_returnsEmptyList() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_a_summary_per_header_document_without_a_version_count() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(
+                Document.createDocument().put("timelineId", 1).put("name", "First")
+                        .put("description", "d1").put("versionCount", 2),
+                Document.createDocument().put("timelineId", 2).put("name", "Second")
+                        .put("description", "d2").put("versionCount", 0)));
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceTimelineSummary> result = timelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(result, is(empty()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), contains(
+                new NamespaceTimelineSummary("First", "d1", 1),
+                new NamespaceTimelineSummary("Second", "d2", 2)));
     }
 
     @Test
-    public void testGetTimelinesForNamespace_whenTimelinesExist_returnsTimelineSummaries() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void fall_back_to_a_generated_name_for_headers_missing_one() throws NamespaceNotFoundException {
+        stubFind(headerCollection, List.of(Document.createDocument().put("timelineId", 7)));
 
-        Document timeline1 = Document.createDocument().put("timelineId", 1001).put("name", "Timeline One").put("description", "First");
-        Document timeline2 = Document.createDocument().put("timelineId", 1002).put("name", "Timeline Two").put("description", "Second");
-        List<Document> timelines = Arrays.asList(timeline1, timeline2);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceTimelineSummary> result = timelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(result, hasSize(2));
-        assertThat(result.get(0).getId(), is(1001));
-        assertThat(result.get(0).getName(), is("Timeline One"));
-        assertThat(result.get(0).getDescription(), is("First"));
-        assertThat(result.get(1).getId(), is(1002));
-        assertThat(result.get(1).getName(), is("Timeline Two"));
-        assertThat(result.get(1).getDescription(), is("Second"));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThat(store.getTimelinesForNamespace(NAMESPACE), contains(
+                new NamespaceTimelineSummary("Timeline 7", "", 7)));
     }
 
-    @Test
-    public void testGetTimelinesForNamespace_whenLegacyDocumentsMissingNameAndDescription_returnsFallbacks() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
 
-        Document legacyDoc = Document.createDocument().put("timelineId", 77);
-        List<Document> timelines = List.of(legacyDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        List<NamespaceTimelineSummary> result = timelineStore.getTimelinesForNamespace(NAMESPACE);
-
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getId(), is(77));
-        assertThat(result.get(0).getName(), is("Timeline 77"));
-        assertThat(result.get(0).getDescription(), is(""));
-    }
+    // --- createTimelineForNamespace ---
 
     @Test
-    public void testCreateTimelineForNamespace_whenNamespaceDoesNotExist_throwsException() {
+    public void throw_a_namespace_exception_when_creating_a_timeline_in_a_missing_namespace() {
         when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
 
-        CreateTimelineRequest request = new CreateTimelineRequest("name", "desc", VALID_JSON);
-
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.createTimelineForNamespace(request, NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.createTimelineForNamespace(createRequest(), NAMESPACE));
     }
 
     @Test
-    public void testCreateTimelineForNamespace_whenInvalidJson_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void reject_invalid_json_when_creating_a_timeline() {
+        CreateTimelineRequest invalid = new CreateTimelineRequest("n", "d", "{invalid json}");
 
-        CreateTimelineRequest request = new CreateTimelineRequest("name", "desc", "Invalid JSON");
-
-        assertThrows(Exception.class, () -> timelineStore.createTimelineForNamespace(request, NAMESPACE));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(JsonParseException.class, () -> store.createTimelineForNamespace(invalid, NAMESPACE));
+        verify(headerCollection, never()).insert(any(Document.class));
     }
 
     @Test
-    public void testCreateTimelineForNamespace_whenNamespaceDocumentDoesNotExist_createsNewDocument() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextTimelineSequenceValue()).thenReturn(TIMELINE_ID);
+    public void reject_null_json_when_creating_a_timeline() {
+        CreateTimelineRequest noJson = new CreateTimelineRequest("n", "d", null);
 
-        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", VALID_JSON);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(null);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline result = timelineStore.createTimelineForNamespace(request, NAMESPACE);
-
-        assertThat(result.getId(), is(TIMELINE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getTimelineJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextTimelineSequenceValue();
-        verify(mockCollection).insert(any(Document.class));
+        // This backend validates up front; Mongo would NPE inside Document.parse instead.
+        assertThrows(JsonParseException.class, () -> store.createTimelineForNamespace(noJson, NAMESPACE));
     }
 
     @Test
-    public void testCreateTimelineForNamespace_whenNamespaceDocumentExists_updatesExistingDocument() throws NamespaceNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-        when(mockCounterStore.getNextTimelineSequenceValue()).thenReturn(TIMELINE_ID);
+    public void create_a_header_and_an_initial_version() throws NamespaceNotFoundException {
+        when(mockCounterStore.getNextTimelineSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument()
+                .put("timelineId", 99).put("versionCount", 0)));
+        stubFind(versionCollection, List.of());
 
-        CreateTimelineRequest request = new CreateTimelineRequest("Test Timeline", "A test", VALID_JSON);
+        Timeline created = store.createTimelineForNamespace(createRequest(), NAMESPACE);
 
-        Document existingTimeline = Document.createDocument().put("timelineId", 1001);
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(existingTimeline);
+        assertThat(created.getId(), is(99));
+        // Was "1-0-0" before this port, so the Location header differed by backend for the
+        // same operation. Now dot-separated on both, matching what is actually stored.
+        assertThat(created.getDotVersion(), is("1.0.0"));
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("timelineId", Integer.class), is(99));
+        assertThat(headerCaptor.getValue().get("versionCount", Integer.class), is(0));
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline result = timelineStore.createTimelineForNamespace(request, NAMESPACE);
-
-        assertThat(result.getId(), is(TIMELINE_ID));
-        assertThat(result.getNamespace(), is(NAMESPACE));
-        assertThat(result.getDotVersion(), is("1.0.0"));
-        assertThat(result.getTimelineJson(), is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCounterStore).getNextTimelineSequenceValue();
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.0"));
+        // Content stays a JSON string in this backend rather than a parsed document.
+        assertThat(versionCaptor.getValue().get("content", String.class), is(VALID_JSON));
     }
 
     @Test
-    public void testGetTimelineVersions_whenNamespaceDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void remove_the_header_again_when_the_first_version_write_fails() {
+        when(mockCounterStore.getNextTimelineSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of());
+        when(versionCollection.insert(any(Document.class)))
+                .thenThrow(new NitriteException("store is closed"));
 
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .build();
+        assertThrows(NitriteException.class,
+                () -> store.createTimelineForNamespace(createRequest(), NAMESPACE));
 
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.getTimelineVersions(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        verify(headerCollection).remove(any(Filter.class));
     }
 
     @Test
-    public void testGetTimelineVersions_whenTimelineDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void fail_rather_than_report_success_when_the_initial_version_already_exists() {
+        when(mockCounterStore.getNextTimelineSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of());
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.0")));
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", new ArrayList<>());
+        assertThrows(StorageWriteException.class,
+                () -> store.createTimelineForNamespace(createRequest(), NAMESPACE));
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+        verify(headerCollection).remove(any(Filter.class));
+    }
 
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .build();
+    // --- getTimelineVersions ---
 
-        assertThrows(TimelineNotFoundException.class, () -> timelineStore.getTimelineVersions(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    @Test
+    public void throw_a_timeline_exception_when_listing_versions_for_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class, () -> store.getTimelineVersions(timeline(null)));
     }
 
     @Test
-    public void testGetTimelineVersions_whenTimelineExists_returnsVersions() throws NamespaceNotFoundException, TimelineNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void list_versions_in_semantic_order() throws NamespaceNotFoundException, TimelineNotFoundException {
+        timelineExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.10.0"),
+                Document.createDocument().put("version", "1.9.0"),
+                Document.createDocument().put("version", "1.0.0")));
 
-        Document namespaceDoc = mock(Document.class);
-        List<Document> timelines = new ArrayList<>();
-        Document timelineDoc = mock(Document.class);
-        Document versions = mock(Document.class);
-
-        timelines.add(timelineDoc);
-
-        when(timelineDoc.get("timelineId", Integer.class)).thenReturn(TIMELINE_ID);
-        when(timelineDoc.get("versions", Document.class)).thenReturn(versions);
-        when(namespaceDoc.get("timelines", List.class)).thenReturn(timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        when(versions.getFields()).thenReturn(java.util.Collections.emptySet());
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .build();
-
-        List<String> result = timelineStore.getTimelineVersions(timeline);
-
-        assertThat(result, is(notNullValue()));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(versions).getFields();
+        assertThat(store.getTimelineVersions(timeline(null)), contains("1.0.0", "1.9.0", "1.10.0"));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenNamespaceDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void return_no_versions_rather_than_not_found_for_a_timeline_with_none() throws NamespaceNotFoundException, TimelineNotFoundException {
+        timelineExists();
+        stubFind(versionCollection, List.of());
 
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .build();
+        assertThat(store.getTimelineVersions(timeline(null)), is(empty()));
+    }
 
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+    // --- getTimelineForVersion ---
+
+    @Test
+    public void throw_a_timeline_exception_when_getting_a_version_of_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class, () -> store.getTimelineForVersion(timeline("1.0.0")));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenTimelineDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_a_version_exception_when_the_version_is_not_stored() {
+        timelineExists();
+        stubFind(versionCollection, List.of());
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        assertThrows(TimelineVersionNotFoundException.class,
+                () -> store.getTimelineForVersion(timeline("9.0.0")));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenVersionDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void return_the_content_of_a_stored_version() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("content", VALID_JSON)));
 
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON);
+        assertThat(store.getTimelineForVersion(timeline("1.0.0")), is(VALID_JSON));
+    }
 
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
+    // --- createTimelineForVersion ---
 
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(timelineDoc);
+    @Test
+    public void reject_invalid_json_before_checking_the_timeline_exists() {
+        timelineDoesNotExist();
+        Timeline invalid = new Timeline.TimelineBuilder()
+                .setNamespace(NAMESPACE).setId(TIMELINE_ID).setVersion("1.0.1")
+                .setTimeline("{invalid json}").build();
 
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        // Deliberate divergence from Mongo, which reports the missing timeline first.
+        assertThrows(JsonParseException.class, () -> store.createTimelineForVersion(invalid));
     }
 
     @Test
-    public void testGetTimelineVersions_whenVersionsDocumentIsNull_throwsTimelineNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_a_timeline_exception_when_creating_a_version_for_a_missing_timeline() {
+        timelineDoesNotExist();
 
-        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", List.of(timelineDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).build();
-
-        assertThrows(TimelineNotFoundException.class, () -> timelineStore.getTimelineVersions(timeline));
+        assertThrows(TimelineNotFoundException.class,
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenVersionsDocumentIsNull_throwsTimelineVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void throw_a_version_exists_exception_when_the_version_is_already_stored() {
+        timelineExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
 
-        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", List.of(timelineDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).setVersion(VERSION).build();
-
-        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
+        assertThrows(TimelineVersionExistsException.class,
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenVersionObjIsNotAString_throwsTimelineVersionNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void not_rename_the_timeline_when_the_version_already_exists() {
+        timelineExists();
+        stubFind(versionCollection, List.of(Document.createDocument().put("version", "1.0.1")));
 
-        Document versions = Document.createDocument().put("1-0-0", 12345);
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", List.of(timelineDoc));
+        assertThrows(TimelineVersionExistsException.class,
+                () -> store.createTimelineForVersion(timeline("1.0.1")));
 
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder().setNamespace(NAMESPACE).setId(TIMELINE_ID).setVersion(VERSION).build();
-
-        assertThrows(TimelineVersionNotFoundException.class, () -> timelineStore.getTimelineForVersion(timeline));
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
     }
 
     @Test
-    public void testGetTimelineForVersion_whenVersionExists_returnsTimelineJson() throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void write_the_version_and_then_the_header_details() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of());
 
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
+        store.createTimelineForVersion(timeline("1.0.1"));
 
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
-
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(timelineDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .build();
-
-        String result = timelineStore.getTimelineForVersion(timeline);
-
-        assertThat(result, is(VALID_JSON));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        ArgumentCaptor<Document> versionCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(versionCaptor.capture());
+        assertThat(versionCaptor.getValue().get("version", String.class), is("1.0.1"));
+        // Two header writes: the versionCount increment, then the name/description update.
+        verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
 
     @Test
-    public void testCreateTimelineForVersion_whenNamespaceDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+    public void leave_the_stored_name_alone_when_a_version_write_carries_none() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of());
 
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
+        store.createTimelineForVersion(timeline("1.0.1", null, null));
 
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.createTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        // Timeline guards these fields where Architecture overwrites them, so only the
+        // versionCount write happens here.
+        verify(headerCollection, times(1)).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- updateTimelineForVersion ---
+
+    @Test
+    public void throw_a_timeline_exception_when_updating_a_version_for_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class,
+                () -> store.updateTimelineForVersion(timeline("1.0.1")));
     }
 
     @Test
-    public void testCreateTimelineForVersion_whenVersionExists_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void replace_the_content_of_an_existing_version_on_update() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of(Document.createDocument()
+                .put("version", "1.0.1").put("content", "{\"old\":true}")));
 
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
+        store.updateTimelineForVersion(timeline("1.0.1"));
 
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
-
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(timelineDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
-
-        assertThrows(TimelineVersionExistsException.class, () -> timelineStore.createTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).update(any(Filter.class), captor.capture());
+        assertThat(captor.getValue().get("content", String.class), is(VALID_JSON));
     }
 
     @Test
-    public void testCreateTimelineForVersion_whenVersionDoesNotExist_createsVersion() throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionExistsException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+    public void create_the_version_when_updating_one_that_does_not_exist() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of());
 
-        Document versions = Document.createDocument()
-                .put("2-0-0", VALID_JSON); // Different version
+        // Preserves the known create-on-PUT behaviour (bugs.md #1) rather than changing it.
+        store.updateTimelineForVersion(timeline("2.0.0"));
 
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
-
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(timelineDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION) // 1.0.0
-                .setTimeline(VALID_JSON)
-                .build();
-
-        Timeline result = timelineStore.createTimelineForVersion(timeline);
-
-        assertThat(result, is(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testCreateTimelineForVersion_whenInvalidJson_throwsJsonParseException() {
-        // JSON is validated immediately after the namespace check, before any version/existence lookup
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline("{ not json")
-                .build();
-
-        assertThrows(JsonParseException.class, () -> timelineStore.createTimelineForVersion(timeline));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenInvalidJson_throwsJsonParseException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline("{ not json")
-                .build();
-
-        assertThrows(JsonParseException.class, () -> timelineStore.updateTimelineForVersion(timeline));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenNullJson_throwsJsonParseException() {
-        // null JSON is rejected by the explicit null guard before any parse/lookup
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(null)
-                .build();
-
-        assertThrows(JsonParseException.class, () -> timelineStore.updateTimelineForVersion(timeline));
-        verify(mockCollection, never()).update(any(Filter.class), any(Document.class));
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenNamespaceDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
-
-        assertThrows(NamespaceNotFoundException.class, () -> timelineStore.updateTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenTimelineDoesNotExist_throwsException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", new ArrayList<>());
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
-
-        assertThrows(TimelineNotFoundException.class, () -> timelineStore.updateTimelineForVersion(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenVersionsDocumentIsNull_throwsTimelineNotFoundException() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document timelineDoc = Document.createDocument().put("timelineId", TIMELINE_ID);
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", List.of(timelineDoc));
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
-
-        assertThrows(TimelineNotFoundException.class, () -> timelineStore.updateTimelineForVersion(timeline));
-    }
-
-    @Test
-    public void testUpdateTimelineForVersion_whenValidParameters_returnsUpdatedTimeline() throws NamespaceNotFoundException, TimelineNotFoundException {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
-
-        Document versions = Document.createDocument()
-                .put("1-0-0", VALID_JSON);
-
-        Document timelineDoc = Document.createDocument()
-                .put("timelineId", TIMELINE_ID)
-                .put("versions", versions);
-
-        List<Document> timelines = new ArrayList<>();
-        timelines.add(timelineDoc);
-
-        Document namespaceDoc = Document.createDocument()
-                .put("namespace", NAMESPACE)
-                .put("timelines", timelines);
-
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(cursor.firstOrNull()).thenReturn(namespaceDoc);
-        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
-
-        Timeline timeline = new Timeline.TimelineBuilder()
-                .setNamespace(NAMESPACE)
-                .setId(TIMELINE_ID)
-                .setVersion(VERSION)
-                .setTimeline(VALID_JSON)
-                .build();
-
-        Timeline result = timelineStore.updateTimelineForVersion(timeline);
-
-        assertThat(result, is(timeline));
-        verify(mockNamespaceStore, atLeastOnce()).namespaceExists(NAMESPACE);
-        verify(mockCollection).update(any(Filter.class), any(Document.class));
+        verify(versionCollection).insert(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/producer/TestTimelineStoreProducerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/producer/TestTimelineStoreProducerShould.java
@@ -1,33 +1,47 @@
 package org.finos.calm.store.producer;
 
-import io.quarkus.test.InjectMock;
-import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.inject.Instance;
 import org.finos.calm.store.TimelineStore;
 import org.finos.calm.store.mongo.MongoTimelineStore;
 import org.finos.calm.store.nitrite.NitriteTimelineStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.when;
 
-@QuarkusTest
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
 public class TestTimelineStoreProducerShould {
 
-    @InjectMock
+    @Mock
     MongoTimelineStore mongoTimelineStore;
 
-    @InjectMock
+    @Mock
+    Instance<MongoTimelineStore> mongoTimelineStoreInstance;
+
+    @Mock
     NitriteTimelineStore nitriteTimelineStore;
+
+    @Mock
+    Instance<NitriteTimelineStore> nitriteTimelineStoreInstance;
 
     private TimelineStoreProducer timelineStoreProducer;
 
     @BeforeEach
     void setup() {
         timelineStoreProducer = new TimelineStoreProducer();
-        timelineStoreProducer.mongoTimelineStore = mongoTimelineStore;
-        timelineStoreProducer.standaloneTimelineStore = nitriteTimelineStore;
+        when(mongoTimelineStoreInstance.get()).thenReturn(mongoTimelineStore);
+        timelineStoreProducer.mongoTimelineStore = mongoTimelineStoreInstance;
+        when(nitriteTimelineStoreInstance.get()).thenReturn(nitriteTimelineStore);
+        timelineStoreProducer.standaloneTimelineStore = nitriteTimelineStoreInstance;
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -529,9 +529,39 @@ class TestMongoVersionDocumentStoreShould {
     }
 
     @Test
+    void store_a_numeric_revision_verbatim_rather_than_canonicalising_it() {
+        MongoVersionDocumentStore numericStore = new MongoVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(acknowledged(1, null));
+
+        // VERSION_REGEX makes both separators optional, so "100" is one of the six accepted
+        // spellings of 1.0.0. Canonicalising it would store ADR revision 100 as "1.0.0",
+        // which NumericVersionOrder then sorts BELOW 99 — the latest-revision read every ADR
+        // goes through would return revision 99's content while 100 exists — and which
+        // MongoAdrStore.getAdrRevisions cannot Integer.parseInt. Revisions 1-99 are
+        // unaffected, which is exactly why this went unnoticed.
+        numericStore.createVersion(NAMESPACE, RESOURCE_ID, "100", new Document());
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insertOne(captor.capture());
+        assertThat(captor.getValue().getString("version"), is("100"));
+    }
+
+    @Test
+    void rank_a_numeric_revision_above_a_smaller_one_that_is_three_digits() {
+        MongoVersionDocumentStore numericStore = new MongoVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
+        stubFind(versionCollection, List.of(
+                new Document("version", "99"),
+                new Document("version", "100")));
+
+        assertThat(numericStore.getLatestVersion(NAMESPACE, RESOURCE_ID), is("100"));
+    }
+
+    @Test
     void resolve_the_latest_version_numerically_when_told_to() {
         MongoVersionDocumentStore numericStore = new MongoVersionDocumentStore(
-                headerCollection, versionCollection, ID_FIELD, LABEL, NumericVersionOrder.ASCENDING);
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
         stubFind(versionCollection, List.of(
                 new Document("version", "2"),
                 new Document("version", "10")));

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -508,6 +508,54 @@ class TestMongoVersionDocumentStoreShould {
         assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), is(empty()));
     }
 
+    // --- getLatestVersion / getLatestVersionContent ---
+
+    @Test
+    void resolve_the_latest_version_by_the_stores_own_ordering() {
+        stubFind(versionCollection, List.of(
+                new Document("version", "1.10.0"),
+                new Document("version", "1.9.0")));
+
+        // Ranked in memory, not by a database sort: the stored values are strings, so Mongo
+        // would rank 1.10.0 below 1.9.0.
+        assertThat(store.getLatestVersion(NAMESPACE, RESOURCE_ID), is("1.10.0"));
+    }
+
+    @Test
+    void return_no_latest_version_for_a_resource_with_none() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getLatestVersion(NAMESPACE, RESOURCE_ID), is(nullValue()));
+    }
+
+    @Test
+    void resolve_the_latest_version_numerically_when_told_to() {
+        MongoVersionDocumentStore numericStore = new MongoVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, NumericVersionOrder.ASCENDING);
+        stubFind(versionCollection, List.of(
+                new Document("version", "2"),
+                new Document("version", "10")));
+
+        // ADR's revisions are integers; the semantic comparator would call 2 the latest.
+        assertThat(numericStore.getLatestVersion(NAMESPACE, RESOURCE_ID), is("10"));
+    }
+
+    @Test
+    void return_no_latest_content_for_a_resource_with_no_versions() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(nullValue()));
+    }
+
+    @Test
+    void return_the_content_of_the_latest_version() {
+        Document content = new Document("title", "Latest");
+        stubFind(versionCollection, List.of(
+                new Document("version", "2.0.0").append("content", content)));
+
+        assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(content));
+    }
+
     // --- listSummariesPaged ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -584,6 +585,17 @@ class TestMongoVersionDocumentStoreShould {
                 new Document("version", "2.0.0").append("content", content)));
 
         assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(content));
+    }
+
+    // --- countHeaders ---
+
+    @Test
+    void count_headers_without_reading_any_version_documents() {
+        when(headerCollection.countDocuments(any(Bson.class))).thenReturn(3L);
+
+        assertThat(store.countHeaders(NAMESPACE), is(3));
+        // The point of the method: no version collection traffic at all.
+        verifyNoInteractions(versionCollection);
     }
 
     // --- listSummariesPaged ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -515,16 +515,17 @@ class TestNitriteVersionDocumentStoreShould {
     }
 
     @Test
-    void sort_headers_that_have_no_id_last_rather_than_failing_the_listing() {
+    void sort_headers_that_have_no_id_first_rather_than_failing_the_listing() {
         // Comparing ids with Integer.compare unboxes, so a single id-less header would NPE
-        // the whole namespace listing into a 500 — where Mongo, which sorts database-side,
-        // returns 200 with the row included. The backends have to agree.
+        // the whole namespace listing into a 500. Nulls sort first to match Mongo, whose
+        // database-side ascending sort ranks BSON Null below every number — otherwise the
+        // same malformed row lands on a different page depending on the backend.
         stubFind(headerCollection, List.of(
-                header(null, "No id", "d", 0),
-                header(1, "First", "d", 1)));
+                header(1, "First", "d", 1),
+                header(null, "No id", "d", 0)));
 
         assertThat(store.listSummariesPaged(NAMESPACE, PageRequest.UNPAGED), contains(
-                new NamespaceResourceSummary("First", "d", 1, 1),
-                new NamespaceResourceSummary("No id", "d", null, 0)));
+                new NamespaceResourceSummary("No id", "d", null, 0),
+                new NamespaceResourceSummary("First", "d", 1, 1)));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -423,9 +423,25 @@ class TestNitriteVersionDocumentStoreShould {
     }
 
     @Test
+    void store_a_numeric_revision_verbatim_rather_than_canonicalising_it() {
+        NitriteVersionDocumentStore numericStore = new NitriteVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
+        stubFind(versionCollection, List.of());
+        stubFind(headerCollection, List.of(header(RESOURCE_ID, "name", "description", 0)));
+
+        // See the Mongo twin: "100" is an accepted spelling of 1.0.0, so canonicalising ADR
+        // revisions rewrites revision 100 and makes it sort below 99.
+        numericStore.createVersion(NAMESPACE, RESOURCE_ID, "100", CONTENT);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(versionCollection).insert(captor.capture());
+        assertThat(captor.getValue().get("version", String.class), is("100"));
+    }
+
+    @Test
     void resolve_the_latest_version_numerically_when_told_to() {
         NitriteVersionDocumentStore numericStore = new NitriteVersionDocumentStore(
-                headerCollection, versionCollection, ID_FIELD, LABEL, NumericVersionOrder.ASCENDING);
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
         stubFind(versionCollection, List.of(versionDocument("2"), versionDocument("10")));
 
         assertThat(numericStore.getLatestVersion(NAMESPACE, RESOURCE_ID), is("10"));

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -413,6 +413,45 @@ class TestNitriteVersionDocumentStoreShould {
         assertThat(store.listVersions(NAMESPACE, RESOURCE_ID), is(empty()));
     }
 
+    // --- getLatestVersion / getLatestVersionContent ---
+
+    @Test
+    void resolve_the_latest_version_by_the_stores_own_ordering() {
+        stubFind(versionCollection, List.of(versionDocument("1.10.0"), versionDocument("1.9.0")));
+
+        assertThat(store.getLatestVersion(NAMESPACE, RESOURCE_ID), is("1.10.0"));
+    }
+
+    @Test
+    void resolve_the_latest_version_numerically_when_told_to() {
+        NitriteVersionDocumentStore numericStore = new NitriteVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, NumericVersionOrder.ASCENDING);
+        stubFind(versionCollection, List.of(versionDocument("2"), versionDocument("10")));
+
+        assertThat(numericStore.getLatestVersion(NAMESPACE, RESOURCE_ID), is("10"));
+    }
+
+    @Test
+    void return_no_latest_version_for_a_resource_with_none() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getLatestVersion(NAMESPACE, RESOURCE_ID), is(nullValue()));
+    }
+
+    @Test
+    void return_the_content_of_the_latest_version() {
+        stubFind(versionCollection, List.of(versionDocument("2.0.0").put("content", CONTENT)));
+
+        assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(CONTENT));
+    }
+
+    @Test
+    void return_no_latest_content_for_a_resource_with_no_versions() {
+        stubFind(versionCollection, List.of());
+
+        assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(nullValue()));
+    }
+
     // --- listSummariesPaged ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -450,6 +450,21 @@ class TestNitriteVersionDocumentStoreShould {
     }
 
     @Test
+    void rank_a_numeric_revision_above_a_smaller_one_that_is_three_digits() {
+        NitriteVersionDocumentStore numericStore = new NitriteVersionDocumentStore(
+                headerCollection, versionCollection, ID_FIELD, LABEL, VersionScheme.NUMERIC);
+        stubFind(versionCollection, List.of(versionDocument("99"), versionDocument("100")));
+
+        // The 2-to-3 digit boundary specifically, not the 1-to-2 boundary the test above
+        // covers. "100" is an accepted spelling of 1.0.0 under VERSION_REGEX, so a store
+        // that canonicalises would rewrite it and rank it BELOW "99" — every latest-revision
+        // read would then serve revision 99 while 100 existed. Revisions 1-99 are unaffected,
+        // which is why "10" over "2" passes either way and cannot catch this. Confirmed to
+        // fail against a SEMANTIC-scheme store before being kept.
+        assertThat(numericStore.getLatestVersion(NAMESPACE, RESOURCE_ID), is("100"));
+    }
+
+    @Test
     void return_no_latest_version_for_a_resource_with_none() {
         stubFind(versionCollection, List.of());
 

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +59,7 @@ class TestNitriteVersionDocumentStoreShould {
         when(collection.find(any(Filter.class))).thenReturn(cursor);
         when(cursor.firstOrNull()).thenReturn(documents.isEmpty() ? null : documents.get(0));
         when(cursor.iterator()).thenAnswer(invocation -> documents.iterator());
+        when(cursor.size()).thenReturn((long) documents.size());
         when(collection.find()).thenReturn(cursor);
     }
 
@@ -466,6 +468,16 @@ class TestNitriteVersionDocumentStoreShould {
         stubFind(versionCollection, List.of());
 
         assertThat(store.getLatestVersionContent(NAMESPACE, RESOURCE_ID), is(nullValue()));
+    }
+
+    // --- countHeaders ---
+
+    @Test
+    void count_headers_without_reading_any_version_documents() {
+        stubFind(headerCollection, List.of(header(1, "First", "d", 1), header(2, "Second", "d", 0)));
+
+        assertThat(store.countHeaders(NAMESPACE), is(2));
+        verifyNoInteractions(versionCollection);
     }
 
     // --- listSummariesPaged ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNumericVersionOrderShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNumericVersionOrderShould.java
@@ -40,8 +40,11 @@ class TestNumericVersionOrderShould {
     }
 
     @Test
-    void tolerate_surrounding_whitespace() {
-        assertThat(sorted(" 2 ", "1"), contains("1", " 2 "));
+    void treat_a_whitespace_padded_revision_as_unparseable() {
+        // Not tolerance for its own sake: Integer.parseInt rejects " 2 ", and every caller
+        // that turns a revision string back into a number uses it. Ranking " 2 " as a real
+        // revision would let it sort as the latest and then throw when read.
+        assertThat(sorted(" 2 ", "1"), contains(" 2 ", "1"));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNumericVersionOrderShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNumericVersionOrderShould.java
@@ -1,0 +1,70 @@
+package org.finos.calm.store.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+class TestNumericVersionOrderShould {
+
+    // Arrays.asList rather than List.of: the latter rejects nulls, and a null is one of the
+    // malformed inputs this comparator has to survive.
+    private static List<String> sorted(String... versions) {
+        List<String> sorted = new ArrayList<>(Arrays.asList(versions));
+        sorted.sort(NumericVersionOrder.ASCENDING);
+        return sorted;
+    }
+
+    @Test
+    void order_revisions_numerically_rather_than_lexicographically() {
+        // The whole reason this exists: a string sort puts 10 before 2, which would make
+        // "latest revision" wrong the moment an ADR reaches double figures.
+        assertThat(sorted("10", "2", "1"), contains("1", "2", "10"));
+    }
+
+    @Test
+    void put_the_highest_revision_last_so_it_reads_as_the_latest() {
+        List<String> ordered = sorted("3", "11", "7");
+
+        assertThat(ordered.get(ordered.size() - 1), is("11"));
+    }
+
+    @Test
+    void order_large_revision_numbers_correctly() {
+        assertThat(sorted("100", "99", "1000"), contains("99", "100", "1000"));
+    }
+
+    @Test
+    void tolerate_surrounding_whitespace() {
+        assertThat(sorted(" 2 ", "1"), contains("1", " 2 "));
+    }
+
+    @Test
+    void sort_unparseable_values_before_every_real_revision() {
+        // So a stray key can never be mistaken for the latest revision, which is what a read
+        // resolving "latest" would otherwise return.
+        assertThat(sorted("2", "not-a-number", "1"), contains("not-a-number", "1", "2"));
+    }
+
+    @Test
+    void sort_a_null_revision_first_rather_than_throwing() {
+        // A comparator that threw would turn one bad stored key into a failed listing for
+        // the whole resource.
+        assertThat(sorted("1", null), contains(null, "1"));
+    }
+
+    @Test
+    void keep_the_order_total_for_two_unparseable_values() {
+        assertThat(sorted("b", "a"), contains("a", "b"));
+    }
+
+    @Test
+    void treat_two_null_revisions_as_equal() {
+        assertThat(sorted(null, null), contains(null, null));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestVersionKeySelectorShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestVersionKeySelectorShould.java
@@ -36,18 +36,6 @@ class TestVersionKeySelectorShould {
         assertNull(VersionKeySelector.latestVersionKey(Set.of()));
     }
 
-    @Test
-    void return_zero_version_count_for_null_keys() {
-        assertEquals(0, VersionKeySelector.versionCount(null));
-    }
 
-    @Test
-    void return_zero_version_count_for_empty_set() {
-        assertEquals(0, VersionKeySelector.versionCount(Set.of()));
-    }
 
-    @Test
-    void return_size_version_count_for_populated_set() {
-        assertEquals(3, VersionKeySelector.versionCount(Set.of("1-0-0", "1-1-0", "2-0-0")));
-    }
 }


### PR DESCRIPTION
## Description

Completes [#2884](https://github.com/finos/architecture-as-code/issues/2884) by migrating **the remaining five versioned types** — Flow, Standard, Interface, Timeline and ADR — following Architecture ([#2923](https://github.com/finos/architecture-as-code/pull/2923)) and Pattern ([#2934](https://github.com/finos/architecture-as-code/pull/2934)).

After this, **all seven versioned types** use the header/version shape on both backends, at schema versions 2 → 9. `decorators` and `controls` keep the one-document-per-namespace shape by decision, not omission — [ADR 0004](../blob/main/calm-hub/decisions/0004-defer-control-and-decorator-storage.md), which is now due the revisit it was deferring for.

One commit per type, so each can be read on its own.

## The types were not interchangeable

The plan predicted this would be five repetitions of the same port. It wasn't, and the differences were behavioural rather than cosmetic. Each was preserved rather than harmonised:

| Type | What differed |
|---|---|
| **Flow** | The one genuine replication of Pattern. No paged listing, so it fetches `UNPAGED` |
| **Standard** | Sets `name`/`description` **unconditionally** — Architecture's behaviour, not Pattern's — and has no update path. Also fixes a `FIXME`: existence was checked by namespace only, ignoring `standardId` |
| **Interface** | Like Standard, plus a summary type with **no `versionCount`**, so the helper's summary is mapped down |
| **Timeline** | Flow, plus the same summary mapping as Interface |
| **ADR** | Genuinely different — see below |

The sharpest of these is the blank-guarding split: Pattern, Flow and Timeline guard those fields where Architecture, Standard and Interface overwrite. Using the wrong helper operation would have introduced a known data-loss bug into a type that never had it, silently.

## ADR needed the helpers extended

Two things, both load-bearing, in `3729dc3d` before the port itself:

**Revisions are integers, not semantic versions.** `SemanticVersionOrder` maps every unparseable value to `0.0.0` and falls back to a string comparison, so ADR revisions would sort `1, 10, 2`. Since every ADR read resolves "the latest revision", **that would have silently started returning revision 2's content the moment an ADR reached double figures** — no error, just stale data. Hence `NumericVersionOrder`, with unparseable values sorting *first* so a stray key can never be mistaken for the latest. Tests pin 10 over 2 on both backends.

**Its summary is built from content, not the entity.** `NamespaceAdrSummary` carries the latest revision's `title` and `status`; ADRs have no name or description of their own. Hence `getLatestVersion` / `getLatestVersionContent`. These recompute rather than caching a pointer, so ADR 0001's rejection of a `latestVersion` header field stands.

ADR is also the only type whose version map is named `revisions`, which is why the shared migration takes that field name as a parameter. Its search path was rewritten rather than reassigned, because it searches on the latest revision's title — something no other type does.

**One trade worth seeing rather than discovering:** listing a namespace's ADRs was one document read; it is now one query for the headers plus two small ones per ADR. More round-trips, far fewer bytes — the old single read pulled every revision of every ADR in the namespace into memory, which is the growth problem this redesign exists to remove.

## Things retired along the way

- **`searchNamespacedCollection`** — Interface was its last caller. Deleted from both search stores, with the null-entries-array test that covered its only remaining branch.
- **The 413 size-limit assertion** — it relocated to a still-unmigrated type on every round (Architecture → Pattern → Flow → Standard → Timeline) and ran out of types. Nothing reachable through these endpoints can hit the ceiling any more. Control keeps the old shape but is domain-scoped with a different envelope, so hosting it there would have meant rewriting it to test a resource this redesign excludes. `MongoWriteFailures` still classifies `BSONObjectTooLarge` and its unit tests still cover that mapping; what is gone is the end-to-end route to provoking it. **The half that matters survives** — ~24MB of architecture history written without a failed write.
- **`VersionKeySelector.versionCount()`** — ADR 0002 predicted it would lose its last caller once the seven types migrated. It did. `latestVersionKey()` remains for the two Control stores and retires with them.

## ADRs

0001–0003 move to `Implemented`. Each status line records what is actually true rather than just flipping the word, including the exceptions — ADR is not dash-encoded and never was, so it is an exception to dot-separation rather than a violation of it.

ADR 0003's operation list grew four times during the rollout, each time because a type's behaviour could not otherwise be preserved. That list is now the most useful thing in the ADR: a record of what the original design missed.

### Additional commits from review

- **`82f11bc9` — ADR revisions past 99 were being corrupted.** `VERSION_REGEX` makes both separators optional, so `"100"` is one of the six accepted spellings of `1.0.0`, and the helpers canonicalised every version on entry. Revision 100 was therefore stored as `"1.0.0"`; revisions 1–99 were unaffected, which is why nothing caught it. `NumericVersionOrder` sorts unparseable values first, so it then ranked *below* revision 99 — and since every ADR read resolves the latest revision, reads returned revision 99's content while 100 existed, silently. Both split migrations and `init-mongo.js` wrote the same corruption into stored data. Root cause was structural: ordering was made pluggable for ADR while canonicalisation stayed hard-wired, with nothing forcing the pair to agree. `VersionScheme` now carries both.
- `2d38b739` — an ADR header with no `adrId` unboxed into a primitive parameter, undoing the helper's deliberate null-id tolerance. In search it was worse: one such header threw out of `/search` for *every* resource type.
- `35b90ea1` — `CountsService` called `getAdrsForNamespace` only to `size()` it, and `NamespaceContentService` only to test `isEmpty()`, each paying `1 + 2N` queries plus `N` JSON parses. New `countHeaders` helper answers both in one query.
- `131e1736` — deletes the eight `createInitialVersion` copies these ports added, now that #2934 moved it onto the version document stores. The tree has none left. ADR keeps its own creation path, its revisions being integers rather than `1.0.0`.
- `1c85ea62`, `5bcccd32`, `2ec4daeb` — ADR 0002/0003 corrections, orphaned imports, a comment describing a since-retired test.

**Known and deliberate:** ADR search is `1 + 2N` per namespace, because it matches on the latest revision's *title* and there is no way to read a title without reading the revision. The count path above removes the amplification where a number or a boolean was all that was wanted; fixing search itself would need a `latestRevision` pointer on the header, which [ADR 0001](../blob/main/calm-hub/decisions/0001-versioned-artefact-storage.md) explicitly rejects. Raising it here rather than leaving it to be found.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (no functional changes)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

**Unit:** 2486 tests, 0 failures, JaCoCo 90%-per-class gate met.

**Integration** (`../mvnw -P integration verify`, TestContainers against real MongoDB): 503 tests, 0 failures — all 14 per-type classes across seven types and both backends, plus both search classes.

**Seed script** verified against a real MongoDB at each step: correct document shapes, `versionCount` as int32, integer revision keys for ADR, and the index inventory correct on both sides of the rollout.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards


