### PR TITLE
feat(calm-hub): add -Pserver-only Maven profile to skip the frontend build

### DIFF
--- a/calm-hub/AGENTS.md
+++ b/calm-hub/AGENTS.md
@@ -23,11 +23,13 @@ This guide helps AI assistants work efficiently with the CALM Hub backend codeba
 ../mvnw clean package                    # Full build
 ../mvnw -P integration verify            # Include integration tests
 ../mvnw test                              # Unit tests only
+../mvnw -Pserver-only clean package       # Backend only — skips the Node/npm frontend stage
 
 # Development Mode (Hot Reload)
 # NOTE: The default profile is secure (401 on all requests). Use no-auth for local testing.
 ../mvnw quarkus:dev -Dquarkus.profile=no-auth        # No-auth (local testing, MongoDB)
 ../mvnw quarkus:dev -Pstandalone                     # Standalone (NitriteDB) — no-auth is implicit
+../mvnw quarkus:dev -Pstandalone,server-only         # Standalone + no frontend build — profiles compose
 ../mvnw quarkus:dev -Dquarkus.profile=secure         # Secure mode (Keycloak)
 
 # Docker
@@ -641,6 +643,10 @@ CALM Hub is largely independent - it's a standalone REST API server.
    field into a `Response` entity or log message triggers CodeQL `java/xss`. `@Pattern` validation
    is not a barrier — wrap the value in `STRICT_SANITIZATION_POLICY.sanitize(...)`. See
    [Preventing Cross-Site Scripting (XSS) in Responses](#preventing-cross-site-scripting-xss-in-responses).
+7. **`-Pserver-only` does not build or refresh the bundled UI**: it skips the Node/npm frontend
+   stage entirely (see [README.md](./README.md#skipping-the-frontend-build)). A fresh clone built
+   with this profile ships no UI at all; never use it for a release, Docker image, or CI build
+   that needs to serve the UI.
 
 ## Known Issues
 

--- a/calm-hub/README.md
+++ b/calm-hub/README.md
@@ -51,15 +51,39 @@ mvn -P integration verify
 
 Development mode is designed to provide a great developer experience from using modern tools and build systems.
 
-### Skipping `npm` build
+### Skipping the frontend build
 
 CalmHub will install and build the frontend every time you run it by default.
-This takes a while and can be rather tedious.
-To disable this, set `skip.npm`, which disables the NPM commands of the frontend Maven plugin:
+This takes a while and can be rather tedious for backend-only work.
+
+The `server-only` Maven profile skips the whole frontend stage — Node/npm download,
+the monorepo `npm install`, and the calm-hub-ui build:
+
+```shell
+../mvnw -Pserver-only package
+```
+
+The realistic day-to-day loop for backend work combines it with `standalone`
+(NitriteDB, no external Mongo needed) — profiles compose comma-separated:
+
+```shell
+../mvnw quarkus:dev -Pstandalone,server-only
+```
+
+If you only want to skip the npm commands but still let Maven install/verify the Node
+toolchain, use the narrower `-Dskip.npm` property instead:
 
 ```shell
 ../mvnw quarkus:dev -Dskip.npm
 ```
+
+**Consequence of skipping the frontend build:** the built UI is copied into
+`src/main/resources/META-INF/resources` by the npm script, and that directory is
+gitignored — `mvn clean` does not remove it, since it lives under `src/`, not `target/`.
+So on a fresh clone, `-Pserver-only` produces a jar/dev server with **no UI at all**
+(404 at `/`); on a machine that has built before, it silently keeps serving whatever UI
+was last built. Never use `-Pserver-only` for a release, Docker image, or CI build that
+needs to ship the UI.
 
 ### Storage Modes
 

--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -448,6 +448,31 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Server-only profile: skips the frontend stage (Node download, monorepo
+             npm install, and the calm-hub-ui Vite build) so backend-only work doesn't
+             pay for it. Deliberately NOT active by default.
+
+             Consequence to understand before using it: the UI is copied into
+             src/main/resources/META-INF/resources by the npm script, that directory is
+             gitignored, and `mvn clean` does not remove it (it lives under src/, not
+             target/). So on a fresh clone this profile produces a jar with NO UI at all
+             (404 at /), and on a machine that has built before it silently ships
+             whatever UI was last built. Never use it for a release or Docker image
+             build — see calm-hub/AGENTS.md and README.md for the full explanation. -->
+        <profile>
+            <id>server-only</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <!-- frontend-maven-plugin reads these as the default-value expressions
+                     for its own <skip> parameters (verified against the plugin
+                     descriptor), so this composes cleanly with the -Dskip.npm escape
+                     hatch documented in README.md: CLI user properties still win. -->
+                <skip.installnodenpm>true</skip.installnodenpm>
+                <skip.npm>true</skip.npm>
+            </properties>
+        </profile>
         <profile>
             <id>dependency-check</id>
             <activation>


### PR DESCRIPTION
## Description
- Adds a new, non-default `server-only` Maven profile to `calm-hub/pom.xml`
- Skips the whole frontend stage (Node/npm download, monorepo `npm install`, calm-hub-ui Vite build) on demand, without touching the default build behaviour
- Sets `skip.installnodenpm` / `skip.npm` as project properties, which are the exact default-value expressions frontend-maven-plugin's own mojos already read — so the existing `-Dskip.npm` escape hatch keeps working unchanged
- Updates `calm-hub/README.md` and `calm-hub/AGENTS.md` with the new commands and the tradeoff to be aware of

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- Single commit: `feat(calm-hub): add -Pserver-only Maven profile to skip the frontend build`

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass

Verification performed:
- `mvn clean package` (no profile) — frontend stage still runs (`install node and npm`, `npm install`, `npm run calm-hub-ui:prod`), `BUILD SUCCESS`
- `mvn -Pserver-only clean package` — none of those three executions run, no Node downloaded, no `META-INF/resources` produced, jar still builds
- `mvn help:active-profiles -Pstandalone,server-only` — both profiles activate together with no conflict
- `mvn -Dskip.npm clean package` — existing escape hatch still works
- `mvn -Pserver-only clean verify` — full unit test suite passes, JaCoCo 90% coverage gate holds

## Notes for reviewers
- `src/main/resources/META-INF/resources` (the UI destination) is gitignored and not removed by `mvn clean`, since it lives under `src/`, not `target/`. A fresh clone built with `-Pserver-only` therefore has **no UI at all**; a machine that has built before keeps serving whatever UI was last built. This is documented in the profile's POM comment and in the README/AGENTS.md updates.
- Deliberately **not** wired into any CI workflow or Docker build script in this PR — those all need the UI baked into the jar. `build-calm-hub-coverage.yml` is a plausible follow-up (it runs `mvn clean verify` purely for JaCoCo and pays the full npm cost for nothing, while `build-calm-hub-ui.yml` already covers the UI build independently) but is left out here to keep this change scoped.

Part of #2943