### PR TITLE
fix(calm-hub): denormalize ADR title onto the header to fix N+1 search cost

### DIFF
--- a/calm-hub/decisions/0006-denormalize-adr-title-onto-header.md
+++ b/calm-hub/decisions/0006-denormalize-adr-title-onto-header.md
@@ -1,0 +1,95 @@
+# ADR 0006: Denormalize ADR title onto the header
+
+**Status**: Implemented.
+
+## Context
+
+[#2946](https://github.com/finos/architecture-as-code/issues/2946) (split out of
+review on [#2935](https://github.com/finos/architecture-as-code/pull/2935), parent
+redesign [#2884](https://github.com/finos/architecture-as-code/issues/2884)):
+`MongoSearchStore`/`NitriteSearchStore`'s `searchAdrCollection` resolves the latest
+revision's title for every ADR header it scans — `1 + 2N` round trips for `N` headers
+scanned, uncapped until 50 *matches* are found (the cap doesn't bound headers scanned).
+On Nitrite it's worse: 2 lock acquisitions and 2 unindexed full-collection scans per
+header, since Nitrite creates no indexes at all.
+
+ADR is the only versioned type this happens to, because it's the only one whose header
+carries no denormalized display field. Every other type — Architecture, Pattern, Flow,
+Standard, Interface, Timeline — writes its `name`/`description` onto the header via
+`{Mongo,Nitrite}VersionDocumentStore#updateHeaderDetails`/`updatePresentHeaderDetails`
+on every version write (e.g. `MongoArchitectureStore.java:156`,
+`MongoPatternStore.java:146`), so their search path reads the header alone, in one
+query. ADR's header is created with `createHeader(namespace, id, null, null)` and never
+updated again — its title has only ever lived in the revision content.
+
+[ADR 0001](0001-versioned-artefact-storage.md) rejected a `latestVersion` pointer on the
+header: "a cached pointer would be one more place for staleness bugs with no current
+consumer." That same ADR, in the same section, later **reversed** an equivalent
+rejection for `versionCount` once a real consumer existed — `calm-hub-ui`'s
+`ItemCard.tsx` reads it on every namespace listing page view — reasoning that reads
+vastly outnumber writes for that field. ADR title now has exactly that shape of
+consumer: search, at scale, versus a title write only on ADR creation or a subsequent
+revision. This ADR follows 0001's own precedent rather than reopening its `latestVersion`
+rejection: it denormalizes a resolved *value* (the title string), not a pointer into the
+version collection, and only for ADR — the one type actually missing it.
+
+Four options were on the table (batch the version reads; cache with a TTL like
+`CountsService`'s; revisit 0001's rejection generically; or this one). Batching was the
+issue's leading suggestion, but denormalizing turned out simpler once it was clear ADR
+was the outlier rather than the norm: it needed no new query shape, no second read path,
+and made ADR consistent with six of seven sibling types instead of adding a new kind of
+read exclusively for it. A `CountsService`-style TTL cache was rejected for the same
+reason 0001's own writeup gives when discussing that pattern: it does nothing for a cold
+cache and adds a staleness window that denormalizing-at-write-time avoids outright.
+
+## Decision
+
+`MongoAdrStore`/`NitriteAdrStore` write a denormalized copy of the title onto the ADR
+header on every write:
+
+- **First version** (`createAdrForNamespace`): resolves the title from
+  `adrMeta.getAdr().getTitle()`, falling back to the literal `"Untitled ADR"` when it's
+  null/blank, and passes that directly into `createHeader(...)`. There is no existing
+  header title a blank one could "leave standing," so a first version needs its own
+  placeholder rather than reusing `updatePresentHeaderDetails`'s no-op-on-blank behaviour.
+- **Later revisions** (`writeRevision`, shared by `updateAdrForNamespace` and
+  `updateAdrStatus`): calls `documentStore.updatePresentHeaderDetails(namespace, id,
+  adrMeta.getAdr().getTitle(), null)` after the version write succeeds — the existing
+  helper already no-ops on a null/blank title, so a revision that omits one leaves the
+  header's current title standing rather than overwriting it with a placeholder.
+
+A one-time migration step per backend (`MongoAdrTitleBackfillStep`,
+`NitriteAdrTitleBackfillStep`, schema version 10 → 11) backfills every pre-existing ADR
+header with no title: resolves it from the latest revision, same `"Untitled ADR"`
+fallback if the revision has none or can't be read.
+
+`searchAdrCollection` on both backends now reads `header.getString("name")` directly,
+falling back to `"ADR " + adrId"` only for a header that predates both the write-path
+change and the backfill (there should be none after the migration runs, but the search
+path stays defensive rather than assuming it). This is now structurally identical to
+`searchHeaderCollection` — one query, no version-collection reads, no lock contention on
+Nitrite's `adrVersions` collection at all.
+
+`NamespaceAdrSummary`/`toAdrSummary` (the `getAdrsForNamespace` listing) is **not**
+changed — it still resolves `status` from the latest revision, which isn't denormalized
+by this ADR (out of scope: nothing in #2946 needs `status` off the header). Only `title`
+moves.
+
+## Consequences
+
+- Creating a version is no longer a single write for ADR either — same trade-off ADR
+  0001 already accepted for `versionCount`: a crash between the version write and the
+  header title update leaves the header's title stale until the next successful
+  revision write. Blast radius is a display string, not lost or corrupted content.
+- `MongoSearchStore`/`NitriteSearchStore` no longer construct a second
+  `{Mongo,Nitrite}VersionDocumentStore` over `adrs`/`adrVersions` at all — the Nitrite
+  class javadoc's "read-only, do not add a write path through this field" caveat about
+  that second instance no longer applies, because the field is gone.
+- Existing deployments need the schema-version-11 backfill to run once before every ADR
+  header has a title; until then, search still functions correctly via the `"ADR "
+  + adrId"` fallback for any header the backfill hasn't reached yet.
+- `calm-hub/mongo/init-mongo.js`'s ADR seed entries now carry a top-level `name` field
+  (mirroring what every other seeded type already does), and
+  `LATEST_SCHEMA_VERSION` is bumped to 11 so a fresh seed declares the backfill already
+  applied — consistent with ADR 0001's "why this matters" note on keeping the seed
+  script's declared version in step with new migration steps.

--- a/calm-hub/decisions/README.md
+++ b/calm-hub/decisions/README.md
@@ -22,6 +22,7 @@ assuming anything here reflects current behaviour.
 | [0003](0003-shared-version-store-helper.md) | Shared header/version store helper | Implemented |
 | [0004](0004-defer-control-and-decorator-storage.md) | Defer Control and Decorator storage redesign | Accepted (no code of its own) |
 | [0005](0005-layout-is-hub-internal-not-a-calm-schema.md) | Layout is a Hub-internal shape, not a CALM schema | Implemented |
+| [0006](0006-denormalize-adr-title-onto-header.md) | Denormalize ADR title onto the header | Implemented |
 
 0001–0003 cover the seven *versioned* resource types. Control and Decorator
 keep the one-document-per-namespace shape by decision, not by omission — see

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -141,7 +141,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 10;
+const LATEST_SCHEMA_VERSION = 11;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });
@@ -6395,6 +6395,11 @@ if (isEmptyDatabase && db.adrs.countDocuments() === 0) {
             adrs: [
                 {
                     adrId: NumberInt(1),
+                    // Denormalized copy of revisions[1].title — see
+                    // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md.
+                    // seedVersionedResource writes this onto the header the same way it
+                    // already does for every other type's `name`.
+                    name: 'Example ADR',
                     revisions: {
                         1: {
                             title: 'Example ADR',
@@ -6477,6 +6482,9 @@ if (isEmptyDatabase && db.adrs.countDocuments() === 0) {
             adrs: [
                 {
                     adrId: NumberInt(1),
+                    // Denormalized copy of revisions[1].title — see
+                    // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md.
+                    name: 'Use Load Balancer for Traffic Distribution',
                     revisions: {
                         1: {
                             title: 'Use Load Balancer for Traffic Distribution',

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrTitleBackfillStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrTitleBackfillStep.java
@@ -1,0 +1,108 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.util.MongoVersionDocumentStore;
+import org.finos.calm.store.util.VersionScheme;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Backfills the denormalized title onto every existing ADR header that doesn't have one yet.
+ *
+ * <p>Version 10 → 11 of the schema. Runs after {@link MongoAdrVersionSplitStep} (version 8 →
+ * 9), so every header this step sees is already in the header/version shape — it only ever
+ * reads and writes through {@link MongoVersionDocumentStore}, the same helper
+ * {@code MongoAdrStore} now uses to keep new headers' titles current. See
+ * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md} for why the title
+ * moved onto the header at all.
+ *
+ * <h2>Idempotency</h2>
+ * A header already carrying a non-blank {@code name} is left alone — that's true of every
+ * header this step has already visited, and of any header the application itself created or
+ * updated (through {@code MongoAdrStore}) since this step last ran partway and failed.
+ *
+ * <h2>Why ids are collected before any write</h2>
+ * Same reason as {@link MongoVersionSplitMigration}: iterating a cursor while writing through
+ * the documents it's reading is not something to rely on, so the untitled headers' identities
+ * are collected first (a small, bounded projection) and each is then resolved and written one
+ * at a time.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoAdrTitleBackfillStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoAdrTitleBackfillStep.class);
+
+    /** Same placeholder {@code MongoAdrStore} writes for a brand-new ADR with no title. */
+    private static final String UNTITLED_ADR = "Untitled ADR";
+
+    private final MongoCollection<Document> headerCollection;
+    private final MongoVersionDocumentStore documentStore;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoAdrTitleBackfillStep(MongoDatabase database) {
+        this.headerCollection = database.getCollection("adrs");
+        this.documentStore = new MongoVersionDocumentStore(
+                headerCollection, database.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
+    }
+
+    @Override
+    public int fromVersion() {
+        return 10;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping ADR title backfill (database mode: {})", databaseMode);
+            return;
+        }
+        backfill();
+    }
+
+    /**
+     * Runs the backfill unconditionally — no {@code databaseMode} check. Public for the same
+     * reason as the version-split steps': integration tests with a real MongoDB container
+     * call it directly.
+     */
+    public void backfill() {
+        List<Document> untitledHeaders = new ArrayList<>();
+        headerCollection.find(Filters.or(Filters.exists("name", false), Filters.eq("name", null)))
+                .projection(Projections.include("namespace", "adrId"))
+                .forEach(untitledHeaders::add);
+
+        int updated = 0;
+        for (Document header : untitledHeaders) {
+            String namespace = header.getString("namespace");
+            Integer adrId = header.getInteger("adrId");
+            if (namespace == null || adrId == null) {
+                // A malformed header search already renders and ignores elsewhere — not this
+                // step's job to fail the whole backfill over one bad document.
+                LOG.warn("Skipping ADR header with no namespace/adrId during title backfill");
+                continue;
+            }
+            documentStore.updatePresentHeaderDetails(namespace, adrId, resolveTitle(namespace, adrId), null);
+            updated++;
+        }
+        LOG.info("ADR title backfill complete: {} header(s) updated", updated);
+    }
+
+    private String resolveTitle(String namespace, int adrId) {
+        Document latest = documentStore.getLatestVersionContent(namespace, adrId);
+        String title = latest == null ? null : latest.getString("title");
+        return title == null || title.isBlank() ? UNTITLED_ADR : title;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrTitleBackfillStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoAdrTitleBackfillStep.java
@@ -2,7 +2,6 @@ package org.finos.calm.migration.steps;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -31,6 +30,14 @@ import java.util.List;
  * A header already carrying a non-blank {@code name} is left alone — that's true of every
  * header this step has already visited, and of any header the application itself created or
  * updated (through {@code MongoAdrStore}) since this step last ran partway and failed.
+ *
+ * <h2>Blank filtered in memory, not by the query</h2>
+ * "Untitled" is decided in Java (null or {@link String#isBlank()}), the same rule
+ * {@code MongoAdrStore#headerTitle} and {@code resolveTitle} below use — not by the Mongo
+ * query, which would need a regex to express "blank or missing" and would be one more query
+ * shape to keep in sync with that rule. Matches {@link NitriteAdrTitleBackfillStep}, which
+ * has to filter in memory anyway since Nitrite has no query-side filtering worth relying on
+ * here.
  *
  * <h2>Why ids are collected before any write</h2>
  * Same reason as {@link MongoVersionSplitMigration}: iterating a cursor while writing through
@@ -80,9 +87,14 @@ public class MongoAdrTitleBackfillStep implements SchemaMigrationStep {
      */
     public void backfill() {
         List<Document> untitledHeaders = new ArrayList<>();
-        headerCollection.find(Filters.or(Filters.exists("name", false), Filters.eq("name", null)))
-                .projection(Projections.include("namespace", "adrId"))
-                .forEach(untitledHeaders::add);
+        headerCollection.find()
+                .projection(Projections.include("namespace", "adrId", "name"))
+                .forEach(header -> {
+                    String name = header.getString("name");
+                    if (name == null || name.isBlank()) {
+                        untitledHeaders.add(header);
+                    }
+                });
 
         int updated = 0;
         for (Document header : untitledHeaders) {

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrTitleBackfillStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/NitriteAdrTitleBackfillStep.java
@@ -1,0 +1,110 @@
+package org.finos.calm.migration.steps;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.finos.calm.store.util.NitriteVersionDocumentStore;
+import org.finos.calm.store.util.VersionScheme;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * NitriteDB counterpart to {@link MongoAdrTitleBackfillStep}: backfills the denormalized
+ * title onto every existing ADR header that doesn't have one yet.
+ *
+ * <p>Version 10 → 11 of the schema, matching the Mongo step's {@code fromVersion()} — the
+ * two are gated by mutually exclusive {@code @LookupIfProperty} values, so
+ * {@code SchemaMigrationRunner}'s duplicate-{@code fromVersion} guard never sees both as CDI
+ * beans at once. See {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}.
+ *
+ * <p>Reads headers with a plain unfiltered {@code find()} rather than a Nitrite filter on a
+ * missing/null field: Nitrite creates no indexes at all (see
+ * {@code NitriteVersionDocumentStore}'s javadoc), so a filtered scan costs the same as an
+ * unfiltered one here, and it matches how the rest of this class's Nitrite siblings
+ * (e.g. {@code NitriteVersionDocumentStore#listSummariesPaged}) already filter in memory.</p>
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+public class NitriteAdrTitleBackfillStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NitriteAdrTitleBackfillStep.class);
+
+    /** Same placeholder {@code NitriteAdrStore} writes for a brand-new ADR with no title. */
+    private static final String UNTITLED_ADR = "Untitled ADR";
+
+    private final NitriteCollection headerCollection;
+    private final NitriteVersionDocumentStore documentStore;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    public NitriteAdrTitleBackfillStep(@StandaloneQualifier Nitrite db) {
+        this.headerCollection = db.getCollection("adrs");
+        this.documentStore = new NitriteVersionDocumentStore(
+                headerCollection, db.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
+    }
+
+    @Override
+    public int fromVersion() {
+        return 10;
+    }
+
+    @Override
+    public void apply() {
+        backfill();
+    }
+
+    /** Public, matching the version-split steps, so integration tests can call it directly. */
+    public void backfill() {
+        List<Document> untitledHeaders = new ArrayList<>();
+        for (Document header : headerCollection.find()) {
+            String name = header.get("name", String.class);
+            if (name == null || name.isBlank()) {
+                untitledHeaders.add(header);
+            }
+        }
+
+        int updated = 0;
+        for (Document header : untitledHeaders) {
+            String namespace = header.get("namespace", String.class);
+            Integer adrId = header.get("adrId", Integer.class);
+            if (namespace == null || adrId == null) {
+                LOG.warn("Skipping ADR header with no namespace/adrId during title backfill");
+                continue;
+            }
+            documentStore.updatePresentHeaderDetails(namespace, adrId, resolveTitle(namespace, adrId), null);
+            updated++;
+        }
+        LOG.info("ADR title backfill complete: {} header(s) updated", updated);
+    }
+
+    private String resolveTitle(String namespace, int adrId) {
+        String latest = documentStore.getLatestVersionContent(namespace, adrId);
+        String title = latest == null ? null : titleOf(latest);
+        return title == null || title.isBlank() ? UNTITLED_ADR : title;
+    }
+
+    /**
+     * Content is a JSON string on this backend, matching the parser
+     * {@code NitriteAdrStore}/the old {@code NitriteSearchStore} used.
+     */
+    private String titleOf(String content) {
+        try {
+            JsonNode title = objectMapper.readTree(content).get("title");
+            return title == null || !title.isTextual() ? null : title.asText();
+        } catch (JsonProcessingException | RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -143,8 +143,11 @@ public class MongoAdrStore implements AdrStore {
         Document content = toContent(adrMeta);
 
         int id = counterStore.getNextAdrSequenceValue();
-        // ADRs carry no name or description of their own — both live in the revision content.
-        documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
+        // ADRs carry no name or description of their own — both live in the revision
+        // content — but the header still denormalizes a copy of the title, same as every
+        // other versioned type's header carries its display name. See
+        // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md.
+        documentStore.createHeader(adrMeta.getNamespace(), id, headerTitle(adrMeta), null);
         documentStore.createFirstVersion(adrMeta.getNamespace(), id,
                 String.valueOf(adrMeta.getRevision()), content);
 
@@ -256,6 +259,23 @@ public class MongoAdrStore implements AdrStore {
                 String.valueOf(adrMeta.getRevision()), content)) {
             throw new AdrRevisionExistsException();
         }
+        // Refresh the header's denormalized title after the version write succeeds, never
+        // before — same rule MongoVersionDocumentStore#updateHeaderDetails documents for
+        // every other type. updatePresentHeaderDetails deliberately no-ops on a blank title,
+        // so a revision that omits one leaves the header's existing title standing rather
+        // than overwriting it with a placeholder.
+        documentStore.updatePresentHeaderDetails(adrMeta.getNamespace(), adrMeta.getId(),
+                adrMeta.getAdr().getTitle(), null);
+    }
+
+    /**
+     * Resolves the title to denormalize onto a brand-new header, falling back to a
+     * placeholder rather than leaving it blank — unlike a later revision, there is no
+     * existing header title a blank one could instead leave standing.
+     */
+    private String headerTitle(AdrMeta adrMeta) {
+        String title = adrMeta.getAdr().getTitle();
+        return title == null || title.isBlank() ? "Untitled ADR" : title;
     }
 
     private Document toContent(AdrMeta adrMeta) throws AdrParseException {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -181,7 +181,7 @@ public class MongoSearchStore implements SearchStore {
                 continue;
             }
             String title = header.getString("name");
-            if (title == null) {
+            if (title == null || title.isBlank()) {
                 title = "ADR " + adrId;
             }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoSearchStore.java
@@ -8,8 +8,6 @@ import org.bson.Document;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
-import org.finos.calm.store.util.MongoVersionDocumentStore;
-import org.finos.calm.store.util.VersionScheme;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,9 +23,10 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * <p>
  * Searches across 7 resource collections by matching the query (case-insensitive)
  * against the {@code name} and {@code description} fields of each resource entry.
- * For ADRs, the {@code title} field of the latest revision is searched instead.
- * Controls are scoped by domain rather than namespace, so they bypass the
- * readable-namespaces filter.
+ * ADR's header carries a denormalized copy of the latest revision's title (see
+ * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}), so it reads the
+ * same as every other type. Controls are scoped by domain rather than namespace, so they
+ * bypass the readable-namespaces filter.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
@@ -43,7 +42,6 @@ public class MongoSearchStore implements SearchStore {
     private final MongoCollection<Document> interfaceCollection;
     private final MongoCollection<Document> controlCollection;
     private final MongoCollection<Document> adrCollection;
-    private final MongoVersionDocumentStore adrDocuments;
 
     public MongoSearchStore(MongoDatabase database) {
         this.architectureCollection = database.getCollection("architectures");
@@ -53,8 +51,6 @@ public class MongoSearchStore implements SearchStore {
         this.interfaceCollection = database.getCollection("interfaces");
         this.controlCollection = database.getCollection("controls");
         this.adrCollection = database.getCollection("adrs");
-        this.adrDocuments = new MongoVersionDocumentStore(adrCollection,
-                database.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
     }
 
     @Override
@@ -160,11 +156,12 @@ public class MongoSearchStore implements SearchStore {
     }
 
     /**
-     * ADR searches on the latest revision's title, so unlike every other type this cannot be
-     * answered from the header alone — the header carries no name. The latest revision is
-     * resolved through the same helper the ADR store uses, which is also what keeps the
-     * integer ordering correct: ranking revisions as strings would make 2 the latest once an
-     * ADR passed revision 9.
+     * ADR's header carries a denormalized copy of the latest revision's title (written by
+     * {@code MongoAdrStore} on every version write — see
+     * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}), so this reads
+     * exactly like {@link #searchHeaderCollection} rather than resolving the version
+     * collection per header. The {@code "ADR " + adrId} fallback only fires for a header
+     * that predates both the write-path change and its one-time migration backfill.
      */
     private List<SearchResult> searchAdrCollection(String lowerQuery, Optional<Set<String>> readableNamespaces) {
         List<SearchResult> results = new ArrayList<>();
@@ -179,15 +176,13 @@ public class MongoSearchStore implements SearchStore {
             }
             Integer adrId = header.getInteger("adrId");
             if (adrId == null) {
-                // SearchResult takes a primitive id, and resolving the latest revision would
-                // unbox this too. An ADR with no id is not addressable, so it is not a result.
+                // SearchResult takes a primitive id, so a header missing its id field would
+                // unbox to a NullPointerException. An ADR with no id is not addressable.
                 continue;
             }
-            String title = "ADR " + adrId;
-
-            Document latest = adrDocuments.getLatestVersionContent(namespace, adrId);
-            if (latest != null && latest.getString("title") != null) {
-                title = latest.getString("title");
+            String title = header.getString("name");
+            if (title == null) {
+                title = "ADR " + adrId;
             }
 
             if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -129,8 +129,11 @@ public class NitriteAdrStore implements AdrStore {
         String content = toContent(adrMeta);
 
         int id = counterStore.getNextAdrSequenceValue();
-        // ADRs carry no name or description of their own — both live in the revision content.
-        documentStore.createHeader(adrMeta.getNamespace(), id, null, null);
+        // ADRs carry no name or description of their own — both live in the revision
+        // content — but the header still denormalizes a copy of the title, same as every
+        // other versioned type's header carries its display name. See
+        // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md.
+        documentStore.createHeader(adrMeta.getNamespace(), id, headerTitle(adrMeta), null);
         documentStore.createFirstVersion(adrMeta.getNamespace(), id,
                 String.valueOf(adrMeta.getRevision()), content);
 
@@ -232,6 +235,23 @@ public class NitriteAdrStore implements AdrStore {
                 String.valueOf(adrMeta.getRevision()), content)) {
             throw new AdrRevisionExistsException();
         }
+        // Refresh the header's denormalized title after the version write succeeds, never
+        // before — same rule NitriteVersionDocumentStore#updateHeaderDetails documents for
+        // every other type. updatePresentHeaderDetails deliberately no-ops on a blank title,
+        // so a revision that omits one leaves the header's existing title standing rather
+        // than overwriting it with a placeholder.
+        documentStore.updatePresentHeaderDetails(adrMeta.getNamespace(), adrMeta.getId(),
+                adrMeta.getAdr().getTitle(), null);
+    }
+
+    /**
+     * Resolves the title to denormalize onto a brand-new header, falling back to a
+     * placeholder rather than leaving it blank — unlike a later revision, there is no
+     * existing header title a blank one could instead leave standing.
+     */
+    private String headerTitle(AdrMeta adrMeta) {
+        String title = adrMeta.getAdr().getTitle();
+        return title == null || title.isBlank() ? "Untitled ADR" : title;
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -183,7 +183,7 @@ public class NitriteSearchStore implements SearchStore {
                 continue;
             }
             String title = header.get("name", String.class);
-            if (title == null) {
+            if (title == null || title.isBlank()) {
                 title = "ADR " + adrId;
             }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteSearchStore.java
@@ -1,8 +1,5 @@
 package org.finos.calm.store.nitrite;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
@@ -13,8 +10,6 @@ import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
-import org.finos.calm.store.util.NitriteVersionDocumentStore;
-import org.finos.calm.store.util.VersionScheme;
 import org.finos.calm.store.util.SearchTextMatcher;
 import org.finos.calm.store.util.TypeSafeNitriteDocument;
 import org.slf4j.Logger;
@@ -31,9 +26,10 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * <p>
  * Searches across 7 resource collections by matching the query (case-insensitive)
  * against the {@code name} and {@code description} fields of each resource entry.
- * For ADRs, the {@code title} field of the latest revision is searched.
- * Controls are scoped by domain rather than namespace, so they bypass the
- * readable-namespaces filter.
+ * ADR's header carries a denormalized copy of the latest revision's title (see
+ * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}), so it reads the
+ * same as every other type. Controls are scoped by domain rather than namespace, so they
+ * bypass the readable-namespaces filter.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -49,23 +45,6 @@ public class NitriteSearchStore implements SearchStore {
     private final NitriteCollection interfaceCollection;
     private final NitriteCollection controlCollection;
     private final NitriteCollection adrCollection;
-    /**
-     * Read-only. Do not add a write path through this field.
-     *
-     * <p>This is a second {@link NitriteVersionDocumentStore} over the same two collections
-     * {@link NitriteAdrStore} uses, and the two carry independent
-     * {@link java.util.concurrent.locks.ReentrantReadWriteLock}s. Writes are safe there only
-     * because that store's lock serialises every writer; a write issued through this instance
-     * would take a different lock and so would not be serialised against them, reintroducing
-     * the duplicate-revision race the lock exists to prevent — {@code createVersion}'s
-     * check-then-act would no longer be atomic with respect to the other instance.</p>
-     *
-     * <p>Reads need no such coordination, which is why two instances are tolerable at all. If
-     * this ever needs to write, share {@code NitriteAdrStore}'s instance rather than widening
-     * this one.</p>
-     */
-    private final NitriteVersionDocumentStore adrDocuments;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Inject
     public NitriteSearchStore(@StandaloneQualifier Nitrite db) {
@@ -76,8 +55,6 @@ public class NitriteSearchStore implements SearchStore {
         this.interfaceCollection = db.getCollection("interfaces");
         this.controlCollection = db.getCollection("controls");
         this.adrCollection = db.getCollection("adrs");
-        this.adrDocuments = new NitriteVersionDocumentStore(adrCollection,
-                db.getCollection("adrVersions"), "adrId", "ADR", VersionScheme.NUMERIC);
         LOG.info("NitriteSearchStore initialized");
     }
 
@@ -181,8 +158,12 @@ public class NitriteSearchStore implements SearchStore {
     }
 
     /**
-     * ADR searches on the latest revision's title. See
-     * {@code MongoSearchStore.searchAdrCollection} for why this goes through the helper.
+     * ADR's header carries a denormalized copy of the latest revision's title (written by
+     * {@code NitriteAdrStore} on every version write — see
+     * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}), so this reads
+     * exactly like {@link #searchHeaderCollection} rather than resolving the version
+     * collection per header. The {@code "ADR " + adrId} fallback only fires for a header
+     * that predates both the write-path change and its one-time migration backfill.
      */
     private List<SearchResult> searchAdrCollection(String lowerQuery, Optional<Set<String>> readableNamespaces) {
         List<SearchResult> results = new ArrayList<>();
@@ -197,18 +178,13 @@ public class NitriteSearchStore implements SearchStore {
             }
             Integer adrId = header.get("adrId", Integer.class);
             if (adrId == null) {
-                // SearchResult takes a primitive id, and resolving the latest revision would
-                // unbox this too. An ADR with no id is not addressable, so it is not a result.
+                // SearchResult takes a primitive id, so a header missing its id field would
+                // unbox to a NullPointerException. An ADR with no id is not addressable.
                 continue;
             }
-            String title = "ADR " + adrId;
-
-            String latest = adrDocuments.getLatestVersionContent(namespace, adrId);
-            if (latest != null) {
-                String documentTitle = titleOf(latest);
-                if (documentTitle != null) {
-                    title = documentTitle;
-                }
+            String title = header.get("name", String.class);
+            if (title == null) {
+                title = "ADR " + adrId;
             }
 
             if (SearchTextMatcher.containsIgnoreCase(title, lowerQuery)) {
@@ -217,26 +193,5 @@ public class NitriteSearchStore implements SearchStore {
         }
 
         return results;
-    }
-
-    /**
-     * Reads an ADR revision's title with the same parser {@code NitriteAdrStore} uses.
-     *
-     * <p>Deliberately Jackson rather than {@code org.bson.Document.parse}: the two disagree
-     * about what is readable, so a BSON-only parse here would show a title in the ADR
-     * listing and a bare "ADR n" in search results for the same document. BSON also has no
-     * business in the Nitrite path, which stores content as a plain JSON string.</p>
-     *
-     * @return the title from a stored ADR revision, or {@code null} if it cannot be read.
-     * Content is a JSON string in this backend, so the field has to be parsed out; a search
-     * must not fail because one ADR's content is unreadable.
-     */
-    private String titleOf(String content) {
-        try {
-            JsonNode title = objectMapper.readTree(content).get("title");
-            return title == null || !title.isTextual() ? null : title.asText();
-        } catch (JsonProcessingException | RuntimeException e) {
-            return null;
-        }
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrTitleBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrTitleBackfillStepShould.java
@@ -59,9 +59,10 @@ class TestMongoAdrTitleBackfillStepShould {
         step.databaseMode = "mongo";
     }
 
-    private void stubUntitledHeaders(List<Document> headers) {
+    /** Every header the collection holds — the step filters untitled ones out itself. */
+    private void stubHeaders(List<Document> headers) {
         FindIterable<Document> iterable = mock(DocumentFindIterable.class);
-        when(headerCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(headerCollection.find()).thenReturn(iterable);
         when(iterable.projection(any())).thenReturn(iterable);
         doAnswer(invocation -> {
             Consumer<Document> consumer = invocation.getArgument(0);
@@ -94,23 +95,38 @@ class TestMongoAdrTitleBackfillStepShould {
 
         step.apply();
 
-        verify(headerCollection, never()).find(any(Bson.class));
+        verify(headerCollection, never()).find();
     }
 
     @Test
-    void query_for_headers_with_no_name() {
-        stubUntitledHeaders(List.of());
+    void skip_a_header_that_already_has_a_title() {
+        stubHeaders(List.of(new Document("namespace", "finos").append("adrId", 1).append("name", "Already Titled")));
 
         step.backfill();
 
-        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
-        verify(headerCollection).find(filterCaptor.capture());
-        assertThat(filterCaptor.getValue().toBsonDocument().toJson(), containsString("name"));
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
     }
 
     @Test
     void write_the_resolved_title_onto_an_untitled_header() throws Exception {
-        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubRevisions(List.of("1"), new Document("title", "Resolved Title"));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        step.backfill();
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().toBsonDocument().toJson(), containsString("Resolved Title"));
+    }
+
+    @Test
+    void write_the_resolved_title_onto_a_header_with_a_blank_title() throws Exception {
+        // A header with name: "   " must be picked up the same as one with no name field at
+        // all — "untitled" is null-or-blank everywhere else in this change, and a Mongo
+        // query for "missing or null" alone would leave a blank title stuck forever.
+        stubHeaders(List.of(new Document("namespace", "finos").append("adrId", 1).append("name", "   ")));
         stubRevisions(List.of("1"), new Document("title", "Resolved Title"));
         when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenReturn(UpdateResult.acknowledged(1, 1L, null));
@@ -124,7 +140,7 @@ class TestMongoAdrTitleBackfillStepShould {
 
     @Test
     void default_to_untitled_adr_when_the_latest_revision_has_no_title() throws Exception {
-        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
         stubRevisions(List.of("1"), new Document("status", "draft"));
         when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenReturn(UpdateResult.acknowledged(1, 1L, null));
@@ -138,7 +154,7 @@ class TestMongoAdrTitleBackfillStepShould {
 
     @Test
     void default_to_untitled_adr_when_there_is_no_readable_revision() throws Exception {
-        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
         stubRevisions(List.of(), null);
         when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
                 .thenReturn(UpdateResult.acknowledged(1, 1L, null));
@@ -152,7 +168,7 @@ class TestMongoAdrTitleBackfillStepShould {
 
     @Test
     void skip_a_malformed_header_with_no_namespace_or_adr_id() {
-        stubUntitledHeaders(List.of(new Document("adrId", 1)));
+        stubHeaders(List.of(new Document("adrId", 1)));
 
         step.backfill();
 

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrTitleBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoAdrTitleBackfillStepShould.java
@@ -1,0 +1,161 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * See {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}. Backfills the
+ * title {@code MongoAdrStore} now denormalizes onto every write, for headers that predate
+ * that change.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoAdrTitleBackfillStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    private MongoDatabase database;
+    private MongoCollection<Document> headerCollection;
+    private MongoCollection<Document> versionCollection;
+    private MongoAdrTitleBackfillStep step;
+
+    @BeforeEach
+    void setup() {
+        database = mock(MongoDatabase.class);
+        headerCollection = mock(DocumentMongoCollection.class);
+        versionCollection = mock(DocumentMongoCollection.class);
+        when(database.getCollection("adrs")).thenReturn(headerCollection);
+        when(database.getCollection("adrVersions")).thenReturn(versionCollection);
+
+        step = new MongoAdrTitleBackfillStep(database);
+        step.databaseMode = "mongo";
+    }
+
+    private void stubUntitledHeaders(List<Document> headers) {
+        FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+        when(headerCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            headers.forEach(consumer);
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    /** Revision documents as listVersions sees them, plus the content getVersion returns. */
+    private void stubRevisions(List<String> revisions, Document latestContent) {
+        FindIterable<Document> iterable = mock(DocumentFindIterable.class);
+        when(versionCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any())).thenReturn(iterable);
+        when(iterable.first()).thenReturn(latestContent == null ? null : new Document("content", latestContent));
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            revisions.forEach(revision -> consumer.accept(new Document("version", revision)));
+            return null;
+        }).when(iterable).forEach(any());
+    }
+
+    @Test
+    void run_at_schema_version_ten() {
+        assertThat(step.fromVersion(), is(10));
+    }
+
+    @Test
+    void skip_the_backfill_when_database_mode_is_not_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verify(headerCollection, never()).find(any(Bson.class));
+    }
+
+    @Test
+    void query_for_headers_with_no_name() {
+        stubUntitledHeaders(List.of());
+
+        step.backfill();
+
+        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).find(filterCaptor.capture());
+        assertThat(filterCaptor.getValue().toBsonDocument().toJson(), containsString("name"));
+    }
+
+    @Test
+    void write_the_resolved_title_onto_an_untitled_header() throws Exception {
+        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubRevisions(List.of("1"), new Document("title", "Resolved Title"));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        step.backfill();
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().toBsonDocument().toJson(), containsString("Resolved Title"));
+    }
+
+    @Test
+    void default_to_untitled_adr_when_the_latest_revision_has_no_title() throws Exception {
+        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubRevisions(List.of("1"), new Document("status", "draft"));
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        step.backfill();
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().toBsonDocument().toJson(), containsString("Untitled ADR"));
+    }
+
+    @Test
+    void default_to_untitled_adr_when_there_is_no_readable_revision() throws Exception {
+        stubUntitledHeaders(List.of(new Document("namespace", "finos").append("adrId", 1)));
+        stubRevisions(List.of(), null);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        step.backfill();
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).updateOne(any(Bson.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().toBsonDocument().toJson(), containsString("Untitled ADR"));
+    }
+
+    @Test
+    void skip_a_malformed_header_with_no_namespace_or_adr_id() {
+        stubUntitledHeaders(List.of(new Document("adrId", 1)));
+
+        step.backfill();
+
+        verify(headerCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrTitleBackfillStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestNitriteAdrTitleBackfillStepShould.java
@@ -1,0 +1,162 @@
+package org.finos.calm.migration.steps;
+
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * NitriteDB counterpart to {@code TestMongoAdrTitleBackfillStepShould}. See
+ * {@code calm-hub/decisions/0006-denormalize-adr-title-onto-header.md}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestNitriteAdrTitleBackfillStepShould {
+
+    private NitriteCollection headerCollection;
+    private NitriteCollection versionCollection;
+    private NitriteAdrTitleBackfillStep step;
+
+    @BeforeEach
+    void setup() {
+        Nitrite db = mock(Nitrite.class);
+        headerCollection = mock(NitriteCollection.class);
+        versionCollection = mock(NitriteCollection.class);
+        when(db.getCollection("adrs")).thenReturn(headerCollection);
+        when(db.getCollection("adrVersions")).thenReturn(versionCollection);
+
+        step = new NitriteAdrTitleBackfillStep(db);
+    }
+
+    private void stubHeaders(List<Document> headers) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headerCollection.find()).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> headers.iterator());
+    }
+
+    /** Revision documents as listVersions sees them, plus the content getVersion returns. */
+    private void stubRevisions(List<String> revisions, String latestContent) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(versionCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(
+                latestContent == null ? null : Document.createDocument().put("content", latestContent));
+        when(cursor.iterator()).thenAnswer(invocation ->
+                revisions.stream().map(r -> Document.createDocument().put("version", r)).iterator());
+    }
+
+    /** The header lookup {@code updatePresentHeaderDetails} performs before writing. */
+    private void stubHeaderLookup(Document header) {
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(headerCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(header);
+    }
+
+    @Test
+    void run_at_schema_version_ten() {
+        // Matches the Mongo step's version. The two never coexist — each is gated on a
+        // different calm.database.mode.
+        assertThat(step.fromVersion(), is(10));
+    }
+
+    @Test
+    void apply_delegates_to_backfill() {
+        stubHeaders(List.of());
+
+        step.apply();
+
+        verify(headerCollection).find();
+    }
+
+    @Test
+    void default_to_untitled_adr_when_the_latest_revision_content_is_not_readable_json() throws Exception {
+        Document header = Document.createDocument().put("namespace", "finos").put("adrId", 1);
+        stubHeaders(List.of(header));
+        stubHeaderLookup(header);
+        stubRevisions(List.of("1"), "{not valid json");
+
+        step.backfill();
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().get("name", String.class), is("Untitled ADR"));
+    }
+
+    @Test
+    void skip_a_header_that_already_has_a_title() {
+        stubHeaders(List.of(Document.createDocument()
+                .put("namespace", "finos").put("adrId", 1).put("name", "Already Titled")));
+
+        step.backfill();
+
+        verify(headerCollection, never()).find(any(Filter.class));
+    }
+
+    @Test
+    void write_the_resolved_title_onto_an_untitled_header() throws Exception {
+        Document header = Document.createDocument().put("namespace", "finos").put("adrId", 1);
+        stubHeaders(List.of(header));
+        stubHeaderLookup(header);
+        stubRevisions(List.of("1"), "{\"title\": \"Resolved Title\"}");
+
+        step.backfill();
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().get("name", String.class), is("Resolved Title"));
+    }
+
+    @Test
+    void default_to_untitled_adr_when_the_latest_revision_has_no_title() throws Exception {
+        Document header = Document.createDocument().put("namespace", "finos").put("adrId", 1);
+        stubHeaders(List.of(header));
+        stubHeaderLookup(header);
+        stubRevisions(List.of("1"), "{\"status\": \"draft\"}");
+
+        step.backfill();
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().get("name", String.class), is("Untitled ADR"));
+    }
+
+    @Test
+    void default_to_untitled_adr_when_there_is_no_readable_revision() throws Exception {
+        Document header = Document.createDocument().put("namespace", "finos").put("adrId", 1);
+        stubHeaders(List.of(header));
+        stubHeaderLookup(header);
+        stubRevisions(List.of(), null);
+
+        step.backfill();
+
+        ArgumentCaptor<Document> updateCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).update(any(Filter.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().get("name", String.class), is("Untitled ADR"));
+    }
+
+    @Test
+    void skip_a_malformed_header_with_no_namespace_or_adr_id() {
+        stubHeaders(List.of(Document.createDocument().put("adrId", 1)));
+
+        step.backfill();
+
+        verify(headerCollection, never()).update(any(Filter.class), any(Document.class));
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -224,6 +224,37 @@ public class TestMongoAdrStoreShould {
     }
 
     @Test
+    void denormalize_the_title_onto_the_header_at_creation() throws Exception {
+        // See calm-hub/decisions/0006-denormalize-adr-title-onto-header.md: unlike every
+        // other type, ADR has no name of its own to write onto the header at creation — it
+        // has to be resolved from the ADR content instead.
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft)));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().getString("name"), is("New"));
+    }
+
+    @Test
+    void default_the_header_title_to_untitled_adr_when_the_first_revision_has_none() throws Exception {
+        when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
+        when(headerCollection.updateOne(any(Bson.class), any(Bson.class)))
+                .thenReturn(UpdateResult.acknowledged(1, 1L, null));
+
+        store.createAdrForNamespace(adrMeta(1, adr(null, Status.draft)));
+
+        // There's no existing header title a blank one could instead leave standing — this
+        // is the one write establishing it for the first time.
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insertOne(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().getString("name"), is("Untitled ADR"));
+    }
+
+    @Test
     void remove_the_header_again_when_the_first_revision_write_fails() {
         when(counterStore.getNextAdrSequenceValue()).thenReturn(99);
         doAnswer(invocation -> {
@@ -378,6 +409,35 @@ public class TestMongoAdrStoreShould {
 
         assertThat(updated.getRevision(), is(2));
         assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+    }
+
+    @Test
+    void refresh_the_header_title_on_a_new_revision() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1", "2"), contentOf("Existing", Status.accepted));
+
+        store.updateAdrForNamespace(adrMeta(1, adr("Rewritten", Status.draft)));
+
+        ArgumentCaptor<Bson> updateCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection, Mockito.atLeastOnce()).updateOne(any(Bson.class), updateCaptor.capture());
+        boolean sawTheNewTitle = updateCaptor.getAllValues().stream()
+                .anyMatch(update -> update.toBsonDocument().toJson().contains("Rewritten"));
+        assertThat(sawTheNewTitle, is(true));
+    }
+
+    @Test
+    void leave_the_header_title_alone_when_a_new_revision_has_none() throws Exception {
+        adrExists();
+        stubRevisions(List.of("1"), contentOf("Existing", Status.draft));
+
+        // updatePresentHeaderDetails no-ops on a blank title rather than overwriting a real
+        // one with a placeholder — no title-update call should reach headerCollection at all.
+        store.updateAdrForNamespace(adrMeta(1, adr(null, Status.draft)));
+
+        boolean sawATitleUpdate = Mockito.mockingDetails(headerCollection).getInvocations().stream()
+                .filter(invocation -> invocation.getMethod().getName().equals("updateOne"))
+                .anyMatch(invocation -> ((Bson) invocation.getArgument(1)).toBsonDocument().toJson().contains("name"));
+        assertThat(sawATitleUpdate, is(false));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -20,9 +20,6 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,9 +49,6 @@ class TestMongoSearchStoreShould {
     @Mock
     private MongoCollection<Document> adrCollection;
 
-    @Mock
-    private MongoCollection<Document> adrVersionCollection;
-
     private MongoSearchStore searchStore;
 
     @BeforeEach
@@ -67,26 +61,7 @@ class TestMongoSearchStoreShould {
         when(database.getCollection("interfaces")).thenReturn(interfaceCollection);
         when(database.getCollection("controls")).thenReturn(controlCollection);
         when(database.getCollection("adrs")).thenReturn(adrCollection);
-        when(database.getCollection("adrVersions")).thenReturn(adrVersionCollection);
         searchStore = new MongoSearchStore(database);
-    }
-
-    /**
-     * Stubs the adrVersions collection the ADR search reads through: the revision list that
-     * ranks them, and the winning revision's content.
-     */
-    @SuppressWarnings("unchecked")
-    private void mockAdrRevisions(List<String> revisions, Document latestContent) {
-        FindIterable<Document> findIterable = mock(FindIterable.class);
-        when(adrVersionCollection.find(any(org.bson.conversions.Bson.class))).thenReturn(findIterable);
-        when(findIterable.projection(any())).thenReturn(findIterable);
-        when(findIterable.first()).thenReturn(
-                latestContent == null ? null : new Document("content", latestContent));
-        doAnswer(invocation -> {
-            java.util.function.Consumer<Document> consumer = invocation.getArgument(0);
-            revisions.forEach(revision -> consumer.accept(new Document("version", revision)));
-            return null;
-        }).when(findIterable).forEach(any());
     }
 
     private static Document architectureHeader(int id, String name, String description) {
@@ -236,13 +211,14 @@ class TestMongoSearchStoreShould {
     }
 
     @Test
-    void search_adr_by_latest_revision_title() {
-        // ADR reads its title from the latest revision's content, so the fixture needs a
-        // header and a revision document rather than one namespace-wide document.
+    void search_adr_by_its_denormalized_header_title() {
+        // ADR's header carries a denormalized copy of the latest revision's title (see
+        // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md), so this reads it
+        // straight off the header like every other type — no version collection involved.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", 1)));
-        mockAdrRevisions(List.of("1"), new Document("title", "Use Event Sourcing"));
+        mockCollectionFind(adrCollection, List.of(
+                new Document("namespace", "finos").append("adrId", 1).append("name", "Use Event Sourcing")));
 
         GroupedSearchResults results = searchStore.search("event");
 
@@ -251,17 +227,33 @@ class TestMongoSearchStoreShould {
     }
 
     @Test
-    void search_adr_uses_latest_revision_when_multiple_exist() {
+    void fall_back_to_a_placeholder_title_when_an_adr_header_has_none() {
+        // Only reachable for a header that predates both the write-path denormalization and
+        // its one-time migration backfill.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", 1)));
-        // Two revisions; the search must read the later one's title.
-        mockAdrRevisions(List.of("1", "2"), new Document("title", "New Title"));
+        mockCollectionFind(adrCollection, List.of(new Document("namespace", "finos").append("adrId", 7)));
 
-        GroupedSearchResults results = searchStore.search("New");
+        GroupedSearchResults results = searchStore.search("ADR 7");
 
         assertEquals(1, results.getAdrs().size());
-        assertEquals("New Title", results.getAdrs().get(0).getName());
+        assertEquals("ADR 7", results.getAdrs().get(0).getName());
+    }
+
+    @Test
+    void cap_adr_results_at_max_per_type() {
+        List<Document> headers = new ArrayList<>();
+        for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
+            headers.add(new Document("namespace", "finos").append("adrId", i).append("name", "Match " + i));
+        }
+
+        mockCollectionFind(adrCollection, headers);
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+
+        GroupedSearchResults results = searchStore.search("match");
+
+        assertEquals(SearchStore.MAX_RESULTS_PER_TYPE, results.getAdrs().size());
     }
 
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoSearchStoreShould.java
@@ -241,6 +241,21 @@ class TestMongoSearchStoreShould {
     }
 
     @Test
+    void fall_back_to_a_placeholder_title_when_an_adr_header_title_is_blank() {
+        // "Untitled" is null-or-blank everywhere else in this change; a header whose title
+        // somehow ended up blank must fall back the same way a missing one does.
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+        mockCollectionFind(adrCollection, List.of(
+                new Document("namespace", "finos").append("adrId", 7).append("name", "   ")));
+
+        GroupedSearchResults results = searchStore.search("ADR 7");
+
+        assertEquals(1, results.getAdrs().size());
+        assertEquals("ADR 7", results.getAdrs().get(0).getName());
+    }
+
+    @Test
     void cap_adr_results_at_max_per_type() {
         List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
@@ -212,6 +212,33 @@ public class TestNitriteAdrStoreShould {
         assertThat(captor.getValue().get("version", String.class), is("1"));
     }
 
+    @Test
+    public void denormalize_the_title_onto_the_header_at_creation() throws Exception {
+        // See calm-hub/decisions/0006-denormalize-adr-title-onto-header.md.
+        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", 99).put("versionCount", 0)));
+        stubRevisions(List.of(), null);
+
+        store.createAdrForNamespace(adrMeta(1, adr("New", Status.draft)));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("name", String.class), is("New"));
+    }
+
+    @Test
+    public void default_the_header_title_to_untitled_adr_when_the_first_revision_has_none() throws Exception {
+        when(mockCounterStore.getNextAdrSequenceValue()).thenReturn(99);
+        stubFind(headerCollection, List.of(Document.createDocument().put("adrId", 99).put("versionCount", 0)));
+        stubRevisions(List.of(), null);
+
+        store.createAdrForNamespace(adrMeta(1, adr(null, Status.draft)));
+
+        ArgumentCaptor<Document> headerCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(headerCollection).insert(headerCaptor.capture());
+        assertThat(headerCaptor.getValue().get("name", String.class), is("Untitled ADR"));
+    }
+
     // --- reads ---
 
     @Test
@@ -313,6 +340,29 @@ public class TestNitriteAdrStoreShould {
 
         assertThat(updated.getRevision(), is(2));
         assertThat(updated.getAdr().getStatus(), is(Status.accepted));
+    }
+
+    @Test
+    public void refresh_the_header_title_on_a_new_revision() throws Exception {
+        adrExists();
+        stubRevisionsForUpdate(List.of("1", "2"), contentOf("Existing", Status.accepted));
+
+        store.updateAdrForNamespace(adrMeta(1, adr("Rewritten", Status.draft)));
+
+        // Two header writes: the versionCount increment and the title refresh.
+        verify(headerCollection, org.mockito.Mockito.times(2)).update(any(Filter.class), any(Document.class));
+    }
+
+    @Test
+    public void leave_the_header_title_alone_when_a_new_revision_has_none() throws Exception {
+        adrExists();
+        stubRevisionsForUpdate(List.of("1"), contentOf("Existing", Status.draft));
+
+        // updatePresentHeaderDetails no-ops on a blank title, so only the versionCount
+        // increment writes the header.
+        store.updateAdrForNamespace(adrMeta(1, adr(null, Status.draft)));
+
+        verify(headerCollection, org.mockito.Mockito.times(1)).update(any(Filter.class), any(Document.class));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -4,7 +4,6 @@ import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
-import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.search.GroupedSearchResults;
 import org.finos.calm.domain.search.SearchResult;
 import org.finos.calm.store.SearchStore;
@@ -21,8 +20,6 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,9 +49,6 @@ class TestNitriteSearchStoreShould {
     @Mock
     private NitriteCollection adrCollection;
 
-    @Mock
-    private NitriteCollection adrVersionCollection;
-
     private NitriteSearchStore searchStore;
 
     @BeforeEach
@@ -67,18 +61,7 @@ class TestNitriteSearchStoreShould {
         when(db.getCollection("interfaces")).thenReturn(interfaceCollection);
         when(db.getCollection("controls")).thenReturn(controlCollection);
         when(db.getCollection("adrs")).thenReturn(adrCollection);
-        when(db.getCollection("adrVersions")).thenReturn(adrVersionCollection);
         searchStore = new NitriteSearchStore(db);
-    }
-
-    /** Stubs the adrVersions collection: the revision list, and the latest revision's content. */
-    private void mockAdrRevisions(List<String> revisions, String latestContent) {
-        DocumentCursor cursor = mock(DocumentCursor.class);
-        when(adrVersionCollection.find(any(Filter.class))).thenReturn(cursor);
-        when(cursor.firstOrNull()).thenReturn(
-                latestContent == null ? null : Document.createDocument("content", latestContent));
-        when(cursor.iterator()).thenAnswer(invocation ->
-                revisions.stream().map(r -> Document.createDocument("version", r)).iterator());
     }
 
     private static Document architectureHeader(int id, String name, String description) {
@@ -186,13 +169,14 @@ class TestNitriteSearchStoreShould {
     }
 
     @Test
-    void search_adr_by_latest_revision_title() {
-        // ADR reads its title from the latest revision's content, held here as a JSON string.
+    void search_adr_by_its_denormalized_header_title() {
+        // ADR's header carries a denormalized copy of the latest revision's title (see
+        // calm-hub/decisions/0006-denormalize-adr-title-onto-header.md), so this reads it
+        // straight off the header like every other type — no version collection involved.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
         mockCollectionFind(adrCollection, List.of(
-                Document.createDocument("namespace", "finos").put("adrId", 1)));
-        mockAdrRevisions(List.of("1"), "{\"title\": \"Use Event Sourcing\"}");
+                Document.createDocument("namespace", "finos").put("adrId", 1).put("name", "Use Event Sourcing")));
 
         GroupedSearchResults results = searchStore.search("event");
 
@@ -201,18 +185,33 @@ class TestNitriteSearchStoreShould {
     }
 
     @Test
-    void search_adr_uses_latest_revision_when_multiple_exist() {
+    void fall_back_to_a_placeholder_title_when_an_adr_header_has_none() {
+        // Only reachable for a header that predates both the write-path denormalization and
+        // its one-time migration backfill.
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
-        mockCollectionFind(adrCollection, List.of(
-                Document.createDocument("namespace", "finos").put("adrId", 1)));
-        // Two revisions; the search must read the later one's title.
-        mockAdrRevisions(List.of("1", "2"), "{\"title\": \"New Title\"}");
+        mockCollectionFind(adrCollection, List.of(Document.createDocument("namespace", "finos").put("adrId", 7)));
 
-        GroupedSearchResults results = searchStore.search("New");
+        GroupedSearchResults results = searchStore.search("ADR 7");
 
         assertEquals(1, results.getAdrs().size());
-        assertEquals("New Title", results.getAdrs().get(0).getName());
+        assertEquals("ADR 7", results.getAdrs().get(0).getName());
+    }
+
+    @Test
+    void cap_adr_results_at_max_per_type() {
+        List<Document> headers = new ArrayList<>();
+        for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {
+            headers.add(Document.createDocument("namespace", "finos").put("adrId", i).put("name", "Match " + i));
+        }
+
+        mockCollectionFind(adrCollection, headers);
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+
+        GroupedSearchResults results = searchStore.search("match");
+
+        assertEquals(SearchStore.MAX_RESULTS_PER_TYPE, results.getAdrs().size());
     }
 
     @Test
@@ -367,10 +366,8 @@ class TestNitriteSearchStoreShould {
         mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
                 standardCollection, interfaceCollection, controlCollection);
         mockCollectionFind(adrCollection, List.of(
-                Document.createDocument("namespace", "finos").put("adrId", 1),
-                Document.createDocument("namespace", "secret-ns").put("adrId", 2)));
-        // Both resolve to the same stubbed title; the filter is what decides the result.
-        mockAdrRevisions(List.of("1"), "{\"title\": \"Allowed ADR\"}");
+                Document.createDocument("namespace", "finos").put("adrId", 1).put("name", "Allowed ADR"),
+                Document.createDocument("namespace", "secret-ns").put("adrId", 2).put("name", "Allowed ADR")));
 
         GroupedSearchResults results = searchStore.search("ADR",
                 Optional.of(Set.of("finos")));

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteSearchStoreShould.java
@@ -199,6 +199,21 @@ class TestNitriteSearchStoreShould {
     }
 
     @Test
+    void fall_back_to_a_placeholder_title_when_an_adr_header_title_is_blank() {
+        // "Untitled" is null-or-blank everywhere else in this change; a header whose title
+        // somehow ended up blank must fall back the same way a missing one does.
+        mockEmptyCollections(architectureCollection, patternCollection, flowCollection,
+                standardCollection, interfaceCollection, controlCollection);
+        mockCollectionFind(adrCollection, List.of(
+                Document.createDocument("namespace", "finos").put("adrId", 7).put("name", "   ")));
+
+        GroupedSearchResults results = searchStore.search("ADR 7");
+
+        assertEquals(1, results.getAdrs().size());
+        assertEquals("ADR 7", results.getAdrs().get(0).getName());
+    }
+
+    @Test
     void cap_adr_results_at_max_per_type() {
         List<Document> headers = new ArrayList<>();
         for (int i = 0; i < SearchStore.MAX_RESULTS_PER_TYPE + 10; i++) {


### PR DESCRIPTION
## Description
Postponed from #2935.

`searchAdrCollection` resolved every ADR header's latest revision to read its title, costing 2 extra DB round trips per header (`1 + 2N` total for `N` ADRs scanned).

Every other versioned type (Architecture, Pattern, Flow, Standard, Interface, Timeline) already denormalizes its display field onto the header at write time via `updateHeaderDetails`/`updatePresentHeaderDetails`. ADR was the one type that never did - its header was created with `createHeader(namespace, id, null, null)` and never updated again.

This PR makes ADR consistent with its six siblings instead of adding a new batched read path exclusively for it:

- `MongoAdrStore`/`NitriteAdrStore` now write the title onto the header on every create/update (first version falls back to `"Untitled ADR"` if none is given; a later revision that omits a title leaves the header's existing title standing, via `updatePresentHeaderDetails`'s existing no-op-on-blank behaviour).
- New one-time migration steps (`MongoAdrTitleBackfillStep` / `NitriteAdrTitleBackfillStep`, schema version 10 → 11) backfill every existing ADR header that has no title yet.
- `searchAdrCollection` on both backends now reads `header.name` directly — one query, structurally identical to `searchHeaderCollection`, no version-collection reads or Nitrite lock contention at all.
- `calm-hub/mongo/init-mongo.js` seed data and `LATEST_SCHEMA_VERSION` updated to match.
- New [ADR 0006](calm-hub/decisions/0006-denormalize-adr-title-onto-header.md) records the reasoning, including why this doesn't reopen [ADR 0001](calm-hub/decisions/0001-versioned-artefact-storage.md)'s rejection of a `latestVersion` pointer — it follows the precedent 0001 already set for `versionCount` (a real, read-heavy consumer justifies a narrow denormalized field), not a pointer into the version collection.

Closes #2946

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [x] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
Commit follows `fix(calm-hub): ...` conventional commit format.

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Ran `../mvnw clean verify -Ddependency-check.skip=true` — 2616 tests, 0 failures, JaCoCo 90%-per-class coverage gate passes on all touched classes. Not run: `-P integration verify` (requires Docker, not available in this environment) — worth a maintainer/CI check given the migration step touches real Mongo/Nitrite behavior.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary (new ADR 0006 + decisions/README.md index)
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards