### PR TITLE
fix(cli): properly configure auth for workspace commands

### DIFF
--- a/cli/src/command-helpers/workspace/commands.spec.ts
+++ b/cli/src/command-helpers/workspace/commands.spec.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => {
         loadManifest: vi.fn(async () => ({})),
         removeDocumentFromManifest: vi.fn(async () => true),
         loadCliConfig: vi.fn(async () => ({ calmHubUrl: 'https://calmhub.example.com' })),
+        loadAuthPlugin: vi.fn(async () => ({ getAuthHeaders: vi.fn(async () => ({})) })),
         CalmHubClient: vi.fn().mockImplementation(function() {
             return { isMockClient: true };
         }),
@@ -89,6 +90,7 @@ vi.mock('../../workspace-resolver', () => ({
 
 vi.mock('../../cli-config', () => ({
     loadCliConfig: mocks.loadCliConfig,
+    loadAuthPlugin: mocks.loadAuthPlugin,
 }));
 
 vi.mock('@finos/calm-shared/src/hub/calm-hub-client', () => ({
@@ -505,6 +507,16 @@ describe('setupWorkspaceCommands', () => {
             });
         });
 
+        it('loads the configured auth plugin and passes it to the CalmHubClient', async () => {
+            mocks.loadCliConfig.mockResolvedValueOnce({ calmHubUrl: 'https://calmhub.example.com', authPluginPath: '/plugins/auth.js' } as never);
+            await program.parseAsync(['node', 'test', 'workspace', 'push']);
+            expect(mocks.loadAuthPlugin).toHaveBeenCalledWith('/plugins/auth.js', false);
+            expect(mocks.CalmHubClient).toHaveBeenCalledWith(expect.objectContaining({
+                calmHubUrl: 'https://calmhub.example.com',
+                authPlugin: expect.objectContaining({ getAuthHeaders: expect.any(Function) }),
+            }));
+        });
+
         it('exits when no workspace bundle is found', async () => {
             mocks.findWorkspaceManifestPath.mockReturnValueOnce(null);
             await expect(program.parseAsync(['node', 'test', 'workspace', 'push'])).rejects.toThrow();
@@ -530,6 +542,17 @@ describe('setupWorkspaceCommands', () => {
             await program.parseAsync(['node', 'test', 'workspace', 'check']);
             expect(mocks.detectChangedResources).toHaveBeenCalledWith('/fake/bundle', expect.objectContaining({ isMockClient: true }));
             expect(exitSpy).not.toHaveBeenCalled();
+        });
+
+        it('loads the configured auth plugin and passes it to the CalmHubClient', async () => {
+            mocks.loadCliConfig.mockResolvedValueOnce({ calmHubUrl: 'https://calmhub.example.com', authPluginPath: '/plugins/auth.js' } as never);
+            mocks.detectChangedResources.mockResolvedValueOnce([]);
+            await program.parseAsync(['node', 'test', 'workspace', 'check']);
+            expect(mocks.loadAuthPlugin).toHaveBeenCalledWith('/plugins/auth.js', false);
+            expect(mocks.CalmHubClient).toHaveBeenCalledWith(expect.objectContaining({
+                calmHubUrl: 'https://calmhub.example.com',
+                authPlugin: expect.objectContaining({ getAuthHeaders: expect.any(Function) }),
+            }));
         });
 
         it('exits 1 when changed documents need bumping', async () => {
@@ -601,6 +624,17 @@ describe('setupWorkspaceCommands', () => {
                 expect.objectContaining({ isMockClient: true }),
                 expect.objectContaining({ increment: 'MINOR', perDocIncrements: expect.any(Map) })
             );
+        });
+
+        it('loads the configured auth plugin and passes it to the CalmHubClient', async () => {
+            mocks.loadCliConfig.mockResolvedValueOnce({ calmHubUrl: 'https://calmhub.example.com', authPluginPath: '/plugins/auth.js' } as never);
+            mocks.detectChangedResources.mockResolvedValueOnce([]);
+            await program.parseAsync(['node', 'test', 'workspace', 'bump']);
+            expect(mocks.loadAuthPlugin).toHaveBeenCalledWith('/plugins/auth.js', false);
+            expect(mocks.CalmHubClient).toHaveBeenCalledWith(expect.objectContaining({
+                calmHubUrl: 'https://calmhub.example.com',
+                authPlugin: expect.objectContaining({ getAuthHeaders: expect.any(Function) }),
+            }));
         });
 
         it('uses the config default increment as the select default', async () => {
@@ -716,7 +750,7 @@ describe('setupWorkspaceCommands', () => {
             mocks.select.mockResolvedValueOnce('MINOR');
             await program.parseAsync(['node', 'test', 'workspace', 'bump', '--inherit-change-type']);
             expect(mocks.bumpWorkspace).toHaveBeenCalled();
-            const callOptions = mocks.bumpWorkspace.mock.calls[0][2];
+            const callOptions = (mocks.bumpWorkspace.mock.calls[0] as unknown[])[2] as { getCascadeIncrement?: unknown };
             expect(callOptions.getCascadeIncrement).toBeUndefined();
         });
     });

--- a/cli/src/command-helpers/workspace/commands.ts
+++ b/cli/src/command-helpers/workspace/commands.ts
@@ -17,6 +17,7 @@ import { CALM_DOCUMENT_TYPES_LIST, isValidCalmDocumentType } from '@finos/calm-m
 import { CalmHubClient, ResourceChangeType } from '@finos/calm-shared/src/hub/calm-hub-client';
 import { isConformantDocumentId, namespaceFromDocumentId } from '@finos/calm-shared/src/hub/document-id-utils';
 import { loadCliConfig } from '../../cli-config';
+import { resolveCalmHubOptions } from '../hub-commands';
 
 const logger: Logger = initLogger(false, 'workspace');
 
@@ -347,13 +348,13 @@ export function setupWorkspaceCommands(program: Command) {
                     process.exit(1);
                 }
 
-                const calmHubUrl = await resolveCalmHubUrl(options.calmHubUrl);
+                const calmHubOptions = await resolveCalmHubOptions({ calmHubUrl: options.calmHubUrl });
 
                 const gitRoot = findGitRoot(process.cwd());
                 const workspaceConfig = gitRoot ? await loadWorkspaceConfig(gitRoot) : undefined;
                 const failIfModified = options.failIfModified ?? workspaceConfig?.push.failIfModified ?? false;
 
-                const client = new CalmHubClient({ calmHubUrl });
+                const client = new CalmHubClient(calmHubOptions);
                 await pushWorkspaceToHub(bundlePath, client, { failIfModified });
             } catch (err) {
                 logger.error('Failed to push workspace: ' + (err instanceof Error ? err.message : String(err)));
@@ -373,8 +374,8 @@ export function setupWorkspaceCommands(program: Command) {
                     process.exit(1);
                 }
 
-                const calmHubUrl = await resolveCalmHubUrl(options.calmHubUrl);
-                const client = new CalmHubClient({ calmHubUrl });
+                const calmHubOptions = await resolveCalmHubOptions({ calmHubUrl: options.calmHubUrl });
+                const client = new CalmHubClient(calmHubOptions);
                 const changed = await detectChangedResources(bundlePath, client);
 
                 let needsBump = false;
@@ -436,14 +437,14 @@ export function setupWorkspaceCommands(program: Command) {
                     process.exit(1);
                 }
 
-                const calmHubUrl = await resolveCalmHubUrl(options.calmHubUrl);
+                const calmHubOptions = await resolveCalmHubOptions({ calmHubUrl: options.calmHubUrl });
 
                 const gitRoot = findGitRoot(process.cwd());
                 const workspaceConfig = gitRoot ? await loadWorkspaceConfig(gitRoot) : undefined;
                 const defaultIncrement: ResourceChangeType =
                     options.major ? 'MAJOR' : options.minor ? 'MINOR' : options.patch ? 'PATCH' : workspaceConfig?.bump.defaultIncrement ?? 'MINOR';
 
-                const client = new CalmHubClient({ calmHubUrl });
+                const client = new CalmHubClient(calmHubOptions);
 
                 // Detect changed resources up-front so interactive prompts can be shown before
                 // any files are written, and to avoid a redundant detection pass inside bumpWorkspace.
@@ -533,20 +534,7 @@ export function setupWorkspaceCommands(program: Command) {
         });
 }
 
-/**
- * Resolve the CalmHub URL from the CLI option or `~/.calm.json`, exiting the process if neither is set.
- */
-async function resolveCalmHubUrl(optionUrl?: string): Promise<string> {
-    const config = await loadCliConfig();
-    const calmHubUrl = optionUrl ?? config?.calmHubUrl;
-    if (!calmHubUrl) {
-        logger.error('No CalmHub URL configured. Use --calm-hub-url or set calmHubUrl in ~/.calm.json');
-        process.exit(1);
-    }
-    return calmHubUrl;
-}
-
-async function enforceOptionPresenceByPrompt(cliInput: string | undefined, prompt: string, choices?: readonly string[]): Promise<string> {
+async function enforceOptionPresenceByPrompt(cliInput: string | undefined, prompt: string, choices?: string[]): Promise<string> {
     if (cliInput) {
         // if it was selected already, just use that
         return cliInput;

--- a/cli/src/command-helpers/workspace/commands.ts
+++ b/cli/src/command-helpers/workspace/commands.ts
@@ -534,7 +534,7 @@ export function setupWorkspaceCommands(program: Command) {
         });
 }
 
-async function enforceOptionPresenceByPrompt(cliInput: string | undefined, prompt: string, choices?: string[]): Promise<string> {
+async function enforceOptionPresenceByPrompt(cliInput: string | undefined, prompt: string, choices?: readonly string[]): Promise<string> {
     if (cliInput) {
         // if it was selected already, just use that
         return cliInput;


### PR DESCRIPTION
## Description
Workspace commands were not previously configuring auth plugins correctly. This PR fixes that by using the same strategy as the hub commands.

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [x] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
