### PR TITLE
docs(docs): document flow-specific spectral validation rules

### DIFF
--- a/docs/docs/core-concepts/flows.md
+++ b/docs/docs/core-concepts/flows.md
@@ -112,6 +112,11 @@ calm validate -a path/to/architecture.json
 
 Validation checks that each flow has a `unique-id`, `name`, `description`, and at least one transition, and that every transition has a `relationship-unique-id`, `sequence-number`, and `description`.
 
+Beyond JSON Schema, CALM enforces two additional hard-error rules specific to flows:
+
+- **`flow-transitions-references-existing-relationship-in-architecture`**: every `relationship-unique-id` in a transition must match an existing relationship in the architecture. A dangling reference is a hard error. This is the enforcement behind the "keeping business and technical views consistent" guarantee: you cannot describe a process step that points at a connection that does not exist.
+- **`flow-transitions-have-unique-sequence-numbers`**: sequence numbers within a single flow must be unique. Duplicate numbers make the ordering of steps ambiguous and are rejected as a hard error.
+
 ## Related
 
 - [Relationships](relationships): The connections that transitions reference.


### PR DESCRIPTION
Follow-up to https://github.com/finos/architecture-as-code/pull/2922#discussion_r3726921055.

Addresses the comment from @markscott-ms — the "Validating Flows" section was under-claiming by omitting two flow-specific hard-error Spectral rules defined in `shared/src/spectral/rules-architecture.ts`:

- `flow-transitions-references-existing-relationship-in-architecture` — dangling `relationship-unique-id` is a hard error. This is the enforcement behind the "keeps business and technical views consistent" claim made under *Using Flows Effectively*.
- `flow-transitions-have-unique-sequence-numbers` — duplicate sequence numbers within a flow are a hard error.