### PR TITLE
feat(calm-hub): tag Docker images with project version

### DIFF
--- a/.github/workflows/docker-publish-calm-hub-native.yml
+++ b/.github/workflows/docker-publish-calm-hub-native.yml
@@ -170,6 +170,20 @@ jobs:
         needs: build
 
         steps:
+            - name: Checkout
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+            - name: Set up JDK
+              uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+              with:
+                  distribution: 'temurin'
+                  java-version: '21'
+
+            - name: Resolve CALM Hub version
+              id: version
+              working-directory: calm-hub
+              run: echo "value=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
             - name: Download digests
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
@@ -193,6 +207,7 @@ jobs:
                   images: ${{ secrets.DOCKER_USERNAME }}/calm-hub
                   tags: |
                       type=raw,value=${{ github.event.inputs.tag || 'latest-native' }}
+                      type=raw,value=${{ steps.version.outputs.value }}-native
                       type=sha,format=short,suffix=-native
                       type=ref,event=tag,suffix=-native
 

--- a/.github/workflows/docker-publish-calm-hub-readonly-native.yml
+++ b/.github/workflows/docker-publish-calm-hub-readonly-native.yml
@@ -164,6 +164,20 @@ jobs:
         needs: build
 
         steps:
+            - name: Checkout
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+            - name: Set up JDK
+              uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+              with:
+                  distribution: 'temurin'
+                  java-version: '21'
+
+            - name: Resolve CALM Hub version
+              id: version
+              working-directory: calm-hub
+              run: echo "value=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
             - name: Download digests
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
@@ -187,6 +201,7 @@ jobs:
                   images: ${{ secrets.DOCKER_USERNAME }}/calm-hub
                   tags: |
                       type=raw,value=${{ github.event.inputs.tag || 'latest-read-only-native' }}
+                      type=raw,value=${{ steps.version.outputs.value }}-read-only-native
                       type=sha,format=short,suffix=-read-only-native
                       type=ref,event=tag,suffix=-read-only-native
 

--- a/.github/workflows/docker-publish-calm-hub-readonly.yml
+++ b/.github/workflows/docker-publish-calm-hub-readonly.yml
@@ -56,6 +56,11 @@ jobs:
             - name: Build and stage seed content
               run: bash calm-hub/build-readonly-image.sh --no-docker
 
+            - name: Resolve CALM Hub version
+              id: version
+              working-directory: calm-hub
+              run: echo "value=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
             # Step 5: Set up Docker Buildx for multi-architecture builds
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -75,6 +80,7 @@ jobs:
                   images: ${{ secrets.DOCKER_USERNAME }}/calm-hub
                   tags: |
                       type=raw,value=${{ github.event.inputs.tag || 'latest-read-only-static' }}
+                      type=raw,value=${{ steps.version.outputs.value }}-read-only-static
                       type=sha,format=short,suffix=-read-only-static
                       type=ref,event=tag,suffix=-read-only-static
 

--- a/.github/workflows/docker-publish-calm-hub.yml
+++ b/.github/workflows/docker-publish-calm-hub.yml
@@ -55,6 +55,11 @@ jobs:
               working-directory: calm-hub
               run: mvn -P integration clean package -Ddependency-check.skip=true
 
+            - name: Resolve CALM Hub version
+              id: version
+              working-directory: calm-hub
+              run: echo "value=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
             # Step 5: Set up Docker Buildx for multi-architecture builds
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -74,6 +79,7 @@ jobs:
                   images: ${{ secrets.DOCKER_USERNAME }}/calm-hub
                   tags: |
                       type=raw,value=${{ github.event.inputs.tag || 'latest' }}
+                      type=raw,value=${{ steps.version.outputs.value }}
                       type=sha,format=short
                       type=ref,event=branch
                       type=ref,event=tag


### PR DESCRIPTION
## Description

Closes #2833.

Adds semantic version tags derived from `calm-hub/pom.xml` to all four CALM Hub Docker publication variants:

- standard: `0.7.6`
- read-only static: `0.7.6-read-only-static`
- native: `0.7.6-native`
- read-only native: `0.7.6-read-only-native`

The existing latest/custom, SHA, branch, and Git tag aliases remain unchanged. This gives consumers an immutable release-oriented tag without removing the current publication conventions.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components

- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [x] CI/CD

## Commit Message Format ✅

The commit follows the repository's Conventional Commits format and includes a DCO sign-off.

## Testing

- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

Local validation:

- parsed all four changed workflow files as YAML;
- resolved and validated the current `calm-hub/pom.xml` version (`0.7.6`) as semantic numeric version data;
- ran `git diff --check`.

The Docker publishing jobs require repository credentials and are therefore left to GitHub Actions.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
