### PR TITLE
feat(calm-hub): add layout persistence support for patterns

### DIFF
--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.test.tsx
@@ -654,17 +654,48 @@ describe('DiagramSection', () => {
             expect(userAccessMock.canWriteNamespace).toHaveBeenCalledWith('arch-namespace');
         });
 
-        it('never shows layout actions for patterns, even with a write grant', async () => {
+        it('shows "Save as default layout" for a pattern once a write grant resolves', async () => {
+            // Numeric id, so this doesn't depend on fetchMappings resolving a slug match —
+            // that path is already covered by the architecture slug tests below.
             userAccessMock.canWriteNamespace.mockReturnValue(true);
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={{ ...patternData, id: '99' }} />
+                </MemoryRouter>
+            );
+
+            await waitFor(() => expect(screen.getByLabelText('Save as default layout')).toBeInTheDocument());
+            expect(userAccessMock.canWriteNamespace).toHaveBeenCalledWith('pattern-namespace');
+        });
+
+        it('shows "Reset to default layout" for patterns regardless of write access, disabled with no scratch layout', async () => {
             render(
                 <MemoryRouter>
                     <DiagramSection data={patternData} />
                 </MemoryRouter>
             );
 
-            await screen.findByTestId('drawer');
-            expect(screen.queryByLabelText('Save as default layout')).not.toBeInTheDocument();
-            expect(screen.queryByLabelText('Reset to default layout')).not.toBeInTheDocument();
+            const resetButton = await screen.findByLabelText('Reset to default layout');
+            expect(resetButton).toBeDisabled();
+        });
+
+        it('shows "Save as default layout" for a pattern on mobile too', async () => {
+            // The mobile view-options menu used to hand-copy the desktop gating condition
+            // instead of reusing showLayoutActions — exactly the kind of drift that would
+            // leave patterns supported on desktop but not mobile.
+            const restore = mockMobileViewport();
+            userAccessMock.canWriteNamespace.mockReturnValue(true);
+            const user = userEvent.setup();
+            render(
+                <MemoryRouter>
+                    <DiagramSection data={{ ...patternData, id: '99' }} />
+                </MemoryRouter>
+            );
+
+            await user.click(screen.getByRole('button', { name: /view options/i }));
+            expect(await screen.findByLabelText('Save as default layout')).toBeInTheDocument();
+            expect(screen.getByLabelText('Reset to default layout')).toBeInTheDocument();
+            restore();
         });
 
         it('shows "Reset to default layout" for architectures regardless of write access, disabled with no scratch layout', async () => {
@@ -686,7 +717,7 @@ describe('DiagramSection', () => {
             );
 
             // Let the slug -> numeric id resolution settle so viewportKey is set
-            // ('arch-namespace/42', per fetchMappings above).
+            // ('arch-namespace/Architectures/42', per fetchMappings above).
             await waitFor(() => expect(calmServiceMock.fetchMappings).toHaveBeenCalled());
             const resetButton = await screen.findByLabelText('Reset to default layout');
             expect(resetButton).toBeDisabled();
@@ -695,7 +726,7 @@ describe('DiagramSection', () => {
             // localStorage first, then report the positions upward via
             // onPositionsChange (a ref-only write in DiagramSection prior to the
             // fix -- no re-render, so the button stayed stuck disabled).
-            saveNodePositions('arch-namespace/42', [{ id: 'node-1', position: { x: 1, y: 2 }, data: {} }] as Node[]);
+            saveNodePositions('arch-namespace/Architectures/42', [{ id: 'node-1', position: { x: 1, y: 2 }, data: {} }] as Node[]);
             const user = userEvent.setup();
             await user.click(screen.getByText('simulate-drag-report'));
 
@@ -712,7 +743,7 @@ describe('DiagramSection', () => {
             await waitFor(() => expect(calmServiceMock.fetchMappings).toHaveBeenCalled());
             const resetButton = await screen.findByLabelText('Reset to default layout');
 
-            saveNodePositions('arch-namespace/42', [{ id: 'node-1', position: { x: 1, y: 2 }, data: {} }] as Node[]);
+            saveNodePositions('arch-namespace/Architectures/42', [{ id: 'node-1', position: { x: 1, y: 2 }, data: {} }] as Node[]);
             const user = userEvent.setup();
             await user.click(screen.getByText('simulate-drag-report'));
             await waitFor(() => expect(resetButton).toBeEnabled());

--- a/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/DiagramSection.tsx
@@ -142,11 +142,13 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel, breadcrumb
     const urlType = isArchitecture ? 'architectures' : 'patterns';
     const typeLabel = isArchitecture ? 'Architecture' : 'Pattern';
 
-    // Save/reset the shared default layout. Cosmetic gating only — see
+    // Save/reset the shared default layout — supported for both architectures
+    // and patterns (backed by separate resources/collections server-side, see
+    // PatternLayoutStore's class javadoc). Cosmetic gating only — see
     // canWriteNamespace's own comment; @PermissionsAllowed(WRITE) on the
     // backend resource is the real gate.
     const { canWriteNamespace } = useUserAccess();
-    const canSaveLayout = isArchitecture && defaultLayoutState.canSave && canWriteNamespace(data.name);
+    const canSaveLayout = defaultLayoutState.canSave && canWriteNamespace(data.name);
 
     // Also re-derive on viewportKey/layoutEpoch changes directly (navigating to
     // a new diagram, or a save/reset bump) so the button reflects reality
@@ -420,9 +422,10 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel, breadcrumb
     );
 
     // Desktop entry point for the shared default layout (mobile's lives in the
-    // view-options menu below). Only meaningful on the diagram tab of an
-    // architecture, and never while comparing versions.
-    const showLayoutActions = !comparing && activeTab === 'diagram' && isArchitecture;
+    // view-options menu below). Only meaningful on the diagram tab, and never
+    // while comparing versions. Not gated on isArchitecture — layout save is
+    // supported for both architectures and patterns.
+    const showLayoutActions = !comparing && activeTab === 'diagram';
     const layoutActions = showLayoutActions && (
         <div className="flex items-center gap-1">
             {canSaveLayout && (
@@ -565,7 +568,7 @@ export function DiagramSection({ data, onItemSelect, hasDetailsPanel, breadcrumb
                                 <span className="flex-1 min-w-0 truncate">Timeline</span>
                             </button>
                         </div>
-                        {!comparing && activeTab === 'diagram' && isArchitecture && (
+                        {showLayoutActions && (
                             <div className="divide-y divide-base-200 border-b border-base-200">
                                 {canSaveLayout && (
                                     <button

--- a/calm-hub-ui/src/hub/hooks/useDefaultLayout.test.tsx
+++ b/calm-hub-ui/src/hub/hooks/useDefaultLayout.test.tsx
@@ -34,15 +34,18 @@ describe('useDefaultLayout', () => {
         vi.clearAllMocks();
     });
 
-    describe('non-architectures', () => {
-        it('never fetches and resolves to no default immediately', async () => {
-            const { result } = renderHook(() => useDefaultLayout(namespace, 'test-pattern', 'Patterns'));
-            expect(result.current.defaultLayout).toBeNull();
-            expect(result.current.viewportKey).toBeUndefined();
-            expect(result.current.canSave).toBe(false);
-            expect(calmServiceMock.fetchMappings).not.toHaveBeenCalled();
-            expect(layoutServiceMock.getDefaultLayout).not.toHaveBeenCalled();
-        });
+    describe('unsupported types', () => {
+        it.each(['Flows', 'ADRs', 'Standards'])(
+            'never fetches and resolves to no default immediately for calmType %s',
+            async (calmType) => {
+                const { result } = renderHook(() => useDefaultLayout(namespace, 'test-id', calmType));
+                expect(result.current.defaultLayout).toBeNull();
+                expect(result.current.viewportKey).toBeUndefined();
+                expect(result.current.canSave).toBe(false);
+                expect(calmServiceMock.fetchMappings).not.toHaveBeenCalled();
+                expect(layoutServiceMock.getDefaultLayout).not.toHaveBeenCalled();
+            }
+        );
     });
 
     describe('numeric id', () => {
@@ -62,7 +65,7 @@ describe('useDefaultLayout', () => {
             expect(result.current.defaultLayout).toBeUndefined(); // loading
             await waitFor(() => expect(result.current.defaultLayout).not.toBeUndefined());
 
-            expect(result.current.viewportKey).toBe('finos/5');
+            expect(result.current.viewportKey).toBe('finos/Architectures/5');
             expect(result.current.defaultLayout).toEqual([{ id: 'node-a', position: { x: 10, y: 20 } }]);
             expect(result.current.canSave).toBe(true);
         });
@@ -83,9 +86,9 @@ describe('useDefaultLayout', () => {
 
             const { result } = renderHook(() => useDefaultLayout(namespace, 'my-arch', 'Architectures'));
 
-            await waitFor(() => expect(result.current.viewportKey).toBe('finos/42'));
+            await waitFor(() => expect(result.current.viewportKey).toBe('finos/Architectures/42'));
             expect(calmServiceMock.fetchMappings).toHaveBeenCalledWith(namespace, 'Architectures');
-            expect(layoutServiceMock.getDefaultLayout).toHaveBeenCalledWith(namespace, 42);
+            expect(layoutServiceMock.getDefaultLayout).toHaveBeenCalledWith(namespace, 42, 'architectures');
             expect(result.current.canSave).toBe(true);
         });
 
@@ -103,8 +106,8 @@ describe('useDefaultLayout', () => {
             const viaSlug = renderHook(() => useDefaultLayout(namespace, 'my-arch', 'Architectures'));
             const viaNumeric = renderHook(() => useDefaultLayout(namespace, '42', 'Architectures'));
 
-            await waitFor(() => expect(viaSlug.result.current.viewportKey).toBe('finos/42'));
-            expect(viaNumeric.result.current.viewportKey).toBe('finos/42');
+            await waitFor(() => expect(viaSlug.result.current.viewportKey).toBe('finos/Architectures/42'));
+            expect(viaNumeric.result.current.viewportKey).toBe('finos/Architectures/42');
             expect(viaSlug.result.current.viewportKey).toBe(viaNumeric.result.current.viewportKey);
         });
 
@@ -168,8 +171,8 @@ describe('useDefaultLayout', () => {
             const { result } = renderHook(() => useDefaultLayout(namespace, '5', 'Architectures'));
             await waitFor(() => expect(result.current.defaultLayout).toBeNull());
 
-            saveNodePositions('finos/5', [{ id: 'node-a', position: { x: 1, y: 2 }, data: {} }] as never);
-            expect(loadStoredNodePositions('finos/5')).not.toBeNull();
+            saveNodePositions('finos/Architectures/5', [{ id: 'node-a', position: { x: 1, y: 2 }, data: {} }] as never);
+            expect(loadStoredNodePositions('finos/Architectures/5')).not.toBeNull();
 
             const positions = [{ id: 'node-a', position: { x: 1, y: 2 } }];
             await act(async () => {
@@ -182,13 +185,14 @@ describe('useDefaultLayout', () => {
                 expect.objectContaining({
                     for: '/api/calm/namespaces/finos/architectures/5',
                     pins: [{ 'unique-id': 'node-a', position: { x: 1, y: 2 } }],
-                })
+                }),
+                'architectures'
             );
             expect(result.current.defaultLayout).toEqual(positions);
             expect(result.current.layoutEpoch).toBe(1);
             expect(result.current.saving).toBe(false);
             expect(result.current.saveError).toBeNull();
-            expect(loadStoredNodePositions('finos/5')).toBeNull();
+            expect(loadStoredNodePositions('finos/Architectures/5')).toBeNull();
         });
 
         it('surfaces an error and leaves state otherwise unchanged on failure', async () => {
@@ -225,17 +229,94 @@ describe('useDefaultLayout', () => {
             layoutServiceMock.getDefaultLayout.mockResolvedValue(null);
 
             const { result } = renderHook(() => useDefaultLayout(namespace, '5', 'Architectures'));
-            await waitFor(() => expect(result.current.viewportKey).toBe('finos/5'));
+            await waitFor(() => expect(result.current.viewportKey).toBe('finos/Architectures/5'));
 
-            saveNodePositions('finos/5', [{ id: 'node-a', position: { x: 1, y: 2 }, data: {} }] as never);
-            expect(loadStoredNodePositions('finos/5')).not.toBeNull();
+            saveNodePositions('finos/Architectures/5', [{ id: 'node-a', position: { x: 1, y: 2 }, data: {} }] as never);
+            expect(loadStoredNodePositions('finos/Architectures/5')).not.toBeNull();
 
             act(() => {
                 result.current.reset();
             });
 
             expect(result.current.layoutEpoch).toBe(1);
-            expect(loadStoredNodePositions('finos/5')).toBeNull();
+            expect(loadStoredNodePositions('finos/Architectures/5')).toBeNull();
+        });
+
+        it('does not touch a same-numbered pattern\'s scratch entry (collision regression)', async () => {
+            // Architecture ids and pattern ids come from independent counters, so an
+            // Architecture 5 and a Pattern 5 can coexist in the same namespace. Before
+            // the calmType qualifier was added to the key, resetting one would have
+            // cleared the other's scratch-position entry too.
+            layoutServiceMock.getDefaultLayout.mockResolvedValue(null);
+
+            const { result } = renderHook(() => useDefaultLayout(namespace, '5', 'Architectures'));
+            await waitFor(() => expect(result.current.viewportKey).toBe('finos/Architectures/5'));
+
+            const patternKey = 'finos/Patterns/5';
+            saveNodePositions(patternKey, [{ id: 'node-a', position: { x: 9, y: 9 }, data: {} }] as never);
+            expect(loadStoredNodePositions(patternKey)).not.toBeNull();
+
+            act(() => {
+                result.current.reset();
+            });
+
+            expect(loadStoredNodePositions(patternKey)).not.toBeNull();
+        });
+    });
+
+    describe('patterns', () => {
+        it('resolves the viewportKey for a numeric pattern id and fetches its layout', async () => {
+            layoutServiceMock.getDefaultLayout.mockResolvedValue(null);
+
+            const { result } = renderHook(() => useDefaultLayout(namespace, '9', 'Patterns'));
+
+            await waitFor(() => expect(result.current.viewportKey).toBe('finos/Patterns/9'));
+            expect(calmServiceMock.fetchMappings).not.toHaveBeenCalled();
+            expect(layoutServiceMock.getDefaultLayout).toHaveBeenCalledWith(namespace, 9, 'patterns');
+            expect(result.current.canSave).toBe(true);
+        });
+
+        it('resolves a slug pattern id via fetchMappings(namespace, Patterns)', async () => {
+            // Asserts the actual argument passed, not just that the mock was called — a
+            // hardcoded 'Architectures' here would silently resolve patterns against the
+            // wrong mapping list.
+            calmServiceMock.fetchMappings.mockResolvedValue([
+                { namespace, customId: 'my-pattern', resourceType: 'Patterns', numericId: 9 },
+            ]);
+            layoutServiceMock.getDefaultLayout.mockResolvedValue(null);
+
+            const { result } = renderHook(() => useDefaultLayout(namespace, 'my-pattern', 'Patterns'));
+
+            await waitFor(() => expect(result.current.viewportKey).toBe('finos/Patterns/9'));
+            expect(calmServiceMock.fetchMappings).toHaveBeenCalledWith(namespace, 'Patterns');
+            expect(result.current.canSave).toBe(true);
+        });
+
+        it('save emits a /patterns/ for-target and PUTs via the patterns urlType', async () => {
+            // The most likely bug to slip through: a stale hardcoded '/architectures/'
+            // segment here would 400 against the backend's for-mismatch check on every
+            // pattern save.
+            layoutServiceMock.getDefaultLayout.mockResolvedValue(null);
+            layoutServiceMock.saveDefaultLayout.mockResolvedValue(undefined);
+
+            const { result } = renderHook(() => useDefaultLayout(namespace, '9', 'Patterns'));
+            await waitFor(() => expect(result.current.defaultLayout).toBeNull());
+
+            const positions = [{ id: 'node-a', position: { x: 1, y: 2 } }];
+            await act(async () => {
+                await result.current.save(positions);
+            });
+
+            expect(layoutServiceMock.saveDefaultLayout).toHaveBeenCalledWith(
+                namespace,
+                9,
+                expect.objectContaining({
+                    for: '/api/calm/namespaces/finos/patterns/9',
+                    pins: [{ 'unique-id': 'node-a', position: { x: 1, y: 2 } }],
+                }),
+                'patterns'
+            );
+            expect(result.current.defaultLayout).toEqual(positions);
         });
     });
 });

--- a/calm-hub-ui/src/hub/hooks/useDefaultLayout.ts
+++ b/calm-hub-ui/src/hub/hooks/useDefaultLayout.ts
@@ -1,31 +1,39 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CalmService } from '../../service/calm-service.js';
-import { LayoutService } from '../../service/layout-service.js';
+import { LayoutService, LayoutResourceType } from '../../service/layout-service.js';
 import { isSlug } from '../../model/calm.js';
 import { CalmLayout, pinsToStoredPositions, storedPositionsToPins } from '../../model/layout.js';
 import { clearStoredNodePositions, StoredNodePosition } from '../../visualizer/services/node-position-service.js';
 
 export interface UseDefaultLayoutResult {
     /**
-     * Namespace + resolved numeric architecture id — the single key both the
+     * Namespace + calmType + resolved numeric id — the single key both the
      * localStorage scratch layer and the server layout are addressed by, so a
      * diagram reached via a slug route and via its numeric route share one
-     * scratch entry and one server call. Three states:
+     * scratch entry and one server call. The calmType component exists
+     * because architecture ids and pattern ids are allocated from independent
+     * counters — an Architecture 7 and a Pattern 7 can coexist in the same
+     * namespace, and without a type qualifier they would collide on one
+     * scratch-position entry and one viewport entry. `Drawer`'s own fallback
+     * key computation must stay in this same `namespace/calmType/id` shape
+     * for the same reason. Three states:
      *  - a string: the resolved key.
-     *  - `undefined`: not applicable (a pattern or dropped file), or a slug that
-     *    is still resolving — callers with a loading state to show key off this.
-     *  - `null`: this *is* an architecture, but resolution finished without a
-     *    numeric id (an unresolvable slug, or the mapping fetch failed). Never
-     *    `undefined` here — a caller that fell back to some other key (e.g. the
-     *    raw slug) in this state would reintroduce the exact split this key
-     *    exists to prevent. See `Drawer`'s `viewportKeyOverride` handling.
+     *  - `undefined`: not applicable (a dropped file, or a calmType this hook
+     *    doesn't support), or a slug that is still resolving — callers with a
+     *    loading state to show key off this.
+     *  - `null`: this *is* a supported type, but resolution finished without
+     *    a numeric id (an unresolvable slug, or the mapping fetch failed).
+     *    Never `undefined` here — a caller that fell back to some other key
+     *    (e.g. the raw slug) in this state would reintroduce the exact split
+     *    this key exists to prevent. See `Drawer`'s `viewportKeyOverride`
+     *    handling.
      */
     viewportKey: string | null | undefined;
     /** undefined = loading, null = none stored, else the resolved default layout. */
     defaultLayout: StoredNodePosition[] | null | undefined;
     /** Bumped after a successful save or a reset, to force a clean re-apply. */
     layoutEpoch: number;
-    /** False while a slug id hasn't resolved to a numeric architecture id — Save stays disabled. */
+    /** False while a slug id hasn't resolved to a numeric id — Save stays disabled. */
     canSave: boolean;
     saving: boolean;
     saveError: string | null;
@@ -33,81 +41,88 @@ export interface UseDefaultLayoutResult {
     reset: () => void;
 }
 
+const SUPPORTED_TYPES: Partial<Record<string, LayoutResourceType>> = {
+    Architectures: 'architectures',
+    Patterns: 'patterns',
+};
+
 /**
- * Resolves and fetches the shared default layout for an architecture, and owns
- * the save/reset actions. Returns an inert result (no fetch, no key) for
- * anything that isn't an architecture — patterns and dropped files are out of
- * scope for server-side layouts in v1.
+ * Resolves and fetches the shared default layout for an architecture or a
+ * pattern, and owns the save/reset actions. Returns an inert result (no
+ * fetch, no key) for anything else — dropped files and any other calmType
+ * are out of scope for server-side layouts.
  */
 export function useDefaultLayout(namespace: string, id: string, calmType: string): UseDefaultLayoutResult {
     const calmService = useMemo(() => new CalmService(), []);
     const layoutService = useMemo(() => new LayoutService(), []);
-    const isArchitecture = calmType === 'Architectures';
+    const urlType = SUPPORTED_TYPES[calmType];
+    const isSupportedType = urlType !== undefined;
 
-    const [architectureId, setArchitectureId] = useState<number | undefined>(() =>
-        isArchitecture && !isSlug(id) ? Number(id) : undefined
+    const [resolvedId, setResolvedId] = useState<number | undefined>(() =>
+        isSupportedType && !isSlug(id) ? Number(id) : undefined
     );
     // Tracks slug→numeric resolution specifically, so a slug that fails to
     // resolve can settle `defaultLayout` to `null` (no default, save disabled)
     // instead of leaving the graph waiting on a fetch that will never start —
-    // `architectureId === undefined` alone can't distinguish "still resolving"
+    // `resolvedId === undefined` alone can't distinguish "still resolving"
     // from "resolution finished but found no match".
-    const [resolvingId, setResolvingId] = useState<boolean>(() => isArchitecture && isSlug(id));
+    const [resolvingId, setResolvingId] = useState<boolean>(() => isSupportedType && isSlug(id));
     const [defaultLayout, setDefaultLayout] = useState<StoredNodePosition[] | null | undefined>(
-        isArchitecture ? undefined : null
+        isSupportedType ? undefined : null
     );
     const [layoutEpoch, setLayoutEpoch] = useState(0);
     const [saving, setSaving] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
 
-    // Resolve a slug id to its numeric architecture id once per (namespace, id).
+    // Resolve a slug id to its numeric id once per (namespace, id, calmType).
     useEffect(() => {
-        if (!isArchitecture) {
-            setArchitectureId(undefined);
+        if (!isSupportedType) {
+            setResolvedId(undefined);
             setResolvingId(false);
             return;
         }
         if (!isSlug(id)) {
-            setArchitectureId(Number(id));
+            setResolvedId(Number(id));
             setResolvingId(false);
             return;
         }
         let cancelled = false;
-        setArchitectureId(undefined);
+        setResolvedId(undefined);
         setResolvingId(true);
         calmService
-            .fetchMappings(namespace, 'Architectures')
+            .fetchMappings(namespace, calmType)
             .then((mappings) => {
                 if (cancelled) return;
                 const match = mappings.find((m) => m.customId === id);
-                setArchitectureId(match ? match.numericId : undefined);
+                setResolvedId(match ? match.numericId : undefined);
                 setResolvingId(false);
             })
             .catch(() => {
                 if (cancelled) return;
-                setArchitectureId(undefined);
+                setResolvedId(undefined);
                 setResolvingId(false);
             });
         return () => {
             cancelled = true;
         };
-    }, [calmService, namespace, id, isArchitecture]);
+    }, [calmService, namespace, id, calmType, isSupportedType]);
 
-    // undefined only while genuinely inapplicable (not an architecture) or still
-    // resolving; once resolution for an architecture has settled without a
-    // match, this is null — not undefined — so Drawer's fallback is suppressed
-    // rather than silently keying off the raw slug (see viewportKeyOverride's doc).
+    // undefined only while genuinely inapplicable (an unsupported type) or
+    // still resolving; once resolution for a supported type has settled
+    // without a match, this is null — not undefined — so Drawer's fallback is
+    // suppressed rather than silently keying off the raw slug (see
+    // viewportKeyOverride's doc).
     const viewportKey =
-        architectureId !== undefined
-            ? `${namespace}/${architectureId}`
-            : isArchitecture && !resolvingId
+        resolvedId !== undefined
+            ? `${namespace}/${calmType}/${resolvedId}`
+            : isSupportedType && !resolvingId
               ? null
               : undefined;
 
-    // Fetch the server default once the architecture id is settled (resolved
-    // to a number, or resolution finished without a match).
+    // Fetch the server default once the id is settled (resolved to a number,
+    // or resolution finished without a match).
     useEffect(() => {
-        if (!isArchitecture) {
+        if (!isSupportedType) {
             setDefaultLayout(null);
             return;
         }
@@ -115,7 +130,7 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
             setDefaultLayout(undefined);
             return;
         }
-        if (architectureId === undefined) {
+        if (resolvedId === undefined) {
             // Resolution finished but the slug didn't match anything — nothing
             // to fetch, and nothing to wait on. Never a silent stuck loading
             // state: settle to "no default" so Save disables with a reason.
@@ -125,7 +140,7 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
         let cancelled = false;
         setDefaultLayout(undefined);
         layoutService
-            .getDefaultLayout(namespace, architectureId)
+            .getDefaultLayout(namespace, resolvedId, urlType)
             .then((layout) => {
                 if (cancelled) return;
                 setDefaultLayout(layout ? pinsToStoredPositions(layout) : null);
@@ -136,19 +151,19 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
         return () => {
             cancelled = true;
         };
-    }, [layoutService, namespace, architectureId, isArchitecture, resolvingId]);
+    }, [layoutService, namespace, resolvedId, isSupportedType, resolvingId, urlType]);
 
     const save = useCallback(
         async (positions: StoredNodePosition[]) => {
-            if (architectureId === undefined) return;
+            if (resolvedId === undefined || urlType === undefined) return;
             setSaving(true);
             setSaveError(null);
             try {
                 const layout: CalmLayout = {
-                    for: `/api/calm/namespaces/${namespace}/architectures/${architectureId}`,
+                    for: `/api/calm/namespaces/${namespace}/${urlType}/${resolvedId}`,
                     pins: storedPositionsToPins(positions),
                 };
-                await layoutService.saveDefaultLayout(namespace, architectureId, layout);
+                await layoutService.saveDefaultLayout(namespace, resolvedId, layout, urlType);
                 if (viewportKey) clearStoredNodePositions(viewportKey);
                 setDefaultLayout(positions);
                 setLayoutEpoch((epoch) => epoch + 1);
@@ -159,7 +174,7 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
                 setSaving(false);
             }
         },
-        [architectureId, namespace, layoutService, viewportKey]
+        [resolvedId, urlType, namespace, layoutService, viewportKey]
     );
 
     const reset = useCallback(() => {
@@ -168,7 +183,7 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
         setLayoutEpoch((epoch) => epoch + 1);
     }, [viewportKey]);
 
-    const canSave = architectureId !== undefined;
+    const canSave = resolvedId !== undefined;
 
     // Memoised so consumers that key a useCallback/useMemo off the whole result
     // (e.g. DiagramSection's handleSaveLayout) get a stable reference instead of

--- a/calm-hub-ui/src/hub/hooks/useDefaultLayout.ts
+++ b/calm-hub-ui/src/hub/hooks/useDefaultLayout.ts
@@ -3,7 +3,7 @@ import { CalmService } from '../../service/calm-service.js';
 import { LayoutService, LayoutResourceType } from '../../service/layout-service.js';
 import { isSlug } from '../../model/calm.js';
 import { CalmLayout, pinsToStoredPositions, storedPositionsToPins } from '../../model/layout.js';
-import { clearStoredNodePositions, StoredNodePosition } from '../../visualizer/services/node-position-service.js';
+import { buildViewportKey, clearStoredNodePositions, StoredNodePosition } from '../../visualizer/services/node-position-service.js';
 
 export interface UseDefaultLayoutResult {
     /**
@@ -14,9 +14,10 @@ export interface UseDefaultLayoutResult {
      * because architecture ids and pattern ids are allocated from independent
      * counters — an Architecture 7 and a Pattern 7 can coexist in the same
      * namespace, and without a type qualifier they would collide on one
-     * scratch-position entry and one viewport entry. `Drawer`'s own fallback
-     * key computation must stay in this same `namespace/calmType/id` shape
-     * for the same reason. Three states:
+     * scratch-position entry and one viewport entry. Built with
+     * `buildViewportKey`, the single source of truth for this shape — shared
+     * with `Drawer`'s own fallback key computation so the two can't drift
+     * apart. Three states:
      *  - a string: the resolved key.
      *  - `undefined`: not applicable (a dropped file, or a calmType this hook
      *    doesn't support), or a slug that is still resolving — callers with a
@@ -114,7 +115,7 @@ export function useDefaultLayout(namespace: string, id: string, calmType: string
     // viewportKeyOverride's doc).
     const viewportKey =
         resolvedId !== undefined
-            ? `${namespace}/${calmType}/${resolvedId}`
+            ? buildViewportKey(namespace, calmType, resolvedId)
             : isSupportedType && !resolvingId
               ? null
               : undefined;

--- a/calm-hub-ui/src/service/layout-service.test.ts
+++ b/calm-hub-ui/src/service/layout-service.test.ts
@@ -27,20 +27,20 @@ describe('LayoutService', () => {
         it('returns the parsed layout on 200', async () => {
             mock.onGet(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(200, layout);
 
-            const result = await layoutService.getDefaultLayout(namespace, architectureId);
+            const result = await layoutService.getDefaultLayout(namespace, architectureId, 'architectures');
             expect(result).toEqual(layout);
         });
 
         it('returns null on 404, not a rejection', async () => {
             mock.onGet(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(404, 'not found');
 
-            await expect(layoutService.getDefaultLayout(namespace, architectureId)).resolves.toBeNull();
+            await expect(layoutService.getDefaultLayout(namespace, architectureId, 'architectures')).resolves.toBeNull();
         });
 
         it('rejects on a 500', async () => {
             mock.onGet(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(500, 'boom');
 
-            await expect(layoutService.getDefaultLayout(namespace, architectureId)).rejects.toThrowError(
+            await expect(layoutService.getDefaultLayout(namespace, architectureId, 'architectures')).rejects.toThrowError(
                 "Couldn't load the default layout — the server returned 500."
             );
         });
@@ -50,9 +50,18 @@ describe('LayoutService', () => {
             // failure and 413 does not apply to a GET at all — this pins the load-side wording.
             mock.onGet(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(403);
 
-            await expect(layoutService.getDefaultLayout(namespace, architectureId)).rejects.toThrowError(
+            await expect(layoutService.getDefaultLayout(namespace, architectureId, 'architectures')).rejects.toThrowError(
                 "Couldn't load the default layout — you don't have access to this namespace."
             );
+        });
+
+        it('GETs the /patterns/ URL and uses pattern wording on 404 when urlType is patterns', async () => {
+            const patternId = 7;
+            mock.onGet(`/api/calm/namespaces/${namespace}/patterns/${patternId}/layout`).reply(404);
+
+            // Asserts the literal URL string, not just that *a* request succeeded — a stale
+            // hardcoded '/architectures/' segment here would silently 404 every pattern load.
+            await expect(layoutService.getDefaultLayout(namespace, patternId, 'patterns')).resolves.toBeNull();
         });
     });
 
@@ -63,13 +72,13 @@ describe('LayoutService', () => {
                 return [204];
             });
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).resolves.toBeUndefined();
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).resolves.toBeUndefined();
         });
 
         it('rejects with a generic message when the save fails without a recognised status', async () => {
             mock.onPut(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(400, 'bad request');
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).rejects.toThrowError(
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).rejects.toThrowError(
                 "Couldn't save the default layout — the server returned 400."
             );
         });
@@ -77,7 +86,7 @@ describe('LayoutService', () => {
         it('rejects with a specific message on 403 (no write access)', async () => {
             mock.onPut(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(403);
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).rejects.toThrowError(
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).rejects.toThrowError(
                 "Couldn't save the default layout — you don't have write access to this namespace."
             );
         });
@@ -85,7 +94,7 @@ describe('LayoutService', () => {
         it('rejects with a specific message on 413 (too large)', async () => {
             mock.onPut(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(413);
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).rejects.toThrowError(
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).rejects.toThrowError(
                 "Couldn't save the default layout — it's too large to store."
             );
         });
@@ -93,7 +102,7 @@ describe('LayoutService', () => {
         it('rejects with a specific message on 404 (architecture no longer exists)', async () => {
             mock.onPut(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).reply(404);
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).rejects.toThrowError(
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).rejects.toThrowError(
                 "Couldn't save the default layout — this architecture no longer exists."
             );
         });
@@ -101,9 +110,34 @@ describe('LayoutService', () => {
         it('rejects with a network-failure message when the server cannot be reached', async () => {
             mock.onPut(`/api/calm/namespaces/${namespace}/architectures/${architectureId}/layout`).networkError();
 
-            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout)).rejects.toThrowError(
+            await expect(layoutService.saveDefaultLayout(namespace, architectureId, layout, 'architectures')).rejects.toThrowError(
                 "Couldn't save the default layout — the server couldn't be reached."
             );
+        });
+
+        it('PUTs the /patterns/ URL when urlType is patterns', async () => {
+            const patternId = 7;
+            const patternLayout: CalmLayout = {
+                for: `/api/calm/namespaces/${namespace}/patterns/${patternId}`,
+                pins: [],
+            };
+            mock.onPut(`/api/calm/namespaces/${namespace}/patterns/${patternId}/layout`).reply((config) => {
+                expect(JSON.parse(config.data)).toEqual(patternLayout);
+                return [204];
+            });
+
+            await expect(
+                layoutService.saveDefaultLayout(namespace, patternId, patternLayout, 'patterns')
+            ).resolves.toBeUndefined();
+        });
+
+        it('rejects with pattern-specific wording on 404 when urlType is patterns', async () => {
+            const patternId = 7;
+            mock.onPut(`/api/calm/namespaces/${namespace}/patterns/${patternId}/layout`).reply(404);
+
+            await expect(
+                layoutService.saveDefaultLayout(namespace, patternId, layout, 'patterns')
+            ).rejects.toThrowError("Couldn't save the default layout — this pattern no longer exists.");
         });
     });
 });

--- a/calm-hub-ui/src/service/layout-service.ts
+++ b/calm-hub-ui/src/service/layout-service.ts
@@ -3,6 +3,13 @@ import { getAuthHeaders } from '../authService.js';
 import { apiClient } from './utils/api-client.js';
 import { CalmLayout } from '../model/layout.js';
 
+/** The URL segment (and backend resource family) a layout belongs to. */
+export type LayoutResourceType = 'architectures' | 'patterns';
+
+function resourceLabel(urlType: LayoutResourceType): string {
+    return urlType === 'architectures' ? 'architecture' : 'pattern';
+}
+
 /**
  * Maps a failed layout request to a message worth showing the user, not just
  * logging. `useDefaultLayout` assigns this straight to `saveError`, which
@@ -10,8 +17,9 @@ import { CalmLayout } from '../model/layout.js';
  * unlike the generic `errorMessage` prefix logged alongside it, this one has
  * to mean something to someone who isn't reading the console.
  */
-function layoutFailureMessage(action: 'save' | 'load', error: unknown): string {
+function layoutFailureMessage(action: 'save' | 'load', urlType: LayoutResourceType, error: unknown): string {
     const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    const label = resourceLabel(urlType);
 
     // 403 and 413 are worded per-action: "write access" and "too large to store"
     // are both write-side facts and would be actively misleading on a failed GET
@@ -24,12 +32,12 @@ function layoutFailureMessage(action: 'save' | 'load', error: unknown): string {
             case 413:
                 return "Couldn't save the default layout — it's too large to store.";
             case 404:
-                return "Couldn't save the default layout — this architecture no longer exists.";
+                return `Couldn't save the default layout — this ${label} no longer exists.`;
         }
     } else if (status === 403) {
         return "Couldn't load the default layout — you don't have access to this namespace.";
     } else if (status === 404) {
-        return "Couldn't load the default layout — this architecture no longer exists.";
+        return `Couldn't load the default layout — this ${label} no longer exists.`;
     }
 
     return status
@@ -38,9 +46,13 @@ function layoutFailureMessage(action: 'save' | 'load', error: unknown): string {
 }
 
 /**
- * Manages the shared, default layout saved for an architecture — the server-side
- * counterpart to the browser-local scratch layer in `node-position-service.tsx`.
- * There is exactly one default layout per architecture; saving is always an upsert.
+ * Manages the shared, default layout saved for an architecture or a pattern — the
+ * server-side counterpart to the browser-local scratch layer in
+ * `node-position-service.tsx`. There is exactly one default layout per resource;
+ * saving is always an upsert. Architectures and patterns are separate backend
+ * resource families (`.../architectures/{id}/layout` vs `.../patterns/{id}/layout`,
+ * distinct storage collections) — see `PatternLayoutStore`'s class javadoc on the
+ * backend for why — so every call site must say which one it means via `urlType`.
  */
 export class LayoutService {
     private readonly ax: AxiosInstance;
@@ -53,32 +65,32 @@ export class LayoutService {
         }
     }
 
-    /** The saved default layout for an architecture, or null when none has been saved. */
-    public async getDefaultLayout(namespace: string, architectureId: number): Promise<CalmLayout | null> {
+    /** The saved default layout for an architecture or pattern, or null when none has been saved. */
+    public async getDefaultLayout(namespace: string, id: number, urlType: LayoutResourceType): Promise<CalmLayout | null> {
         const headers = await getAuthHeaders();
         return this.ax
-            .get(`/api/calm/namespaces/${encodeURIComponent(namespace)}/architectures/${architectureId}/layout`, { headers })
+            .get(`/api/calm/namespaces/${encodeURIComponent(namespace)}/${urlType}/${id}/layout`, { headers })
             .then((res) => res.data as CalmLayout)
             .catch((error) => {
                 if (error?.response?.status === 404) {
                     return null;
                 }
-                const errorMessage = `Error fetching default layout for architecture ${architectureId} in namespace ${namespace}:`;
+                const errorMessage = `Error fetching default layout for ${resourceLabel(urlType)} ${id} in namespace ${namespace}:`;
                 console.error('%s', errorMessage, error);
-                return Promise.reject(new Error(layoutFailureMessage('load', error)));
+                return Promise.reject(new Error(layoutFailureMessage('load', urlType, error)));
             });
     }
 
-    /** Save (create or overwrite) the default layout for an architecture. */
-    public async saveDefaultLayout(namespace: string, architectureId: number, layout: CalmLayout): Promise<void> {
+    /** Save (create or overwrite) the default layout for an architecture or pattern. */
+    public async saveDefaultLayout(namespace: string, id: number, layout: CalmLayout, urlType: LayoutResourceType): Promise<void> {
         const headers = await getAuthHeaders();
         return this.ax
-            .put(`/api/calm/namespaces/${encodeURIComponent(namespace)}/architectures/${architectureId}/layout`, layout, { headers })
+            .put(`/api/calm/namespaces/${encodeURIComponent(namespace)}/${urlType}/${id}/layout`, layout, { headers })
             .then(() => undefined)
             .catch((error) => {
-                const errorMessage = `Error saving default layout for architecture ${architectureId} in namespace ${namespace}:`;
+                const errorMessage = `Error saving default layout for ${resourceLabel(urlType)} ${id} in namespace ${namespace}:`;
                 console.error('%s', errorMessage, error);
-                return Promise.reject(new Error(layoutFailureMessage('save', error)));
+                return Promise.reject(new Error(layoutFailureMessage('save', urlType, error)));
             });
     }
 }

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
@@ -34,11 +34,19 @@ vi.mock('../reactflow/MetadataPanel.js', () => ({
 
 // Mock dependencies
 vi.mock('../reactflow/ReactFlowVisualizer.js', () => ({
-    ReactFlowVisualizer: ({ calmData, viewportKey }: ReactFlowVisualizerProps) => (
+    ReactFlowVisualizer: ({ calmData, viewportKey, defaultLayout, layoutEpoch, onPositionsChange }: ReactFlowVisualizerProps) => (
         <div data-testid="reactflow-visualizer">
             <div data-testid="node-count">{calmData?.nodes?.length ?? 0}</div>
             <div data-testid="relationship-count">{calmData?.relationships?.length ?? 0}</div>
             <div data-testid="viewport-key">{viewportKey ?? '(none)'}</div>
+            <div data-testid="architecture-default-layout">{defaultLayout === undefined ? '(undefined)' : JSON.stringify(defaultLayout)}</div>
+            <div data-testid="architecture-layout-epoch">{layoutEpoch ?? '(none)'}</div>
+            <button
+                data-testid="architecture-report-positions"
+                onClick={() => onPositionsChange?.([{ id: 'n1', position: { x: 1, y: 2 } }])}
+            >
+                report
+            </button>
         </div>
     ),
 }));
@@ -250,6 +258,75 @@ describe('Drawer', () => {
 
         expect(screen.queryByText(/Couldn't read that file/i)).not.toBeInTheDocument();
         expect(screen.getByTestId('reactflow-visualizer')).toBeInTheDocument();
+    });
+
+    // Regression coverage for the dropped-file stale-layout bug: `defaultLayout`/
+    // `layoutEpoch` describe the currently-*loaded* resource's saved server layout,
+    // so they must collapse alongside `viewportKey` once a file is dropped —
+    // otherwise a dropped file inherits the previously-loaded resource's positions.
+    it('suppresses defaultLayout/layoutEpoch for a dropped pattern file', async () => {
+        const defaultLayout = [{ id: 'n1', position: { x: 5, y: 10 } }];
+        render(<Drawer data={patternData} defaultLayout={defaultLayout} layoutEpoch={3} />);
+
+        expect(screen.getByTestId('pattern-default-layout')).toHaveTextContent(JSON.stringify(defaultLayout));
+        expect(screen.getByTestId('pattern-layout-epoch')).toHaveTextContent('3');
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([
+                fakeFile(JSON.stringify({ properties: { nodes: { prefixItems: [] } } })),
+            ]);
+        });
+
+        expect(screen.getByTestId('pattern-default-layout')).toHaveTextContent('(undefined)');
+        expect(screen.getByTestId('pattern-layout-epoch')).toHaveTextContent('(none)');
+    });
+
+    it('suppresses defaultLayout/layoutEpoch for a dropped architecture file', async () => {
+        const defaultLayout = [{ id: 'n1', position: { x: 5, y: 10 } }];
+        render(<Drawer data={architectureData} defaultLayout={defaultLayout} layoutEpoch={3} />);
+
+        expect(screen.getByTestId('architecture-default-layout')).toHaveTextContent(JSON.stringify(defaultLayout));
+        expect(screen.getByTestId('architecture-layout-epoch')).toHaveTextContent('3');
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([
+                fakeFile(JSON.stringify({ nodes: [], relationships: [] })),
+            ]);
+        });
+
+        expect(screen.getByTestId('architecture-default-layout')).toHaveTextContent('(undefined)');
+        expect(screen.getByTestId('architecture-layout-epoch')).toHaveTextContent('(none)');
+    });
+
+    it('does not report a dropped pattern file\'s positions via onPositionsChange', async () => {
+        const onPositionsChange = vi.fn();
+        render(<Drawer data={patternData} onPositionsChange={onPositionsChange} />);
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([
+                fakeFile(JSON.stringify({ properties: { nodes: { prefixItems: [] } } })),
+            ]);
+        });
+
+        expect(screen.getByTestId('pattern-report-positions')).toBeInTheDocument();
+        // onPositionsChange itself is undefined once a file is dropped, so the mock's
+        // report button has nothing to call — proven by the click being a no-op.
+        screen.getByTestId('pattern-report-positions').click();
+        expect(onPositionsChange).not.toHaveBeenCalled();
+    });
+
+    it('does not report a dropped architecture file\'s positions via onPositionsChange', async () => {
+        const onPositionsChange = vi.fn();
+        render(<Drawer data={architectureData} onPositionsChange={onPositionsChange} />);
+
+        await act(async () => {
+            await mockDropzone.onDrop?.([
+                fakeFile(JSON.stringify({ nodes: [], relationships: [] })),
+            ]);
+        });
+
+        screen.getByTestId('architecture-report-positions').click();
+        expect(onPositionsChange).not.toHaveBeenCalled();
     });
 });
 

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import { Drawer } from './Drawer.js';
 import { Data } from '../../../model/calm.js';
 import type { ReactFlowVisualizerProps } from '../../contracts/contracts.js';
+import type { PatternVisualizerProps } from '../reactflow/PatternVisualizer.js';
 import { DropzoneOptions } from 'react-dropzone';
 
 // Captures the `onDrop` the Drawer hands to react-dropzone so tests can invoke
@@ -38,6 +39,21 @@ vi.mock('../reactflow/ReactFlowVisualizer.js', () => ({
             <div data-testid="node-count">{calmData?.nodes?.length ?? 0}</div>
             <div data-testid="relationship-count">{calmData?.relationships?.length ?? 0}</div>
             <div data-testid="viewport-key">{viewportKey ?? '(none)'}</div>
+        </div>
+    ),
+}));
+vi.mock('../reactflow/PatternVisualizer.js', () => ({
+    PatternVisualizer: ({ viewportKey, defaultLayout, layoutEpoch, onPositionsChange }: PatternVisualizerProps) => (
+        <div data-testid="pattern-visualizer">
+            <div data-testid="viewport-key">{viewportKey ?? '(none)'}</div>
+            <div data-testid="pattern-default-layout">{defaultLayout === undefined ? '(undefined)' : JSON.stringify(defaultLayout)}</div>
+            <div data-testid="pattern-layout-epoch">{layoutEpoch ?? '(none)'}</div>
+            <button
+                data-testid="pattern-report-positions"
+                onClick={() => onPositionsChange?.([{ id: 'n1', position: { x: 1, y: 2 } }])}
+            >
+                report
+            </button>
         </div>
     ),
 }));
@@ -147,9 +163,49 @@ describe('Drawer', () => {
         expect(screen.queryByLabelText('Close details')).not.toBeInTheDocument();
     });
 
-    it('falls back to the name/id key when no viewportKeyOverride is given', () => {
+    it('forwards defaultLayout and layoutEpoch to PatternVisualizer for pattern data', () => {
+        const defaultLayout = [{ id: 'n1', position: { x: 5, y: 10 } }];
+        render(<Drawer data={patternData} defaultLayout={defaultLayout} layoutEpoch={3} />);
+
+        expect(screen.getByTestId('pattern-visualizer')).toBeInTheDocument();
+        expect(screen.getByTestId('pattern-default-layout')).toHaveTextContent(JSON.stringify(defaultLayout));
+        expect(screen.getByTestId('pattern-layout-epoch')).toHaveTextContent('3');
+    });
+
+    it('forwards onPositionsChange to PatternVisualizer for pattern data', () => {
+        const onPositionsChange = vi.fn();
+        render(<Drawer data={patternData} onPositionsChange={onPositionsChange} />);
+
+        screen.getByTestId('pattern-report-positions').click();
+
+        expect(onPositionsChange).toHaveBeenCalledWith([{ id: 'n1', position: { x: 1, y: 2 } }]);
+    });
+
+    it('falls back to the name/calmType/id key when no viewportKeyOverride is given', () => {
         render(<Drawer data={calmData as unknown as Data} />);
-        expect(screen.getByTestId('viewport-key')).toHaveTextContent(`${calmData.name}/${calmData.id}`);
+        expect(screen.getByTestId('viewport-key')).toHaveTextContent(
+            `${calmData.name}/${calmData.calmType}/${calmData.id}`
+        );
+    });
+
+    it('does not collide when an architecture and a pattern share the same namespace and numeric id', () => {
+        // Architecture ids and pattern ids come from independent counters, so an
+        // Architecture 7 and a Pattern 7 can legitimately coexist in one namespace.
+        // Without the calmType component in the fallback key, they would share one
+        // scratch-position entry and one viewport entry.
+        const architectureSeven: Data = { ...architectureData, id: '7' };
+        const patternSeven: Data = { ...patternData, id: '7' };
+
+        const architectureRender = render(<Drawer data={architectureSeven} />);
+        const architectureKey = screen.getByTestId('viewport-key').textContent;
+        architectureRender.unmount();
+
+        render(<Drawer data={patternSeven} />);
+        const patternKey = screen.getByTestId('viewport-key').textContent;
+
+        expect(architectureKey).toBe('my-namespace/Architectures/7');
+        expect(patternKey).toBe('my-namespace/Patterns/7');
+        expect(architectureKey).not.toBe(patternKey);
     });
 
     it('uses the resolved viewportKeyOverride when one is provided', () => {

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -6,6 +6,7 @@ import { PatternVisualizer } from '../reactflow/PatternVisualizer.js';
 import { MetadataPanel } from '../reactflow/MetadataPanel.js';
 import { toSidebarNodeData, toSidebarEdgeData } from '../reactflow/utils/patternClickHandlers.js';
 import { CalmService } from '../../../service/calm-service.js';
+import { buildViewportKey } from '../../services/node-position-service.js';
 import { DropzoneEmptyState } from './DropzoneEmptyState.js';
 import { colors } from '../../../theme/colors.js';
 import type { DrawerProps, Flow, Control, Decorator } from '../../contracts/contracts.js';
@@ -96,8 +97,18 @@ export function Drawer({
     // architecture ids and pattern ids are allocated from separate counters, so
     // an Architecture 7 and a Pattern 7 can coexist in the same namespace —
     // without it they'd share one scratch-position entry and one viewport entry.
-    const computedViewportKey = !fileInstance && data ? `${data.name}/${data.calmType}/${data.id}` : undefined;
+    const computedViewportKey = !fileInstance && data ? buildViewportKey(data.name, data.calmType, data.id) : undefined;
     const viewportKey = fileInstance || viewportKeyOverride === null ? undefined : (viewportKeyOverride ?? computedViewportKey);
+
+    // `defaultLayout`/`layoutEpoch` must collapse alongside `viewportKey` for the same
+    // reason: they describe the currently-*loaded* resource's saved server layout, not
+    // whatever was just dropped. Without this, dragging in a locally-edited copy of the
+    // same file would re-apply the loaded resource's saved positions (matched by node id)
+    // onto the dropped file's freshly-parsed nodes instead of a fresh auto-layout — the
+    // graph's `awaitingDefaultLayout` gate only reads these two props, it doesn't know
+    // about `fileInstance`.
+    const effectiveDefaultLayout = fileInstance ? undefined : defaultLayout;
+    const effectiveLayoutEpoch = fileInstance ? undefined : layoutEpoch;
 
     useEffect(() => {
         const source = fileInstance ?? data?.data;
@@ -274,8 +285,8 @@ export function Drawer({
                                 onEdgeClick={handlePatternEdgeClick}
                                 onBackgroundClick={closeSidebar}
                                 viewportKey={viewportKey}
-                                defaultLayout={defaultLayout}
-                                layoutEpoch={layoutEpoch}
+                                defaultLayout={effectiveDefaultLayout}
+                                layoutEpoch={effectiveLayoutEpoch}
                                 // See ReactFlowVisualizer's onPositionsChange below: never
                                 // reported for a dropped file, which has no stable identity
                                 // to save a shared default layout against.
@@ -288,8 +299,8 @@ export function Drawer({
                                 onEdgeClick={handleEdgeClick}
                                 onBackgroundClick={closeSidebar}
                                 viewportKey={viewportKey}
-                                defaultLayout={defaultLayout}
-                                layoutEpoch={layoutEpoch}
+                                defaultLayout={effectiveDefaultLayout}
+                                layoutEpoch={effectiveLayoutEpoch}
                                 // Never reported for a dropped file: `onPositionsChange`
                                 // ultimately feeds DiagramSection's "Save as default
                                 // layout", which is scoped to the *loaded architecture*

--- a/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
+++ b/calm-hub-ui/src/visualizer/components/drawer/Drawer.tsx
@@ -92,7 +92,11 @@ export function Drawer({
     // override (a slug that finished resolving with no match) suppresses the
     // fallback rather than triggering it — falling back to the slug here would
     // reintroduce exactly the key split the override exists to close.
-    const computedViewportKey = !fileInstance && data ? `${data.name}/${data.id}` : undefined;
+    // The calmType component guards against a second, independent collision:
+    // architecture ids and pattern ids are allocated from separate counters, so
+    // an Architecture 7 and a Pattern 7 can coexist in the same namespace —
+    // without it they'd share one scratch-position entry and one viewport entry.
+    const computedViewportKey = !fileInstance && data ? `${data.name}/${data.calmType}/${data.id}` : undefined;
     const viewportKey = fileInstance || viewportKeyOverride === null ? undefined : (viewportKeyOverride ?? computedViewportKey);
 
     useEffect(() => {
@@ -270,6 +274,12 @@ export function Drawer({
                                 onEdgeClick={handlePatternEdgeClick}
                                 onBackgroundClick={closeSidebar}
                                 viewportKey={viewportKey}
+                                defaultLayout={defaultLayout}
+                                layoutEpoch={layoutEpoch}
+                                // See ReactFlowVisualizer's onPositionsChange below: never
+                                // reported for a dropped file, which has no stable identity
+                                // to save a shared default layout against.
+                                onPositionsChange={fileInstance ? undefined : onPositionsChange}
                             />
                         ) : calmInstance ? (
                             <ReactFlowVisualizer

--- a/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/ArchitectureGraph.tsx
@@ -160,9 +160,11 @@ export function ArchitectureGraph({
 
     // Still fetching the server default for this diagram: hold off applying
     // positions rather than flashing the auto-layout and then jumping to the
-    // restored one. Only architectures (which have `viewportKey` set by
-    // DiagramSection's useDefaultLayout) ever see `defaultLayout === undefined`;
-    // patterns/dropped files resolve it to `null` immediately.
+    // restored one. Only a resource type useDefaultLayout supports (currently
+    // architectures and patterns — see its SUPPORTED_TYPES — ever has
+    // `viewportKey` set by DiagramSection while `defaultLayout` is still
+    // `undefined`; dropped files resolve it to `null` immediately, and so does
+    // any caller that never sets `viewportKey` in the first place.
     const awaitingDefaultLayout = !!viewportKey && defaultLayout === undefined;
 
     useEffect(() => {

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.test.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import type { Node } from 'reactflow';
+import { PatternGraph } from './PatternGraph';
+import { saveNodePositions } from '../../services/node-position-service.js';
+
+/**
+ * Capture the props ReactFlow is rendered with. Mirrors ArchitectureGraph.test.tsx's
+ * mock: keep the real reactflow hooks (useNodesState/useEdgesState) so the graph's
+ * node state populates as it does in production, and stub only the heavy,
+ * DOM-measuring view components. PatternGraph renders two <Panel>s (decision
+ * selector + search bar), so Panel must be stubbed too.
+ */
+const reactFlowProps: { current: Record<string, unknown> | null } = { current: null };
+let reactFlowMountCount = 0;
+
+function MockReactFlow(props: Record<string, unknown>) {
+    reactFlowProps.current = props;
+    const [instanceId] = useState(() => ++reactFlowMountCount);
+    return (
+        <div data-testid="react-flow" data-instance={instanceId}>
+            {props.children as ReactNode}
+        </div>
+    );
+}
+
+vi.mock('reactflow', async () => {
+    const actual = await vi.importActual<typeof import('reactflow')>('reactflow');
+    return {
+        ...actual,
+        __esModule: true,
+        default: MockReactFlow,
+        Background: () => <div data-testid="rf-background" />,
+        Controls: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-controls">{children}</div>
+        ),
+        MiniMap: () => <div data-testid="diagram-minimap" />,
+        Panel: ({ children }: { children?: ReactNode }) => (
+            <div data-testid="rf-panel">{children}</div>
+        ),
+    };
+});
+
+// Helpers mirroring patternTransformer.test.ts — node ids come straight from
+// `unique-id`, unlike Drawer.test.tsx's fixture (empty prefixItems, which would
+// render EmptyGraphState and make a precedence assertion vacuous).
+function schemaNode(uniqueId: string, name: string, nodeType: string) {
+    return {
+        properties: {
+            'unique-id': { const: uniqueId },
+            name: { const: name },
+            'node-type': { const: nodeType },
+        },
+    };
+}
+
+function makePattern(nodes: unknown[]) {
+    return {
+        properties: {
+            nodes: { prefixItems: nodes },
+            relationships: { prefixItems: [] },
+        },
+    };
+}
+
+const mockPatternData = makePattern([
+    schemaNode('node-1', 'Service A', 'service'),
+    schemaNode('node-2', 'Database B', 'database'),
+]);
+
+describe('PatternGraph', () => {
+    beforeEach(() => {
+        reactFlowProps.current = null;
+        reactFlowMountCount = 0;
+        sessionStorage.clear();
+        vi.clearAllMocks();
+    });
+
+    describe('default layout precedence', () => {
+        const key = 'ns/id';
+
+        function nodePosition(id: string) {
+            const nodes = reactFlowProps.current?.nodes as Node[] | undefined;
+            return nodes?.find((n) => n.id === id)?.position;
+        }
+
+        it('applies the local scratch layout, even when a different server default exists', () => {
+            saveNodePositions(key, [{ id: 'node-1', position: { x: 111, y: 222 }, data: {} }] as Node[]);
+
+            render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 999, y: 999 } }]}
+                />
+            );
+
+            expect(nodePosition('node-1')).toEqual({ x: 111, y: 222 });
+        });
+
+        it('applies the server default when no local scratch is stored', () => {
+            render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 333, y: 444 } }]}
+                />
+            );
+
+            expect(nodePosition('node-1')).toEqual({ x: 333, y: 444 });
+        });
+
+        it('falls back to the auto-layout when neither scratch nor a server default exist', () => {
+            render(<PatternGraph patternData={mockPatternData} viewportKey={key} defaultLayout={null} />);
+
+            // No loading gate, no forced position — the graph renders with its own layout.
+            expect(screen.getByTestId('react-flow')).toBeInTheDocument();
+            expect(nodePosition('node-1')).toBeDefined();
+        });
+
+        it('shows a loading placeholder and withholds the graph while the server default is still loading', () => {
+            render(<PatternGraph patternData={mockPatternData} viewportKey={key} defaultLayout={undefined} />);
+
+            expect(screen.getByText('Loading saved layout…')).toBeInTheDocument();
+            expect(screen.queryByTestId('react-flow')).not.toBeInTheDocument();
+        });
+
+        it('does not gate on a missing viewportKey (e.g. a dropped file) even with defaultLayout undefined', () => {
+            render(<PatternGraph patternData={mockPatternData} defaultLayout={undefined} />);
+
+            expect(screen.getByTestId('react-flow')).toBeInTheDocument();
+        });
+
+        it('re-applies positions when layoutEpoch changes, picking up a cleared scratch layout', () => {
+            saveNodePositions(key, [{ id: 'node-1', position: { x: 111, y: 222 }, data: {} }] as Node[]);
+
+            const { rerender } = render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 333, y: 444 } }]}
+                    layoutEpoch={0}
+                />
+            );
+            expect(nodePosition('node-1')).toEqual({ x: 111, y: 222 });
+
+            // Simulate "reset to default": the scratch entry is cleared and the
+            // epoch bumps, forcing a clean re-apply of the server default.
+            localStorage.removeItem('calm-hub:node-positions:ns/id');
+            rerender(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 333, y: 444 } }]}
+                    layoutEpoch={1}
+                />
+            );
+
+            expect(nodePosition('node-1')).toEqual({ x: 333, y: 444 });
+        });
+
+        it('does not remount ReactFlow on a layoutEpoch bump, so the current viewport survives a save/reset', () => {
+            const { rerender } = render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 5, y: 6 } }]}
+                    layoutEpoch={0}
+                />
+            );
+            const instanceBefore = screen.getByTestId('react-flow').getAttribute('data-instance');
+
+            rerender(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 333, y: 444 } }]}
+                    layoutEpoch={1}
+                />
+            );
+
+            expect(screen.getByTestId('react-flow').getAttribute('data-instance')).toBe(instanceBefore);
+            expect(nodePosition('node-1')).toEqual({ x: 333, y: 444 });
+        });
+
+        it('reports applied positions upward via onPositionsChange', () => {
+            const onPositionsChange = vi.fn();
+            render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={[{ id: 'node-1', position: { x: 5, y: 6 } }]}
+                    onPositionsChange={onPositionsChange}
+                />
+            );
+
+            expect(onPositionsChange).toHaveBeenCalled();
+            const reported = onPositionsChange.mock.calls.at(-1)?.[0];
+            expect(reported.find((p: { id: string }) => p.id === 'node-1')?.position).toEqual({ x: 5, y: 6 });
+        });
+
+        it('does not re-run the parse effect when onPositionsChange gets a new identity', () => {
+            const stableDefaultLayout = [{ id: 'node-1', position: { x: 5, y: 6 } }];
+
+            const firstCallback = vi.fn();
+            const { rerender } = render(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={stableDefaultLayout}
+                    onPositionsChange={firstCallback}
+                />
+            );
+            expect(firstCallback).toHaveBeenCalledTimes(1);
+
+            // Same props except a brand-new function identity, as a naive inline
+            // arrow at a call site would produce. The parse effect must not treat
+            // this as a real dependency change.
+            const secondCallback = vi.fn();
+            rerender(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={stableDefaultLayout}
+                    onPositionsChange={secondCallback}
+                />
+            );
+
+            expect(firstCallback).toHaveBeenCalledTimes(1);
+            expect(secondCallback).not.toHaveBeenCalled();
+
+            // The next genuine re-apply (layoutEpoch bump) reports through the
+            // *current* callback, proving the ref is kept up to date.
+            rerender(
+                <PatternGraph
+                    patternData={mockPatternData}
+                    viewportKey={key}
+                    defaultLayout={stableDefaultLayout}
+                    onPositionsChange={secondCallback}
+                    layoutEpoch={1}
+                />
+            );
+            expect(secondCallback).toHaveBeenCalledTimes(1);
+            expect(firstCallback).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternGraph.tsx
@@ -22,7 +22,7 @@ import { EmptyGraphState } from './EmptyGraphState.js';
 import { parsePatternData } from './utils/patternTransformer.js';
 import { getMatchingNodeIds, isEdgeVisible, getUniqueNodeTypes } from './utils/searchUtils.js';
 import { useGraphInteractions } from './hooks/useGraphInteractions.js';
-import { applyStoredPositions } from '../../services/node-position-service.js';
+import { applyPositions, loadStoredNodePositions, toStoredPositions, type StoredNodePosition } from '../../services/node-position-service.js';
 import { useIsMobile } from '../../../hooks/useMediaQuery.js';
 import { useNodeSearch } from './node-search-context.js';
 import { DecisionSelectorPanel } from './DecisionSelectorPanel.js';
@@ -47,13 +47,36 @@ interface PatternGraphProps {
     onNodeClick?: (nodeData: Record<string, unknown>) => void;
     onEdgeClick?: (edgeData: Record<string, unknown>) => void;
     viewportKey?: string;
+    /** Server-stored default layout for a pattern. undefined = loading, null = none stored. */
+    defaultLayout?: StoredNodePosition[] | null;
+    /** Bumped to force a clean re-apply of positions (used by "reset to default"). */
+    layoutEpoch?: number;
+    onPositionsChange?: (positions: StoredNodePosition[]) => void;
 }
 
-export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKey }: PatternGraphProps) {
+export function PatternGraph({
+    patternData,
+    onNodeClick,
+    onEdgeClick,
+    viewportKey,
+    defaultLayout,
+    layoutEpoch,
+    onPositionsChange,
+}: PatternGraphProps) {
     const savedViewport = useMemo<Viewport | undefined>(
         () => (viewportKey ? readViewportForKey(viewportKey) : undefined),
         [viewportKey]
     );
+
+    // See ArchitectureGraph: holds the latest onPositionsChange in a ref so the
+    // parse effect below doesn't have to depend on the caller's function identity.
+    const onPositionsChangeRef = useRef(onPositionsChange);
+    useEffect(() => {
+        onPositionsChangeRef.current = onPositionsChange;
+    });
+    const reportPositions = useCallback((positions: StoredNodePosition[]) => {
+        onPositionsChangeRef.current?.(positions);
+    }, []);
 
     const [nodes, setNodes, onNodesChangeBase] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -83,19 +106,46 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
         onEdgeClick,
         groupNodeTypes: GROUP_NODE_TYPES,
         persistKey: viewportKey,
+        onPositionsChange: reportPositions,
     });
 
+    // Still fetching the server default for this diagram: hold off applying
+    // positions rather than flashing the auto-layout and then jumping to the
+    // restored one. See ArchitectureGraph's awaitingDefaultLayout for the
+    // invariant this relies on: DiagramSection is the only caller that ever
+    // sets `viewportKey` here, and it always does so via useDefaultLayout,
+    // which settles `defaultLayout` away from `undefined` for every type it
+    // supports — so this can't get stuck for a caller that forgot to pass one.
+    const awaitingDefaultLayout = !!viewportKey && defaultLayout === undefined;
+
     useEffect(() => {
+        if (awaitingDefaultLayout) return;
+
         const { nodes: parsedNodes, edges: parsedEdges } = parsePatternData(patternData);
         sourceNodesRef.current = parsedNodes;
         sourceEdgesRef.current = parsedEdges;
-        // Restore any custom layout the user dragged for this diagram, falling
-        // back to the parsed auto-layout when none is stored.
-        setNodes(viewportKey ? applyStoredPositions(viewportKey, parsedNodes) : parsedNodes);
+        // Precedence: an unsaved local drag always wins over the saved default,
+        // which in turn wins over the parsed auto-layout when neither is present.
+        const localPositions = viewportKey ? loadStoredNodePositions(viewportKey) : null;
+        const effectivePositions = localPositions ?? defaultLayout ?? null;
+        const positionedNodes = applyPositions(parsedNodes, effectivePositions);
+
+        setNodes(positionedNodes);
         setEdges(parsedEdges);
         setAvailableNodeTypes(getUniqueNodeTypes(parsedNodes));
         setDecisionPoints(extractDecisionPoints(parsedNodes));
-    }, [patternData, setNodes, setEdges, setAvailableNodeTypes, viewportKey]);
+        reportPositions(toStoredPositions(positionedNodes));
+    }, [
+        patternData,
+        setNodes,
+        setEdges,
+        setAvailableNodeTypes,
+        viewportKey,
+        defaultLayout,
+        layoutEpoch,
+        awaitingDefaultLayout,
+        reportPositions,
+    ]);
 
     // Search & filter
     const isSearchActive = searchTerm !== '' || typeFilter !== '';
@@ -165,6 +215,10 @@ export function PatternGraph({ patternData, onNodeClick, onEdgeClick, viewportKe
     const handleDecisionReset = useCallback(() => {
         setDecisionSelections(new Map());
     }, []);
+
+    if (awaitingDefaultLayout) {
+        return <EmptyGraphState message="Loading saved layout…" />;
+    }
 
     if (nodes.length === 0) {
         return <EmptyGraphState message="No pattern data to display. Load a CALM pattern to visualize." />;

--- a/calm-hub-ui/src/visualizer/components/reactflow/PatternVisualizer.tsx
+++ b/calm-hub-ui/src/visualizer/components/reactflow/PatternVisualizer.tsx
@@ -1,4 +1,5 @@
 import { PatternGraph } from './PatternGraph.js';
+import type { StoredNodePosition } from '../../services/node-position-service.js';
 
 export interface PatternVisualizerProps {
     patternData: Record<string, unknown>;
@@ -7,6 +8,11 @@ export interface PatternVisualizerProps {
     onBackgroundClick?: () => void;
     /** Identifies the diagram (namespace/id) so its viewport can be remembered. */
     viewportKey?: string;
+    /** Server-stored default layout for a pattern. undefined = loading, null = none stored. */
+    defaultLayout?: StoredNodePosition[] | null;
+    /** Bumped to force a clean re-apply of positions (used by "reset to default"). */
+    layoutEpoch?: number;
+    onPositionsChange?: (positions: StoredNodePosition[]) => void;
 }
 
 export function PatternVisualizer({
@@ -15,6 +21,9 @@ export function PatternVisualizer({
     onEdgeClick,
     onBackgroundClick,
     viewportKey,
+    defaultLayout,
+    layoutEpoch,
+    onPositionsChange,
 }: PatternVisualizerProps) {
     const handleBackgroundClick = (event: React.MouseEvent) => {
         if ((event.target as HTMLElement).classList.contains('react-flow__pane')) {
@@ -39,6 +48,9 @@ export function PatternVisualizer({
                 onNodeClick={onNodeClick}
                 onEdgeClick={onEdgeClick}
                 viewportKey={viewportKey}
+                defaultLayout={defaultLayout}
+                layoutEpoch={layoutEpoch}
+                onPositionsChange={onPositionsChange}
             />
         </div>
     );

--- a/calm-hub-ui/src/visualizer/contracts/visualizer-contracts.ts
+++ b/calm-hub-ui/src/visualizer/contracts/visualizer-contracts.ts
@@ -34,14 +34,15 @@ export interface DrawerProps {
     onItemSelect?: (item: SelectedItem) => void;
     decorators?: Decorator[];
     /**
-     * Overrides Drawer's own `${data.name}/${data.id}` viewport key computation.
-     * Used by DiagramSection to key the graph off a slug's *resolved numeric*
-     * architecture id instead of the raw slug, so the same architecture reached
-     * via a slug route and a numeric route share one localStorage scratch entry
-     * and one server layout call. Three states:
+     * Overrides Drawer's own `${data.name}/${data.calmType}/${data.id}` viewport
+     * key computation. Used by DiagramSection to key the graph off a slug's
+     * *resolved numeric* architecture id instead of the raw slug, so the same
+     * architecture reached via a slug route and a numeric route share one
+     * localStorage scratch entry and one server layout call. Three states:
      *  - a string: the resolved key to use.
-     *  - `undefined`: no opinion — Drawer falls back to its own `${data.name}/${data.id}`
-     *    computation. This is the state while a slug is still resolving (never `null`
+     *  - `undefined`: no opinion — Drawer falls back to its own
+     *    `${data.name}/${data.calmType}/${data.id}` computation. This is the
+     *    state while a slug is still resolving (never `null`
      *    then — see `useDefaultLayout`), and always the state for patterns and dropped
      *    files, which never receive an override.
      *  - `null`: an explicit "there is no stable key" — a slug that finished resolving

--- a/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
@@ -69,6 +69,37 @@ describe('node-position-service', () => {
             storage.setItem(`${STORAGE_PREFIX}${key}`, '{"id":"node-1"}');
             expect(loadStoredNodePositions(key, storage)).toBeNull();
         });
+
+        it('falls back to the pre-calmType-qualified key and migrates it forward', () => {
+            const legacyKey = 'finos/42';
+            const newKey = 'finos/Architectures/42';
+            saveNodePositions(legacyKey, nodes, storage);
+
+            expect(loadStoredNodePositions(newKey, storage)).toEqual(storedPositions);
+            // Migrated: readable directly under the new key next time, and the
+            // legacy entry is gone so it can't resurface for a different diagram.
+            expect(storage.getItem(`${STORAGE_PREFIX}${newKey}`)).not.toBeNull();
+            expect(storage.getItem(`${STORAGE_PREFIX}${legacyKey}`)).toBeNull();
+        });
+
+        it('does not fall back when the current key already has stored positions', () => {
+            const legacyKey = 'finos/42';
+            const newKey = 'finos/Architectures/42';
+            saveNodePositions(legacyKey, [{ id: 'legacy-node', position: { x: 1, y: 1 }, data: {} }], storage);
+            saveNodePositions(newKey, nodes, storage);
+
+            expect(loadStoredNodePositions(newKey, storage)).toEqual(storedPositions);
+            // Untouched: the legacy entry belongs to whichever other diagram (if
+            // any) still needs it — only an empty current key triggers migration.
+            expect(storage.getItem(`${STORAGE_PREFIX}${legacyKey}`)).not.toBeNull();
+        });
+
+        it('does not attempt a fallback for a key that has no legacy shape', () => {
+            // A dropped file's key (undefined) never reaches here; a 2-segment key
+            // like the pre-existing `key` fixture already IS the legacy shape.
+            expect(loadStoredNodePositions(key, storage)).toBeNull();
+            expect(storage.length).toBe(0);
+        });
     });
 
     describe('applyStoredPositions', () => {

--- a/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.test.tsx
@@ -3,6 +3,7 @@ import type { Node } from 'reactflow';
 import {
     applyPositions,
     applyStoredPositions,
+    buildViewportKey,
     clearStoredNodePositions,
     loadStoredNodePositions,
     saveNodePositions,
@@ -99,6 +100,24 @@ describe('node-position-service', () => {
             // like the pre-existing `key` fixture already IS the legacy shape.
             expect(loadStoredNodePositions(key, storage)).toBeNull();
             expect(storage.length).toBe(0);
+        });
+    });
+
+    describe('buildViewportKey', () => {
+        it('joins namespace, calmType and id with a slash', () => {
+            expect(buildViewportKey('finos', 'Architectures', 42)).toBe('finos/Architectures/42');
+        });
+
+        it('accepts a string id, matching a resolved slug id', () => {
+            expect(buildViewportKey('finos', 'Patterns', '7')).toBe('finos/Patterns/7');
+        });
+
+        it('round-trips through legacyStorageKeyFor\'s three-segment recognition', () => {
+            const legacyKey = 'finos/42';
+            const newKey = buildViewportKey('finos', 'Architectures', 42);
+            saveNodePositions(legacyKey, nodes, storage);
+
+            expect(loadStoredNodePositions(newKey, storage)).toEqual(storedPositions);
         });
     });
 

--- a/calm-hub-ui/src/visualizer/services/node-position-service.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.tsx
@@ -24,17 +24,40 @@ const STORAGE_PREFIX = 'calm-hub:node-positions:';
 const storageKeyFor = (key: string) => `${STORAGE_PREFIX}${key}`;
 
 /**
+ * A diagram key has exactly this many `/`-separated segments — see
+ * `buildViewportKey`. Exported so `legacyStorageKeyFor` and any other code
+ * that needs to recognise the shape (rather than build it) shares the same
+ * constant instead of a bare `3` magic number.
+ */
+export const VIEWPORT_KEY_SEGMENTS = 3;
+
+/**
+ * Builds the diagram key identifying a resource's viewport/scratch-position/
+ * default-layout storage, independent of the version being viewed:
+ * `namespace/calmType/id`. The single source of truth for this shape — call
+ * this rather than hand-building the template, so a future change to the key
+ * (e.g. adding a version component) can't update one call site and silently
+ * drift from another, reintroducing the architecture/pattern id collision
+ * this key shape was introduced to close (an Architecture 7 and a Pattern 7
+ * can coexist in one namespace, since the two ids are drawn from independent
+ * counters).
+ */
+export function buildViewportKey(namespace: string, calmType: string, id: string | number): string {
+    return `${namespace}/${calmType}/${id}`;
+}
+
+/**
  * Derives the pre-calmType-qualified key (`namespace/id`) a diagram key
  * (`namespace/calmType/id`) would have been stored under before the calmType
  * component was added to prevent an architecture and a pattern with the same
  * numeric id from colliding. Used only as a one-time read fallback in
  * `loadStoredNodePositions`, so a user's already-dragged-but-unsaved layout
  * from before that change isn't silently discarded. `undefined` for any key
- * not in the three-segment shape (e.g. a dropped file has no key at all).
+ * not in the `buildViewportKey` shape (e.g. a dropped file has no key at all).
  */
 function legacyStorageKeyFor(key: string): string | undefined {
     const parts = key.split('/');
-    return parts.length === 3 ? `${parts[0]}/${parts[2]}` : undefined;
+    return parts.length === VIEWPORT_KEY_SEGMENTS ? `${parts[0]}/${parts[2]}` : undefined;
 }
 
 /** Reduce a diagram's nodes to just the id/position pairs worth persisting. */

--- a/calm-hub-ui/src/visualizer/services/node-position-service.tsx
+++ b/calm-hub-ui/src/visualizer/services/node-position-service.tsx
@@ -23,6 +23,20 @@ const STORAGE_PREFIX = 'calm-hub:node-positions:';
 
 const storageKeyFor = (key: string) => `${STORAGE_PREFIX}${key}`;
 
+/**
+ * Derives the pre-calmType-qualified key (`namespace/id`) a diagram key
+ * (`namespace/calmType/id`) would have been stored under before the calmType
+ * component was added to prevent an architecture and a pattern with the same
+ * numeric id from colliding. Used only as a one-time read fallback in
+ * `loadStoredNodePositions`, so a user's already-dragged-but-unsaved layout
+ * from before that change isn't silently discarded. `undefined` for any key
+ * not in the three-segment shape (e.g. a dropped file has no key at all).
+ */
+function legacyStorageKeyFor(key: string): string | undefined {
+    const parts = key.split('/');
+    return parts.length === 3 ? `${parts[0]}/${parts[2]}` : undefined;
+}
+
 /** Reduce a diagram's nodes to just the id/position pairs worth persisting. */
 export function toStoredPositions(nodes: Node[]): StoredNodePosition[] {
     return nodes.map((node) => ({
@@ -49,19 +63,40 @@ export function clearStoredNodePositions(key: string, storage: Storage = localSt
     }
 }
 
-/** The stored positions for a diagram key, or null when none/unreadable. */
+/**
+ * The stored positions for a diagram key, or null when none/unreadable. Falls
+ * back to the pre-calmType-qualified key (see `legacyStorageKeyFor`) when
+ * nothing is stored under the current key, migrating any match forward (and
+ * removing the legacy entry) so it is found directly next time and an
+ * architecture/pattern id collision under the old key can't resurface it for
+ * the wrong diagram later.
+ */
 export function loadStoredNodePositions(key: string, storage: Storage = localStorage): StoredNodePosition[] | null {
     try {
         const data = storage.getItem(storageKeyFor(key));
-        if (!data) return null;
-        const parsed = JSON.parse(data);
-        // Guard against valid JSON of an unexpected shape (e.g. tampered or
-        // collided storage): only an array is usable downstream.
-        return Array.isArray(parsed) ? (parsed as StoredNodePosition[]) : null;
+        if (data) return parseStoredPositions(data);
+
+        const legacyKey = legacyStorageKeyFor(key);
+        if (!legacyKey) return null;
+        const legacyData = storage.getItem(storageKeyFor(legacyKey));
+        if (!legacyData) return null;
+
+        const positions = parseStoredPositions(legacyData);
+        if (!positions) return null;
+
+        storage.setItem(storageKeyFor(key), legacyData);
+        storage.removeItem(storageKeyFor(legacyKey));
+        return positions;
     } catch (err) {
         console.error('Failed to load node positions:', err);
         return null;
     }
+}
+
+/** Guards against valid JSON of an unexpected shape (e.g. tampered storage): only an array is usable downstream. */
+function parseStoredPositions(data: string): StoredNodePosition[] | null {
+    const parsed = JSON.parse(data);
+    return Array.isArray(parsed) ? (parsed as StoredNodePosition[]) : null;
 }
 
 /**

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -155,16 +155,18 @@ if (isEmptyDatabase) {
         { $set: { version: NumberInt(LATEST_SCHEMA_VERSION) } },
         { upsert: true });
 
-    // Mirrors MongoIndexInitializationStep and MongoLayoutIndexStep, which the pin above
-    // skips. Keep all three in step. All seven versioned types now use the header/version
-    // shape (ADR 0001), so each gets a unique (namespace, <type>Id) instead of the old
-    // unique (namespace) — which is what allows more than one resource of a type per
-    // namespace at all — plus a unique (namespace, <type>Id, version) on its sibling
-    // versions collection. Controls and decorators keep the one-document-per-namespace
-    // index, by ADR 0004 rather than pending migration. Layouts is a fourth, distinct
-    // shape: flat and non-versioned, one document per (namespace, architectureId), with
-    // no sibling versions collection and no version axis at all — see MongoLayoutIndexStep.
-    // Do not fold it into the one-document-per-namespace loop below.
+    // Mirrors MongoIndexInitializationStep, MongoLayoutIndexStep, and
+    // MongoPatternLayoutIndexStep, which the pin above skips. Keep all four in step. All
+    // seven versioned types now use the header/version shape (ADR 0001), so each gets a
+    // unique (namespace, <type>Id) instead of the old unique (namespace) — which is what
+    // allows more than one resource of a type per namespace at all — plus a unique
+    // (namespace, <type>Id, version) on its sibling versions collection. Controls and
+    // decorators keep the one-document-per-namespace index, by ADR 0004 rather than
+    // pending migration. Layouts and pattern_layouts are a fourth, distinct shape: flat
+    // and non-versioned, one document per (namespace, architectureId) / (namespace,
+    // patternId), with no sibling versions collection and no version axis at all — see
+    // MongoLayoutIndexStep / MongoPatternLayoutIndexStep. Do not fold either into the
+    // one-document-per-namespace loop below.
     db.namespaces.createIndex({ name: 1 }, unique);
     db.domains.createIndex({ name: 1 }, unique);
     db.schemas.createIndex({ version: 1 }, unique);
@@ -188,6 +190,7 @@ if (isEmptyDatabase) {
     db.adrs.createIndex({ namespace: 1, adrId: 1 }, unique);
     db.adrVersions.createIndex({ namespace: 1, adrId: 1, version: 1 }, unique);
     db.layouts.createIndex({ namespace: 1, architectureId: 1 }, unique);
+    db.pattern_layouts.createIndex({ namespace: 1, patternId: 1 }, unique);
 
     // Still one document per namespace until each of these migrates, at which point its
     // entry moves up alongside architectures and patterns.

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -141,7 +141,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 12;
+const LATEST_SCHEMA_VERSION = 13;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -10,6 +10,7 @@ import org.finos.calm.migration.steps.MongoAdrVersionSplitStep;
 import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoInterfaceVersionSplitStep;
 import org.finos.calm.migration.steps.MongoLayoutIndexStep;
+import org.finos.calm.migration.steps.MongoPatternLayoutIndexStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
 import org.finos.calm.migration.steps.MongoResourceMappingIndexStep;
 import org.finos.calm.migration.steps.MongoTimelineVersionSplitStep;
@@ -67,6 +68,11 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             // container would run with no unique constraint on (namespace, architectureId),
             // and MongoLayoutStore's duplicate-key retry would go untested against a real index.
             new MongoLayoutIndexStep(database).createIndexes();
+            // Same reasoning as MongoLayoutIndexStep immediately above, mirrored for patterns:
+            // without this, pattern_layouts would run with no unique constraint on
+            // (namespace, patternId) under this container, and MongoPatternLayoutStore's
+            // duplicate-key retry would go untested against a real index.
+            new MongoPatternLayoutIndexStep(database).createIndexes();
             // Widens resource_mappings' unique index to (namespace, resourceType, customId) —
             // MongoIndexInitializationStep above only ever creates the old, narrower
             // (namespace, customId) index (it is never edited after being merged), so without

--- a/calm-hub/src/main/java/org/finos/calm/domain/audit/AuditEntityType.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/audit/AuditEntityType.java
@@ -18,5 +18,6 @@ public enum AuditEntityType {
     TIMELINE,
     USER_ACCESS,
     SCHEMA,
-    LAYOUT
+    LAYOUT,
+    PATTERN_LAYOUT
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoPatternLayoutIndexStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoPatternLayoutIndexStep.java
@@ -1,0 +1,87 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates the unique index the pattern-layout storage shape needs: one document per
+ * {@code (namespace, patternId)} in the {@code pattern_layouts} collection, mirroring
+ * {@link MongoLayoutIndexStep} at {@code fromVersion() == 9} for architecture layouts.
+ *
+ * <h2>Why {@code fromVersion() == 11}</h2>
+ * {@code 9} ({@link MongoLayoutIndexStep}) was the highest {@code fromVersion()} in use when
+ * this step was first drafted, making {@code 10} the next unused value — but
+ * {@code MongoAdrTitleBackfillStep} landed at {@code fromVersion() == 10} first, so this step
+ * was moved to {@code 11}. A wrong or duplicate {@code fromVersion()} is a fatal startup
+ * {@code IllegalStateException} — see {@code SchemaMigrationRunner}'s duplicate-{@code fromVersion}
+ * guard — so this must be re-verified as still unused immediately before implementing, not just
+ * once at design time.
+ *
+ * <h2>Why this needs no data migration</h2>
+ * As with {@link MongoLayoutIndexStep}, this is a brand-new collection with no pre-existing
+ * data to move — this step only ever needs to establish the index.
+ *
+ * <h2>Why {@code init-mongo.js} must change too</h2>
+ * A freshly-seeded database pins {@code LATEST_SCHEMA_VERSION} directly and never runs any
+ * migration step, including this one. {@code calm-hub/mongo/init-mongo.js} must create the same
+ * unique index at seed time and bump {@code LATEST_SCHEMA_VERSION} to {@code 12} in the same
+ * change, or a fresh install silently ships with no uniqueness guarantee on
+ * {@code pattern_layouts} at all.
+ *
+ * <h2>Mongo-only</h2>
+ * Nitrite creates no indexes at all (see {@code NitriteVersionSplitMigration}'s javadoc), so
+ * there is no Nitrite twin at this {@code fromVersion()}.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoPatternLayoutIndexStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoPatternLayoutIndexStep.class);
+
+    private static final String COLLECTION = "pattern_layouts";
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String PATTERN_ID_FIELD = "patternId";
+
+    private final MongoDatabase database;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoPatternLayoutIndexStep(MongoDatabase database) {
+        this.database = database;
+    }
+
+    @Override
+    public int fromVersion() {
+        return 11;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping pattern layout index creation (database mode: {})", databaseMode);
+            return;
+        }
+        createIndexes();
+    }
+
+    /**
+     * Creates the index unconditionally — no {@code databaseMode} check. Public, like
+     * {@code MongoLayoutIndexStep#createIndexes()}, specifically so integration-test
+     * infrastructure with a known-real MongoDB container can call it directly.
+     */
+    public void createIndexes() {
+        MongoCollection<Document> patternLayouts = database.getCollection(COLLECTION);
+        patternLayouts.createIndex(new Document(NAMESPACE_FIELD, 1).append(PATTERN_ID_FIELD, 1),
+                new IndexOptions().unique(true));
+        LOG.info("Ensured unique index on {}.({}, {})", COLLECTION, NAMESPACE_FIELD, PATTERN_ID_FIELD);
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoPatternLayoutIndexStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoPatternLayoutIndexStep.java
@@ -16,14 +16,16 @@ import org.slf4j.LoggerFactory;
  * {@code (namespace, patternId)} in the {@code pattern_layouts} collection, mirroring
  * {@link MongoLayoutIndexStep} at {@code fromVersion() == 9} for architecture layouts.
  *
- * <h2>Why {@code fromVersion() == 11}</h2>
+ * <h2>Why {@code fromVersion() == 12}</h2>
  * {@code 9} ({@link MongoLayoutIndexStep}) was the highest {@code fromVersion()} in use when
  * this step was first drafted, making {@code 10} the next unused value — but
  * {@code MongoAdrTitleBackfillStep} landed at {@code fromVersion() == 10} first, so this step
- * was moved to {@code 11}. A wrong or duplicate {@code fromVersion()} is a fatal startup
- * {@code IllegalStateException} — see {@code SchemaMigrationRunner}'s duplicate-{@code fromVersion}
- * guard — so this must be re-verified as still unused immediately before implementing, not just
- * once at design time.
+ * moved to {@code 11}. It was then bumped again to {@code 12}, since {@code
+ * MongoResourceMappingIndexStep} (landed first, fixing the {@code resource_mappings}
+ * namespace+customId collision) took {@code 11}. A wrong or duplicate {@code fromVersion()}
+ * is a fatal startup {@code IllegalStateException} — see {@code SchemaMigrationRunner}'s
+ * duplicate-{@code fromVersion} guard — so this must be re-verified as still unused
+ * immediately before implementing, not just once at design time.
  *
  * <h2>Why this needs no data migration</h2>
  * As with {@link MongoLayoutIndexStep}, this is a brand-new collection with no pre-existing
@@ -32,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * <h2>Why {@code init-mongo.js} must change too</h2>
  * A freshly-seeded database pins {@code LATEST_SCHEMA_VERSION} directly and never runs any
  * migration step, including this one. {@code calm-hub/mongo/init-mongo.js} must create the same
- * unique index at seed time and bump {@code LATEST_SCHEMA_VERSION} to {@code 12} in the same
+ * unique index at seed time and bump {@code LATEST_SCHEMA_VERSION} to {@code 13} in the same
  * change, or a fresh install silently ships with no uniqueness guarantee on
  * {@code pattern_layouts} at all.
  *
@@ -61,7 +63,7 @@ public class MongoPatternLayoutIndexStep implements SchemaMigrationStep {
 
     @Override
     public int fromVersion() {
-        return 11;
+        return 12;
     }
 
     @Override

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -56,15 +56,38 @@ public class CalmResourceErrorResponses {
     }
 
     /**
+     * Returns a 404 response for a pattern layout write against a pattern id that does not
+     * exist. Mirrors {@link #architectureNotFoundResponse(String, int)}.
+     */
+    public static Response patternNotFoundResponse(String namespace, int patternId) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity("Pattern " + patternId + " does not exist in namespace: "
+                        + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
+                .build();
+    }
+
+    /**
+     * Mirrors {@link #layoutNotFoundResponse(String, int)} for a pattern's default layout.
+     */
+    public static Response patternLayoutNotFoundResponse(String namespace, int patternId) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity("No default layout saved for pattern " + patternId + " in namespace: "
+                        + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
+                .build();
+    }
+
+    /**
      * Returns a 400 response for a layout PUT whose {@code for} target does not match the
-     * architecture named in the URL. {@code forPath} is user-derived (parsed straight out of
+     * resource named in the URL. {@code forPath} is user-derived (parsed straight out of
      * the request body) and is sanitized before being echoed back; {@code expectedPath} is
      * server-constructed from validated path parameters and is trusted as-is.
+     *
+     * @param resourceType the kind of resource the layout belongs to (e.g. "architecture", "pattern")
      */
-    public static Response invalidLayoutTargetResponse(String forPath, String expectedPath) {
+    public static Response invalidLayoutTargetResponse(String forPath, String expectedPath, String resourceType) {
         String sanitizedForPath = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(forPath);
         return Response.status(Response.Status.BAD_REQUEST)
-                .entity("Layout 'for' [" + sanitizedForPath + "] does not match architecture [" + expectedPath + "]")
+                .entity("Layout 'for' [" + sanitizedForPath + "] does not match " + resourceType + " [" + expectedPath + "]")
                 .build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -35,45 +35,44 @@ public class CalmResourceErrorResponses {
     }
 
     /**
-     * Returns a 404 response for a layout write against an architecture id that does not
-     * exist. Deliberately not a reuse of {@link org.finos.calm.resources.ArchitectureResource}'s
-     * own not-found response — that one is terser ("Invalid architecture provided") and
-     * changing it would alter five existing, already-tested response bodies for a change
-     * scoped to layout saves.
+     * Returns a 404 response for a layout write against a resource id that does not exist.
+     * Deliberately not a reuse of {@link org.finos.calm.resources.ArchitectureResource}'s own
+     * not-found response — that one is terser ("Invalid architecture provided") and changing it
+     * would alter five existing, already-tested response bodies for a change scoped to layout
+     * saves. Parameterized on {@code resourceType} rather than one hard-coded-noun method per
+     * type, the same convention {@link #invalidLayoutTargetResponse} already uses — a wording or
+     * sanitization fix here now reaches every layout-owning resource type at once.
+     *
+     * @param resourceType the kind of resource, lowercase (e.g. "architecture", "pattern");
+     *                      capitalized in the response body
+     * @param namespace    the namespace the resource belongs to
+     * @param id           the id of the missing resource
      */
-    public static Response architectureNotFoundResponse(String namespace, int architectureId) {
+    public static Response resourceNotFoundResponse(String resourceType, String namespace, int id) {
         return Response.status(Response.Status.NOT_FOUND)
-                .entity("Architecture " + architectureId + " does not exist in namespace: "
-                        + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
-                .build();
-    }
-
-    public static Response layoutNotFoundResponse(String namespace, int architectureId) {
-        return Response.status(Response.Status.NOT_FOUND)
-                .entity("No default layout saved for architecture " + architectureId + " in namespace: "
-                        + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
-                .build();
-    }
-
-    /**
-     * Returns a 404 response for a pattern layout write against a pattern id that does not
-     * exist. Mirrors {@link #architectureNotFoundResponse(String, int)}.
-     */
-    public static Response patternNotFoundResponse(String namespace, int patternId) {
-        return Response.status(Response.Status.NOT_FOUND)
-                .entity("Pattern " + patternId + " does not exist in namespace: "
+                .entity(capitalize(resourceType) + " " + id + " does not exist in namespace: "
                         + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
                 .build();
     }
 
     /**
-     * Mirrors {@link #layoutNotFoundResponse(String, int)} for a pattern's default layout.
+     * Returns a 404 response for a resource with no saved default layout. See
+     * {@link #resourceNotFoundResponse} for why this is parameterized on {@code resourceType}
+     * rather than one method per resource type.
+     *
+     * @param resourceType the kind of resource, lowercase (e.g. "architecture", "pattern")
+     * @param namespace    the namespace the resource belongs to
+     * @param id           the id of the resource
      */
-    public static Response patternLayoutNotFoundResponse(String namespace, int patternId) {
+    public static Response resourceLayoutNotFoundResponse(String resourceType, String namespace, int id) {
         return Response.status(Response.Status.NOT_FOUND)
-                .entity("No default layout saved for pattern " + patternId + " in namespace: "
+                .entity("No default layout saved for " + resourceType + " " + id + " in namespace: "
                         + ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace))
                 .build();
+    }
+
+    private static String capitalize(String value) {
+        return value.isEmpty() ? value : Character.toUpperCase(value.charAt(0)) + value.substring(1);
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/resources/LayoutRequestParsing.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/LayoutRequestParsing.java
@@ -1,0 +1,51 @@
+package org.finos.calm.resources;
+
+import org.bson.Document;
+import org.bson.json.JsonParseException;
+
+/**
+ * Shared body-parsing and path-building logic for {@link LayoutResource} and
+ * {@link PatternLayoutResource}'s {@code saveLayout} endpoints, which are structural
+ * twins of each other — see {@link PatternLayoutStore}'s class javadoc.
+ */
+final class LayoutRequestParsing {
+
+    private LayoutRequestParsing() {
+    }
+
+    /**
+     * Parses a layout request body just far enough to read its optional {@code for}
+     * property, so a save whose {@code for} silently names a different resource than the
+     * URL can be rejected before it reaches the store. A layout with no {@code for} at all
+     * is accepted; the field's contract is defined entirely by the caller's own behaviour —
+     * compared against {@link #canonicalPath} and rejected with a 400 on mismatch — not by
+     * an external schema document.
+     *
+     * @throws JsonParseException if the body is null, blank, or not valid JSON
+     */
+    static String parseForTarget(String layoutJson) {
+        // A null body would NPE straight into Document.parse; an absent body instead arrives
+        // here as "" (confirmed empirically — RESTEasy binds a missing raw-String entity to an
+        // empty string, not null), which Document.parse doesn't reject as malformed JSON either
+        // — it throws BsonInvalidOperationException, a different exception entirely, one that
+        // the JsonParseException catch below doesn't see. Both must be rejected up front so
+        // every "no real body" case lands on the same honest 400.
+        if (layoutJson == null || layoutJson.isBlank()) {
+            throw new JsonParseException("Layout JSON must not be null or empty");
+        }
+        Document parsed = Document.parse(layoutJson);
+        Object forTarget = parsed.get("for");
+        return forTarget instanceof String forPath ? forPath : null;
+    }
+
+    /**
+     * Builds the canonical path for a numeric-ID resource, e.g.
+     * {@code /api/calm/namespaces/finos/architectures/5}.
+     *
+     * @param resourceTypeSegment the plural path segment for the resource type
+     *                            (e.g. {@code "architectures"}, {@code "patterns"})
+     */
+    static String canonicalPath(String namespace, String resourceTypeSegment, int id) {
+        return "/api/calm/namespaces/" + namespace + "/" + resourceTypeSegment + "/" + id;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/LayoutResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/LayoutResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.bson.Document;
 import org.bson.json.JsonParseException;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -110,10 +109,10 @@ public class LayoutResource {
             String layoutJson
     ) {
         try {
-            String forPath = parseForTarget(layoutJson);
-            String expectedPath = canonicalArchitecturePath(namespace, architectureId);
+            String forPath = LayoutRequestParsing.parseForTarget(layoutJson);
+            String expectedPath = LayoutRequestParsing.canonicalPath(namespace, "architectures", architectureId);
             if (forPath != null && !forPath.equals(expectedPath)) {
-                return CalmResourceErrorResponses.invalidLayoutTargetResponse(forPath, expectedPath);
+                return CalmResourceErrorResponses.invalidLayoutTargetResponse(forPath, expectedPath, "architecture");
             }
 
             // Checked on the write path only, not on get: a layout with nothing to attach to
@@ -135,34 +134,5 @@ public class LayoutResource {
             logger.error("Invalid namespace [{}] when saving layout for architecture [{}]", namespace, architectureId, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
         }
-    }
-
-    /**
-     * Parses the layout body just far enough to read its optional {@code for} property,
-     * so a save whose {@code for} silently names a different architecture than the URL can be
-     * rejected before it reaches the store. A layout with no {@code for} at all is accepted;
-     * the field's contract is defined entirely by this resource's own behaviour — compared
-     * against {@link #canonicalArchitecturePath} and rejected with a 400 on mismatch — not by
-     * an external schema document.
-     *
-     * @throws JsonParseException if the body is null, blank, or not valid JSON
-     */
-    private String parseForTarget(String layoutJson) {
-        // A null body would NPE straight into Document.parse; an absent body instead arrives
-        // here as "" (confirmed empirically — RESTEasy binds a missing raw-String entity to an
-        // empty string, not null), which Document.parse doesn't reject as malformed JSON either
-        // — it throws BsonInvalidOperationException, a different exception entirely, one that
-        // the JsonParseException catch below doesn't see. Both must be rejected up front so
-        // every "no real body" case lands on the same honest 400.
-        if (layoutJson == null || layoutJson.isBlank()) {
-            throw new JsonParseException("Layout JSON must not be null or empty");
-        }
-        Document parsed = Document.parse(layoutJson);
-        Object forTarget = parsed.get("for");
-        return forTarget instanceof String forPath ? forPath : null;
-    }
-
-    private String canonicalArchitecturePath(String namespace, int architectureId) {
-        return "/api/calm/namespaces/" + namespace + "/architectures/" + architectureId;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/LayoutResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/LayoutResource.java
@@ -16,9 +16,9 @@ import jakarta.ws.rs.core.Response;
 import org.bson.json.JsonParseException;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
-import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.LayoutStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,13 +43,11 @@ import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REG
 public class LayoutResource {
 
     private final LayoutStore layoutStore;
-    private final ArchitectureStore architectureStore;
     private final Logger logger = LoggerFactory.getLogger(LayoutResource.class);
 
     @Inject
-    public LayoutResource(LayoutStore layoutStore, ArchitectureStore architectureStore) {
+    public LayoutResource(LayoutStore layoutStore) {
         this.layoutStore = layoutStore;
-        this.architectureStore = architectureStore;
     }
 
     /**
@@ -75,7 +73,7 @@ public class LayoutResource {
         try {
             return layoutStore.getLayout(namespace, architectureId)
                     .map(layoutJson -> Response.ok(layoutJson).build())
-                    .orElseGet(() -> CalmResourceErrorResponses.layoutNotFoundResponse(namespace, architectureId));
+                    .orElseGet(() -> CalmResourceErrorResponses.resourceLayoutNotFoundResponse("architecture", namespace, architectureId));
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving layout for architecture [{}]", namespace, architectureId, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
@@ -118,13 +116,10 @@ public class LayoutResource {
             // Checked on the write path only, not on get: a layout with nothing to attach to
             // is a real problem (an orphan that blocks namespace deletion — see
             // NamespaceContentService.hasContent), but a GET for an unknown architecture id
-            // already 404s via layoutNotFoundResponse below, which the UI already treats as
-            // "no default saved". No need to pay for a second existence check there.
-            if (!architectureStore.architectureExists(namespace, architectureId)) {
-                logger.warn("No architecture [{}] in namespace [{}] to save a layout against", architectureId, namespace);
-                return CalmResourceErrorResponses.architectureNotFoundResponse(namespace, architectureId);
-            }
-
+            // already 404s via resourceLayoutNotFoundResponse below, which the UI already
+            // treats as "no default saved". No need to pay for a second existence check there.
+            // The check itself lives inside LayoutStore#upsertLayout — see that method's
+            // javadoc for why it isn't done here via ArchitectureStore#architectureExists.
             layoutStore.upsertLayout(namespace, architectureId, layoutJson);
             return Response.noContent().build();
         } catch (JsonParseException e) {
@@ -133,6 +128,9 @@ public class LayoutResource {
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when saving layout for architecture [{}]", namespace, architectureId, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (ArchitectureNotFoundException e) {
+            logger.warn("No architecture [{}] in namespace [{}] to save a layout against", architectureId, namespace);
+            return CalmResourceErrorResponses.resourceNotFoundResponse("architecture", namespace, architectureId);
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternLayoutResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternLayoutResource.java
@@ -17,9 +17,9 @@ import org.bson.json.JsonParseException;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.store.PatternLayoutStore;
-import org.finos.calm.store.PatternStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,14 +28,16 @@ import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REG
 
 /**
  * Resource for managing the shared, default layout of a pattern in a given namespace. A
- * structural twin of {@link LayoutResource} — see {@link PatternLayoutStore}'s class javadoc
+ * structural twin of {@link LayoutResource}; see {@link PatternLayoutStore}'s class javadoc
  * for why patterns get their own resource/store/collection rather than a
- * {@code resourceType}-discriminated extension of the architecture layout stack. Keeping this
- * as a separate resource class (rather than adding a {@code {namespace}/patterns/{patternId}/layout}
- * path to {@link LayoutResource} itself) also keeps {@code AuditRequestFilter}'s
- * one-resource-class-to-one-entity-type-to-one-path-param-name mapping simple: a shared
+ * {@code resourceType}-discriminated extension of the architecture layout stack.
+ *
+ * <p>This resource's own reason for existing as a separate class (rather than adding a
+ * {@code {namespace}/patterns/{patternId}/layout} path to {@link LayoutResource} itself) is
+ * independent of the store-level one: it keeps {@code AuditRequestFilter}'s
+ * one-resource-class-to-one-entity-type-to-one-path-param-name mapping simple. A shared
  * resource class serving both {@code architectureId} and {@code patternId} paths would look up
- * the wrong path-param name for one of the two, silently auditing a null entity id.
+ * the wrong path-param name for one of the two, silently auditing a null entity id.</p>
  *
  * <p>As with architecture layouts, a pattern's layout is not versioned — see
  * {@link PatternLayoutStore}'s class javadoc — so there is exactly one layout per pattern,
@@ -55,13 +57,11 @@ import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REG
 public class PatternLayoutResource {
 
     private final PatternLayoutStore patternLayoutStore;
-    private final PatternStore patternStore;
     private final Logger logger = LoggerFactory.getLogger(PatternLayoutResource.class);
 
     @Inject
-    public PatternLayoutResource(PatternLayoutStore patternLayoutStore, PatternStore patternStore) {
+    public PatternLayoutResource(PatternLayoutStore patternLayoutStore) {
         this.patternLayoutStore = patternLayoutStore;
-        this.patternStore = patternStore;
     }
 
     /**
@@ -87,7 +87,7 @@ public class PatternLayoutResource {
         try {
             return patternLayoutStore.getLayout(namespace, patternId)
                     .map(layoutJson -> Response.ok(layoutJson).build())
-                    .orElseGet(() -> CalmResourceErrorResponses.patternLayoutNotFoundResponse(namespace, patternId));
+                    .orElseGet(() -> CalmResourceErrorResponses.resourceLayoutNotFoundResponse("pattern", namespace, patternId));
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving layout for pattern [{}]", namespace, patternId, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
@@ -128,11 +128,8 @@ public class PatternLayoutResource {
             }
 
             // Checked on the write path only, not on get — mirrors LayoutResource#saveLayout.
-            if (!patternStore.patternExists(namespace, patternId)) {
-                logger.warn("No pattern [{}] in namespace [{}] to save a layout against", patternId, namespace);
-                return CalmResourceErrorResponses.patternNotFoundResponse(namespace, patternId);
-            }
-
+            // The check itself lives inside PatternLayoutStore#upsertLayout — see that
+            // method's javadoc for why it isn't done here via PatternStore#patternExists.
             patternLayoutStore.upsertLayout(namespace, patternId, layoutJson);
             return Response.noContent().build();
         } catch (JsonParseException e) {
@@ -141,6 +138,9 @@ public class PatternLayoutResource {
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when saving layout for pattern [{}]", namespace, patternId, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (PatternNotFoundException e) {
+            logger.warn("No pattern [{}] in namespace [{}] to save a layout against", patternId, namespace);
+            return CalmResourceErrorResponses.resourceNotFoundResponse("pattern", namespace, patternId);
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternLayoutResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternLayoutResource.java
@@ -1,0 +1,146 @@
+package org.finos.calm.resources;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.bson.json.JsonParseException;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.store.PatternLayoutStore;
+import org.finos.calm.store.PatternStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_REGEX;
+
+/**
+ * Resource for managing the shared, default layout of a pattern in a given namespace. A
+ * structural twin of {@link LayoutResource} — see {@link PatternLayoutStore}'s class javadoc
+ * for why patterns get their own resource/store/collection rather than a
+ * {@code resourceType}-discriminated extension of the architecture layout stack. Keeping this
+ * as a separate resource class (rather than adding a {@code {namespace}/patterns/{patternId}/layout}
+ * path to {@link LayoutResource} itself) also keeps {@code AuditRequestFilter}'s
+ * one-resource-class-to-one-entity-type-to-one-path-param-name mapping simple: a shared
+ * resource class serving both {@code architectureId} and {@code patternId} paths would look up
+ * the wrong path-param name for one of the two, silently auditing a null entity id.
+ *
+ * <p>As with architecture layouts, a pattern's layout is not versioned — see
+ * {@link PatternLayoutStore}'s class javadoc — so there is exactly one layout per pattern,
+ * addressed with no {@code version} path segment. Saving is a {@code PUT} rather than a
+ * {@code POST} because it is always an idempotent upsert.</p>
+ *
+ * <p>The {@code for}-target check below doubles as a cross-type guard: a {@code for} naming
+ * the <em>architecture</em> path for the same numeric id (a real possibility, since
+ * architecture ids and pattern ids are drawn from independent counters — see
+ * {@link PatternLayoutStore}'s class javadoc) does not equal this resource's pattern-canonical
+ * path either, so it is rejected by the same equality check as any other mismatched target, with
+ * no separate case needed.</p>
+ */
+@Tag(name = "Storage API", description = "Numeric-ID based CALM storage endpoints")
+@Path("/api/calm/namespaces")
+@Authenticated
+public class PatternLayoutResource {
+
+    private final PatternLayoutStore patternLayoutStore;
+    private final PatternStore patternStore;
+    private final Logger logger = LoggerFactory.getLogger(PatternLayoutResource.class);
+
+    @Inject
+    public PatternLayoutResource(PatternLayoutStore patternLayoutStore, PatternStore patternStore) {
+        this.patternLayoutStore = patternLayoutStore;
+        this.patternStore = patternStore;
+    }
+
+    /**
+     * Retrieve the default layout for a pattern, if one has been saved.
+     *
+     * @param namespace the namespace the pattern belongs to
+     * @param patternId the id of the pattern
+     * @return the layout, or a 404 if none has been saved
+     */
+    @GET
+    @Path("{namespace}/patterns/{patternId}/layout")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Retrieve the default layout for a pattern",
+            description = "Returns the shared default layout saved for this pattern, if one has been saved. "
+                    + "A layout is not version-scoped: it applies across every version of the pattern."
+    )
+    @PermissionsAllowed(CalmHubScopes.READ)
+    public Response getLayout(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("patternId") @Min(value = 1, message = "Pattern ID must be a positive integer") int patternId
+    ) {
+        try {
+            return patternLayoutStore.getLayout(namespace, patternId)
+                    .map(layoutJson -> Response.ok(layoutJson).build())
+                    .orElseGet(() -> CalmResourceErrorResponses.patternLayoutNotFoundResponse(namespace, patternId));
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when retrieving layout for pattern [{}]", namespace, patternId, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        }
+    }
+
+    /**
+     * Save (create or overwrite) the default layout for a pattern.
+     *
+     * @param namespace  the namespace the pattern belongs to
+     * @param patternId  the id of the pattern
+     * @param layoutJson the layout as a raw JSON body — a CALM Hub-internal shape, not a
+     *                   validated CALM community schema; see {@link PatternLayoutStore}'s class
+     *                   javadoc and ADR 0005
+     * @return 204 on success, or an appropriate error response
+     */
+    @PUT
+    @Path("{namespace}/patterns/{patternId}/layout")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Save the default layout for a pattern",
+            description = "Creates or overwrites the shared default layout for this pattern, requiring "
+                    + "namespace write access. If the layout body includes a `for` target, it must reference "
+                    + "this pattern's canonical path. The pattern must already exist."
+    )
+    @PermissionsAllowed(CalmHubScopes.WRITE)
+    public Response saveLayout(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("patternId") @Min(value = 1, message = "Pattern ID must be a positive integer") int patternId,
+            String layoutJson
+    ) {
+        try {
+            String forPath = LayoutRequestParsing.parseForTarget(layoutJson);
+            String expectedPath = LayoutRequestParsing.canonicalPath(namespace, "patterns", patternId);
+            if (forPath != null && !forPath.equals(expectedPath)) {
+                return CalmResourceErrorResponses.invalidLayoutTargetResponse(forPath, expectedPath, "pattern");
+            }
+
+            // Checked on the write path only, not on get — mirrors LayoutResource#saveLayout.
+            if (!patternStore.patternExists(namespace, patternId)) {
+                logger.warn("No pattern [{}] in namespace [{}] to save a layout against", patternId, namespace);
+                return CalmResourceErrorResponses.patternNotFoundResponse(namespace, patternId);
+            }
+
+            patternLayoutStore.upsertLayout(namespace, patternId, layoutJson);
+            return Response.noContent().build();
+        } catch (JsonParseException e) {
+            logger.error("Cannot parse layout JSON for pattern [{}] in namespace [{}]", patternId, namespace, e);
+            return CalmResourceErrorResponses.invalidJsonResponse("layout");
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when saving layout for pattern [{}]", namespace, patternId, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
@@ -28,6 +28,7 @@ import org.finos.calm.resources.InterfaceResource;
 import org.finos.calm.resources.LayoutResource;
 import org.finos.calm.resources.MappingControllerResource;
 import org.finos.calm.resources.NamespaceResource;
+import org.finos.calm.resources.PatternLayoutResource;
 import org.finos.calm.resources.PatternResource;
 import org.finos.calm.resources.StandardResource;
 import org.finos.calm.resources.TimelineResource;
@@ -161,7 +162,8 @@ public class AuditRequestFilter implements ContainerResponseFilter {
             Map.entry(UserAccessResource.class, AuditEntityType.USER_ACCESS),
             Map.entry(DomainUserAccessResource.class, AuditEntityType.USER_ACCESS),
             Map.entry(CoreSchemaResource.class, AuditEntityType.SCHEMA),
-            Map.entry(LayoutResource.class, AuditEntityType.LAYOUT)
+            Map.entry(LayoutResource.class, AuditEntityType.LAYOUT),
+            Map.entry(PatternLayoutResource.class, AuditEntityType.PATTERN_LAYOUT)
     );
 
     /** The path parameter that names an entity's own ID, for types resolved generically via path params. */
@@ -175,7 +177,8 @@ public class AuditRequestFilter implements ContainerResponseFilter {
             Map.entry(AuditEntityType.ADR, "adrId"),
             Map.entry(AuditEntityType.DECORATOR, "id"),
             Map.entry(AuditEntityType.USER_ACCESS, "userAccessId"),
-            Map.entry(AuditEntityType.LAYOUT, "architectureId")
+            Map.entry(AuditEntityType.LAYOUT, "architectureId"),
+            Map.entry(AuditEntityType.PATTERN_LAYOUT, "patternId")
     );
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/security/LocationSegmentParser.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/LocationSegmentParser.java
@@ -52,11 +52,11 @@ final class LocationSegmentParser {
             case USER_ACCESS -> new LocationIds(lastSegment(segments), null);
             // .../decorators/{id}
             case DECORATOR -> new LocationIds(lastSegment(segments), null);
-            // Layout PUT always returns 204 with no Location header, so this case is
+            // Layout PUT always returns 204 with no Location header, so these two cases are
             // unreachable at runtime — parse() short-circuits on a null/blank locationPath
-            // before reaching this switch. It exists only because the switch is exhaustive
-            // over AuditEntityType and LAYOUT must be handled to compile.
-            case LAYOUT -> new LocationIds(null, null);
+            // before reaching this switch. They exist only because the switch is exhaustive
+            // over AuditEntityType and LAYOUT/PATTERN_LAYOUT must be handled to compile.
+            case LAYOUT, PATTERN_LAYOUT -> new LocationIds(null, null);
         };
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/NamespaceContentService.java
@@ -9,6 +9,7 @@ import org.finos.calm.store.DecoratorStore;
 import org.finos.calm.store.FlowStore;
 import org.finos.calm.store.InterfaceStore;
 import org.finos.calm.store.LayoutStore;
+import org.finos.calm.store.PatternLayoutStore;
 import org.finos.calm.store.PatternStore;
 import org.finos.calm.store.StandardStore;
 import org.finos.calm.store.TimelineStore;
@@ -33,6 +34,7 @@ public class NamespaceContentService {
     private final TimelineStore timelineStore;
     private final DecoratorStore decoratorStore;
     private final LayoutStore layoutStore;
+    private final PatternLayoutStore patternLayoutStore;
 
     @Inject
     @SuppressWarnings("java:S107") // emptiness check legitimately needs every namespace-scoped store
@@ -44,7 +46,8 @@ public class NamespaceContentService {
                                    InterfaceStore interfaceStore,
                                    TimelineStore timelineStore,
                                    DecoratorStore decoratorStore,
-                                   LayoutStore layoutStore) {
+                                   LayoutStore layoutStore,
+                                   PatternLayoutStore patternLayoutStore) {
         this.architectureStore = architectureStore;
         this.patternStore = patternStore;
         this.flowStore = flowStore;
@@ -54,12 +57,13 @@ public class NamespaceContentService {
         this.timelineStore = timelineStore;
         this.decoratorStore = decoratorStore;
         this.layoutStore = layoutStore;
+        this.patternLayoutStore = patternLayoutStore;
     }
 
     /**
      * @param namespace the namespace to check
      * @return true if the namespace holds any architecture, pattern, flow, standard, adr,
-     *         interface, timeline, decorator, or saved layout
+     *         interface, timeline, decorator, or saved architecture/pattern layout
      */
     public boolean hasContent(String namespace) {
         return isNotEmpty(() -> architectureStore.getArchitecturesForNamespace(namespace))
@@ -76,7 +80,12 @@ public class NamespaceContentService {
                 // dead code: ArchitectureResource exposes no DELETE, so there is no live path to
                 // remove the architecture out from under an already-saved layout, and this check
                 // stays correct if that ever changes.
-                || isNotEmpty(() -> layoutStore.getArchitectureIdsWithLayoutForNamespace(namespace));
+                || isNotEmpty(() -> layoutStore.getArchitectureIdsWithLayoutForNamespace(namespace))
+                // Same reasoning as the architecture layout check above, mirrored for patterns:
+                // PatternLayoutResource.saveLayout rejects a PUT against a pattern id that
+                // doesn't exist, so this never fires while the pattern branch above would also
+                // be empty today, but PatternResource exposes no DELETE either.
+                || isNotEmpty(() -> patternLayoutStore.getPatternIdsWithLayoutForNamespace(namespace));
     }
 
     /**

--- a/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
@@ -30,20 +30,6 @@ public interface ArchitectureStore {
      */
     List<NamespaceResourceSummary> getArchitecturesForNamespace(String namespace, PageRequest page) throws NamespaceNotFoundException;
 
-    /**
-     * Reports whether an architecture exists, without fetching its content or versions.
-     * Used by resources that reference an architecture id from outside the architecture's
-     * own path segment (e.g. {@code LayoutResource}, which addresses
-     * {@code .../architectures/{id}/layout} directly) and need to reject a write against an
-     * id that resolves to nothing, rather than silently creating an orphan.
-     *
-     * @param namespace      the namespace the architecture would belong to
-     * @param architectureId the id to check
-     * @return true if a header document exists for this (namespace, architectureId)
-     * @throws NamespaceNotFoundException if the namespace itself does not exist
-     */
-    boolean architectureExists(String namespace, int architectureId) throws NamespaceNotFoundException;
-
     Architecture createArchitectureForNamespace(Architecture architecture) throws NamespaceNotFoundException;
     List<String> getArchitectureVersions(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException;
     String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException;

--- a/calm-hub/src/main/java/org/finos/calm/store/LayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/LayoutStore.java
@@ -1,5 +1,6 @@
 package org.finos.calm.store;
 
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 
 import java.util.List;
@@ -33,14 +34,20 @@ public interface LayoutStore {
 
     /**
      * Save the default layout for an architecture, creating it if none exists yet or
-     * overwriting whatever was saved before.
+     * overwriting whatever was saved before. Rejects a write against an architecture id that
+     * doesn't exist, so a layout can never be saved as an orphan with nothing to attach to
+     * (see {@code NamespaceContentService.hasContent}) — the implementation checks this itself
+     * rather than requiring the caller to check {@code ArchitectureStore} first, so the whole
+     * save is one round trip through the namespace check instead of two.
      *
      * @param namespace      the namespace the architecture belongs to
      * @param architectureId the id of the architecture
      * @param layoutJson     the layout as a raw JSON string
-     * @throws NamespaceNotFoundException if the namespace does not exist
+     * @throws NamespaceNotFoundException    if the namespace does not exist
+     * @throws ArchitectureNotFoundException if no architecture with this id exists in the namespace
      */
-    void upsertLayout(String namespace, int architectureId, String layoutJson) throws NamespaceNotFoundException;
+    void upsertLayout(String namespace, int architectureId, String layoutJson)
+            throws NamespaceNotFoundException, ArchitectureNotFoundException;
 
     /**
      * Architecture ids in this namespace that currently have a saved default layout. Used

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternLayoutStore.java
@@ -1,6 +1,7 @@
 package org.finos.calm.store;
 
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,11 +10,14 @@ import java.util.Optional;
  * Interface for storing the shared, default layout of a pattern: where its nodes are drawn in
  * the CALM Hub visualiser. A structural twin of {@link LayoutStore}, kept as a separate
  * interface and storage family (its own {@code pattern_layouts} collection) rather than a
- * generalized {@code resourceType}-discriminated extension of {@link LayoutStore} — see
- * {@code PatternLayoutResource}'s class javadoc for why. There is exactly one layout per
- * pattern — saving is an upsert, not a create-with-allocated-id — and, like an architecture's
- * layout, a pattern's layout is <b>not versioned</b>: it is keyed by namespace + patternId alone
- * and floats across every version of the pattern it targets.
+ * generalized {@code resourceType}-discriminated extension of {@link LayoutStore}, because
+ * architecture ids and pattern ids are drawn from independent counters and can coincide within
+ * one namespace; a single collection keyed only by id would need that discriminator threaded
+ * through every filter and the unique index to avoid an architecture and a pattern silently
+ * sharing one layout document. There is exactly one layout per pattern — saving is an upsert,
+ * not a create-with-allocated-id — and, like an architecture's layout, a pattern's layout is
+ * <b>not versioned</b>: it is keyed by namespace + patternId alone and floats across every
+ * version of the pattern it targets.
  *
  * <p>The layout content itself is treated as an opaque JSON string here, the same convention as
  * {@link LayoutStore} and {@link org.finos.calm.store.DecoratorStore}.</p>
@@ -32,14 +36,20 @@ public interface PatternLayoutStore {
 
     /**
      * Save the default layout for a pattern, creating it if none exists yet or overwriting
-     * whatever was saved before.
+     * whatever was saved before. Rejects a write against a pattern id that doesn't exist, so a
+     * layout can never be saved as an orphan with nothing to attach to — the implementation
+     * checks this itself rather than requiring the caller to check {@code PatternStore} first,
+     * so the whole save is one round trip through the namespace check instead of two. Mirrors
+     * {@link LayoutStore#upsertLayout}.
      *
      * @param namespace  the namespace the pattern belongs to
      * @param patternId  the id of the pattern
      * @param layoutJson the layout as a raw JSON string
      * @throws NamespaceNotFoundException if the namespace does not exist
+     * @throws PatternNotFoundException   if no pattern with this id exists in the namespace
      */
-    void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException;
+    void upsertLayout(String namespace, int patternId, String layoutJson)
+            throws NamespaceNotFoundException, PatternNotFoundException;
 
     /**
      * Pattern ids in this namespace that currently have a saved default layout. Used only by

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternLayoutStore.java
@@ -1,0 +1,53 @@
+package org.finos.calm.store;
+
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for storing the shared, default layout of a pattern: where its nodes are drawn in
+ * the CALM Hub visualiser. A structural twin of {@link LayoutStore}, kept as a separate
+ * interface and storage family (its own {@code pattern_layouts} collection) rather than a
+ * generalized {@code resourceType}-discriminated extension of {@link LayoutStore} — see
+ * {@code PatternLayoutResource}'s class javadoc for why. There is exactly one layout per
+ * pattern — saving is an upsert, not a create-with-allocated-id — and, like an architecture's
+ * layout, a pattern's layout is <b>not versioned</b>: it is keyed by namespace + patternId alone
+ * and floats across every version of the pattern it targets.
+ *
+ * <p>The layout content itself is treated as an opaque JSON string here, the same convention as
+ * {@link LayoutStore} and {@link org.finos.calm.store.DecoratorStore}.</p>
+ */
+public interface PatternLayoutStore {
+
+    /**
+     * Retrieve the default layout for a pattern, if one has been saved.
+     *
+     * @param namespace the namespace the pattern belongs to
+     * @param patternId the id of the pattern
+     * @return the layout JSON, or empty if no default layout has been saved
+     * @throws NamespaceNotFoundException if the namespace does not exist
+     */
+    Optional<String> getLayout(String namespace, int patternId) throws NamespaceNotFoundException;
+
+    /**
+     * Save the default layout for a pattern, creating it if none exists yet or overwriting
+     * whatever was saved before.
+     *
+     * @param namespace  the namespace the pattern belongs to
+     * @param patternId  the id of the pattern
+     * @param layoutJson the layout as a raw JSON string
+     * @throws NamespaceNotFoundException if the namespace does not exist
+     */
+    void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException;
+
+    /**
+     * Pattern ids in this namespace that currently have a saved default layout. Used only by
+     * {@code NamespaceContentService} to guard namespace deletion.
+     *
+     * @param namespace the namespace to check
+     * @return the pattern ids with a saved layout
+     * @throws NamespaceNotFoundException if the namespace does not exist
+     */
+    List<Integer> getPatternIdsWithLayoutForNamespace(String namespace) throws NamespaceNotFoundException;
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
@@ -32,17 +32,6 @@ public interface PatternStore {
      */
     List<NamespaceResourceSummary> getPatternsForNamespace(String namespace, PageRequest page) throws NamespaceNotFoundException;
 
-    /**
-     * Whether a pattern with the given id exists in the namespace, regardless of how many
-     * versions it has. Mirrors {@link ArchitectureStore#architectureExists}.
-     *
-     * @param namespace the namespace the pattern belongs to
-     * @param patternId the id of the pattern
-     * @return true if a pattern header exists for this id
-     * @throws NamespaceNotFoundException if the namespace does not exist
-     */
-    boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException;
-
     Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException, JsonParseException;
     List<String> getPatternVersions(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException;
     String getPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
@@ -31,6 +31,18 @@ public interface PatternStore {
      * @return a (possibly paged) list of pattern summaries
      */
     List<NamespaceResourceSummary> getPatternsForNamespace(String namespace, PageRequest page) throws NamespaceNotFoundException;
+
+    /**
+     * Whether a pattern with the given id exists in the namespace, regardless of how many
+     * versions it has. Mirrors {@link ArchitectureStore#architectureExists}.
+     *
+     * @param namespace the namespace the pattern belongs to
+     * @param patternId the id of the pattern
+     * @return true if a pattern header exists for this id
+     * @throws NamespaceNotFoundException if the namespace does not exist
+     */
+    boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException;
+
     Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException, JsonParseException;
     List<String> getPatternVersions(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException;
     String getPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -73,12 +73,6 @@ public class MongoArchitectureStore implements ArchitectureStore {
     }
 
     @Override
-    public boolean architectureExists(String namespace, int architectureId) throws NamespaceNotFoundException {
-        namespaceStore.requireNamespace(namespace);
-        return documentStore.headerExists(namespace, architectureId);
-    }
-
-    @Override
     public Architecture createArchitectureForNamespace(Architecture architecture) throws NamespaceNotFoundException {
         namespaceStore.requireNamespace(architecture.getNamespace());
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoLayoutStore.java
@@ -1,7 +1,5 @@
 package org.finos.calm.store.mongo;
 
-import com.mongodb.ErrorCategory;
-import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -10,13 +8,11 @@ import com.mongodb.client.model.ReplaceOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
-import org.bson.BsonMaximumSizeExceededException;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.store.LayoutStore;
-import org.finos.calm.store.util.MongoWriteFailures;
+import org.finos.calm.store.util.MongoUpsertRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,23 +99,7 @@ public class MongoLayoutStore implements LayoutStore {
                 .append(LAYOUT_FIELD, layoutDoc);
         ReplaceOptions upsert = new ReplaceOptions().upsert(true);
 
-        try {
-            replaceLayout(filter, replacement, upsert);
-        } catch (MongoWriteException e) {
-            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
-                throw MongoWriteFailures.toStorageWriteException(e);
-            }
-            // Two saves for the same architecture both missed the filter and both attempted an
-            // insert; the unique index on (namespace, architectureId) let exactly one through.
-            // The document exists now, so the identical call matches and updates it. Retried
-            // once only — a second duplicate key would mean the index no longer agrees with
-            // this filter, which is a fault rather than a race to ride out.
-            try {
-                replaceLayout(filter, replacement, upsert);
-            } catch (MongoWriteException retryFailure) {
-                throw MongoWriteFailures.toStorageWriteException(retryFailure);
-            }
-        }
+        MongoUpsertRetry.replaceOnceWithRetry(layoutCollection, filter, replacement, upsert);
         LOG.debug("Saved default layout for architecture {} in namespace '{}'", architectureId, namespace);
     }
 
@@ -140,22 +120,6 @@ public class MongoLayoutStore implements LayoutStore {
                     }
                 });
         return architectureIds;
-    }
-
-    /**
-     * Isolates the two ways MongoDB's 16MB ceiling can surface on this write: a
-     * {@link MongoWriteException} when the server rejects an oversized document, or (since
-     * unlike the old shape a single write can already exceed the ceiling before it is even
-     * sent) a client-side {@link BsonMaximumSizeExceededException} the driver raises while
-     * serializing the command, which never reaches the server and so is never a
-     * {@code MongoWriteException}. Both must map to the same capacity-exceeded outcome.
-     */
-    private void replaceLayout(Bson filter, Document replacement, ReplaceOptions upsert) {
-        try {
-            layoutCollection.replaceOne(filter, replacement, upsert);
-        } catch (BsonMaximumSizeExceededException e) {
-            throw MongoWriteFailures.toStorageWriteException(e);
-        }
     }
 
     private Bson layoutFilter(String namespace, int architectureId) {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoLayoutStore.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.LayoutStore;
 import org.finos.calm.store.util.MongoUpsertRetry;
@@ -53,6 +54,13 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * race, so it is surfaced rather than retried further. Two saves racing on the very same
  * architecture's layout are last-write-wins — acceptable for a layout, unlike for versioned
  * content.
+ *
+ * <h2>Existence check</h2>
+ * {@link #upsertLayout} rejects a write against an architecture id with no header document,
+ * by querying the {@code architectures} collection directly rather than delegating to
+ * {@code ArchitectureStore#architectureExists} — that method does its own
+ * {@code requireNamespace} call, and calling it from here would mean two namespace-existence
+ * round trips per save instead of one.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
@@ -63,13 +71,18 @@ public class MongoLayoutStore implements LayoutStore {
     private static final String NAMESPACE_FIELD = "namespace";
     private static final String ARCHITECTURE_ID_FIELD = "architectureId";
     private static final String LAYOUT_FIELD = "layout";
+    // Mirrors MongoArchitectureStore's HEADER_COLLECTION/ID_FIELD — see the class javadoc for
+    // why this queries the collection directly instead of going through that store.
+    private static final String ARCHITECTURE_HEADER_COLLECTION = "architectures";
 
     private final MongoCollection<Document> layoutCollection;
+    private final MongoCollection<Document> architectureHeaderCollection;
     private final MongoNamespaceStore namespaceStore;
 
     @Inject
     public MongoLayoutStore(MongoDatabase database, MongoNamespaceStore namespaceStore) {
         this.layoutCollection = database.getCollection("layouts");
+        this.architectureHeaderCollection = database.getCollection(ARCHITECTURE_HEADER_COLLECTION);
         this.namespaceStore = namespaceStore;
     }
 
@@ -87,8 +100,12 @@ public class MongoLayoutStore implements LayoutStore {
     }
 
     @Override
-    public void upsertLayout(String namespace, int architectureId, String layoutJson) throws NamespaceNotFoundException {
+    public void upsertLayout(String namespace, int architectureId, String layoutJson)
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
         namespaceStore.requireNamespace(namespace);
+        if (!architectureHeaderExists(namespace, architectureId)) {
+            throw new ArchitectureNotFoundException();
+        }
 
         // Parsed before any write, so malformed JSON never reaches the database.
         Document layoutDoc = Document.parse(layoutJson);
@@ -124,5 +141,12 @@ public class MongoLayoutStore implements LayoutStore {
 
     private Bson layoutFilter(String namespace, int architectureId) {
         return Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(ARCHITECTURE_ID_FIELD, architectureId));
+    }
+
+    private boolean architectureHeaderExists(String namespace, int architectureId) {
+        return architectureHeaderCollection
+                .find(Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(ARCHITECTURE_ID_FIELD, architectureId)))
+                .projection(Projections.include("_id"))
+                .first() != null;
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternLayoutStore.java
@@ -1,0 +1,117 @@
+package org.finos.calm.store.mongo;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.ReplaceOptions;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.PatternLayoutStore;
+import org.finos.calm.store.util.MongoUpsertRetry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+
+/**
+ * MongoDB implementation of {@link PatternLayoutStore}.
+ *
+ * <h2>Document model</h2>
+ * One flat document per {@code (namespace, patternId)} in its own {@code pattern_layouts}
+ * collection: {@code {namespace, patternId, layout}}, enforced by a unique index on
+ * {@code (namespace, patternId)} (see {@code MongoPatternLayoutIndexStep}). A structural twin of
+ * {@link MongoLayoutStore} — see that class's javadoc for the full shape rationale — kept in a
+ * separate collection rather than folded into {@code layouts} with a {@code resourceType}
+ * discriminator, because architecture ids and pattern ids are drawn from independent counters
+ * (see {@code MongoCounterStore}) and can coincide within one namespace; a single collection
+ * keyed only by id would need that discriminator threaded through every filter and the unique
+ * index to avoid an architecture and a pattern silently sharing one layout document.
+ *
+ * <h2>Concurrency</h2>
+ * Identical to {@link MongoLayoutStore}: a single {@code replaceOne(filter, replacement,
+ * upsert(true))}, retried once on a concurrent-insert {@code DUPLICATE_KEY} race via
+ * {@link MongoUpsertRetry}.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+@Typed(MongoPatternLayoutStore.class)
+public class MongoPatternLayoutStore implements PatternLayoutStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoPatternLayoutStore.class);
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String PATTERN_ID_FIELD = "patternId";
+    private static final String LAYOUT_FIELD = "layout";
+
+    private final MongoCollection<Document> layoutCollection;
+    private final MongoNamespaceStore namespaceStore;
+
+    @Inject
+    public MongoPatternLayoutStore(MongoDatabase database, MongoNamespaceStore namespaceStore) {
+        this.layoutCollection = database.getCollection("pattern_layouts");
+        this.namespaceStore = namespaceStore;
+    }
+
+    @Override
+    public Optional<String> getLayout(String namespace, int patternId) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+
+        Document document = layoutCollection.find(layoutFilter(namespace, patternId)).first();
+        if (document == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(document.get(LAYOUT_FIELD, Document.class)).map(Document::toJson);
+    }
+
+    @Override
+    public void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+
+        // Parsed before any write, so malformed JSON never reaches the database.
+        Document layoutDoc = Document.parse(layoutJson);
+
+        Bson filter = layoutFilter(namespace, patternId);
+        Document replacement = new Document(NAMESPACE_FIELD, namespace)
+                .append(PATTERN_ID_FIELD, patternId)
+                .append(LAYOUT_FIELD, layoutDoc);
+        ReplaceOptions upsert = new ReplaceOptions().upsert(true);
+
+        MongoUpsertRetry.replaceOnceWithRetry(layoutCollection, filter, replacement, upsert);
+        LOG.debug("Saved default layout for pattern {} in namespace '{}'", patternId, namespace);
+    }
+
+    @Override
+    public List<Integer> getPatternIdsWithLayoutForNamespace(String namespace) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+
+        List<Integer> patternIds = new ArrayList<>();
+        layoutCollection.find(Filters.eq(NAMESPACE_FIELD, namespace))
+                .projection(Projections.fields(Projections.include(PATTERN_ID_FIELD), Projections.excludeId()))
+                .forEach(document -> {
+                    Integer patternId = document.getInteger(PATTERN_ID_FIELD);
+                    if (patternId != null) {
+                        patternIds.add(patternId);
+                    }
+                });
+        return patternIds;
+    }
+
+    private Bson layoutFilter(String namespace, int patternId) {
+        return Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(PATTERN_ID_FIELD, patternId));
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternLayoutStore.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.store.PatternLayoutStore;
 import org.finos.calm.store.util.MongoUpsertRetry;
 import org.slf4j.Logger;
@@ -23,23 +24,26 @@ import java.util.Optional;
 import io.quarkus.arc.lookup.LookupIfProperty;
 
 /**
- * MongoDB implementation of {@link PatternLayoutStore}.
+ * MongoDB implementation of {@link PatternLayoutStore} — see that interface's class javadoc for
+ * why patterns get their own collection rather than a {@code resourceType}-discriminated
+ * extension of {@link MongoLayoutStore}.
  *
  * <h2>Document model</h2>
  * One flat document per {@code (namespace, patternId)} in its own {@code pattern_layouts}
  * collection: {@code {namespace, patternId, layout}}, enforced by a unique index on
  * {@code (namespace, patternId)} (see {@code MongoPatternLayoutIndexStep}). A structural twin of
- * {@link MongoLayoutStore} — see that class's javadoc for the full shape rationale — kept in a
- * separate collection rather than folded into {@code layouts} with a {@code resourceType}
- * discriminator, because architecture ids and pattern ids are drawn from independent counters
- * (see {@code MongoCounterStore}) and can coincide within one namespace; a single collection
- * keyed only by id would need that discriminator threaded through every filter and the unique
- * index to avoid an architecture and a pattern silently sharing one layout document.
+ * {@link MongoLayoutStore} — see that class's javadoc for the full shape rationale.
  *
  * <h2>Concurrency</h2>
  * Identical to {@link MongoLayoutStore}: a single {@code replaceOne(filter, replacement,
  * upsert(true))}, retried once on a concurrent-insert {@code DUPLICATE_KEY} race via
  * {@link MongoUpsertRetry}.
+ *
+ * <h2>Existence check</h2>
+ * Identical to {@link MongoLayoutStore}: {@link #upsertLayout} rejects a write against a
+ * pattern id with no header document by querying the {@code patterns} collection directly,
+ * rather than delegating to {@code PatternStore#patternExists} and paying for a second
+ * namespace-existence round trip.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
 @ApplicationScoped
@@ -50,13 +54,18 @@ public class MongoPatternLayoutStore implements PatternLayoutStore {
     private static final String NAMESPACE_FIELD = "namespace";
     private static final String PATTERN_ID_FIELD = "patternId";
     private static final String LAYOUT_FIELD = "layout";
+    // Mirrors MongoPatternStore's HEADER_COLLECTION/ID_FIELD — see the class javadoc for why
+    // this queries the collection directly instead of going through that store.
+    private static final String PATTERN_HEADER_COLLECTION = "patterns";
 
     private final MongoCollection<Document> layoutCollection;
+    private final MongoCollection<Document> patternHeaderCollection;
     private final MongoNamespaceStore namespaceStore;
 
     @Inject
     public MongoPatternLayoutStore(MongoDatabase database, MongoNamespaceStore namespaceStore) {
         this.layoutCollection = database.getCollection("pattern_layouts");
+        this.patternHeaderCollection = database.getCollection(PATTERN_HEADER_COLLECTION);
         this.namespaceStore = namespaceStore;
     }
 
@@ -72,8 +81,12 @@ public class MongoPatternLayoutStore implements PatternLayoutStore {
     }
 
     @Override
-    public void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException {
+    public void upsertLayout(String namespace, int patternId, String layoutJson)
+            throws NamespaceNotFoundException, PatternNotFoundException {
         requireNamespace(namespace);
+        if (!patternHeaderExists(namespace, patternId)) {
+            throw new PatternNotFoundException();
+        }
 
         // Parsed before any write, so malformed JSON never reaches the database.
         Document layoutDoc = Document.parse(layoutJson);
@@ -106,6 +119,13 @@ public class MongoPatternLayoutStore implements PatternLayoutStore {
 
     private Bson layoutFilter(String namespace, int patternId) {
         return Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(PATTERN_ID_FIELD, patternId));
+    }
+
+    private boolean patternHeaderExists(String namespace, int patternId) {
+        return patternHeaderCollection
+                .find(Filters.and(Filters.eq(NAMESPACE_FIELD, namespace), Filters.eq(PATTERN_ID_FIELD, patternId)))
+                .projection(Projections.include("_id"))
+                .first() != null;
     }
 
     private void requireNamespace(String namespace) throws NamespaceNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -69,12 +69,6 @@ public class MongoPatternStore implements PatternStore {
     }
 
     @Override
-    public boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException {
-        requireNamespace(namespace);
-        return documentStore.headerExists(namespace, patternId);
-    }
-
-    @Override
     public Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -69,6 +69,12 @@ public class MongoPatternStore implements PatternStore {
     }
 
     @Override
+    public boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+        return documentStore.headerExists(namespace, patternId);
+    }
+
+    @Override
     public Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -80,12 +80,6 @@ public class NitriteArchitectureStore implements ArchitectureStore {
     }
 
     @Override
-    public boolean architectureExists(String namespace, int architectureId) throws NamespaceNotFoundException {
-        namespaceStore.requireNamespace(namespace);
-        return documentStore.headerExists(namespace, architectureId);
-    }
-
-    @Override
     public Architecture createArchitectureForNamespace(Architecture architecture) throws NamespaceNotFoundException {
         namespaceStore.requireNamespace(architecture.getNamespace());
         validateArchitectureJson(architecture.getArchitectureJson());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteLayoutStore.java
@@ -9,6 +9,7 @@ import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.LayoutStore;
 import org.slf4j.Logger;
@@ -47,6 +48,13 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * shape does not remove the need for the lock, only its cost: the critical section used to
  * serialize a full-namespace read-modify-write of a growing array; it is now a small find plus a
  * single-document insert or update.
+ *
+ * <h2>Existence check</h2>
+ * {@link #upsertLayout} rejects a write against an architecture id with no header document, by
+ * querying the {@code architectures} collection directly rather than delegating to
+ * {@code ArchitectureStore#architectureExists} — that method does its own
+ * {@code requireNamespace} call, and calling it from here would mean two namespace-existence
+ * round trips per save instead of one.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -58,14 +66,19 @@ public class NitriteLayoutStore implements LayoutStore {
     private static final String NAMESPACE_FIELD = "namespace";
     private static final String ARCHITECTURE_ID_FIELD = "architectureId";
     private static final String LAYOUT_FIELD = "layout";
+    // Mirrors NitriteArchitectureStore's HEADER_COLLECTION/ID_FIELD — see the class javadoc
+    // for why this queries the collection directly instead of going through that store.
+    private static final String ARCHITECTURE_HEADER_COLLECTION = "architectures";
 
     private final NitriteCollection layoutCollection;
+    private final NitriteCollection architectureHeaderCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final Lock lock = new ReentrantLock();
 
     @Inject
     public NitriteLayoutStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore) {
         this.layoutCollection = db.getCollection(COLLECTION_NAME);
+        this.architectureHeaderCollection = db.getCollection(ARCHITECTURE_HEADER_COLLECTION);
         this.namespaceStore = namespaceStore;
         LOG.info("NitriteLayoutStore initialized with collection: {}", COLLECTION_NAME);
     }
@@ -79,8 +92,12 @@ public class NitriteLayoutStore implements LayoutStore {
     }
 
     @Override
-    public void upsertLayout(String namespace, int architectureId, String layoutJson) throws NamespaceNotFoundException {
+    public void upsertLayout(String namespace, int architectureId, String layoutJson)
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
         namespaceStore.requireNamespace(namespace);
+        if (!architectureHeaderExists(namespace, architectureId)) {
+            throw new ArchitectureNotFoundException();
+        }
         validateLayoutJson(layoutJson);
 
         lock.lock();
@@ -133,6 +150,11 @@ public class NitriteLayoutStore implements LayoutStore {
             LOG.error("Invalid JSON format for layout: {}", e.getMessage());
             throw e;
         }
+    }
+
+    private boolean architectureHeaderExists(String namespace, int architectureId) {
+        Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(ARCHITECTURE_ID_FIELD).eq(architectureId));
+        return architectureHeaderCollection.find(filter).firstOrNull() != null;
     }
 
     private Document fetchLayoutDocument(String namespace, int architectureId) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternLayoutStore.java
@@ -10,6 +10,7 @@ import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.config.StandaloneQualifier;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.store.PatternLayoutStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,12 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * Identical to {@link NitriteLayoutStore}: all mutating operations run under a single
  * {@link ReentrantLock}, following the check-then-write pattern used by every other Nitrite
  * store.
+ *
+ * <h2>Existence check</h2>
+ * Identical to {@link NitriteLayoutStore}: {@link #upsertLayout} rejects a write against a
+ * pattern id with no header document by querying the {@code patterns} collection directly,
+ * rather than delegating to {@code PatternStore#patternExists} and paying for a second
+ * namespace-existence round trip.
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -49,14 +56,19 @@ public class NitritePatternLayoutStore implements PatternLayoutStore {
     private static final String NAMESPACE_FIELD = "namespace";
     private static final String PATTERN_ID_FIELD = "patternId";
     private static final String LAYOUT_FIELD = "layout";
+    // Mirrors NitritePatternStore's HEADER_COLLECTION/ID_FIELD — see the class javadoc for why
+    // this queries the collection directly instead of going through that store.
+    private static final String PATTERN_HEADER_COLLECTION = "patterns";
 
     private final NitriteCollection layoutCollection;
+    private final NitriteCollection patternHeaderCollection;
     private final NitriteNamespaceStore namespaceStore;
     private final Lock lock = new ReentrantLock();
 
     @Inject
     public NitritePatternLayoutStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore) {
         this.layoutCollection = db.getCollection(COLLECTION_NAME);
+        this.patternHeaderCollection = db.getCollection(PATTERN_HEADER_COLLECTION);
         this.namespaceStore = namespaceStore;
         LOG.info("NitritePatternLayoutStore initialized with collection: {}", COLLECTION_NAME);
     }
@@ -70,8 +82,12 @@ public class NitritePatternLayoutStore implements PatternLayoutStore {
     }
 
     @Override
-    public void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException {
+    public void upsertLayout(String namespace, int patternId, String layoutJson)
+            throws NamespaceNotFoundException, PatternNotFoundException {
         requireNamespace(namespace);
+        if (!patternHeaderExists(namespace, patternId)) {
+            throw new PatternNotFoundException();
+        }
         validateLayoutJson(layoutJson);
 
         lock.lock();
@@ -121,6 +137,11 @@ public class NitritePatternLayoutStore implements PatternLayoutStore {
             LOG.error("Invalid JSON format for layout: {}", e.getMessage());
             throw e;
         }
+    }
+
+    private boolean patternHeaderExists(String namespace, int patternId) {
+        Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(PATTERN_ID_FIELD).eq(patternId));
+        return patternHeaderCollection.find(filter).firstOrNull() != null;
     }
 
     private Document fetchLayoutDocument(String namespace, int patternId) {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternLayoutStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternLayoutStore.java
@@ -1,0 +1,137 @@
+package org.finos.calm.store.nitrite;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Inject;
+import org.bson.json.JsonParseException;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.config.StandaloneQualifier;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.PatternLayoutStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.dizitart.no2.filters.FluentFilter.where;
+import io.quarkus.arc.lookup.LookupIfProperty;
+
+/**
+ * NitriteDB implementation of {@link PatternLayoutStore}, used in standalone mode.
+ *
+ * <h2>Document model</h2>
+ * One flat document per {@code (namespace, patternId)} in its own {@code pattern_layouts}
+ * collection, mirroring {@link org.finos.calm.store.mongo.MongoPatternLayoutStore} — see that
+ * class's javadoc for why a separate collection is used rather than a discriminated extension
+ * of {@code layouts}. As with {@link NitriteLayoutStore}, {@code layout} is kept as a raw JSON
+ * string rather than a parsed document, and JSON is validated up front by
+ * {@link #validateLayoutJson}, before any locking or existence checks.
+ *
+ * <h2>Concurrency</h2>
+ * Identical to {@link NitriteLayoutStore}: all mutating operations run under a single
+ * {@link ReentrantLock}, following the check-then-write pattern used by every other Nitrite
+ * store.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
+@ApplicationScoped
+@Typed(NitritePatternLayoutStore.class)
+public class NitritePatternLayoutStore implements PatternLayoutStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NitritePatternLayoutStore.class);
+    private static final String COLLECTION_NAME = "pattern_layouts";
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String PATTERN_ID_FIELD = "patternId";
+    private static final String LAYOUT_FIELD = "layout";
+
+    private final NitriteCollection layoutCollection;
+    private final NitriteNamespaceStore namespaceStore;
+    private final Lock lock = new ReentrantLock();
+
+    @Inject
+    public NitritePatternLayoutStore(@StandaloneQualifier Nitrite db, NitriteNamespaceStore namespaceStore) {
+        this.layoutCollection = db.getCollection(COLLECTION_NAME);
+        this.namespaceStore = namespaceStore;
+        LOG.info("NitritePatternLayoutStore initialized with collection: {}", COLLECTION_NAME);
+    }
+
+    @Override
+    public Optional<String> getLayout(String namespace, int patternId) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+
+        Document document = fetchLayoutDocument(namespace, patternId);
+        return document == null ? Optional.empty() : Optional.ofNullable(document.get(LAYOUT_FIELD, String.class));
+    }
+
+    @Override
+    public void upsertLayout(String namespace, int patternId, String layoutJson) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+        validateLayoutJson(layoutJson);
+
+        lock.lock();
+        try {
+            Document existing = fetchLayoutDocument(namespace, patternId);
+            if (existing == null) {
+                layoutCollection.insert(Document.createDocument(NAMESPACE_FIELD, namespace)
+                        .put(PATTERN_ID_FIELD, patternId)
+                        .put(LAYOUT_FIELD, layoutJson));
+                LOG.debug("Created default layout for pattern {} in namespace '{}'", patternId, namespace);
+                return;
+            }
+            existing.put(LAYOUT_FIELD, layoutJson);
+            layoutCollection.update(existing);
+            LOG.debug("Saved default layout for pattern {} in namespace '{}'", patternId, namespace);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public List<Integer> getPatternIdsWithLayoutForNamespace(String namespace) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+
+        List<Integer> patternIds = new ArrayList<>();
+        for (Document document : layoutCollection.find(where(NAMESPACE_FIELD).eq(namespace))) {
+            Integer patternId = document.get(PATTERN_ID_FIELD, Integer.class);
+            if (patternId != null) {
+                patternIds.add(patternId);
+            }
+        }
+        return patternIds;
+    }
+
+    /**
+     * Validates that the supplied layout JSON is parseable, throwing {@link JsonParseException} if not so the
+     * REST layer can surface a 400. Mirrors {@code NitriteLayoutStore#validateLayoutJson}.
+     */
+    private void validateLayoutJson(String layoutJson) {
+        if (layoutJson == null) {
+            LOG.error("Layout JSON must not be null");
+            throw new JsonParseException("Layout JSON must not be null");
+        }
+        try {
+            org.bson.Document.parse(layoutJson);
+        } catch (JsonParseException e) {
+            LOG.error("Invalid JSON format for layout: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    private Document fetchLayoutDocument(String namespace, int patternId) {
+        Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace), where(PATTERN_ID_FIELD).eq(patternId));
+        return layoutCollection.find(filter).firstOrNull();
+    }
+
+    private void requireNamespace(String namespace) throws NamespaceNotFoundException {
+        if (!namespaceStore.namespaceExists(namespace)) {
+            LOG.warn("Namespace '{}' not found", namespace);
+            throw new NamespaceNotFoundException();
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -73,6 +73,12 @@ public class NitritePatternStore implements PatternStore {
     }
 
     @Override
+    public boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException {
+        requireNamespace(namespace);
+        return documentStore.headerExists(namespace, patternId);
+    }
+
+    @Override
     public Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException, JsonParseException {
         namespaceStore.requireNamespace(namespace);
         validatePatternJson(patternRequest.getPatternJson());

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -73,12 +73,6 @@ public class NitritePatternStore implements PatternStore {
     }
 
     @Override
-    public boolean patternExists(String namespace, int patternId) throws NamespaceNotFoundException {
-        requireNamespace(namespace);
-        return documentStore.headerExists(namespace, patternId);
-    }
-
-    @Override
     public Pattern createPatternForNamespace(CreatePatternRequest patternRequest, String namespace) throws NamespaceNotFoundException, JsonParseException {
         namespaceStore.requireNamespace(namespace);
         validatePatternJson(patternRequest.getPatternJson());

--- a/calm-hub/src/main/java/org/finos/calm/store/producer/PatternLayoutStoreProducer.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/producer/PatternLayoutStoreProducer.java
@@ -1,0 +1,42 @@
+package org.finos.calm.store.producer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.store.PatternLayoutStore;
+import org.finos.calm.store.mongo.MongoPatternLayoutStore;
+import org.finos.calm.store.nitrite.NitritePatternLayoutStore;
+
+/**
+ * Producer for PatternLayoutStore implementations.
+ * Selects the appropriate implementation based on the configured database mode.
+ */
+@ApplicationScoped
+public class PatternLayoutStoreProducer {
+
+    @Inject
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    @Inject
+    Instance<MongoPatternLayoutStore> mongoPatternLayoutStore;
+
+    @Inject
+    Instance<NitritePatternLayoutStore> nitritePatternLayoutStore;
+
+    /**
+     * Produces the appropriate PatternLayoutStore implementation based on the configured database mode.
+     *
+     * @return the PatternLayoutStore implementation
+     */
+    @Produces
+    @ApplicationScoped
+    public PatternLayoutStore producePatternLayoutStore() {
+        if ("standalone".equals(databaseMode)) {
+            return nitritePatternLayoutStore.get();
+        }
+        return mongoPatternLayoutStore.get();
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertRetry.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoUpsertRetry.java
@@ -1,0 +1,60 @@
+package org.finos.calm.store.util;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.BsonMaximumSizeExceededException;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+/**
+ * Shared {@code replaceOne(filter, replacement, upsert(true))}-with-retry mechanics for the
+ * "one flat document per (namespace, id)" storage shape used by {@code MongoLayoutStore} and
+ * {@code MongoPatternLayoutStore}. See {@code MongoLayoutStore}'s class javadoc for the full
+ * rationale — the duplicate-key race this retries once, and why a second duplicate key is a
+ * fault rather than a race to keep retrying. This class only extracts the mechanics so the two
+ * callers don't duplicate them.
+ */
+public final class MongoUpsertRetry {
+
+    private MongoUpsertRetry() {
+    }
+
+    /**
+     * Replaces (or inserts, on no match) a single document, retrying once if the first attempt
+     * loses a concurrent insert race on a unique index. Throws {@link org.finos.calm.domain.exception.StorageWriteException}
+     * on any non-retryable failure, including a second duplicate key on the retry and the
+     * client-side 16MB-document ceiling.
+     */
+    public static void replaceOnceWithRetry(MongoCollection<Document> collection, Bson filter,
+                                             Document replacement, ReplaceOptions upsert) {
+        try {
+            replaceOne(collection, filter, replacement, upsert);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw MongoWriteFailures.toStorageWriteException(e);
+            }
+            try {
+                replaceOne(collection, filter, replacement, upsert);
+            } catch (MongoWriteException retryFailure) {
+                throw MongoWriteFailures.toStorageWriteException(retryFailure);
+            }
+        }
+    }
+
+    /**
+     * Isolates the two ways MongoDB's 16MB ceiling can surface on this write: a
+     * {@link MongoWriteException} when the server rejects an oversized document, or a
+     * client-side {@link BsonMaximumSizeExceededException} the driver raises while serializing
+     * the command, which never reaches the server and so is never a {@code MongoWriteException}.
+     */
+    private static void replaceOne(MongoCollection<Document> collection, Bson filter,
+                                    Document replacement, ReplaceOptions upsert) {
+        try {
+            collection.replaceOne(filter, replacement, upsert);
+        } catch (BsonMaximumSizeExceededException e) {
+            throw MongoWriteFailures.toStorageWriteException(e);
+        }
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoPatternLayoutIndexStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoPatternLayoutIndexStepShould.java
@@ -41,11 +41,11 @@ class TestMongoPatternLayoutIndexStepShould {
     }
 
     @Test
-    void run_at_schema_version_eleven() {
-        // 10 (MongoAdrTitleBackfillStep) is the highest fromVersion() currently in use; a
+    void run_at_schema_version_twelve() {
+        // 11 (MongoResourceMappingIndexStep) is the highest fromVersion() currently in use; a
         // wrong or duplicate value is a fatal startup IllegalStateException — see
         // SchemaMigrationRunner's duplicate-fromVersion guard.
-        assertThat(step.fromVersion(), is(11));
+        assertThat(step.fromVersion(), is(12));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoPatternLayoutIndexStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoPatternLayoutIndexStepShould.java
@@ -1,0 +1,78 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoPatternLayoutIndexStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private MongoDatabase database;
+    private MongoCollection<Document> patternLayouts;
+    private MongoPatternLayoutIndexStep step;
+
+    @BeforeEach
+    void setup() {
+        database = mock(MongoDatabase.class);
+        patternLayouts = mock(DocumentMongoCollection.class);
+        when(database.getCollection("pattern_layouts")).thenReturn(patternLayouts);
+
+        step = new MongoPatternLayoutIndexStep(database);
+        step.databaseMode = "mongo";
+    }
+
+    @Test
+    void run_at_schema_version_eleven() {
+        // 10 (MongoAdrTitleBackfillStep) is the highest fromVersion() currently in use; a
+        // wrong or duplicate value is a fatal startup IllegalStateException — see
+        // SchemaMigrationRunner's duplicate-fromVersion guard.
+        assertThat(step.fromVersion(), is(11));
+    }
+
+    @Test
+    void skip_index_creation_when_database_mode_is_not_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verifyNoInteractions(database);
+    }
+
+    @Test
+    void create_the_compound_unique_index_on_pattern_layouts() {
+        step.apply();
+
+        verify(patternLayouts).createIndex(eq(new Document("namespace", 1).append("patternId", 1)), any());
+    }
+
+    @Test
+    void create_indexes_directly_without_needing_the_database_mode_configured() {
+        // createIndexes() is the entry point integration-test infrastructure (EndToEndResource)
+        // calls directly against a real, known-Mongo container — it must not depend on the
+        // CDI-injected databaseMode field, which is never set outside a running application.
+        MongoPatternLayoutIndexStep unconfigured = new MongoPatternLayoutIndexStep(database);
+
+        unconfigured.createIndexes();
+
+        verify(patternLayouts).createIndex(eq(new Document("namespace", 1).append("patternId", 1)), any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCalmErrorResponsesShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCalmErrorResponsesShould.java
@@ -32,4 +32,28 @@ public class TestCalmErrorResponsesShould {
                     equalTo("Version 1.0.1 already exists for architecture 'repo' in namespace 'finos'"));
         }
     }
+
+    @Test
+    void create_a_resource_not_found_response_capitalizing_the_resource_type() {
+        try (Response response = CalmResourceErrorResponses.resourceNotFoundResponse("architecture", "finos", 5)) {
+            assertThat(response.getStatus(), equalTo(404));
+            assertThat(response.getEntity(), equalTo("Architecture 5 does not exist in namespace: finos"));
+        }
+    }
+
+    @Test
+    void create_a_resource_not_found_response_for_a_pattern() {
+        try (Response response = CalmResourceErrorResponses.resourceNotFoundResponse("pattern", "finos", 5)) {
+            assertThat(response.getStatus(), equalTo(404));
+            assertThat(response.getEntity(), equalTo("Pattern 5 does not exist in namespace: finos"));
+        }
+    }
+
+    @Test
+    void create_a_resource_layout_not_found_response() {
+        try (Response response = CalmResourceErrorResponses.resourceLayoutNotFoundResponse("architecture", "finos", 5)) {
+            assertThat(response.getStatus(), equalTo(404));
+            assertThat(response.getEntity(), equalTo("No default layout saved for architecture 5 in namespace: finos"));
+        }
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestLayoutResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestLayoutResourceShould.java
@@ -5,8 +5,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import org.bson.json.JsonParseException;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
-import org.finos.calm.store.ArchitectureStore;
 import org.finos.calm.store.LayoutStore;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.Test;
@@ -28,14 +28,7 @@ public class TestLayoutResourceShould {
     LayoutStore mockLayoutStore;
 
     @InjectMock
-    ArchitectureStore mockArchitectureStore;
-
-    @InjectMock
     UserAccessStore mockUserAccessStore;
-
-    private void givenArchitectureExists() throws NamespaceNotFoundException {
-        when(mockArchitectureStore.architectureExists("finos", 5)).thenReturn(true);
-    }
 
     private static final String VALID_LAYOUT_JSON = """
             {
@@ -115,9 +108,7 @@ public class TestLayoutResourceShould {
     // ---- PUT /api/calm/namespaces/{namespace}/architectures/{architectureId}/layout ----
 
     @Test
-    void return_204_when_layout_saved() throws NamespaceNotFoundException {
-        givenArchitectureExists();
-
+    void return_204_when_layout_saved() throws NamespaceNotFoundException, ArchitectureNotFoundException {
         given()
                 .contentType(ContentType.JSON)
                 .body(VALID_LAYOUT_JSON)
@@ -131,8 +122,7 @@ public class TestLayoutResourceShould {
     }
 
     @Test
-    void accept_put_when_for_is_absent() throws NamespaceNotFoundException {
-        givenArchitectureExists();
+    void accept_put_when_for_is_absent() throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String layoutWithoutFor = "{ \"pins\": [] }";
 
         given()
@@ -162,7 +152,6 @@ public class TestLayoutResourceShould {
                 .body(containsString("does not match architecture"));
 
         verifyNoInteractions(mockLayoutStore);
-        verifyNoInteractions(mockArchitectureStore);
     }
 
     @Test
@@ -177,7 +166,6 @@ public class TestLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockLayoutStore);
-        verifyNoInteractions(mockArchitectureStore);
     }
 
     @Test
@@ -194,7 +182,6 @@ public class TestLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockLayoutStore);
-        verifyNoInteractions(mockArchitectureStore);
     }
 
     @Test
@@ -209,12 +196,13 @@ public class TestLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockLayoutStore);
-        verifyNoInteractions(mockArchitectureStore);
     }
 
     @Test
-    void return_404_when_architecture_does_not_exist_for_put_layout() throws NamespaceNotFoundException {
-        when(mockArchitectureStore.architectureExists("finos", 5)).thenReturn(false);
+    void return_404_when_architecture_does_not_exist_for_put_layout()
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        doThrow(new ArchitectureNotFoundException())
+                .when(mockLayoutStore).upsertLayout(eq("finos"), eq(5), anyString());
 
         given()
                 .contentType(ContentType.JSON)
@@ -224,13 +212,13 @@ public class TestLayoutResourceShould {
                 .then()
                 .statusCode(404)
                 .body(containsString("Architecture 5 does not exist in namespace: finos"));
-
-        verify(mockLayoutStore, never()).upsertLayout(anyString(), anyInt(), anyString());
     }
 
     @Test
-    void return_404_when_namespace_not_found_for_put_layout() throws NamespaceNotFoundException {
-        doThrow(new NamespaceNotFoundException()).when(mockArchitectureStore).architectureExists(anyString(), anyInt());
+    void return_404_when_namespace_not_found_for_put_layout()
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        doThrow(new NamespaceNotFoundException())
+                .when(mockLayoutStore).upsertLayout(anyString(), anyInt(), anyString());
 
         given()
                 .contentType(ContentType.JSON)
@@ -240,8 +228,6 @@ public class TestLayoutResourceShould {
                 .then()
                 .statusCode(404)
                 .body(containsString("Invalid namespace provided: missing"));
-
-        verifyNoInteractions(mockLayoutStore);
     }
 
     @Test
@@ -286,6 +272,5 @@ public class TestLayoutResourceShould {
                 .statusCode(403);
 
         verifyNoInteractions(mockLayoutStore);
-        verifyNoInteractions(mockArchitectureStore);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternLayoutResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternLayoutResourceShould.java
@@ -1,0 +1,311 @@
+package org.finos.calm.resources;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.http.ContentType;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.PatternLayoutStore;
+import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.UserAccessStore;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@TestSecurity(authorizationEnabled = false)
+@QuarkusTest
+public class TestPatternLayoutResourceShould {
+
+    @InjectMock
+    PatternLayoutStore mockPatternLayoutStore;
+
+    @InjectMock
+    PatternStore mockPatternStore;
+
+    @InjectMock
+    UserAccessStore mockUserAccessStore;
+
+    private void givenPatternExists() throws NamespaceNotFoundException {
+        when(mockPatternStore.patternExists("finos", 5)).thenReturn(true);
+    }
+
+    private static final String VALID_LAYOUT_JSON = """
+            {
+                "for": "/api/calm/namespaces/finos/patterns/5",
+                "name": "Default",
+                "pins": [
+                    { "unique-id": "node-a", "position": { "x": 0, "y": 0 } }
+                ]
+            }
+            """;
+
+    // ---- GET /api/calm/namespaces/{namespace}/patterns/{patternId}/layout ----
+
+    @Test
+    void return_layout_when_saved() throws NamespaceNotFoundException {
+        when(mockPatternLayoutStore.getLayout("finos", 5)).thenReturn(Optional.of(VALID_LAYOUT_JSON));
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(200)
+                .body("for", equalTo("/api/calm/namespaces/finos/patterns/5"))
+                .body("pins[0].unique-id", equalTo("node-a"));
+
+        verify(mockPatternLayoutStore, times(1)).getLayout("finos", 5);
+    }
+
+    @Test
+    void return_404_when_no_layout_saved() throws NamespaceNotFoundException {
+        when(mockPatternLayoutStore.getLayout("finos", 5)).thenReturn(Optional.empty());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(404)
+                .body(containsString("No default layout saved for pattern 5 in namespace: finos"));
+    }
+
+    @Test
+    void return_404_when_namespace_not_found_for_get_layout() throws NamespaceNotFoundException {
+        when(mockPatternLayoutStore.getLayout("missing", 5)).thenThrow(new NamespaceNotFoundException());
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/missing/patterns/5/layout")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid namespace provided: missing"));
+    }
+
+    @Test
+    void return_400_when_namespace_invalid_for_get_layout() {
+        given()
+                .when()
+                .get("/api/calm/namespaces/invalid@namespace/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("namespace must match pattern"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+    }
+
+    @Test
+    void return_400_when_pattern_id_is_zero_for_get_layout() {
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns/0/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("Pattern ID must be a positive integer"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+    }
+
+    // ---- PUT /api/calm/namespaces/{namespace}/patterns/{patternId}/layout ----
+
+    @Test
+    void return_204_when_layout_saved() throws NamespaceNotFoundException {
+        givenPatternExists();
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(VALID_LAYOUT_JSON)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(204);
+
+        verify(mockPatternLayoutStore, times(1)).upsertLayout(
+                eq("finos"), eq(5), argThat(json -> json != null && json.strip().equals(VALID_LAYOUT_JSON.strip())));
+    }
+
+    @Test
+    void accept_put_when_for_is_absent() throws NamespaceNotFoundException {
+        givenPatternExists();
+        String layoutWithoutFor = "{ \"pins\": [] }";
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(layoutWithoutFor)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(204);
+
+        verify(mockPatternLayoutStore, times(1)).upsertLayout(eq("finos"), eq(5), anyString());
+    }
+
+    @Test
+    void return_400_when_for_target_does_not_match_pattern() {
+        String mismatchedLayout = """
+                { "for": "/api/calm/namespaces/finos/patterns/999", "pins": [] }
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(mismatchedLayout)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("does not match pattern"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+
+    @Test
+    void return_400_when_for_target_names_the_architecture_path_for_the_same_numeric_id() {
+        // Architecture ids and pattern ids are drawn from independent counters (see
+        // MongoCounterStore), so a request could legitimately try to save a pattern's layout
+        // with a `for` that names an architecture with the same numeric id. The plain
+        // equality check against this resource's own pattern-canonical path already rejects
+        // it, exactly like any other mismatched target — no separate cross-type case needed.
+        String architecturePathLayout = """
+                { "for": "/api/calm/namespaces/finos/architectures/5", "pins": [] }
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(architecturePathLayout)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("does not match pattern"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+
+    @Test
+    void return_400_when_layout_json_is_invalid() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("not-valid-json")
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("The layout JSON could not be parsed"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+
+    @Test
+    void return_400_rather_than_500_when_the_layout_body_is_absent() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("The layout JSON could not be parsed"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+
+    @Test
+    void return_400_rather_than_500_when_the_layout_body_is_an_empty_string() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("")
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("The layout JSON could not be parsed"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+
+    @Test
+    void return_404_when_pattern_does_not_exist_for_put_layout() throws NamespaceNotFoundException {
+        when(mockPatternStore.patternExists("finos", 5)).thenReturn(false);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(VALID_LAYOUT_JSON)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(404)
+                .body(containsString("Pattern 5 does not exist in namespace: finos"));
+
+        verify(mockPatternLayoutStore, never()).upsertLayout(anyString(), anyInt(), anyString());
+    }
+
+    @Test
+    void return_404_when_namespace_not_found_for_put_layout() throws NamespaceNotFoundException {
+        doThrow(new NamespaceNotFoundException()).when(mockPatternStore).patternExists(anyString(), anyInt());
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{ \"pins\": [] }")
+                .when()
+                .put("/api/calm/namespaces/missing/patterns/5/layout")
+                .then()
+                .statusCode(404)
+                .body(containsString("Invalid namespace provided: missing"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+    }
+
+    @Test
+    void return_400_when_namespace_invalid_for_put_layout() {
+        given()
+                .contentType(ContentType.JSON)
+                .body(VALID_LAYOUT_JSON)
+                .when()
+                .put("/api/calm/namespaces/invalid@namespace/patterns/5/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("namespace must match pattern"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+    }
+
+    @Test
+    void return_400_when_pattern_id_is_zero_for_put_layout() {
+        given()
+                .contentType(ContentType.JSON)
+                .body(VALID_LAYOUT_JSON)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/0/layout")
+                .then()
+                .statusCode(400)
+                .body(containsString("Pattern ID must be a positive integer"));
+
+        verifyNoInteractions(mockPatternLayoutStore);
+    }
+
+    @Test
+    @TestSecurity(user = "bob")
+    void return_403_when_write_scope_missing_for_put_layout() {
+        when(mockUserAccessStore.getGrantsForUser("bob")).thenReturn(Collections.emptyList());
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(VALID_LAYOUT_JSON)
+                .when()
+                .put("/api/calm/namespaces/finos/patterns/5/layout")
+                .then()
+                .statusCode(403);
+
+        verifyNoInteractions(mockPatternLayoutStore);
+        verifyNoInteractions(mockPatternStore);
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternLayoutResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternLayoutResourceShould.java
@@ -5,8 +5,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.store.PatternLayoutStore;
-import org.finos.calm.store.PatternStore;
 import org.finos.calm.store.UserAccessStore;
 import org.junit.jupiter.api.Test;
 
@@ -27,14 +27,7 @@ public class TestPatternLayoutResourceShould {
     PatternLayoutStore mockPatternLayoutStore;
 
     @InjectMock
-    PatternStore mockPatternStore;
-
-    @InjectMock
     UserAccessStore mockUserAccessStore;
-
-    private void givenPatternExists() throws NamespaceNotFoundException {
-        when(mockPatternStore.patternExists("finos", 5)).thenReturn(true);
-    }
 
     private static final String VALID_LAYOUT_JSON = """
             {
@@ -114,9 +107,7 @@ public class TestPatternLayoutResourceShould {
     // ---- PUT /api/calm/namespaces/{namespace}/patterns/{patternId}/layout ----
 
     @Test
-    void return_204_when_layout_saved() throws NamespaceNotFoundException {
-        givenPatternExists();
-
+    void return_204_when_layout_saved() throws NamespaceNotFoundException, PatternNotFoundException {
         given()
                 .contentType(ContentType.JSON)
                 .body(VALID_LAYOUT_JSON)
@@ -130,8 +121,7 @@ public class TestPatternLayoutResourceShould {
     }
 
     @Test
-    void accept_put_when_for_is_absent() throws NamespaceNotFoundException {
-        givenPatternExists();
+    void accept_put_when_for_is_absent() throws NamespaceNotFoundException, PatternNotFoundException {
         String layoutWithoutFor = "{ \"pins\": [] }";
 
         given()
@@ -161,7 +151,6 @@ public class TestPatternLayoutResourceShould {
                 .body(containsString("does not match pattern"));
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 
     @Test
@@ -185,7 +174,6 @@ public class TestPatternLayoutResourceShould {
                 .body(containsString("does not match pattern"));
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 
     @Test
@@ -200,7 +188,6 @@ public class TestPatternLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 
     @Test
@@ -214,7 +201,6 @@ public class TestPatternLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 
     @Test
@@ -229,12 +215,13 @@ public class TestPatternLayoutResourceShould {
                 .body(containsString("The layout JSON could not be parsed"));
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 
     @Test
-    void return_404_when_pattern_does_not_exist_for_put_layout() throws NamespaceNotFoundException {
-        when(mockPatternStore.patternExists("finos", 5)).thenReturn(false);
+    void return_404_when_pattern_does_not_exist_for_put_layout()
+            throws NamespaceNotFoundException, PatternNotFoundException {
+        doThrow(new PatternNotFoundException())
+                .when(mockPatternLayoutStore).upsertLayout(eq("finos"), eq(5), anyString());
 
         given()
                 .contentType(ContentType.JSON)
@@ -244,13 +231,13 @@ public class TestPatternLayoutResourceShould {
                 .then()
                 .statusCode(404)
                 .body(containsString("Pattern 5 does not exist in namespace: finos"));
-
-        verify(mockPatternLayoutStore, never()).upsertLayout(anyString(), anyInt(), anyString());
     }
 
     @Test
-    void return_404_when_namespace_not_found_for_put_layout() throws NamespaceNotFoundException {
-        doThrow(new NamespaceNotFoundException()).when(mockPatternStore).patternExists(anyString(), anyInt());
+    void return_404_when_namespace_not_found_for_put_layout()
+            throws NamespaceNotFoundException, PatternNotFoundException {
+        doThrow(new NamespaceNotFoundException())
+                .when(mockPatternLayoutStore).upsertLayout(anyString(), anyInt(), anyString());
 
         given()
                 .contentType(ContentType.JSON)
@@ -260,8 +247,6 @@ public class TestPatternLayoutResourceShould {
                 .then()
                 .statusCode(404)
                 .body(containsString("Invalid namespace provided: missing"));
-
-        verifyNoInteractions(mockPatternLayoutStore);
     }
 
     @Test
@@ -306,6 +291,5 @@ public class TestPatternLayoutResourceShould {
                 .statusCode(403);
 
         verifyNoInteractions(mockPatternLayoutStore);
-        verifyNoInteractions(mockPatternStore);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestNamespaceContentServiceShould.java
@@ -8,6 +8,7 @@ import org.finos.calm.store.DecoratorStore;
 import org.finos.calm.store.FlowStore;
 import org.finos.calm.store.InterfaceStore;
 import org.finos.calm.store.LayoutStore;
+import org.finos.calm.store.PatternLayoutStore;
 import org.finos.calm.store.PatternStore;
 import org.finos.calm.store.StandardStore;
 import org.finos.calm.store.TimelineStore;
@@ -49,6 +50,8 @@ class TestNamespaceContentServiceShould {
     DecoratorStore mockDecoratorStore;
     @Mock
     LayoutStore mockLayoutStore;
+    @Mock
+    PatternLayoutStore mockPatternLayoutStore;
 
     NamespaceContentService service;
 
@@ -56,7 +59,8 @@ class TestNamespaceContentServiceShould {
     void setUp() {
         service = new NamespaceContentService(
                 mockArchitectureStore, mockPatternStore, mockFlowStore, mockStandardStore,
-                mockAdrStore, mockInterfaceStore, mockTimelineStore, mockDecoratorStore, mockLayoutStore);
+                mockAdrStore, mockInterfaceStore, mockTimelineStore, mockDecoratorStore, mockLayoutStore,
+                mockPatternLayoutStore);
     }
 
     @Test
@@ -72,6 +76,7 @@ class TestNamespaceContentServiceShould {
         verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
         verify(mockDecoratorStore).getDecoratorsForNamespace(NAMESPACE, null, null);
         verify(mockLayoutStore).getArchitectureIdsWithLayoutForNamespace(NAMESPACE);
+        verify(mockPatternLayoutStore).getPatternIdsWithLayoutForNamespace(NAMESPACE);
     }
 
     @Test
@@ -84,10 +89,11 @@ class TestNamespaceContentServiceShould {
         verify(mockPatternStore, never()).getPatternsForNamespace(NAMESPACE);
         verify(mockDecoratorStore, never()).getDecoratorsForNamespace(NAMESPACE, null, null);
         verify(mockLayoutStore, never()).getArchitectureIdsWithLayoutForNamespace(NAMESPACE);
+        verify(mockPatternLayoutStore, never()).getPatternIdsWithLayoutForNamespace(NAMESPACE);
     }
 
     @Test
-    void return_true_when_only_the_last_checked_store_has_content() throws Exception {
+    void return_true_when_only_the_architecture_layout_store_has_content() throws Exception {
         when(mockLayoutStore.getArchitectureIdsWithLayoutForNamespace(NAMESPACE))
                 .thenReturn(List.of(1));
 
@@ -96,6 +102,22 @@ class TestNamespaceContentServiceShould {
         verify(mockArchitectureStore).getArchitecturesForNamespace(NAMESPACE);
         verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
         verify(mockDecoratorStore).getDecoratorsForNamespace(NAMESPACE, null, null);
+        verify(mockLayoutStore).getArchitectureIdsWithLayoutForNamespace(NAMESPACE);
+        verify(mockPatternLayoutStore, never()).getPatternIdsWithLayoutForNamespace(NAMESPACE);
+    }
+
+    @Test
+    void return_true_when_only_the_last_checked_store_has_content() throws Exception {
+        when(mockPatternLayoutStore.getPatternIdsWithLayoutForNamespace(NAMESPACE))
+                .thenReturn(List.of(1));
+
+        assertThat(service.hasContent(NAMESPACE), is(true));
+
+        verify(mockArchitectureStore).getArchitecturesForNamespace(NAMESPACE);
+        verify(mockTimelineStore).getTimelinesForNamespace(NAMESPACE);
+        verify(mockDecoratorStore).getDecoratorsForNamespace(NAMESPACE, null, null);
+        verify(mockLayoutStore).getArchitectureIdsWithLayoutForNamespace(NAMESPACE);
+        verify(mockPatternLayoutStore).getPatternIdsWithLayoutForNamespace(NAMESPACE);
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -171,29 +171,6 @@ public class TestMongoArchitectureStoreShould {
                 new NamespaceResourceSummary("Architecture 7", "", 7, 0)));
     }
 
-    // --- architectureExists ---
-
-    @Test
-    void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
-        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> store.architectureExists(NAMESPACE, ARCHITECTURE_ID));
-    }
-
-    @Test
-    void return_true_when_the_architecture_header_exists() throws NamespaceNotFoundException {
-        architectureExists();
-
-        assertThat(store.architectureExists(NAMESPACE, ARCHITECTURE_ID), is(true));
-    }
-
-    @Test
-    void return_false_when_the_architecture_header_is_absent() throws NamespaceNotFoundException {
-        architectureDoesNotExist();
-
-        assertThat(store.architectureExists(NAMESPACE, ARCHITECTURE_ID), is(false));
-    }
-
     // --- createArchitectureForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoLayoutStoreShould.java
@@ -11,6 +11,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonMaximumSizeExceededException;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StorageWriteException;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,9 @@ class TestMongoLayoutStoreShould {
     private MongoCollection<Document> layoutCollection;
 
     @Mock
+    private MongoCollection<Document> architectureHeaderCollection;
+
+    @Mock
     private MongoNamespaceStore namespaceStore;
 
     private MongoLayoutStore layoutStore;
@@ -60,7 +64,16 @@ class TestMongoLayoutStoreShould {
     void setUp() throws NamespaceNotFoundException {
         doCallRealMethod().when(namespaceStore).requireNamespace(anyString());
         when(database.getCollection("layouts")).thenReturn(layoutCollection);
+        when(database.getCollection("architectures")).thenReturn(architectureHeaderCollection);
         layoutStore = new MongoLayoutStore(database, namespaceStore);
+    }
+
+    /** Stubs the architecture-header existence check {@code upsertLayout} runs before writing. */
+    private void stubArchitectureHeaderExists() {
+        FindIterable<Document> headerFindIterable = mock(DocumentFindIterable.class);
+        when(architectureHeaderCollection.find(any(Bson.class))).thenReturn(headerFindIterable);
+        when(headerFindIterable.projection(any())).thenReturn(headerFindIterable);
+        when(headerFindIterable.first()).thenReturn(new Document("_id", "some-id"));
     }
 
     // ---- getLayout ----
@@ -124,9 +137,10 @@ class TestMongoLayoutStoreShould {
     // ---- upsertLayout ----
 
     @Test
-    void save_via_a_single_replace_one_upsert() throws NamespaceNotFoundException {
+    void save_via_a_single_replace_one_upsert() throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
 
@@ -134,9 +148,11 @@ class TestMongoLayoutStoreShould {
     }
 
     @Test
-    void retry_the_replace_once_when_two_concurrent_upserts_collide() throws NamespaceNotFoundException {
+    void retry_the_replace_once_when_two_concurrent_upserts_collide()
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         // Both saves missed the filter and both attempted an insert; the unique index on
         // (namespace, architectureId) let only the other one through.
@@ -153,6 +169,7 @@ class TestMongoLayoutStoreShould {
     void surface_a_write_failure_when_the_retry_also_hits_a_duplicate_key() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         // A second duplicate key on the retry means the index no longer agrees with the
         // filter — a fault, not a race to keep retrying.
@@ -168,6 +185,7 @@ class TestMongoLayoutStoreShould {
     void surface_capacity_exceeded_when_the_server_rejects_an_oversized_document() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
                 .thenThrow(new MongoWriteException(new WriteError(10334, "object to save is too large", new BsonDocument()), new ServerAddress(), List.of()));
@@ -183,6 +201,7 @@ class TestMongoLayoutStoreShould {
     void surface_capacity_exceeded_when_the_layout_itself_exceeds_the_bson_limit() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         // Unlike the old shape, a single write can already exceed the 16MB ceiling before it
         // is even sent — the driver rejects it client-side while serializing the command, so
@@ -201,6 +220,7 @@ class TestMongoLayoutStoreShould {
     void propagate_non_duplicate_key_write_errors() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
                 .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
@@ -218,6 +238,20 @@ class TestMongoLayoutStoreShould {
         when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void throw_architecture_not_found_when_no_architecture_header_exists_for_the_target_id() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        FindIterable<Document> headerFindIterable = mock(DocumentFindIterable.class);
+        when(architectureHeaderCollection.find(any(Bson.class))).thenReturn(headerFindIterable);
+        when(headerFindIterable.projection(any())).thenReturn(headerFindIterable);
+        when(headerFindIterable.first()).thenReturn(null);
+
+        assertThrows(ArchitectureNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
         verify(layoutCollection, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternLayoutStoreShould.java
@@ -1,0 +1,283 @@
+package org.finos.calm.store.mongo;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
+import org.bson.BsonDocument;
+import org.bson.BsonMaximumSizeExceededException;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.StorageWriteException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestMongoPatternLayoutStoreShould {
+
+    private interface DocumentFindIterable extends FindIterable<Document> {
+    }
+
+    @Mock
+    private MongoDatabase database;
+
+    @Mock
+    private MongoCollection<Document> layoutCollection;
+
+    @Mock
+    private MongoNamespaceStore namespaceStore;
+
+    private MongoPatternLayoutStore layoutStore;
+
+    private static final String LAYOUT_JSON = "{\"for\": \"/api/calm/namespaces/finos/patterns/5\", \"pins\": []}";
+
+    @BeforeEach
+    void setUp() {
+        when(database.getCollection("pattern_layouts")).thenReturn(layoutCollection);
+        layoutStore = new MongoPatternLayoutStore(database, namespaceStore);
+    }
+
+    // ---- getLayout ----
+
+    @Test
+    void return_layout_when_document_exists() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document layoutDoc = Document.parse(LAYOUT_JSON);
+        Document document = new Document("namespace", namespace).append("patternId", 5).append("layout", layoutDoc);
+
+        FindIterable<Document> findIterable = mock(DocumentFindIterable.class);
+        when(layoutCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(document);
+
+        Optional<String> result = layoutStore.getLayout(namespace, 5);
+
+        assertTrue(result.isPresent());
+        assertEquals(layoutDoc, Document.parse(result.get()));
+        verify(namespaceStore).namespaceExists(namespace);
+    }
+
+    @Test
+    void return_empty_when_no_document_matches_pattern() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        FindIterable<Document> findIterable = mock(DocumentFindIterable.class);
+        when(layoutCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(null);
+
+        Optional<String> result = layoutStore.getLayout(namespace, 5);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void return_empty_when_the_document_holds_no_layout() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document document = new Document("namespace", namespace).append("patternId", 5);
+
+        FindIterable<Document> findIterable = mock(DocumentFindIterable.class);
+        when(layoutCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(document);
+
+        assertFalse(layoutStore.getLayout(namespace, 5).isPresent());
+    }
+
+    @Test
+    void throw_namespace_not_found_when_getting_layout_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.getLayout(namespace, 5));
+        verify(layoutCollection, never()).find(any(Bson.class));
+    }
+
+    // ---- upsertLayout ----
+
+    @Test
+    void save_via_a_single_replace_one_upsert() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
+
+        verify(layoutCollection, times(1)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void retry_the_replace_once_when_two_concurrent_upserts_collide() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        // Both saves missed the filter and both attempted an insert; the unique index on
+        // (namespace, patternId) let only the other one through.
+        when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()))
+                .thenReturn(null);
+
+        layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
+
+        verify(layoutCollection, times(2)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void surface_a_write_failure_when_the_retry_also_hits_a_duplicate_key() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        // A second duplicate key on the retry means the index no longer agrees with the
+        // filter — a fault, not a race to keep retrying.
+        when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(11000, "duplicate key", new BsonDocument()), new ServerAddress(), List.of()));
+
+        assertThrows(StorageWriteException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+
+        verify(layoutCollection, times(2)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void surface_capacity_exceeded_when_the_server_rejects_an_oversized_document() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(10334, "object to save is too large", new BsonDocument()), new ServerAddress(), List.of()));
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+
+        assertTrue(exception.isCapacityExceeded());
+        verify(layoutCollection, times(1)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void surface_capacity_exceeded_when_the_layout_itself_exceeds_the_bson_limit() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        // Unlike the old shape, a single write can already exceed the 16MB ceiling before it
+        // is even sent — the driver rejects it client-side while serializing the command, so
+        // no MongoWriteException is ever raised.
+        when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
+                .thenThrow(new BsonMaximumSizeExceededException("document exceeds maximum allowed size"));
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+
+        assertTrue(exception.isCapacityExceeded());
+        verify(layoutCollection, times(1)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void propagate_non_duplicate_key_write_errors() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
+                .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
+
+        StorageWriteException exception = assertThrows(StorageWriteException.class,
+                () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+
+        assertFalse(exception.isCapacityExceeded());
+        verify(layoutCollection, times(1)).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void throw_namespace_not_found_when_saving_layout_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    // ---- getPatternIdsWithLayoutForNamespace ----
+
+    @Test
+    void return_pattern_ids_with_saved_layouts() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        stubProjectedDocuments(List.of(
+                new Document("patternId", 5),
+                new Document("patternId", 6)
+        ));
+
+        List<Integer> ids = layoutStore.getPatternIdsWithLayoutForNamespace(namespace);
+
+        assertEquals(List.of(5, 6), ids);
+    }
+
+    @Test
+    void skip_a_document_with_no_pattern_id() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        stubProjectedDocuments(List.of(new Document()));
+
+        assertTrue(layoutStore.getPatternIdsWithLayoutForNamespace(namespace).isEmpty());
+    }
+
+    @Test
+    void return_empty_list_when_no_layouts_exist_for_the_namespace() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        stubProjectedDocuments(List.of());
+
+        assertTrue(layoutStore.getPatternIdsWithLayoutForNamespace(namespace).isEmpty());
+    }
+
+    @Test
+    void throw_namespace_not_found_when_listing_layout_ids_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.getPatternIdsWithLayoutForNamespace(namespace));
+        verify(layoutCollection, never()).find(any(Bson.class));
+    }
+
+    /**
+     * Models {@code getPatternIdsWithLayoutForNamespace}'s {@code find(...).projection(...).forEach(...)}
+     * chain — the projected iterable drives the given documents through the consumer passed to
+     * {@code forEach}.
+     */
+    private void stubProjectedDocuments(List<Document> documents) {
+        FindIterable<Document> findIterable = mock(DocumentFindIterable.class);
+        when(layoutCollection.find(any(Bson.class))).thenReturn(findIterable);
+        when(findIterable.projection(any())).thenReturn(findIterable);
+        doAnswer(invocation -> {
+            Consumer<Document> consumer = invocation.getArgument(0);
+            documents.forEach(consumer);
+            return null;
+        }).when(findIterable).forEach(ArgumentMatchers.<Consumer<? super Document>>any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternLayoutStoreShould.java
@@ -12,6 +12,7 @@ import org.bson.BsonMaximumSizeExceededException;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.domain.exception.StorageWriteException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,9 @@ class TestMongoPatternLayoutStoreShould {
     private MongoCollection<Document> layoutCollection;
 
     @Mock
+    private MongoCollection<Document> patternHeaderCollection;
+
+    @Mock
     private MongoNamespaceStore namespaceStore;
 
     private MongoPatternLayoutStore layoutStore;
@@ -58,7 +62,16 @@ class TestMongoPatternLayoutStoreShould {
     @BeforeEach
     void setUp() {
         when(database.getCollection("pattern_layouts")).thenReturn(layoutCollection);
+        when(database.getCollection("patterns")).thenReturn(patternHeaderCollection);
         layoutStore = new MongoPatternLayoutStore(database, namespaceStore);
+    }
+
+    /** Stubs the pattern-header existence check {@code upsertLayout} runs before writing. */
+    private void stubPatternHeaderExists() {
+        FindIterable<Document> headerFindIterable = mock(DocumentFindIterable.class);
+        when(patternHeaderCollection.find(any(Bson.class))).thenReturn(headerFindIterable);
+        when(headerFindIterable.projection(any())).thenReturn(headerFindIterable);
+        when(headerFindIterable.first()).thenReturn(new Document("_id", "some-id"));
     }
 
     // ---- getLayout ----
@@ -122,9 +135,10 @@ class TestMongoPatternLayoutStoreShould {
     // ---- upsertLayout ----
 
     @Test
-    void save_via_a_single_replace_one_upsert() throws NamespaceNotFoundException {
+    void save_via_a_single_replace_one_upsert() throws NamespaceNotFoundException, PatternNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
 
@@ -132,9 +146,11 @@ class TestMongoPatternLayoutStoreShould {
     }
 
     @Test
-    void retry_the_replace_once_when_two_concurrent_upserts_collide() throws NamespaceNotFoundException {
+    void retry_the_replace_once_when_two_concurrent_upserts_collide()
+            throws NamespaceNotFoundException, PatternNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         // Both saves missed the filter and both attempted an insert; the unique index on
         // (namespace, patternId) let only the other one through.
@@ -151,6 +167,7 @@ class TestMongoPatternLayoutStoreShould {
     void surface_a_write_failure_when_the_retry_also_hits_a_duplicate_key() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         // A second duplicate key on the retry means the index no longer agrees with the
         // filter — a fault, not a race to keep retrying.
@@ -166,6 +183,7 @@ class TestMongoPatternLayoutStoreShould {
     void surface_capacity_exceeded_when_the_server_rejects_an_oversized_document() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
                 .thenThrow(new MongoWriteException(new WriteError(10334, "object to save is too large", new BsonDocument()), new ServerAddress(), List.of()));
@@ -181,6 +199,7 @@ class TestMongoPatternLayoutStoreShould {
     void surface_capacity_exceeded_when_the_layout_itself_exceeds_the_bson_limit() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         // Unlike the old shape, a single write can already exceed the 16MB ceiling before it
         // is even sent — the driver rejects it client-side while serializing the command, so
@@ -199,6 +218,7 @@ class TestMongoPatternLayoutStoreShould {
     void propagate_non_duplicate_key_write_errors() {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         when(layoutCollection.replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class)))
                 .thenThrow(new MongoWriteException(new WriteError(12, "some other error", new BsonDocument()), new ServerAddress(), List.of()));
@@ -216,6 +236,20 @@ class TestMongoPatternLayoutStoreShould {
         when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    @Test
+    void throw_pattern_not_found_when_no_pattern_header_exists_for_the_target_id() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        FindIterable<Document> headerFindIterable = mock(DocumentFindIterable.class);
+        when(patternHeaderCollection.find(any(Bson.class))).thenReturn(headerFindIterable);
+        when(headerFindIterable.projection(any())).thenReturn(headerFindIterable);
+        when(headerFindIterable.first()).thenReturn(null);
+
+        assertThrows(PatternNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
         verify(layoutCollection, never()).replaceOne(any(Bson.class), any(Document.class), any(ReplaceOptions.class));
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -141,29 +141,6 @@ public class TestMongoPatternStoreShould {
         return new CreatePatternRequest("pattern-name", "pattern-description", VALID_JSON);
     }
 
-    // --- patternExists ---
-
-    @Test
-    void return_true_when_pattern_exists() throws NamespaceNotFoundException {
-        patternExists();
-
-        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(true));
-    }
-
-    @Test
-    void return_false_when_pattern_does_not_exist() throws NamespaceNotFoundException {
-        patternDoesNotExist();
-
-        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(false));
-    }
-
-    @Test
-    void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
-        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> store.patternExists(NAMESPACE, PATTERN_ID));
-    }
-
     // --- getPatternsForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -141,6 +141,29 @@ public class TestMongoPatternStoreShould {
         return new CreatePatternRequest("pattern-name", "pattern-description", VALID_JSON);
     }
 
+    // --- patternExists ---
+
+    @Test
+    void return_true_when_pattern_exists() throws NamespaceNotFoundException {
+        patternExists();
+
+        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(true));
+    }
+
+    @Test
+    void return_false_when_pattern_does_not_exist() throws NamespaceNotFoundException {
+        patternDoesNotExist();
+
+        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(false));
+    }
+
+    @Test
+    void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.patternExists(NAMESPACE, PATTERN_ID));
+    }
+
     // --- getPatternsForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -160,29 +160,6 @@ public class TestNitriteArchitectureStoreShould {
                 new NamespaceResourceSummary("Second", "", 2, 1)));
     }
 
-    // --- architectureExists ---
-
-    @Test
-    public void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> store.architectureExists(NAMESPACE, ARCHITECTURE_ID));
-    }
-
-    @Test
-    public void return_true_when_the_architecture_header_exists() throws NamespaceNotFoundException {
-        architectureExists();
-
-        assertThat(store.architectureExists(NAMESPACE, ARCHITECTURE_ID), is(true));
-    }
-
-    @Test
-    public void return_false_when_the_architecture_header_is_absent() throws NamespaceNotFoundException {
-        architectureDoesNotExist();
-
-        assertThat(store.architectureExists(NAMESPACE, ARCHITECTURE_ID), is(false));
-    }
-
     // --- createArchitectureForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteLayoutStoreShould.java
@@ -6,6 +6,7 @@ import org.dizitart.no2.collection.Document;
 import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
+import org.finos.calm.domain.exception.ArchitectureNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,10 +40,16 @@ class TestNitriteLayoutStoreShould {
     private NitriteCollection layoutCollection;
 
     @Mock
+    private NitriteCollection architectureHeaderCollection;
+
+    @Mock
     private NitriteNamespaceStore namespaceStore;
 
     @Mock
     private DocumentCursor cursor;
+
+    @Mock
+    private DocumentCursor headerCursor;
 
     private NitriteLayoutStore layoutStore;
 
@@ -52,7 +59,14 @@ class TestNitriteLayoutStoreShould {
     void setUp() throws NamespaceNotFoundException {
         doCallRealMethod().when(namespaceStore).requireNamespace(anyString());
         when(db.getCollection("layouts")).thenReturn(layoutCollection);
+        when(db.getCollection("architectures")).thenReturn(architectureHeaderCollection);
         layoutStore = new NitriteLayoutStore(db, namespaceStore);
+    }
+
+    /** Stubs the architecture-header existence check {@code upsertLayout} runs before writing. */
+    private void stubArchitectureHeaderExists() {
+        when(architectureHeaderCollection.find(any(Filter.class))).thenReturn(headerCursor);
+        when(headerCursor.firstOrNull()).thenReturn(Document.createDocument("architectureId", 5));
     }
 
     // ---- getLayout ----
@@ -97,9 +111,11 @@ class TestNitriteLayoutStoreShould {
     // ---- upsertLayout ----
 
     @Test
-    void insert_a_new_document_when_none_exists_for_this_architecture() throws NamespaceNotFoundException {
+    void insert_a_new_document_when_none_exists_for_this_architecture()
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
         when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
         when(cursor.firstOrNull()).thenReturn(null);
 
@@ -114,9 +130,11 @@ class TestNitriteLayoutStoreShould {
     }
 
     @Test
-    void insert_a_second_document_for_another_architecture_in_the_same_namespace() throws NamespaceNotFoundException {
+    void insert_a_second_document_for_another_architecture_in_the_same_namespace()
+            throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
         // find() is scoped to (namespace, architectureId), so a document for a different
         // architecture in the same namespace never matches — insert, not update.
         when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
@@ -130,9 +148,10 @@ class TestNitriteLayoutStoreShould {
     }
 
     @Test
-    void update_the_existing_document_in_place() throws NamespaceNotFoundException {
+    void update_the_existing_document_in_place() throws NamespaceNotFoundException, ArchitectureNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         Document existing = Document.createDocument("namespace", namespace)
                 .put("architectureId", 5).put("layout", "{\"pins\":[]}");
@@ -149,6 +168,7 @@ class TestNitriteLayoutStoreShould {
     @Test
     void throw_json_parse_exception_when_layout_json_is_malformed() {
         when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, "not-valid-json"));
         verify(layoutCollection, never()).insert(any(Document.class));
@@ -158,6 +178,7 @@ class TestNitriteLayoutStoreShould {
     @Test
     void throw_json_parse_exception_when_layout_json_is_null() {
         when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+        stubArchitectureHeaderExists();
 
         assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, null));
     }
@@ -168,6 +189,18 @@ class TestNitriteLayoutStoreShould {
         when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).insert(any(Document.class));
+        verify(layoutCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void throw_architecture_not_found_when_no_architecture_header_exists_for_the_target_id() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(architectureHeaderCollection.find(any(Filter.class))).thenReturn(headerCursor);
+        when(headerCursor.firstOrNull()).thenReturn(null);
+
+        assertThrows(ArchitectureNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
         verify(layoutCollection, never()).insert(any(Document.class));
         verify(layoutCollection, never()).update(any(Document.class));
     }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternLayoutStoreShould.java
@@ -7,6 +7,7 @@ import org.dizitart.no2.collection.DocumentCursor;
 import org.dizitart.no2.collection.NitriteCollection;
 import org.dizitart.no2.filters.Filter;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,10 +38,16 @@ class TestNitritePatternLayoutStoreShould {
     private NitriteCollection layoutCollection;
 
     @Mock
+    private NitriteCollection patternHeaderCollection;
+
+    @Mock
     private NitriteNamespaceStore namespaceStore;
 
     @Mock
     private DocumentCursor cursor;
+
+    @Mock
+    private DocumentCursor headerCursor;
 
     private NitritePatternLayoutStore layoutStore;
 
@@ -49,7 +56,14 @@ class TestNitritePatternLayoutStoreShould {
     @BeforeEach
     void setUp() {
         when(db.getCollection("pattern_layouts")).thenReturn(layoutCollection);
+        when(db.getCollection("patterns")).thenReturn(patternHeaderCollection);
         layoutStore = new NitritePatternLayoutStore(db, namespaceStore);
+    }
+
+    /** Stubs the pattern-header existence check {@code upsertLayout} runs before writing. */
+    private void stubPatternHeaderExists() {
+        when(patternHeaderCollection.find(any(Filter.class))).thenReturn(headerCursor);
+        when(headerCursor.firstOrNull()).thenReturn(Document.createDocument("patternId", 5));
     }
 
     // ---- getLayout ----
@@ -94,9 +108,11 @@ class TestNitritePatternLayoutStoreShould {
     // ---- upsertLayout ----
 
     @Test
-    void insert_a_new_document_when_none_exists_for_this_pattern() throws NamespaceNotFoundException {
+    void insert_a_new_document_when_none_exists_for_this_pattern()
+            throws NamespaceNotFoundException, PatternNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
         when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
         when(cursor.firstOrNull()).thenReturn(null);
 
@@ -111,9 +127,11 @@ class TestNitritePatternLayoutStoreShould {
     }
 
     @Test
-    void insert_a_second_document_for_another_pattern_in_the_same_namespace() throws NamespaceNotFoundException {
+    void insert_a_second_document_for_another_pattern_in_the_same_namespace()
+            throws NamespaceNotFoundException, PatternNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
         // find() is scoped to (namespace, patternId), so a document for a different pattern in
         // the same namespace never matches — insert, not update.
         when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
@@ -127,9 +145,10 @@ class TestNitritePatternLayoutStoreShould {
     }
 
     @Test
-    void update_the_existing_document_in_place() throws NamespaceNotFoundException {
+    void update_the_existing_document_in_place() throws NamespaceNotFoundException, PatternNotFoundException {
         String namespace = "finos";
         when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubPatternHeaderExists();
 
         Document existing = Document.createDocument("namespace", namespace)
                 .put("patternId", 5).put("layout", "{\"pins\":[]}");
@@ -146,6 +165,7 @@ class TestNitritePatternLayoutStoreShould {
     @Test
     void throw_json_parse_exception_when_layout_json_is_malformed() {
         when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+        stubPatternHeaderExists();
 
         assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, "not-valid-json"));
         verify(layoutCollection, never()).insert(any(Document.class));
@@ -155,6 +175,7 @@ class TestNitritePatternLayoutStoreShould {
     @Test
     void throw_json_parse_exception_when_layout_json_is_null() {
         when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+        stubPatternHeaderExists();
 
         assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, null));
     }
@@ -165,6 +186,18 @@ class TestNitritePatternLayoutStoreShould {
         when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).insert(any(Document.class));
+        verify(layoutCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void throw_pattern_not_found_when_no_pattern_header_exists_for_the_target_id() {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(patternHeaderCollection.find(any(Filter.class))).thenReturn(headerCursor);
+        when(headerCursor.firstOrNull()).thenReturn(null);
+
+        assertThrows(PatternNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
         verify(layoutCollection, never()).insert(any(Document.class));
         verify(layoutCollection, never()).update(any(Document.class));
     }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternLayoutStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternLayoutStoreShould.java
@@ -1,0 +1,222 @@
+package org.finos.calm.store.nitrite;
+
+import org.bson.json.JsonParseException;
+import org.dizitart.no2.Nitrite;
+import org.dizitart.no2.collection.Document;
+import org.dizitart.no2.collection.DocumentCursor;
+import org.dizitart.no2.collection.NitriteCollection;
+import org.dizitart.no2.filters.Filter;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestNitritePatternLayoutStoreShould {
+
+    @Mock
+    private Nitrite db;
+
+    @Mock
+    private NitriteCollection layoutCollection;
+
+    @Mock
+    private NitriteNamespaceStore namespaceStore;
+
+    @Mock
+    private DocumentCursor cursor;
+
+    private NitritePatternLayoutStore layoutStore;
+
+    private static final String LAYOUT_JSON = "{\"for\": \"/api/calm/namespaces/finos/patterns/5\", \"pins\": []}";
+
+    @BeforeEach
+    void setUp() {
+        when(db.getCollection("pattern_layouts")).thenReturn(layoutCollection);
+        layoutStore = new NitritePatternLayoutStore(db, namespaceStore);
+    }
+
+    // ---- getLayout ----
+
+    @Test
+    void return_layout_when_document_exists() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document document = Document.createDocument("namespace", namespace)
+                .put("patternId", 5).put("layout", LAYOUT_JSON);
+
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(document);
+
+        Optional<String> result = layoutStore.getLayout(namespace, 5);
+
+        assertTrue(result.isPresent());
+        assertEquals(LAYOUT_JSON, result.get());
+        verify(namespaceStore).namespaceExists(namespace);
+    }
+
+    @Test
+    void return_empty_when_no_document_matches_pattern() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(null);
+
+        assertFalse(layoutStore.getLayout(namespace, 5).isPresent());
+    }
+
+    @Test
+    void throw_namespace_not_found_when_getting_layout_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.getLayout(namespace, 5));
+        verify(layoutCollection, never()).find(any(Filter.class));
+    }
+
+    // ---- upsertLayout ----
+
+    @Test
+    void insert_a_new_document_when_none_exists_for_this_pattern() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(null);
+
+        layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(layoutCollection).insert(captor.capture());
+        Document inserted = captor.getValue();
+        assertEquals(namespace, inserted.get("namespace"));
+        assertEquals(5, inserted.get("patternId"));
+        assertEquals(LAYOUT_JSON, inserted.get("layout"));
+    }
+
+    @Test
+    void insert_a_second_document_for_another_pattern_in_the_same_namespace() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        // find() is scoped to (namespace, patternId), so a document for a different pattern in
+        // the same namespace never matches — insert, not update.
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(null);
+
+        layoutStore.upsertLayout(namespace, 6, LAYOUT_JSON);
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(layoutCollection).insert(captor.capture());
+        assertEquals(6, captor.getValue().get("patternId"));
+    }
+
+    @Test
+    void update_the_existing_document_in_place() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document existing = Document.createDocument("namespace", namespace)
+                .put("patternId", 5).put("layout", "{\"pins\":[]}");
+
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(existing);
+
+        layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON);
+
+        verify(layoutCollection).update(existing);
+        assertEquals(LAYOUT_JSON, existing.get("layout"));
+    }
+
+    @Test
+    void throw_json_parse_exception_when_layout_json_is_malformed() {
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, "not-valid-json"));
+        verify(layoutCollection, never()).insert(any(Document.class));
+        verify(layoutCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void throw_json_parse_exception_when_layout_json_is_null() {
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        assertThrows(JsonParseException.class, () -> layoutStore.upsertLayout("finos", 5, null));
+    }
+
+    @Test
+    void throw_namespace_not_found_when_saving_layout_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.upsertLayout(namespace, 5, LAYOUT_JSON));
+        verify(layoutCollection, never()).insert(any(Document.class));
+        verify(layoutCollection, never()).update(any(Document.class));
+    }
+
+    // ---- getPatternIdsWithLayoutForNamespace ----
+
+    @Test
+    void return_pattern_ids_with_saved_layouts() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document first = Document.createDocument("namespace", namespace).put("patternId", 5).put("layout", LAYOUT_JSON);
+        Document second = Document.createDocument("namespace", namespace).put("patternId", 6).put("layout", LAYOUT_JSON);
+        stubIterableCursor(List.of(first, second));
+
+        List<Integer> ids = layoutStore.getPatternIdsWithLayoutForNamespace(namespace);
+
+        assertEquals(List.of(5, 6), ids);
+    }
+
+    @Test
+    void skip_a_document_with_no_pattern_id() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document noId = Document.createDocument("namespace", namespace).put("layout", LAYOUT_JSON);
+        stubIterableCursor(List.of(noId));
+
+        assertTrue(layoutStore.getPatternIdsWithLayoutForNamespace(namespace).isEmpty());
+    }
+
+    @Test
+    void return_empty_list_when_no_layouts_exist_for_the_namespace() throws NamespaceNotFoundException {
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        stubIterableCursor(List.of());
+
+        assertTrue(layoutStore.getPatternIdsWithLayoutForNamespace(namespace).isEmpty());
+    }
+
+    @Test
+    void throw_namespace_not_found_when_listing_layout_ids_in_unknown_namespace() {
+        String namespace = "unknown";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> layoutStore.getPatternIdsWithLayoutForNamespace(namespace));
+        verify(layoutCollection, never()).find(any(Filter.class));
+    }
+
+    /** Models the {@code DocumentCursor}'s plain-iteration path used by the ids listing. */
+    private void stubIterableCursor(List<Document> documents) {
+        when(layoutCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.iterator()).thenAnswer(invocation -> (Iterator<Document>) documents.iterator());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -120,29 +120,6 @@ public class TestNitritePatternStoreShould {
         return new CreatePatternRequest(PATTERN_NAME, PATTERN_DESCRIPTION, VALID_JSON);
     }
 
-    // --- patternExists ---
-
-    @Test
-    public void return_true_when_pattern_exists() throws NamespaceNotFoundException {
-        patternExists();
-
-        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(true));
-    }
-
-    @Test
-    public void return_false_when_pattern_does_not_exist() throws NamespaceNotFoundException {
-        patternDoesNotExist();
-
-        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(false));
-    }
-
-    @Test
-    public void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
-        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
-
-        assertThrows(NamespaceNotFoundException.class, () -> store.patternExists(NAMESPACE, PATTERN_ID));
-    }
-
     // --- getPatternsForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -120,6 +120,29 @@ public class TestNitritePatternStoreShould {
         return new CreatePatternRequest(PATTERN_NAME, PATTERN_DESCRIPTION, VALID_JSON);
     }
 
+    // --- patternExists ---
+
+    @Test
+    public void return_true_when_pattern_exists() throws NamespaceNotFoundException {
+        patternExists();
+
+        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(true));
+    }
+
+    @Test
+    public void return_false_when_pattern_does_not_exist() throws NamespaceNotFoundException {
+        patternDoesNotExist();
+
+        assertThat(store.patternExists(NAMESPACE, PATTERN_ID), is(false));
+    }
+
+    @Test
+    public void throw_a_namespace_exception_when_checking_existence_for_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.patternExists(NAMESPACE, PATTERN_ID));
+    }
+
     // --- getPatternsForNamespace ---
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/producer/TestPatternLayoutStoreProducerShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/producer/TestPatternLayoutStoreProducerShould.java
@@ -1,0 +1,82 @@
+package org.finos.calm.store.producer;
+
+import org.finos.calm.store.PatternLayoutStore;
+import org.finos.calm.store.mongo.MongoPatternLayoutStore;
+import org.finos.calm.store.nitrite.NitritePatternLayoutStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.when;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+public class TestPatternLayoutStoreProducerShould {
+
+    @Mock
+    MongoPatternLayoutStore mongoPatternLayoutStore;
+
+    @Mock
+    Instance<MongoPatternLayoutStore> mongoPatternLayoutStoreInstance;
+
+    @Mock
+    NitritePatternLayoutStore nitritePatternLayoutStore;
+
+    @Mock
+    Instance<NitritePatternLayoutStore> nitritePatternLayoutStoreInstance;
+
+    private PatternLayoutStoreProducer patternLayoutStoreProducer;
+
+    @BeforeEach
+    void setup() {
+        patternLayoutStoreProducer = new PatternLayoutStoreProducer();
+        when(mongoPatternLayoutStoreInstance.get()).thenReturn(mongoPatternLayoutStore);
+        patternLayoutStoreProducer.mongoPatternLayoutStore = mongoPatternLayoutStoreInstance;
+        when(nitritePatternLayoutStoreInstance.get()).thenReturn(nitritePatternLayoutStore);
+        patternLayoutStoreProducer.nitritePatternLayoutStore = nitritePatternLayoutStoreInstance;
+    }
+
+    @Test
+    void return_mongo_pattern_layout_store_when_database_mode_is_mongo() {
+        // Given
+        patternLayoutStoreProducer.databaseMode = "mongo";
+
+        // When
+        PatternLayoutStore result = patternLayoutStoreProducer.producePatternLayoutStore();
+
+        // Then
+        assertThat(result, is(sameInstance(mongoPatternLayoutStore)));
+    }
+
+    @Test
+    void return_nitrite_pattern_layout_store_when_database_mode_is_standalone() {
+        // Given
+        patternLayoutStoreProducer.databaseMode = "standalone";
+
+        // When
+        PatternLayoutStore result = patternLayoutStoreProducer.producePatternLayoutStore();
+
+        // Then
+        assertThat(result, is(sameInstance(nitritePatternLayoutStore)));
+    }
+
+    @Test
+    void return_mongo_pattern_layout_store_when_database_mode_is_not_recognized() {
+        // Given
+        patternLayoutStoreProducer.databaseMode = "unknown";
+
+        // When
+        PatternLayoutStore result = patternLayoutStoreProducer.producePatternLayoutStore();
+
+        // Then
+        assertThat(result, is(sameInstance(mongoPatternLayoutStore)));
+    }
+}


### PR DESCRIPTION
## Description

- Add a pattern layout store/resource/migration, structurally mirroring the existing per-namespace architecture layout stack
- Wire save/reset default layout actions through to patterns end-to-end (DiagramSection -> Drawer -> PatternVisualizer -> PatternGraph)
- Key scratch-position and viewport storage by namespace+calmType+id, since architecture and pattern ids are drawn from independent counters and could otherwise collide; migrate pre-existing localStorage entries forward on first read
- Return resource-specific wording (architecture vs pattern) from the shared layout-mismatch error response

### Review round 2 — addressed all feedback from @markscott-ms

- Fixed a real correctness bug: `Drawer.tsx` forwarded `defaultLayout`/`layoutEpoch` unconditionally, so a dropped file inherited the previously-loaded resource's saved layout; both now collapse alongside `viewportKey` when a file is dropped
- Added `PatternGraph.test.tsx` (mirroring `ArchitectureGraph.test.tsx`'s precedence/gating coverage) and `Drawer.test.tsx` regression tests for the above — verified they fail against the pre-fix code
- Extracted `buildViewportKey` as the single source of truth for the `namespace/calmType/id` key shape, replacing hand-duplicated templates in `Drawer.tsx` and `useDefaultLayout.ts`
- Parameterized `CalmResourceErrorResponses`'s not-found responses on `resourceType`, replacing four near-identical architecture/pattern methods (message text unchanged)
- Pushed the target-existence check into `LayoutStore`/`PatternLayoutStore#upsertLayout`, removing a duplicate namespace-existence round trip on every layout save; removed the now-dead `architectureExists`/`patternExists`
- Resolved `PatternLayoutResource`/`PatternLayoutStore`'s circular javadoc cross-reference
- Rebased onto `main` now that #2971 has merged, and renumbered `MongoPatternLayoutIndexStep` to `fromVersion() == 12` / `LATEST_SCHEMA_VERSION` `13`, since #2971's `MongoResourceMappingIndexStep` took `11` first

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (no functional changes)
- [x] ✅ Test additions or updates

## Affected Components
<!-- Check all that apply -->
- [x] CALM Hub (`calm-hub/`)
- [x] CALM Hub UI (`calm-hub-ui/`)

## Commit Message Format ✅

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

- 2690 unit tests pass (`../mvnw test`)
- 526 integration tests pass (`../mvnw -P integration verify`, TestContainers Mongo), JaCoCo coverage gate met
- `npm test --workspace calm-hub-ui`: 115 files / 1395 tests pass
- `npm run lint` (all workspaces): 0 errors

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
