### PR TITLE
chore: enforce spacing inside braces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,15 @@ For complete details on our commit message rules, see our [`commitlint.config.js
 - Update documentation if you're adding new features
 - Consider the appropriate scope for your changes
 
+### Import Formatting
+
+Use spaces inside named-import braces. ESLint enforces this consistently across
+the TypeScript workspaces:
+
+```typescript
+import { CalmWidget } from './types';
+```
+
 ## Responsible Use of AI Coding Assistants
 
 AI coding assistants are welcome, but their output must be treated as draft input. Before submitting a PR, contributors must understand and be able to explain all changes, validate behaviour with the project's required checks, and review the full diff for correctness, security, privacy, licensing, and dependency impact.

--- a/calm-guard/eslint.config.mjs
+++ b/calm-guard/eslint.config.mjs
@@ -19,6 +19,11 @@ const config = [
       '.planning/**',
     ],
   },
+  {
+    rules: {
+      'object-curly-spacing': ['error', 'always'],
+    },
+  },
   ...compat.extends('next/core-web-vitals'),
 ];
 

--- a/calm-models/eslint.config.mjs
+++ b/calm-models/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
             "linebreak-style": ["error", "unix"],
             quotes: ["error", "single"],
             semi: ["error", "always"],
+            "object-curly-spacing": ["error", "always"],
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [
                 "error",

--- a/calm-models/src/model/control.spec.ts
+++ b/calm-models/src/model/control.spec.ts
@@ -1,7 +1,7 @@
 import { CalmControl, CalmControlDetail } from './control.js';
 import { CalmControls } from './control';
-import {CalmControlsSchema} from '../types/control-types';
-import {Resolvable} from './resolvable';
+import { CalmControlsSchema } from '../types/control-types';
+import { Resolvable } from './resolvable';
 
 describe('CalmControls', () => {
     const controlsSchema:CalmControlsSchema = {

--- a/calm-models/src/model/control.ts
+++ b/calm-models/src/model/control.ts
@@ -1,6 +1,6 @@
 import { Resolvable } from './resolvable.js';
-import {CalmAdaptable} from './adaptable.js';
-import {CalmControlDetailSchema, CalmControlSchema, CalmControlsSchema} from '../types';
+import { CalmAdaptable } from './adaptable.js';
+import { CalmControlDetailSchema, CalmControlSchema, CalmControlsSchema } from '../types';
 import {
     CalmControlCanonicalModel,
     CalmControlDetailCanonicalModel,

--- a/calm-models/src/model/core.spec.ts
+++ b/calm-models/src/model/core.spec.ts
@@ -1,6 +1,6 @@
 import { CalmCoreSchema } from '../types/core-types.js';
 import { CalmCore } from './core.js';
-import {ResolvableAndAdaptable} from './resolvable';
+import { ResolvableAndAdaptable } from './resolvable';
 
 describe('CalmCore', () => {
     it('should create from minimal schema', () => {

--- a/calm-models/src/model/core.ts
+++ b/calm-models/src/model/core.ts
@@ -5,7 +5,7 @@ import { CalmRelationship } from './relationship.js';
 import { CalmControls } from './control.js';
 import { CalmFlow } from './flow.js';
 import { CalmCoreSchema } from '../types/core-types.js';
-import {CalmCoreCanonicalModel} from '../canonical/template-models.js';
+import { CalmCoreCanonicalModel } from '../canonical/template-models.js';
 
 export type Architecture = CalmCore
 

--- a/calm-models/src/model/flow.ts
+++ b/calm-models/src/model/flow.ts
@@ -1,8 +1,8 @@
 import { CalmFlowSchema, CalmFlowTransitionSchema } from '../types';
 import { CalmAdaptable } from './adaptable.js';
-import {CalmFlowCanonicalModel, CalmFlowTransitionCanonicalModel} from '../canonical/template-models.js';
-import {CalmControls} from './control.js';
-import {CalmMetadata} from './metadata.js';
+import { CalmFlowCanonicalModel, CalmFlowTransitionCanonicalModel } from '../canonical/template-models.js';
+import { CalmControls } from './control.js';
+import { CalmMetadata } from './metadata.js';
 
 export type CalmFlowDirection = 'source-to-destination' | 'destination-to-source';
 

--- a/calm-models/src/model/interface.spec.ts
+++ b/calm-models/src/model/interface.spec.ts
@@ -125,7 +125,7 @@ describe('CalmNodeInterface', () => {
         const schema: CalmNodeInterfaceSchema = { node: 'node-2' };
         const ni = CalmNodeInterface.fromSchema(schema);
         expect(ni.interfaces).toBeUndefined();
-        expect(ni.toCanonicalSchema()).toEqual({ node: 'node-2'});
+        expect(ni.toCanonicalSchema()).toEqual({ node: 'node-2' });
     });
 });
 

--- a/calm-models/src/model/interface.ts
+++ b/calm-models/src/model/interface.ts
@@ -6,8 +6,8 @@ import {
 } from '../types';
 
 import { CalmAdaptable } from './adaptable.js';
-import {CalmInterfaceSchema} from '../types';
-import {CalmInterfaceCanonicalModel, CalmNodeInterfaceCanonicalModel} from '../canonical/template-models.js';
+import { CalmInterfaceSchema } from '../types';
+import { CalmInterfaceCanonicalModel, CalmNodeInterfaceCanonicalModel } from '../canonical/template-models.js';
 
 export abstract class CalmInterface {
     protected constructor(public uniqueId: string) {}

--- a/calm-models/src/model/metadata.ts
+++ b/calm-models/src/model/metadata.ts
@@ -1,6 +1,6 @@
 import { CalmMetadataSchema } from '../types/metadata-types.js';
 import { CalmAdaptable } from './adaptable.js';
-import {CalmMetadataCanonicalModel} from '../canonical/template-models.js';
+import { CalmMetadataCanonicalModel } from '../canonical/template-models.js';
 
 export class CalmMetadata implements CalmAdaptable<CalmMetadataSchema,CalmMetadataCanonicalModel> {
     constructor(

--- a/calm-models/src/model/node.spec.ts
+++ b/calm-models/src/model/node.spec.ts
@@ -1,7 +1,7 @@
 import { CalmNode, CalmNodeDetails } from './node.js';
-import {CalmNodeSchema, CalmNodeDetailsSchema} from '../types/core-types.js';
-import {ResolvableAndAdaptable} from './resolvable';
-import {CalmCore} from './core';
+import { CalmNodeSchema, CalmNodeDetailsSchema } from '../types/core-types.js';
+import { ResolvableAndAdaptable } from './resolvable';
+import { CalmCore } from './core';
 
 describe('CalmNodeDetails', () => {
     it('should create from schema with both fields', () => {

--- a/calm-models/src/model/node.ts
+++ b/calm-models/src/model/node.ts
@@ -2,14 +2,14 @@ import { CalmInterface } from './interface.js';
 import { CalmControls } from './control.js';
 import { CalmMetadata } from './metadata.js';
 import { CalmCore } from './core.js';
-import {ResolvableAndAdaptable} from './resolvable.js';
+import { ResolvableAndAdaptable } from './resolvable.js';
 import {
     CalmCoreSchema,
     CalmNodeDetailsSchema,
     CalmNodeSchema
 } from '../types';
-import {CalmAdaptable, NullSchema} from './adaptable.js';
-import {CalmNodeCanonicalModel} from '../canonical/template-models.js';
+import { CalmAdaptable, NullSchema } from './adaptable.js';
+import { CalmNodeCanonicalModel } from '../canonical/template-models.js';
 
 export type CalmNodeType =
     | 'actor'

--- a/calm-models/src/model/relationship.spec.ts
+++ b/calm-models/src/model/relationship.spec.ts
@@ -7,7 +7,7 @@ import {
     CalmOptionsRelationshipType,
     CalmDecisionType
 } from './relationship.js';
-import { CalmRelationshipSchema} from '../types/core-types.js';
+import { CalmRelationshipSchema } from '../types/core-types.js';
 import { CalmNodeInterface } from './interface.js';
 
 describe('CalmRelationship (hibernate-model)', () => {

--- a/calm-models/src/model/relationship.ts
+++ b/calm-models/src/model/relationship.ts
@@ -1,5 +1,5 @@
 import { CalmMetadata } from './metadata.js';
-import { CalmControls} from './control.js';
+import { CalmControls } from './control.js';
 import { CalmNodeInterface } from './interface.js';
 import {
     CalmComposedOfRelationshipSchema,
@@ -12,7 +12,7 @@ import {
     CalmRelationshipTypeSchema
 } from '../types/core-types.js';
 import { CalmAdaptable } from './adaptable.js';
-import {CalmRelationshipCanonicalModel, CalmRelationshipTypeCanonicalModel, CalmDecisionCanonicalModel} from '../canonical/template-models.js';
+import { CalmRelationshipCanonicalModel, CalmRelationshipTypeCanonicalModel, CalmDecisionCanonicalModel } from '../canonical/template-models.js';
 
 export class CalmRelationship
 implements CalmAdaptable<CalmRelationshipSchema, CalmRelationshipCanonicalModel> {
@@ -97,7 +97,7 @@ export class CalmInteractsType extends CalmRelationshipType
     }
 
     toCanonicalSchema(): CalmRelationshipTypeCanonicalModel {
-        return { interacts: { actor: this.actor, nodes: this.nodes }};
+        return { interacts: { actor: this.actor, nodes: this.nodes } };
     }
 
     static fromSchema(schema: CalmInteractsRelationshipSchema): CalmInteractsType {
@@ -123,7 +123,7 @@ export class CalmConnectsType extends CalmRelationshipType
     }
 
     toCanonicalSchema(): CalmRelationshipTypeCanonicalModel {
-        return { connects: { source: this.source.toCanonicalSchema(), destination: this.destination.toCanonicalSchema() }};
+        return { connects: { source: this.source.toCanonicalSchema(), destination: this.destination.toCanonicalSchema() } };
     }
 
     static fromSchema(schema: CalmConnectsRelationshipSchema): CalmConnectsType {
@@ -152,7 +152,7 @@ export class CalmDeployedInType extends CalmRelationshipType
     }
 
     toCanonicalSchema(): CalmRelationshipTypeCanonicalModel {
-        return { 'deployed-in': { container: this.container, nodes: this.nodes }};
+        return { 'deployed-in': { container: this.container, nodes: this.nodes } };
     }
 
     static fromSchema(schema: CalmDeployedInRelationshipSchema): CalmDeployedInType {
@@ -176,7 +176,7 @@ export class CalmComposedOfType extends CalmRelationshipType
     }
 
     toCanonicalSchema(): CalmRelationshipTypeCanonicalModel {
-        return { 'composed-of': { container: this.container, nodes: this.nodes }};
+        return { 'composed-of': { container: this.container, nodes: this.nodes } };
     }
 
     static fromSchema(schema: CalmComposedOfRelationshipSchema): CalmComposedOfType {

--- a/calm-models/src/types/flow-types.ts
+++ b/calm-models/src/types/flow-types.ts
@@ -1,5 +1,5 @@
-import {CalmControlsSchema} from './control-types.js';
-import {CalmMetadataSchema} from './metadata-types.js';
+import { CalmControlsSchema } from './control-types.js';
+import { CalmMetadataSchema } from './metadata-types.js';
 
 export type CalmFlowTransitionDirectionSchema =  'source-to-destination' | 'destination-to-source';
 

--- a/calm-plugins/vscode/eslint.config.mjs
+++ b/calm-plugins/vscode/eslint.config.mjs
@@ -6,6 +6,11 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
     { ignores: ['dist', 'node_modules', '**/*.vsix'] },
     {
+        rules: {
+            'object-curly-spacing': ['error', 'always'],
+        },
+    },
+    {
         // Webview (React) sources — browser environment.
         extends: [js.configs.recommended, ...tseslint.configs.recommended],
         files: ['src/webview/**/*.{ts,tsx}'],

--- a/calm-server/eslint.config.mjs
+++ b/calm-server/eslint.config.mjs
@@ -40,6 +40,7 @@ export default [
             "linebreak-style": ["error", "unix"],
             quotes: ["error", "single"],
             semi: ["error", "always"],
+            "object-curly-spacing": ["error", "always"],
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [
               "error",

--- a/calm-server/src/server/routes/validation-route.spec.ts
+++ b/calm-server/src/server/routes/validation-route.spec.ts
@@ -207,7 +207,7 @@ describe('ValidationRouter', () => {
 
         const response = await request(localApp)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}) });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }) });
 
         expect(response.status).toBe(500);
         expect(response.body.error).toContain('Failed to validate architecture');
@@ -267,7 +267,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
     test('should return 400 when pattern JSON is invalid', async () => {
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}), pattern: 'not valid json {' });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }), pattern: 'not valid json {' });
             
         expect(response.status).toBe(400);
         expect(response.body).toEqual({
@@ -278,7 +278,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
     test('should return 400 when $id is missing from the pattern', async () => {
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}), pattern: '{}' });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }), pattern: '{}' });
             
         expect(response.status).toBe(400);
         expect(response.body).toEqual({
@@ -289,7 +289,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
     test('should return 400 when $schema in architecture does not match $id in pattern', async () => {
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}), pattern: JSON.stringify({ $id: 'https://example.com/different-schema' }) });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }), pattern: JSON.stringify({ $id: 'https://example.com/different-schema' }) });
             
         expect(response.status).toBe(400);
         expect(response.body).toEqual({
@@ -313,7 +313,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
 
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}), pattern: JSON.stringify({ $id: 'https://example.com/schema' }) });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }), pattern: JSON.stringify({ $id: 'https://example.com/schema' }) });
             
         expect(response.status).toBe(500);
         expect(response.body).toEqual({
@@ -380,7 +380,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
         const pattern = JSON.stringify({
             $id: 'example schema',
             type: 'object',
-            properties: { nodes: { type: 'array', minItems: 99} },
+            properties: { nodes: { type: 'array', minItems: 99 } },
             required: ['nodes']
         });
 
@@ -395,7 +395,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
     test('should return 400 when the parsed architecture is not an object', async () => {
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: 'null', pattern: JSON.stringify({ $id: 'https://example.com/schema'}) });
+            .send({ architecture: 'null', pattern: JSON.stringify({ $id: 'https://example.com/schema' }) });
 
         expect(response.status).toBe(400);
         expect(response.body).toEqual({
@@ -406,7 +406,7 @@ describe('ValidationRouter - /calm/validate with a pattern', () => {
     test('should return 400 when the parsed pattern is not an object', async () => {
         const response = await request(app)
             .post('/calm/validate')
-            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema'}), pattern: '42' });
+            .send({ architecture: JSON.stringify({ $schema: 'https://example.com/schema' }), pattern: '42' });
 
         expect(response.status).toBe(400);
         expect(response.body).toEqual({

--- a/calm-widgets/eslint.config.mjs
+++ b/calm-widgets/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
             "linebreak-style": ["error", "unix"],
             quotes: ["error", "single"],
             semi: ["error", "always"],
+            "object-curly-spacing": ["error", "always"],
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [
               "error",

--- a/calm-widgets/src/widgets/block-architecture/core/utils.ts
+++ b/calm-widgets/src/widgets/block-architecture/core/utils.ts
@@ -1,4 +1,4 @@
-import {CalmNodeCanonicalModel, CalmNodeInterfaceCanonicalModel} from '@finos/calm-models/canonical';
+import { CalmNodeCanonicalModel, CalmNodeInterfaceCanonicalModel } from '@finos/calm-models/canonical';
 
 /**
  * Convert an identifier (e.g. "my_service-id") into a human-friendly label. Useful for rendering node names when an explicit label is not provided.

--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
             "linebreak-style": ["error", "unix"],
             quotes: ["error", "single"],
             semi: ["error", "always"],
+            "object-curly-spacing": ["error", "always"],
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [
               "error",

--- a/shared/eslint.config.mjs
+++ b/shared/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
             "linebreak-style": ["error", "unix"],
             quotes: ["error", "single"],
             semi: ["error", "always"],
+            "object-curly-spacing": ["error", "always"],
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [
               "error",

--- a/shared/src/commands/generate/components/instantiate.spec.ts
+++ b/shared/src/commands/generate/components/instantiate.spec.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach, Mock} from 'vitest';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import * as fs from 'fs';
 import { instantiate } from './instantiate'; // replace with actual relative path
 import { SchemaDirectory } from '../../../schema-directory';
@@ -234,7 +234,7 @@ describe('instantiate', () => {
                             },
                             required: ['key']
                         },
-                        { const: [ 'nested-array' ]},
+                        { const: [ 'nested-array' ] },
                     ]
                 }
             }

--- a/shared/src/commands/generate/components/options.spec.ts
+++ b/shared/src/commands/generate/components/options.spec.ts
@@ -26,7 +26,7 @@ const applicationYtoZ: CalmChoice = {
     relationships: ['application-y-to-z']
 };
 
-function buildPatternChoice({description, nodes, relationships}: CalmChoice) {
+function buildPatternChoice({ description, nodes, relationships }: CalmChoice) {
     return {
         'properties': {
             'description': {

--- a/shared/src/docify/graphing/control-registry.spec.ts
+++ b/shared/src/docify/graphing/control-registry.spec.ts
@@ -1,8 +1,8 @@
 import { ControlRegistry } from './control-registry';
 import { CalmCore, Architecture, CalmNode, CalmRelationship, CalmFlow, CalmControls } from '@finos/calm-models/model';
-import { CalmControlsSchema} from '@finos/calm-models/types';
+import { CalmControlsSchema } from '@finos/calm-models/types';
 import { InMemoryResolver } from '../../resolver/calm-reference-resolver';
-import {DereferencingVisitor} from '../../model-visitor/dereference-visitor';
+import { DereferencingVisitor } from '../../model-visitor/dereference-visitor';
 
 describe('ControlRegistry', () => {
     let controlRegistry: ControlRegistry;

--- a/shared/src/model-visitor/dereference-visitor.spec.ts
+++ b/shared/src/model-visitor/dereference-visitor.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { DereferencingVisitor } from './dereference-visitor';
-import { CalmCore, Resolvable, ResolvableAndAdaptable} from '@finos/calm-models/model';
+import { CalmCore, Resolvable, ResolvableAndAdaptable } from '@finos/calm-models/model';
 import { InMemoryResolver } from '../resolver/calm-reference-resolver';
-import {CalmCoreSchema} from '@finos/calm-models/types';
-import {CalmCoreCanonicalModel} from '@finos/calm-models/canonical';
+import { CalmCoreSchema } from '@finos/calm-models/types';
+import { CalmCoreCanonicalModel } from '@finos/calm-models/canonical';
 
 // Use the same architecture as in the LoggingVisitor test
 const testArch = {

--- a/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.spec.ts
@@ -23,15 +23,15 @@ describe('idsAreUnique', () => {
                     nodes: [
                         {
                             'unique-id': 'node1',
-                            'interfaces': [{'unique-id': 'intf1'}]
+                            'interfaces': [{ 'unique-id': 'intf1' }]
                         },
                         {
                             'unique-id': 'node2'
                         }
                     ],
                     relationships: [
-                        {'unique-id': 'rel1'},
-                        {'unique-id': 'rel2'}
+                        { 'unique-id': 'rel1' },
+                        { 'unique-id': 'rel2' }
                     ]
                 }
             }
@@ -47,8 +47,8 @@ describe('idsAreUnique', () => {
             document: {
                 data: {
                     nodes: [
-                        {'unique-id': 'node1'},
-                        {'unique-id': 'node1'}
+                        { 'unique-id': 'node1' },
+                        { 'unique-id': 'node1' }
                     ]
                 }
             }
@@ -65,8 +65,8 @@ describe('idsAreUnique', () => {
             document: {
                 data: {
                     relationships: [
-                        {'unique-id': 'rel1'},
-                        {'unique-id': 'rel1'}
+                        { 'unique-id': 'rel1' },
+                        { 'unique-id': 'rel1' }
                     ]
                 }
             }
@@ -86,11 +86,11 @@ describe('idsAreUnique', () => {
                     nodes: [
                         {
                             'unique-id': 'node1',
-                            'interfaces': [{'unique-id': 'intf1'}]
+                            'interfaces': [{ 'unique-id': 'intf1' }]
                         },
                         {
                             'unique-id': 'node2',
-                            'interfaces': [{'unique-id': 'intf1'}]
+                            'interfaces': [{ 'unique-id': 'intf1' }]
                         }
                     ]
                 }
@@ -110,12 +110,12 @@ describe('idsAreUnique', () => {
             document: {
                 data: {
                     nodes: [
-                        {'unique-id': 'node1'},
-                        {'unique-id': 'node2'}
+                        { 'unique-id': 'node1' },
+                        { 'unique-id': 'node2' }
                     ],
                     relationships: [
-                        {'unique-id': 'node1'},
-                        {'unique-id': 'rel2'}
+                        { 'unique-id': 'node1' },
+                        { 'unique-id': 'rel2' }
                     ]
                 }
             }

--- a/shared/src/spectral/functions/architecture/ids-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/ids-are-unique.ts
@@ -10,9 +10,9 @@ export function idsAreUnique(input: unknown, _: unknown, context: RulesetFunctio
         return [];
     }
     // get uniqueIds of all nodes
-    const nodeIdMatches = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data as object, resultType: 'all'});
-    const relationshipIdMatches = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data as object, resultType: 'all'});
-    const interfaceIdMatches = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object, resultType: 'all'});
+    const nodeIdMatches = JSONPath({ path: '$.nodes[*].unique-id', json: context.document.data as object, resultType: 'all' });
+    const relationshipIdMatches = JSONPath({ path: '$.relationships[*].unique-id', json: context.document.data as object, resultType: 'all' });
+    const interfaceIdMatches = JSONPath({ path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object, resultType: 'all' });
 
     const seenIds = new Set();
 

--- a/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists-on-node.spec.ts
@@ -50,7 +50,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'} // will match this interface
+                                { 'unique-id': 'intf1' } // will match this interface
                             ]
                         }
                     ]
@@ -67,7 +67,7 @@ describe('interfaceIdExistsOnNode', () => {
         const context = {
             document: {
                 data: {
-                    nodes: [{'unique-id': 'node1'}]
+                    nodes: [{ 'unique-id': 'node1' }]
                 }
             },
             path: ['/relationships/0/connects/destination']
@@ -87,7 +87,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]
@@ -111,7 +111,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]
@@ -132,7 +132,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]
@@ -156,7 +156,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]
@@ -179,7 +179,7 @@ describe('interfaceIdExistsOnNode', () => {
                         {
                             'unique-id': 'node1',
                             'interfaces': [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]

--- a/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists.spec.ts
@@ -23,7 +23,7 @@ describe('interfaceIdExists', () => {
                         {
                             'unique-id': 'node1',
                             interfaces: [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]
@@ -44,7 +44,7 @@ describe('interfaceIdExists', () => {
                         {
                             'unique-id': 'node1',
                             interfaces: [
-                                {'unique-id': 'intf1'}
+                                { 'unique-id': 'intf1' }
                             ]
                         }
                     ]

--- a/shared/src/spectral/functions/architecture/interface-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/interface-id-exists.ts
@@ -10,7 +10,7 @@ export function interfaceIdExists(input: unknown, _: unknown, context: RulesetFu
     }
 
     // get uniqueIds of all interfaces
-    const names = JSONPath({path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object});
+    const names = JSONPath({ path: '$.nodes[*].interfaces[*].unique-id', json: context.document.data as object });
     const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {

--- a/shared/src/spectral/functions/architecture/node-has-relationship.ts
+++ b/shared/src/spectral/functions/architecture/node-has-relationship.ts
@@ -7,7 +7,7 @@ import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-cor
 export function nodeHasRelationship(input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] {
     const nodeName = input;
 
-    const relationshipLabels = JSONPath({path: '$.relationships[*].relationship-type..*@string()', json: context.document.data as object});
+    const relationshipLabels = JSONPath({ path: '$.relationships[*].relationship-type..*@string()', json: context.document.data as object });
     const results: IFunctionResult[] = [];
     if (!relationshipLabels) {
         return [{

--- a/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/node-id-exists.spec.ts
@@ -20,7 +20,7 @@ describe('nodeIdExists', () => {
             document: {
                 data: {
                     nodes: [
-                        {'unique-id': 'node1'}
+                        { 'unique-id': 'node1' }
                     ]
                 }
             }
@@ -36,7 +36,7 @@ describe('nodeIdExists', () => {
             document: {
                 data: {
                     nodes: [
-                        {'unique-id': 'node1'}
+                        { 'unique-id': 'node1' }
                     ]
                 }
             },

--- a/shared/src/spectral/functions/architecture/node-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/node-id-exists.ts
@@ -9,7 +9,7 @@ export function nodeIdExists(input: unknown, _: unknown, context: RulesetFunctio
         return [];
     }
     // get uniqueIds of all nodes
-    const names = JSONPath({path: '$.nodes[*].unique-id', json: context.document.data as object});
+    const names = JSONPath({ path: '$.nodes[*].unique-id', json: context.document.data as object });
     const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {

--- a/shared/src/spectral/functions/architecture/relationship-id-exists.spec.ts
+++ b/shared/src/spectral/functions/architecture/relationship-id-exists.spec.ts
@@ -20,7 +20,7 @@ describe('relationshipIdExists', () => {
             document: {
                 data: {
                     relationships: [
-                        {'unique-id': 'relationship1'}
+                        { 'unique-id': 'relationship1' }
                     ]
                 }
             }
@@ -36,7 +36,7 @@ describe('relationshipIdExists', () => {
             document: {
                 data: {
                     relationships: [
-                        {'unique-id': 'relationship1'}
+                        { 'unique-id': 'relationship1' }
                     ]
                 }
             },

--- a/shared/src/spectral/functions/architecture/relationship-id-exists.ts
+++ b/shared/src/spectral/functions/architecture/relationship-id-exists.ts
@@ -10,7 +10,7 @@ export function relationshipIdExists(input: unknown, _: unknown, context: Rulese
     }
 
     // get uniqueIds of all relationships
-    const names = JSONPath({path: '$.relationships[*].unique-id', json: context.document.data as object});
+    const names = JSONPath({ path: '$.relationships[*].unique-id', json: context.document.data as object });
     const results: IFunctionResult[] = [];
 
     if (!names.includes(input)) {

--- a/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
+++ b/shared/src/spectral/functions/architecture/sequence-numbers-are-unique.ts
@@ -9,7 +9,7 @@ export function sequenceNumbersAreUnique(input: unknown, _: unknown, context: Ru
         return [];
     }
     // get sequence-number of all transitions
-    const sequenceNumbers = JSONPath({path: '$[*].sequence-number', json: input as object, resultType: 'all'});
+    const sequenceNumbers = JSONPath({ path: '$[*].sequence-number', json: input as object, resultType: 'all' });
 
     const seen = new Set();
     const messages: IFunctionResult[] = [];

--- a/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.spec.ts
@@ -23,17 +23,17 @@ describe('idsAreUnique', () => {
                     properties: {
                         nodes: {
                             prefixItems: [
-                                {'properties': {
-                                    'unique-id': {'const': 'node1'},
-                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                { 'properties': {
+                                    'unique-id': { 'const': 'node1' },
+                                    'interfaces': { prefixItems: [{ 'properties': { 'unique-id': { 'const': 'intf1' } } }] } }
                                 },
-                                {'properties': {'unique-id': {'const': 'node2'}}}
+                                { 'properties': { 'unique-id': { 'const': 'node2' } } }
                             ]
                         },
                         relationships: {
                             prefixItems: [
-                                {'properties': {'unique-id': {'const': 'rel1'}}},
-                                {'properties': {'unique-id': {'const': 'rel2'}}}
+                                { 'properties': { 'unique-id': { 'const': 'rel1' } } },
+                                { 'properties': { 'unique-id': { 'const': 'rel2' } } }
                             ]
                         }
                     }
@@ -53,8 +53,8 @@ describe('idsAreUnique', () => {
                     properties: {
                         nodes: {
                             prefixItems: [
-                                {'properties': {'unique-id': {'const': 'node1'}}},
-                                {'properties': {'unique-id': {'const': 'node1'}}}
+                                { 'properties': { 'unique-id': { 'const': 'node1' } } },
+                                { 'properties': { 'unique-id': { 'const': 'node1' } } }
                             ]
                         }
                     }
@@ -75,8 +75,8 @@ describe('idsAreUnique', () => {
                     properties: {
                         relationships: {
                             prefixItems: [
-                                {'properties': {'unique-id': {'const': 'rel1'}}},
-                                {'properties': {'unique-id': {'const': 'rel1'}}}
+                                { 'properties': { 'unique-id': { 'const': 'rel1' } } },
+                                { 'properties': { 'unique-id': { 'const': 'rel1' } } }
                             ]
                         }
                     }
@@ -98,13 +98,13 @@ describe('idsAreUnique', () => {
                     properties: {
                         nodes: {
                             prefixItems: [
-                                {'properties': {
-                                    'unique-id': {'const': 'node1'},
-                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                { 'properties': {
+                                    'unique-id': { 'const': 'node1' },
+                                    'interfaces': { prefixItems: [{ 'properties': { 'unique-id': { 'const': 'intf1' } } }] } }
                                 },
-                                {'properties': {
-                                    'unique-id': {'const': 'node2'},
-                                    'interfaces': {prefixItems: [{'properties': {'unique-id': {'const': 'intf1'}}}]}}
+                                { 'properties': {
+                                    'unique-id': { 'const': 'node2' },
+                                    'interfaces': { prefixItems: [{ 'properties': { 'unique-id': { 'const': 'intf1' } } }] } }
                                 }
                             ]
                         }
@@ -128,14 +128,14 @@ describe('idsAreUnique', () => {
                     properties: {
                         nodes: {
                             prefixItems: [
-                                {'properties': {'unique-id': {'const': 'node1'}}},
-                                {'properties': {'unique-id': {'const': 'node2'}}}
+                                { 'properties': { 'unique-id': { 'const': 'node1' } } },
+                                { 'properties': { 'unique-id': { 'const': 'node2' } } }
                             ]
                         },
                         relationships: {
                             prefixItems: [
-                                {'properties': {'unique-id': {'const': 'node1'}}},
-                                {'properties': {'unique-id': {'const': 'rel2'}}}
+                                { 'properties': { 'unique-id': { 'const': 'node1' } } },
+                                { 'properties': { 'unique-id': { 'const': 'rel2' } } }
                             ]
                         }
                     }

--- a/shared/src/spectral/functions/pattern/ids-are-unique.ts
+++ b/shared/src/spectral/functions/pattern/ids-are-unique.ts
@@ -9,9 +9,9 @@ export default (input: unknown, _: unknown, context: RulesetFunctionContext): IF
         return [];
     }
     // get uniqueIds of all nodes
-    const nodeIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
-    const relationshipIdMatches = JSONPath({path: '$.properties.relationships.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
-    const interfaceIdMatches = JSONPath({path: '$.properties.nodes.prefixItems[*].properties.interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all'});
+    const nodeIdMatches = JSONPath({ path: '$.properties.nodes.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all' });
+    const relationshipIdMatches = JSONPath({ path: '$.properties.relationships.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all' });
+    const interfaceIdMatches = JSONPath({ path: '$.properties.nodes.prefixItems[*].properties.interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object, resultType: 'all' });
 
     const seenIds = new Set();
 

--- a/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists-on-node.spec.ts
@@ -51,10 +51,10 @@ describe('interfaceIdExistsOnNode', () => {
                             prefixItems: [
                                 {
                                     properties: {
-                                        'unique-id': {const: 'node1'},
+                                        'unique-id': { const: 'node1' },
                                         'interfaces': {
                                             prefixItems: [
-                                                {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                                                { properties: { 'unique-id': { const: 'intf1' } } } // will match this interface
                                             ]
                                         }
                                     }
@@ -80,7 +80,7 @@ describe('interfaceIdExistsOnNode', () => {
                             prefixItems: [
                                 {
                                     properties: {
-                                        'unique-id': {const: 'node1'}
+                                        'unique-id': { const: 'node1' }
                                     }
                                 }
                             ]
@@ -106,10 +106,10 @@ describe('interfaceIdExistsOnNode', () => {
                             prefixItems: [
                                 {
                                     properties: {
-                                        'unique-id': {const: 'node1'},
+                                        'unique-id': { const: 'node1' },
                                         'interfaces': {
                                             prefixItems: [
-                                                {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                                                { properties: { 'unique-id': { const: 'intf1' } } } // will match this interface
                                             ]
                                         }
                                     }
@@ -138,10 +138,10 @@ describe('interfaceIdExistsOnNode', () => {
                             prefixItems: [
                                 {
                                     properties: {
-                                        'unique-id': {const: 'node1'},
+                                        'unique-id': { const: 'node1' },
                                         'interfaces': {
                                             prefixItems: [
-                                                {properties: {'unique-id': {const: 'intf1'}}}
+                                                { properties: { 'unique-id': { const: 'intf1' } } }
                                             ]
                                         }
                                     }

--- a/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists.spec.ts
@@ -21,7 +21,7 @@ describe('interfaceIdExists', () => {
                 data: {
                     interfaces: {
                         prefixItems: [
-                            {properties: {'unique-id': {const: 'intf1'}}} // will match this interface
+                            { properties: { 'unique-id': { const: 'intf1' } } } // will match this interface
                         ]
                     }
                 }
@@ -39,7 +39,7 @@ describe('interfaceIdExists', () => {
                 data: {
                     interfaces: {
                         prefixItems: [
-                            {properties: {'unique-id': {const: 'intf1'}}}
+                            { properties: { 'unique-id': { const: 'intf1' } } }
                         ]
                     }
                 }

--- a/shared/src/spectral/functions/pattern/interface-id-exists.ts
+++ b/shared/src/spectral/functions/pattern/interface-id-exists.ts
@@ -9,7 +9,7 @@ export function interfaceIdExists(input: unknown, _: unknown, context: RulesetFu
         return [];
     }
     // get uniqueIds of all interfaces
-    const uniqueIds = JSONPath({path: '$..interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object});
+    const uniqueIds = JSONPath({ path: '$..interfaces.prefixItems[*].properties.unique-id.const', json: context.document.data as object });
     const results: IFunctionResult[] = [];
 
     if (!uniqueIds.includes(input)) {

--- a/shared/src/spectral/functions/pattern/node-has-relationship.ts
+++ b/shared/src/spectral/functions/pattern/node-has-relationship.ts
@@ -7,7 +7,7 @@ import { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-cor
 export default (input: unknown, _: unknown, context: RulesetFunctionContext): IFunctionResult[] => {
     const nodeId = input;
 
-    const referencedNodeIds = JSONPath({path: '$..relationship-type..*@string()', json: context.document.data as object});
+    const referencedNodeIds = JSONPath({ path: '$..relationship-type..*@string()', json: context.document.data as object });
 
     const results: IFunctionResult[] = [];
     if (!referencedNodeIds) {

--- a/shared/src/spectral/functions/timeline/ids-are-unique.spec.ts
+++ b/shared/src/spectral/functions/timeline/ids-are-unique.spec.ts
@@ -21,8 +21,8 @@ describe('idsAreUnique', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'node1'},
-                        {'unique-id': 'node2'},
+                        { 'unique-id': 'node1' },
+                        { 'unique-id': 'node2' },
                     ]
                 }
             }
@@ -38,9 +38,9 @@ describe('idsAreUnique', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'node1'},
-                        {'unique-id': 'node2'},
-                        {'unique-id': 'node1'}, // duplicate
+                        { 'unique-id': 'node1' },
+                        { 'unique-id': 'node2' },
+                        { 'unique-id': 'node1' }, // duplicate
                     ]
                 }
             }

--- a/shared/src/spectral/functions/timeline/moment-id-exists.spec.ts
+++ b/shared/src/spectral/functions/timeline/moment-id-exists.spec.ts
@@ -20,8 +20,8 @@ describe('momentIdExists', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1'}, // will match this moment
-                        {'unique-id': 'moment2'}
+                        { 'unique-id': 'moment1' }, // will match this moment
+                        { 'unique-id': 'moment2' }
                     ]
                 }
             }
@@ -37,8 +37,8 @@ describe('momentIdExists', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1'},
-                        {'unique-id': 'moment2'}
+                        { 'unique-id': 'moment1' },
+                        { 'unique-id': 'moment2' }
                     ]
                 }
             },

--- a/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.spec.ts
+++ b/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.spec.ts
@@ -34,8 +34,8 @@ describe('validFromNotAfterCurrentMoment', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1'},
-                        {'unique-id': 'moment2'}
+                        { 'unique-id': 'moment1' },
+                        { 'unique-id': 'moment2' }
                     ]
                 }
             }
@@ -51,9 +51,9 @@ describe('validFromNotAfterCurrentMoment', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1', 'valid-from': '2023-01-01'},
-                        {'unique-id': 'moment2'},
-                        {'unique-id': 'moment3'}
+                        { 'unique-id': 'moment1', 'valid-from': '2023-01-01' },
+                        { 'unique-id': 'moment2' },
+                        { 'unique-id': 'moment3' }
                     ]
                 }
             }
@@ -69,9 +69,9 @@ describe('validFromNotAfterCurrentMoment', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1', 'valid-from': '2023-01-01'},
-                        {'unique-id': 'moment2', 'valid-from': '2024-01-01'},
-                        {'unique-id': 'moment3'}
+                        { 'unique-id': 'moment1', 'valid-from': '2023-01-01' },
+                        { 'unique-id': 'moment2', 'valid-from': '2024-01-01' },
+                        { 'unique-id': 'moment3' }
                     ]
                 }
             }
@@ -87,9 +87,9 @@ describe('validFromNotAfterCurrentMoment', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1', 'valid-from': '2023-01-01'},
-                        {'unique-id': 'moment2', 'valid-from': '2024-01-01'},
-                        {'unique-id': 'moment3', 'valid-from': '2025-01-01'}
+                        { 'unique-id': 'moment1', 'valid-from': '2023-01-01' },
+                        { 'unique-id': 'moment2', 'valid-from': '2024-01-01' },
+                        { 'unique-id': 'moment3', 'valid-from': '2025-01-01' }
                     ]
                 }
             }
@@ -105,9 +105,9 @@ describe('validFromNotAfterCurrentMoment', () => {
             document: {
                 data: {
                     moments: [
-                        {'unique-id': 'moment1', 'valid-from': '2023-01-01'},
-                        {'unique-id': 'moment2', 'valid-from': '2024-01-01'},
-                        {'unique-id': 'moment3', 'valid-from': '2025-01-01'}
+                        { 'unique-id': 'moment1', 'valid-from': '2023-01-01' },
+                        { 'unique-id': 'moment2', 'valid-from': '2024-01-01' },
+                        { 'unique-id': 'moment3', 'valid-from': '2025-01-01' }
                     ]
                 }
             }

--- a/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.ts
+++ b/shared/src/spectral/functions/timeline/valid-from-not-after-current-moment.ts
@@ -26,7 +26,7 @@ export function validFromNotAfterCurrentMoment(input: unknown, _: unknown, conte
         }
 
         if (checkingValidFroms) {
-            const validFrom: string = JSONPath({path: '$.valid-from', json: moment, wrap: false }) as string;
+            const validFrom: string = JSONPath({ path: '$.valid-from', json: moment, wrap: false }) as string;
             if (validFrom) {
                 results.push({
                     message: `Moment with unique-id "${momentId}" is after current-moment "${currentMomentId}" but has a valid-from.`

--- a/shared/src/template/template-default-transformer.ts
+++ b/shared/src/template/template-default-transformer.ts
@@ -1,5 +1,5 @@
-import {CalmTemplateTransformer} from './types';
-import {CalmCore} from '@finos/calm-models/model';
+import { CalmTemplateTransformer } from './types';
+import { CalmCore } from '@finos/calm-models/model';
 
 export default class TemplateDefaultTransformer implements CalmTemplateTransformer {
 

--- a/shared/src/template/template-path-extractor.spec.ts
+++ b/shared/src/template/template-path-extractor.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {JsonFragment, TemplatePathExtractor } from './template-path-extractor';
+import { JsonFragment, TemplatePathExtractor } from './template-path-extractor';
 
 const architecture = {
     $schema: 'https://calm.finos.org/workshop/account-system.pattern.json',


### PR DESCRIPTION
## Description

Closes #1502.

Adds `object-curly-spacing: ['error', 'always']` to each flat ESLint configuration, applies the rule with the root `lint-fix` command, and documents the expected import style in `CONTRIBUTING.md`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components

- [x] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [x] CALM Server (`calm-server/`)
- [x] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [x] Shared (`shared/`)
- [x] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

The rule also applies to `calm-models` and `calm-guard`, which are not listed separately above.

## Commit Message Format ✅

The commit uses the conventional `chore:` prefix and includes the required DCO sign-off.

## Testing

- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

Validated in the repository's required Node 26 environment:

- `npm run lint-fix`
- `npm run lint` (zero errors; existing warnings only)
- `git diff --check`

No runtime behavior changed, so I did not add or run unit tests. Cypress installation was disabled for the lint-only container run.

## Checklist

- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

AI assistance was used to apply and validate the mechanical formatting change; I reviewed the resulting diff.
