### PR TITLE
fix(vscode): apply pre-release flag when packaging, not just publishing

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -69,12 +69,8 @@ jobs:
             - name: Install workspace
               run: npm ci
 
-            - name: Package VS Code Extension
-              run: npm run package:vscode
-
             - name: Determine pre-release flag
               id: prerelease
-              if: github.event.inputs.publish_to_marketplace == 'true'
               working-directory: ./calm-plugins/vscode
               run: |
                   case "${{ github.event.inputs.pre_release }}" in
@@ -93,6 +89,12 @@ jobs:
                       fi
                       ;;
                   esac
+
+            - name: Package VS Code Extension
+              run: |
+                  npm run build:shared
+                  npm run build --workspace calm-plugins/vscode
+                  (cd calm-plugins/vscode && npx @vscode/vsce package ${{ steps.prerelease.outputs.flag }} --no-dependencies)
 
             - name: Publish to VS Code Marketplace
               if: github.event.inputs.publish_to_marketplace == 'true'


### PR DESCRIPTION
## Description
The [VS Code extension publish workflow failed](https://github.com/finos/architecture-as-code/actions/runs/31325506556/job/93275268016) with:

```
Cannot use '--pre-release' flag with a package that was not packaged as pre-release. Please package it using the '--pre-release' flag and publish again.
```

`vsce` requires `--pre-release` to match between `vsce package` and `vsce publish` for the same artifact. #2957 added a `Determine pre-release flag` step that auto-resolves the flag from version parity (odd minor = pre-release, e.g. current `0.9.0`), but it was only wired into the `Publish to VS Code Marketplace` step — the `Package VS Code Extension` step still ran `npm run package:vscode`, which always packages without `--pre-release`. Once the auto-detected flag resolved to `--pre-release`, the mismatch broke publishing.

This moves the `Determine pre-release flag` step earlier (dropping its `publish_to_marketplace == 'true'` guard, since it's a cheap check) and applies its output to both the package and publish steps.

The documentation I read on this seemed to imply (or it was my reading of it) that `--pre-release` was not required on both. My mistake!

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [x] CI/CD

## Commit Message Format ✅
- Commit follows conventional commit format: `fix(vscode): ...`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Verified locally (Node 26) by running the same commands the workflow now runs:
```
npm run build:shared
npm run build --workspace calm-plugins/vscode
(cd calm-plugins/vscode && npx @vscode/vsce package --pre-release --no-dependencies)
```
and confirmed the resulting `.vsix`'s `extension.vsixmanifest` has `Microsoft.VisualStudio.Code.PreRelease="true"`. Also verified packaging with an empty flag (the release path) still succeeds.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards