### PR TITLE
feat(vscode): add pre-release toggle to publish workflow

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -19,6 +19,15 @@ on:
                 required: false
                 default: false
                 type: boolean
+            pre_release:
+                description: 'Publish as pre-release (auto = on for odd minor versions, e.g. 0.1.x, 0.3.x)'
+                required: false
+                default: 'auto'
+                type: choice
+                options:
+                    - auto
+                    - 'true'
+                    - 'false'
 
 jobs:
     build-and-test:
@@ -63,10 +72,32 @@ jobs:
             - name: Package VS Code Extension
               run: npm run package:vscode
 
+            - name: Determine pre-release flag
+              id: prerelease
+              if: github.event.inputs.publish_to_marketplace == 'true'
+              working-directory: ./calm-plugins/vscode
+              run: |
+                  case "${{ github.event.inputs.pre_release }}" in
+                    true)
+                      echo "flag=--pre-release" >> "$GITHUB_OUTPUT"
+                      ;;
+                    false)
+                      echo "flag=" >> "$GITHUB_OUTPUT"
+                      ;;
+                    *)
+                      MINOR=$(node -p "require('./package.json').version.split('.')[1]")
+                      if [ $((MINOR % 2)) -eq 1 ]; then
+                        echo "flag=--pre-release" >> "$GITHUB_OUTPUT"
+                      else
+                        echo "flag=" >> "$GITHUB_OUTPUT"
+                      fi
+                      ;;
+                  esac
+
             - name: Publish to VS Code Marketplace
               if: github.event.inputs.publish_to_marketplace == 'true'
               working-directory: ./calm-plugins/vscode
-              run: npx vsce publish --pre-release --packagePath *.vsix
+              run: npx vsce publish ${{ steps.prerelease.outputs.flag }} --packagePath *.vsix
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 


### PR DESCRIPTION
## Description
The VS Code extension is currently at version 0.9.0, i.e. a pre-release version. This PR adds a `pre_release` toggle to the publish workflow so that marketplace releases can be published without being offered as the default upgrade to users on the stable release channel, while it's still pre-1.0.

The toggle defaults to `auto`, which enables `--pre-release` for odd minor versions (0.1.x, 0.3.x, 0.5.x, ...) and disables it for even minor versions (0.2.x, 0.4.x, ...), following VS Code's own pre-release/stable versioning convention. It can also be forced to `true`/`false` via workflow_dispatch.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [x] CI/CD

## Commit Message Format ✅
- Uses `feat(vscode): add pre-release toggle to publish workflow`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

Validated the workflow YAML with `actionlint` (no issues found). This is a CI-only change with no application code paths to unit test.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
