### PR TITLE
fix(calm-hub): scope resource mapping identity by resource type

### DIFF
--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -141,7 +141,7 @@ logSection("Schema baseline");
 // Raise LATEST_SCHEMA_VERSION whenever a migration step is added, and seed that step's
 // target shape below. Document shape must match MongoSchemaVersionStore: _id
 // "schemaVersion", int version, in the calm collection.
-const LATEST_SCHEMA_VERSION = 11;
+const LATEST_SCHEMA_VERSION = 12;
 const unique = { unique: true };
 
 const existingSchemaVersion = db.calm.findOne({ _id: "schemaVersion" });

--- a/calm-hub/mongo/init-mongo.js
+++ b/calm-hub/mongo/init-mongo.js
@@ -6788,7 +6788,10 @@ if (isEmptyDatabase && db.interfaces.countDocuments() === 0) {
 }
 
 logSection("Resource Mappings");
-db.resource_mappings.createIndex({ namespace: 1, customId: 1 }, { unique: true });
+// resourceType is part of the unique key so the same customId can be reused across different
+// resource types (e.g. a pattern and an architecture can both be named "repo") — see
+// MongoResourceMappingIndexStep for the migration that carries existing deployments to this shape.
+db.resource_mappings.createIndex({ namespace: 1, resourceType: 1, customId: 1 }, { unique: true });
 db.resource_mappings.createIndex({ namespace: 1, resourceType: 1, numericId: 1 });
 logSuccess("Created resource_mappings indexes");
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -11,6 +11,7 @@ import org.finos.calm.migration.steps.MongoFlowVersionSplitStep;
 import org.finos.calm.migration.steps.MongoInterfaceVersionSplitStep;
 import org.finos.calm.migration.steps.MongoLayoutIndexStep;
 import org.finos.calm.migration.steps.MongoPatternVersionSplitStep;
+import org.finos.calm.migration.steps.MongoResourceMappingIndexStep;
 import org.finos.calm.migration.steps.MongoTimelineVersionSplitStep;
 import org.finos.calm.migration.steps.MongoStandardVersionSplitStep;
 import org.slf4j.Logger;
@@ -66,6 +67,12 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             // container would run with no unique constraint on (namespace, architectureId),
             // and MongoLayoutStore's duplicate-key retry would go untested against a real index.
             new MongoLayoutIndexStep(database).createIndexes();
+            // Widens resource_mappings' unique index to (namespace, resourceType, customId) —
+            // without this, MongoIndexInitializationStep's own index creation above already
+            // establishes the 3-field shape on a fresh container, but running this step too
+            // keeps the container's index state consistent with what a real deployment ends up
+            // with after both schema versions 0 and 11 have applied.
+            new MongoResourceMappingIndexStep(database).createIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }
 

--- a/calm-hub/src/integration-test/java/integration/EndToEndResource.java
+++ b/calm-hub/src/integration-test/java/integration/EndToEndResource.java
@@ -68,10 +68,11 @@ public class EndToEndResource implements QuarkusTestResourceLifecycleManager {
             // and MongoLayoutStore's duplicate-key retry would go untested against a real index.
             new MongoLayoutIndexStep(database).createIndexes();
             // Widens resource_mappings' unique index to (namespace, resourceType, customId) —
-            // without this, MongoIndexInitializationStep's own index creation above already
-            // establishes the 3-field shape on a fresh container, but running this step too
-            // keeps the container's index state consistent with what a real deployment ends up
-            // with after both schema versions 0 and 11 have applied.
+            // MongoIndexInitializationStep above only ever creates the old, narrower
+            // (namespace, customId) index (it is never edited after being merged), so without
+            // this the container keeps that 2-field unique index and a customId shared by a
+            // pattern and an architecture would still collide, same as a real deployment
+            // that hadn't yet reached schema version 12.
             new MongoResourceMappingIndexStep(database).createIndexes();
             logger.info("Ensured MongoDB indexes for integration tests");
         }

--- a/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
@@ -365,4 +365,104 @@ public class MongoMappingControllerIntegration {
                 .then()
                 .statusCode(404);
     }
+
+    // =========================================================================
+    // Regression coverage for #2970 — customId collisions across resource types.
+    // A pattern and an architecture share the customId "repo"; the mapping identity must be
+    // scoped by (namespace, resourceType, customId), not just (namespace, customId).
+    // =========================================================================
+
+    @Test
+    @Order(28)
+    void create_pattern_and_architecture_with_the_same_custom_id() {
+        String patternPayload = "{\"title\": \"Repo Pattern\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/repo/versions/1.0.0\"}";
+        given()
+                .body(patternPayload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/repo/versions/1.0.0"));
+
+        String architecturePayload = "{\"title\": \"Repo Architecture\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/architectures/repo/versions/1.0.0\"}";
+        given()
+                .body(architecturePayload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/architectures/repo/versions/1.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/architectures/repo/versions/1.0.0"));
+    }
+
+    @Test
+    @Order(29)
+    void reading_pattern_repo_returns_the_pattern_not_the_architecture() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Pattern"))
+                .body(not(containsString("Repo Architecture")));
+    }
+
+    @Test
+    @Order(30)
+    void reading_architecture_repo_returns_the_architecture_not_the_pattern() {
+        given()
+                .when().get("/calm/namespaces/finos/architectures/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Architecture"))
+                .body(not(containsString("Repo Pattern")));
+    }
+
+    @Test
+    @Order(31)
+    void listing_patterns_includes_repo_exactly_once() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.customId", hasItem("repo"));
+    }
+
+    @Test
+    @Order(32)
+    void listing_architectures_includes_repo_exactly_once() {
+        given()
+                .when().get("/calm/namespaces/finos/architectures")
+                .then()
+                .statusCode(200)
+                .body("values.customId", hasItem("repo"));
+    }
+
+    @Test
+    @Order(33)
+    void adding_a_second_pattern_version_does_not_touch_the_architecture() {
+        String payload = "{\"title\": \"Repo Pattern v2\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/repo/versions/1.1.0\"}";
+        given()
+                .body(payload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/repo/versions/1.1.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/repo/versions/1.1.0"));
+
+        given()
+                .when().get("/calm/namespaces/finos/architectures/repo/versions")
+                .then()
+                .statusCode(200)
+                .body("values", hasSize(1))
+                .body("values[0]", equalTo("1.0.0"));
+    }
+
+    @Test
+    @Order(34)
+    void repo_pattern_version_1_0_0_is_still_the_pattern_after_the_architecture_was_created() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Pattern"));
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
@@ -423,7 +423,7 @@ public class MongoMappingControllerIntegration {
                 .when().get("/calm/namespaces/finos/patterns")
                 .then()
                 .statusCode(200)
-                .body("values.customId", hasItem("repo"));
+                .body("values.customId.count { it == 'repo' }", equalTo(1));
     }
 
     @Test
@@ -433,7 +433,7 @@ public class MongoMappingControllerIntegration {
                 .when().get("/calm/namespaces/finos/architectures")
                 .then()
                 .statusCode(200)
-                .body("values.customId", hasItem("repo"));
+                .body("values.customId.count { it == 'repo' }", equalTo(1));
     }
 
     @Test

--- a/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
@@ -376,7 +376,7 @@ public class NitriteMappingControllerIntegration {
                 .when().get("/calm/namespaces/finos/patterns")
                 .then()
                 .statusCode(200)
-                .body("values.customId", hasItem("repo"));
+                .body("values.customId.count { it == 'repo' }", equalTo(1));
     }
 
     @Test
@@ -386,7 +386,7 @@ public class NitriteMappingControllerIntegration {
                 .when().get("/calm/namespaces/finos/architectures")
                 .then()
                 .statusCode(200)
-                .body("values.customId", hasItem("repo"));
+                .body("values.customId.count { it == 'repo' }", equalTo(1));
     }
 
     @Test

--- a/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteMappingControllerIntegration.java
@@ -318,4 +318,104 @@ public class NitriteMappingControllerIntegration {
                 .then()
                 .statusCode(404);
     }
+
+    // =========================================================================
+    // Regression coverage for #2970 — customId collisions across resource types.
+    // A pattern and an architecture share the customId "repo"; the mapping identity must be
+    // scoped by (namespace, resourceType, customId), not just (namespace, customId).
+    // =========================================================================
+
+    @Test
+    @Order(27)
+    void create_pattern_and_architecture_with_the_same_custom_id() {
+        String patternPayload = "{\"title\": \"Repo Pattern\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/repo/versions/1.0.0\"}";
+        given()
+                .body(patternPayload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/repo/versions/1.0.0"));
+
+        String architecturePayload = "{\"title\": \"Repo Architecture\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/architectures/repo/versions/1.0.0\"}";
+        given()
+                .body(architecturePayload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/architectures/repo/versions/1.0.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/architectures/repo/versions/1.0.0"));
+    }
+
+    @Test
+    @Order(28)
+    void reading_pattern_repo_returns_the_pattern_not_the_architecture() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Pattern"))
+                .body(not(containsString("Repo Architecture")));
+    }
+
+    @Test
+    @Order(29)
+    void reading_architecture_repo_returns_the_architecture_not_the_pattern() {
+        given()
+                .when().get("/calm/namespaces/finos/architectures/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Architecture"))
+                .body(not(containsString("Repo Pattern")));
+    }
+
+    @Test
+    @Order(30)
+    void listing_patterns_includes_repo_exactly_once() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.customId", hasItem("repo"));
+    }
+
+    @Test
+    @Order(31)
+    void listing_architectures_includes_repo_exactly_once() {
+        given()
+                .when().get("/calm/namespaces/finos/architectures")
+                .then()
+                .statusCode(200)
+                .body("values.customId", hasItem("repo"));
+    }
+
+    @Test
+    @Order(32)
+    void adding_a_second_pattern_version_does_not_touch_the_architecture() {
+        String payload = "{\"title\": \"Repo Pattern v2\", \"$id\": \"http://localhost:8080/calm/namespaces/finos/patterns/repo/versions/1.1.0\"}";
+        given()
+                .body(payload)
+                .header("Content-Type", "application/json")
+                .when().post("/calm/namespaces/finos/patterns/repo/versions/1.1.0")
+                .then()
+                .statusCode(201)
+                .header("Location", containsString("/calm/namespaces/finos/patterns/repo/versions/1.1.0"));
+
+        given()
+                .when().get("/calm/namespaces/finos/architectures/repo/versions")
+                .then()
+                .statusCode(200)
+                .body("values", hasSize(1))
+                .body("values[0]", equalTo("1.0.0"));
+    }
+
+    @Test
+    @Order(33)
+    void repo_pattern_version_1_0_0_is_still_the_pattern_after_the_architecture_was_created() {
+        given()
+                .when().get("/calm/namespaces/finos/patterns/repo/versions/1.0.0")
+                .then()
+                .statusCode(200)
+                .body(containsString("Repo Pattern"));
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -173,10 +173,14 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
                 .createIndex(new Document("domain", 1), uniqueIndex);
         LOG.info("Ensured unique index on controls.domain");
 
-        // Resource mappings — unique (namespace, customId) and reverse lookup index
+        // Resource mappings — unique (namespace, resourceType, customId) and reverse lookup
+        // index. resourceType is part of the key so the same customId can be reused across
+        // different resource types (e.g. a pattern and an architecture can both be "repo") —
+        // see MongoResourceMappingIndexStep for the migration that carries existing deployments
+        // to this shape.
         database.getCollection("resource_mappings")
-                .createIndex(new Document("namespace", 1).append("customId", 1), uniqueIndex);
-        LOG.info("Ensured unique index on resource_mappings.(namespace, customId)");
+                .createIndex(new Document("namespace", 1).append("resourceType", 1).append("customId", 1), uniqueIndex);
+        LOG.info("Ensured unique index on resource_mappings.(namespace, resourceType, customId)");
 
         database.getCollection("resource_mappings")
                 .createIndex(new Document("namespace", 1).append("resourceType", 1).append("numericId", 1));

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoIndexInitializationStep.java
@@ -173,14 +173,10 @@ public class MongoIndexInitializationStep implements SchemaMigrationStep {
                 .createIndex(new Document("domain", 1), uniqueIndex);
         LOG.info("Ensured unique index on controls.domain");
 
-        // Resource mappings — unique (namespace, resourceType, customId) and reverse lookup
-        // index. resourceType is part of the key so the same customId can be reused across
-        // different resource types (e.g. a pattern and an architecture can both be "repo") —
-        // see MongoResourceMappingIndexStep for the migration that carries existing deployments
-        // to this shape.
+        // Resource mappings — unique (namespace, customId) and reverse lookup index
         database.getCollection("resource_mappings")
-                .createIndex(new Document("namespace", 1).append("resourceType", 1).append("customId", 1), uniqueIndex);
-        LOG.info("Ensured unique index on resource_mappings.(namespace, resourceType, customId)");
+                .createIndex(new Document("namespace", 1).append("customId", 1), uniqueIndex);
+        LOG.info("Ensured unique index on resource_mappings.(namespace, customId)");
 
         database.getCollection("resource_mappings")
                 .createIndex(new Document("namespace", 1).append("resourceType", 1).append("numericId", 1));

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoResourceMappingIndexStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoResourceMappingIndexStep.java
@@ -17,13 +17,16 @@ import org.slf4j.LoggerFactory;
  * {@code (namespace, resourceType, customId)}, so the same customId can be reused across
  * different resource types (e.g. a pattern and an architecture can both be named {@code "repo"}).
  *
- * <h2>Why this is a migration step and not just a corrected line in {@code MongoIndexInitializationStep}</h2>
- * {@code MongoIndexInitializationStep} runs at {@code fromVersion() == 0}, and any deployment
- * already past schema version 0 never re-runs it. Simply correcting that step's index definition
- * would fix fresh databases only — every existing deployment would keep the old 2-field unique
- * index forever, still silently colliding a pattern and an architecture of the same name. A new
- * step at {@link #fromVersion()} {@code == 11} reaches those deployments the same way every other
- * post-launch schema change does. See {@link MongoLayoutIndexStep} for the precedent this follows.
+ * <h2>Why this is a migration step and not a corrected line in {@code MongoIndexInitializationStep}</h2>
+ * Already-merged migration steps must keep working unchanged, in sequence, whether replayed
+ * against an empty CalmHub or applied on top of a fully up-to-date one — so
+ * {@code MongoIndexInitializationStep}, which runs once at {@code fromVersion() == 0}, is never
+ * edited after the fact. That means this step is the only place the 3-field unique index is
+ * established, for a fresh database and an existing deployment alike: a fresh database creates
+ * the old 2-field index at version 0 like it always has, and this step (at
+ * {@link #fromVersion()} {@code == 11}) then widens it, the same way every other post-launch
+ * schema change reaches both new and existing deployments. See {@link MongoLayoutIndexStep} for
+ * the precedent this follows.
  *
  * <h2>Why this needs no data migration</h2>
  * {@code resourceType} is present on every {@code resource_mappings} document already — the

--- a/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoResourceMappingIndexStep.java
+++ b/calm-hub/src/main/java/org/finos/calm/migration/steps/MongoResourceMappingIndexStep.java
@@ -1,0 +1,114 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.finos.calm.migration.SchemaMigrationStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Widens the {@code resource_mappings} unique index from {@code (namespace, customId)} to
+ * {@code (namespace, resourceType, customId)}, so the same customId can be reused across
+ * different resource types (e.g. a pattern and an architecture can both be named {@code "repo"}).
+ *
+ * <h2>Why this is a migration step and not just a corrected line in {@code MongoIndexInitializationStep}</h2>
+ * {@code MongoIndexInitializationStep} runs at {@code fromVersion() == 0}, and any deployment
+ * already past schema version 0 never re-runs it. Simply correcting that step's index definition
+ * would fix fresh databases only — every existing deployment would keep the old 2-field unique
+ * index forever, still silently colliding a pattern and an architecture of the same name. A new
+ * step at {@link #fromVersion()} {@code == 11} reaches those deployments the same way every other
+ * post-launch schema change does. See {@link MongoLayoutIndexStep} for the precedent this follows.
+ *
+ * <h2>Why this needs no data migration</h2>
+ * {@code resourceType} is present on every {@code resource_mappings} document already — the
+ * document readers ({@code MongoResourceMappingStore#documentToMapping}) call
+ * {@code ResourceType.valueOf(...)} on it unguarded, so a missing value would already throw
+ * today. Widening a unique index from a tighter key to a looser one (adding a field) can never
+ * fail on pre-existing data: every document that satisfied uniqueness under the old key still
+ * satisfies it under the new, strictly-more-specific key. No backfill pass is required.
+ *
+ * <h2>The stale-index drop</h2>
+ * {@link #createIndexes()} tolerantly drops {@code resource_mappings.namespace_1_customId_1}
+ * (MongoDB's default name for the index {@link MongoIndexInitializationStep} created at schema
+ * version 0), ignoring {@code IndexNotFound} (code 27), before creating the replacement. Without
+ * the drop, the old narrower unique index would remain in place alongside the new one and would
+ * still reject a cross-type customId reuse.
+ *
+ * <h2>Mongo-only</h2>
+ * NitriteDB creates no indexes — its uniqueness check is enforced at the application level in
+ * {@code NitriteResourceMappingStore#createMapping}, which already includes {@code resourceType}
+ * in its duplicate-detection filter. There is no Nitrite twin at this {@code fromVersion()}.
+ */
+@LookupIfProperty(name = "calm.database.mode", stringValue = "mongo", lookupIfMissing = true)
+@ApplicationScoped
+public class MongoResourceMappingIndexStep implements SchemaMigrationStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoResourceMappingIndexStep.class);
+
+    private static final String COLLECTION = "resource_mappings";
+    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String RESOURCE_TYPE_FIELD = "resourceType";
+    private static final String CUSTOM_ID_FIELD = "customId";
+
+    /** MongoDB's default name for the {@code (namespace, customId)} index created at schema version 0. */
+    private static final String STALE_NAMESPACE_CUSTOM_ID_INDEX = "namespace_1_customId_1";
+
+    /** MongoDB's {@code IndexNotFound} error code. */
+    private static final int INDEX_NOT_FOUND = 27;
+
+    private final MongoDatabase database;
+
+    @ConfigProperty(name = "calm.database.mode", defaultValue = "mongo")
+    String databaseMode;
+
+    public MongoResourceMappingIndexStep(MongoDatabase database) {
+        this.database = database;
+    }
+
+    @Override
+    public int fromVersion() {
+        return 11;
+    }
+
+    @Override
+    public void apply() {
+        if (!"mongo".equals(databaseMode)) {
+            LOG.info("Skipping resource_mappings index migration (database mode: {})", databaseMode);
+            return;
+        }
+        createIndexes();
+    }
+
+    /**
+     * Creates the index unconditionally — no {@code databaseMode} check. Public, like
+     * {@code MongoIndexInitializationStep#createIndexes()} and {@code MongoLayoutIndexStep#createIndexes()},
+     * specifically so integration-test infrastructure with a known-real MongoDB container can
+     * call it directly.
+     */
+    public void createIndexes() {
+        MongoCollection<Document> mappings = database.getCollection(COLLECTION);
+        dropStaleNamespaceCustomIdIndex(mappings);
+
+        mappings.createIndex(new Document(NAMESPACE_FIELD, 1).append(RESOURCE_TYPE_FIELD, 1).append(CUSTOM_ID_FIELD, 1),
+                new IndexOptions().unique(true));
+        LOG.info("Ensured unique index on {}.({}, {}, {})", COLLECTION, NAMESPACE_FIELD, RESOURCE_TYPE_FIELD, CUSTOM_ID_FIELD);
+    }
+
+    private void dropStaleNamespaceCustomIdIndex(MongoCollection<Document> mappings) {
+        try {
+            mappings.dropIndex(STALE_NAMESPACE_CUSTOM_ID_INDEX);
+            LOG.info("Dropped the stale unique index {}.{}", COLLECTION, STALE_NAMESPACE_CUSTOM_ID_INDEX);
+        } catch (MongoCommandException e) {
+            if (e.getErrorCode() != INDEX_NOT_FOUND) {
+                throw e;
+            }
+            LOG.info("No stale {}.{} index to drop", COLLECTION, STALE_NAMESPACE_CUSTOM_ID_INDEX);
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/CalmResourceErrorResponses.java
@@ -1,6 +1,7 @@
 package org.finos.calm.resources;
 
 import jakarta.ws.rs.core.Response;
+import org.finos.calm.domain.ResourceType;
 
 public class CalmResourceErrorResponses {
     public static Response invalidNamespaceResponse(String namespace) {
@@ -93,6 +94,38 @@ public class CalmResourceErrorResponses {
         String sanitizedDomain = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(domain);
         return Response.status(Response.Status.CONFLICT)
                 .entity("Domain " + sanitizedDomain + " contains controls and cannot be deleted")
+                .build();
+    }
+
+    /**
+     * Returns a 409 response for a resource push whose customId already maps to a resource of
+     * the given type in the namespace. {@code resourceType} is server-controlled (an enum
+     * constant, never user input) and is interpolated as-is; {@code name} and {@code namespace}
+     * are user-derived and sanitized.
+     */
+    public static Response resourceAlreadyExistsResponse(ResourceType resourceType, String name, String namespace) {
+        String sanitizedName = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(name);
+        String sanitizedNamespace = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace);
+        return Response.status(Response.Status.CONFLICT)
+                .entity(resourceType.name().toLowerCase() + " '" + sanitizedName
+                        + "' already exists in namespace '" + sanitizedNamespace + "'")
+                .build();
+    }
+
+    /**
+     * Returns a 409 response for a resource push whose explicit version already exists.
+     * {@code resourceType} is server-controlled and interpolated as-is; {@code version} is
+     * echoed unsanitized, matching every other version-conflict message in this codebase
+     * (e.g. {@code ArchitectureTools}, {@code MongoVersionDocumentStore}) — the version comes
+     * from the request's already {@code @Pattern}-validated version path/field, not free text.
+     * {@code name} and {@code namespace} are user-derived and sanitized.
+     */
+    public static Response versionAlreadyExistsResponse(String version, ResourceType resourceType, String name, String namespace) {
+        String sanitizedName = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(name);
+        String sanitizedNamespace = ResourceValidationConstants.STRICT_SANITIZATION_POLICY.sanitize(namespace);
+        return Response.status(Response.Status.CONFLICT)
+                .entity("Version " + version + " already exists for " + resourceType.name().toLowerCase()
+                        + " '" + sanitizedName + "' in namespace '" + sanitizedNamespace + "'")
                 .build();
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/MappingControllerResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/MappingControllerResource.java
@@ -208,7 +208,7 @@ public class MappingControllerResource {
         }
         ResourceMapping existing;
         try {
-            existing = service.getMapping(canonical.namespace(), canonical.name());
+            existing = service.getMapping(canonical.namespace(), canonical.resourceType(), canonical.name());
         } catch (MappingNotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND)
                     .entity("Resource not found: " + STRICT_SANITIZATION_POLICY.sanitize(canonical.name())).build();
@@ -312,7 +312,7 @@ public class MappingControllerResource {
                     .entity("Unsupported resource type: " + STRICT_SANITIZATION_POLICY.sanitize(type)).build();
         }
         try {
-            ResourceMapping mapping = service.getMapping(namespace, name);
+            ResourceMapping mapping = service.getMapping(namespace, resourceType, name);
             List<String> versions = service.getVersionsForMapping(mapping);
             List<String> sortedVersions = versions.stream()
                     .sorted(Comparator.comparing(Semver::tryParse))
@@ -361,7 +361,7 @@ public class MappingControllerResource {
                     .entity("Unsupported resource type: " + STRICT_SANITIZATION_POLICY.sanitize(type)).build();
         }
         try {
-            ResourceMapping mapping = service.getMapping(namespace, name);
+            ResourceMapping mapping = service.getMapping(namespace, resourceType, name);
             String json = service.getResourceJsonForVersion(mapping, version);
             String rewrittenJson = documentParser.rewriteId(json, namespace, type, name, version);
             return Response.ok(rewrittenJson).build();

--- a/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
@@ -84,7 +84,7 @@ public class MappingControllerService {
         try {
             ResourceMapping existing;
             try {
-                existing = mappingStore.getMapping(namespace, name);
+                existing = mappingStore.getMapping(namespace, resourceType, name);
             } catch (MappingNotFoundException ignored) {
                 existing = null;
             }
@@ -123,9 +123,9 @@ public class MappingControllerService {
         }
     }
 
-    public ResourceMapping getMapping(String namespace, String name)
+    public ResourceMapping getMapping(String namespace, ResourceType type, String name)
             throws MappingNotFoundException, NamespaceNotFoundException {
-        return mappingStore.getMapping(namespace, name);
+        return mappingStore.getMapping(namespace, type, name);
     }
 
     public List<String> getVersionsForMapping(ResourceMapping mapping) throws Exception {
@@ -443,10 +443,10 @@ public class MappingControllerService {
             mappingStore.createMapping(namespace, name, resourceType, 0);
             try {
                 int numericId = createResourceInStore(resourceType, namespace, json, title, description);
-                mappingStore.updateMappingNumericId(namespace, name, numericId);
+                mappingStore.updateMappingNumericId(namespace, resourceType, name, numericId);
             } catch (Exception e) {
                 try {
-                    mappingStore.deleteMapping(namespace, name);
+                    mappingStore.deleteMapping(namespace, resourceType, name);
                 } catch (Exception rollbackEx) {
                     logger.error("Failed to rollback mapping for [{}] in namespace [{}]",
                             STRICT_SANITIZATION_POLICY.sanitize(name),
@@ -462,7 +462,8 @@ public class MappingControllerService {
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
         } catch (DuplicateMappingException e) {
             return Response.status(Response.Status.CONFLICT)
-                    .entity("Resource name already exists in namespace: " + STRICT_SANITIZATION_POLICY.sanitize(name)).build();
+                    .entity(resourceType.name().toLowerCase() + " '" + STRICT_SANITIZATION_POLICY.sanitize(name)
+                            + "' already exists in namespace '" + STRICT_SANITIZATION_POLICY.sanitize(namespace) + "'").build();
         } catch (Exception e) {
             logger.error("Error creating resource [{}] in namespace [{}]",
                     STRICT_SANITIZATION_POLICY.sanitize(name), STRICT_SANITIZATION_POLICY.sanitize(namespace), e);
@@ -487,8 +488,10 @@ public class MappingControllerService {
             // Reject if the explicit version already exists.
             if (versions.contains(versionSpec.version())) {
                 return Response.status(Response.Status.CONFLICT)
-                        .entity("Version " + versionSpec.version() + " already exists for resource: "
-                                + STRICT_SANITIZATION_POLICY.sanitize(name)).build();
+                        .entity("Version " + versionSpec.version() + " already exists for "
+                                + mapping.getResourceType().name().toLowerCase() + " '"
+                                + STRICT_SANITIZATION_POLICY.sanitize(name) + "' in namespace '"
+                                + STRICT_SANITIZATION_POLICY.sanitize(namespace) + "'").build();
             }
             String newVersion = versionSpec.version();
             String title = documentParser.extractStringField(json, "title");

--- a/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/MappingControllerService.java
@@ -461,9 +461,7 @@ public class MappingControllerService {
                     STRICT_SANITIZATION_POLICY.sanitize(namespace), e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
         } catch (DuplicateMappingException e) {
-            return Response.status(Response.Status.CONFLICT)
-                    .entity(resourceType.name().toLowerCase() + " '" + STRICT_SANITIZATION_POLICY.sanitize(name)
-                            + "' already exists in namespace '" + STRICT_SANITIZATION_POLICY.sanitize(namespace) + "'").build();
+            return CalmResourceErrorResponses.resourceAlreadyExistsResponse(resourceType, name, namespace);
         } catch (Exception e) {
             logger.error("Error creating resource [{}] in namespace [{}]",
                     STRICT_SANITIZATION_POLICY.sanitize(name), STRICT_SANITIZATION_POLICY.sanitize(namespace), e);
@@ -487,11 +485,8 @@ public class MappingControllerService {
             }
             // Reject if the explicit version already exists.
             if (versions.contains(versionSpec.version())) {
-                return Response.status(Response.Status.CONFLICT)
-                        .entity("Version " + versionSpec.version() + " already exists for "
-                                + mapping.getResourceType().name().toLowerCase() + " '"
-                                + STRICT_SANITIZATION_POLICY.sanitize(name) + "' in namespace '"
-                                + STRICT_SANITIZATION_POLICY.sanitize(namespace) + "'").build();
+                return CalmResourceErrorResponses.versionAlreadyExistsResponse(
+                        versionSpec.version(), mapping.getResourceType(), name, namespace);
             }
             String newVersion = versionSpec.version();
             String title = documentParser.extractStringField(json, "title");

--- a/calm-hub/src/main/java/org/finos/calm/store/ResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ResourceMappingStore.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 public interface ResourceMappingStore {
     ResourceMapping createMapping(String namespace, String customId, ResourceType type, int numericId) throws DuplicateMappingException, NamespaceNotFoundException;
-    ResourceMapping getMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException;
+    ResourceMapping getMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException;
     List<ResourceMapping> listMappings(String namespace, ResourceType typeFilter) throws NamespaceNotFoundException;
     ResourceMapping getMappingByNumericId(String namespace, ResourceType type, int numericId) throws MappingNotFoundException, NamespaceNotFoundException;
     List<ResourceMapping> listMappingsByNumericIds(String namespace, ResourceType type, List<Integer> ids) throws NamespaceNotFoundException;
-    void updateMappingNumericId(String namespace, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException;
-    void deleteMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException;
+    void updateMappingNumericId(String namespace, ResourceType type, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException;
+    void deleteMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
@@ -28,12 +28,14 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * <h2>Document model</h2>
  * Uses a flat {@code resource_mappings} collection where each document represents a single
  * mapping: {@code { namespace, customId, resourceType, numericId }}.
- * A unique compound index on {@code (namespace, customId)} prevents duplicate custom IDs
- * within the same namespace.
+ * A unique compound index on {@code (namespace, resourceType, customId)} prevents duplicate
+ * custom IDs within the same namespace and resource type — the same customId may be reused
+ * across different resource types (e.g. a pattern and an architecture can both be named
+ * {@code "repo"}).
  *
  * <h2>Concurrency</h2>
  * Duplicate prevention is handled by the unique index — a second insert with the same
- * {@code (namespace, customId)} throws a {@link MongoWriteException} with
+ * {@code (namespace, resourceType, customId)} throws a {@link MongoWriteException} with
  * {@link ErrorCategory#DUPLICATE_KEY}, which is translated to {@link DuplicateMappingException}.
  *
  */
@@ -74,11 +76,12 @@ public class MongoResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public ResourceMapping getMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public ResourceMapping getMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
         Bson filter = Filters.and(
                 Filters.eq("namespace", namespace),
+                Filters.eq("resourceType", type.name()),
                 Filters.eq("customId", customId)
         );
 
@@ -165,11 +168,12 @@ public class MongoResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public void updateMappingNumericId(String namespace, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public void updateMappingNumericId(String namespace, ResourceType type, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
         Bson filter = Filters.and(
                 Filters.eq("namespace", namespace),
+                Filters.eq("resourceType", type.name()),
                 Filters.eq("customId", customId)
         );
 
@@ -180,11 +184,12 @@ public class MongoResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public void deleteMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public void deleteMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
         Bson filter = Filters.and(
                 Filters.eq("namespace", namespace),
+                Filters.eq("resourceType", type.name()),
                 Filters.eq("customId", customId)
         );
 

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteResourceMappingStore.java
@@ -31,7 +31,9 @@ import io.quarkus.arc.lookup.LookupIfProperty;
  * <h2>Concurrency strategy — ReentrantLock</h2>
  * NitriteDB does not support unique index constraints, so this class uses a
  * {@link ReentrantLock} to serialize write operations and enforce the uniqueness
- * of {@code (namespace, customId)} pairs at the application level.
+ * of {@code (namespace, resourceType, customId)} triples at the application level. The same
+ * customId may be reused across different resource types (e.g. a pattern and an architecture
+ * can both be named {@code "repo"}).
  */
 @LookupIfProperty(name = "calm.database.mode", stringValue = "standalone")
 @ApplicationScoped
@@ -62,8 +64,10 @@ public class NitriteResourceMappingStore implements ResourceMappingStore {
 
         lock.lock();
         try {
-            // Check for duplicate (namespace, customId) pair
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(CUSTOM_ID_FIELD).eq(customId));
+            // Check for duplicate (namespace, resourceType, customId) triple
+            Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(RESOURCE_TYPE_FIELD).eq(type.name()),
+                    where(CUSTOM_ID_FIELD).eq(customId));
             Document existing = mappingCollection.find(filter).firstOrNull();
             if (existing != null) {
                 throw new DuplicateMappingException();
@@ -85,10 +89,12 @@ public class NitriteResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public ResourceMapping getMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public ResourceMapping getMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
-        Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(CUSTOM_ID_FIELD).eq(customId));
+        Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                where(RESOURCE_TYPE_FIELD).eq(type.name()),
+                where(CUSTOM_ID_FIELD).eq(customId));
         Document result = mappingCollection.find(filter).firstOrNull();
         if (result == null) {
             throw new MappingNotFoundException();
@@ -170,12 +176,14 @@ public class NitriteResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public void updateMappingNumericId(String namespace, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public void updateMappingNumericId(String namespace, ResourceType type, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
         lock.lock();
         try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(CUSTOM_ID_FIELD).eq(customId));
+            Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(RESOURCE_TYPE_FIELD).eq(type.name()),
+                    where(CUSTOM_ID_FIELD).eq(customId));
             Document existing = mappingCollection.find(filter).firstOrNull();
             if (existing == null) {
                 throw new MappingNotFoundException();
@@ -189,12 +197,14 @@ public class NitriteResourceMappingStore implements ResourceMappingStore {
     }
 
     @Override
-    public void deleteMapping(String namespace, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
+    public void deleteMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException {
         namespaceStore.requireNamespace(namespace);
 
         lock.lock();
         try {
-            Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(CUSTOM_ID_FIELD).eq(customId));
+            Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(RESOURCE_TYPE_FIELD).eq(type.name()),
+                    where(CUSTOM_ID_FIELD).eq(customId));
             Document existing = mappingCollection.find(filter).firstOrNull();
             if (existing == null) {
                 throw new MappingNotFoundException();

--- a/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoResourceMappingIndexStepShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/migration/steps/TestMongoResourceMappingIndexStepShould.java
@@ -1,0 +1,120 @@
+package org.finos.calm.migration.steps;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TestMongoResourceMappingIndexStepShould {
+
+    private interface DocumentMongoCollection extends MongoCollection<Document> {
+    }
+
+    private MongoDatabase database;
+    private MongoCollection<Document> resourceMappings;
+    private MongoResourceMappingIndexStep step;
+
+    @BeforeEach
+    void setup() {
+        database = mock(MongoDatabase.class);
+        resourceMappings = mock(DocumentMongoCollection.class);
+        when(database.getCollection("resource_mappings")).thenReturn(resourceMappings);
+
+        step = new MongoResourceMappingIndexStep(database);
+        step.databaseMode = "mongo";
+    }
+
+    private static MongoCommandException commandException(int code, String message) {
+        BsonDocument response = new BsonDocument("ok", new BsonInt32(0))
+                .append("code", new BsonInt32(code))
+                .append("errmsg", new BsonString(message));
+        return new MongoCommandException(response, new ServerAddress());
+    }
+
+    @Test
+    void run_at_schema_version_eleven() {
+        assertThat(step.fromVersion(), is(11));
+    }
+
+    @Test
+    void skip_index_creation_when_database_mode_is_not_mongo() {
+        step.databaseMode = "standalone";
+
+        step.apply();
+
+        verifyNoInteractions(database);
+    }
+
+    @Test
+    void create_the_compound_unique_index_on_resource_mappings() {
+        step.apply();
+
+        verify(resourceMappings).createIndex(
+                eq(new Document("namespace", 1).append("resourceType", 1).append("customId", 1)), any());
+    }
+
+    @Test
+    void drop_the_stale_namespace_custom_id_index_before_creating_the_compound_one() {
+        step.apply();
+
+        // The (namespace, customId) unique index MongoIndexInitializationStep created at schema
+        // version 0 collides a pattern and an architecture sharing a customId (#2970) — it has
+        // to go before the wider (namespace, resourceType, customId) index can take its place.
+        verify(resourceMappings).dropIndex("namespace_1_customId_1");
+    }
+
+    @Test
+    void tolerate_the_stale_index_being_absent() {
+        doThrow(commandException(27, "index not found with name [namespace_1_customId_1]"))
+                .when(resourceMappings).dropIndex(anyString());
+
+        assertDoesNotThrow(() -> step.apply());
+        verify(resourceMappings).createIndex(
+                eq(new Document("namespace", 1).append("resourceType", 1).append("customId", 1)), any());
+    }
+
+    @Test
+    void propagate_index_drop_failures_that_are_not_a_missing_index() {
+        doThrow(commandException(13, "not authorized")).when(resourceMappings).dropIndex(anyString());
+
+        assertThrows(MongoCommandException.class, () -> step.apply());
+    }
+
+    @Test
+    void create_indexes_directly_without_needing_the_database_mode_configured() {
+        // createIndexes() is the entry point integration-test infrastructure (EndToEndResource)
+        // calls directly against a real, known-Mongo container — it must not depend on the
+        // CDI-injected databaseMode field, which is never set outside a running application.
+        MongoResourceMappingIndexStep unconfigured = new MongoResourceMappingIndexStep(database);
+
+        unconfigured.createIndexes();
+
+        verify(resourceMappings).createIndex(
+                eq(new Document("namespace", 1).append("resourceType", 1).append("customId", 1)), any());
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestCalmErrorResponsesShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestCalmErrorResponsesShould.java
@@ -1,6 +1,7 @@
 package org.finos.calm.resources;
 
 import jakarta.ws.rs.core.Response;
+import org.finos.calm.domain.ResourceType;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,6 +13,23 @@ public class TestCalmErrorResponsesShould {
     void create_an_invalid_namespace_response() {
         try (Response response = CalmResourceErrorResponses.invalidNamespaceResponse("finos")) {
             assertThat(response.getStatus(), equalTo(404));
+        }
+    }
+
+    @Test
+    void create_a_resource_already_exists_response() {
+        try (Response response = CalmResourceErrorResponses.resourceAlreadyExistsResponse(ResourceType.PATTERN, "repo", "finos")) {
+            assertThat(response.getStatus(), equalTo(409));
+            assertThat(response.getEntity(), equalTo("pattern 'repo' already exists in namespace 'finos'"));
+        }
+    }
+
+    @Test
+    void create_a_version_already_exists_response() {
+        try (Response response = CalmResourceErrorResponses.versionAlreadyExistsResponse("1.0.1", ResourceType.ARCHITECTURE, "repo", "finos")) {
+            assertThat(response.getStatus(), equalTo(409));
+            assertThat(response.getEntity(),
+                    equalTo("Version 1.0.1 already exists for architecture 'repo' in namespace 'finos'"));
         }
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourcePutShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourcePutShould.java
@@ -54,7 +54,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "patterns", "api-gateway", "1.0.0", "test pattern"))
@@ -70,7 +70,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-arch")
                 .setResourceType(ResourceType.ARCHITECTURE).setNumericId(2).build();
-        when(mockMappingStore.getMapping("finos", "my-arch")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.ARCHITECTURE, "my-arch")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "architectures", "my-arch", "1.0.0", "test architecture"))
@@ -86,7 +86,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-flow")
                 .setResourceType(ResourceType.FLOW).setNumericId(5).build();
-        when(mockMappingStore.getMapping("finos", "my-flow")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.FLOW, "my-flow")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "flows", "my-flow", "1.0.0", "test flow"))
@@ -102,7 +102,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-standard")
                 .setResourceType(ResourceType.STANDARD).setNumericId(3).build();
-        when(mockMappingStore.getMapping("finos", "my-standard")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.STANDARD, "my-standard")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "standards", "my-standard", "1.0.0", "test standard"))
@@ -115,7 +115,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-interface")
                 .setResourceType(ResourceType.INTERFACE).setNumericId(4).build();
-        when(mockMappingStore.getMapping("finos", "my-interface")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.INTERFACE, "my-interface")).thenReturn(existing);
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "interfaces", "my-interface", "1.0.0", "test interface"))
@@ -125,7 +125,7 @@ public class TestMappingControllerResourcePutShould {
 
     @Test
     void return_404_when_mapping_not_found_on_put() throws Exception {
-        when(mockMappingStore.getMapping("finos", "nonexistent")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "nonexistent")).thenThrow(new MappingNotFoundException());
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("finos", "patterns", "nonexistent", "1.0.0", "whatever"))
@@ -142,7 +142,7 @@ public class TestMappingControllerResourcePutShould {
 
     @Test
     void return_404_when_namespace_not_found_on_put() throws Exception {
-        when(mockMappingStore.getMapping("invalid", "api-gateway")).thenThrow(new NamespaceNotFoundException());
+        when(mockMappingStore.getMapping("invalid", ResourceType.PATTERN, "api-gateway")).thenThrow(new NamespaceNotFoundException());
 
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("invalid", "patterns", "api-gateway", "1.0.0", "test pattern"))
@@ -180,7 +180,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         doThrow(new NamespaceNotFoundException()).when(mockPatternStore)
                 .updatePatternForVersion(any(Pattern.class));
         given().header("Content-Type", "application/json")
@@ -194,7 +194,7 @@ public class TestMappingControllerResourcePutShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         doThrow(new RuntimeException("unexpected store failure")).when(mockPatternStore)
                 .updatePatternForVersion(any(Pattern.class));
         given().header("Content-Type", "application/json")

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceShould.java
@@ -66,7 +66,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_201_when_creating_a_new_pattern_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("api-gateway"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("api-gateway")
@@ -80,12 +80,12 @@ public class TestMappingControllerResourceShould {
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/patterns/api-gateway/versions/1.0.0"));
 
-        verify(mockMappingStore).updateMappingNumericId("finos", "api-gateway", 1);
+        verify(mockMappingStore).updateMappingNumericId("finos", ResourceType.PATTERN, "api-gateway", 1);
     }
 
     @Test
     void return_201_when_creating_a_new_architecture_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "my-arch")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.ARCHITECTURE, "my-arch")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("my-arch"), eq(ResourceType.ARCHITECTURE), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("my-arch")
@@ -99,12 +99,12 @@ public class TestMappingControllerResourceShould {
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/architectures/my-arch/versions/1.0.0"));
 
-        verify(mockMappingStore).updateMappingNumericId("finos", "my-arch", 2);
+        verify(mockMappingStore).updateMappingNumericId("finos", ResourceType.ARCHITECTURE, "my-arch", 2);
     }
 
     @Test
     void return_201_when_creating_a_new_flow_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "my-flow")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.FLOW, "my-flow")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("my-flow"), eq(ResourceType.FLOW), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("my-flow")
@@ -118,12 +118,12 @@ public class TestMappingControllerResourceShould {
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/flows/my-flow/versions/1.0.0"));
 
-        verify(mockMappingStore).updateMappingNumericId("finos", "my-flow", 5);
+        verify(mockMappingStore).updateMappingNumericId("finos", ResourceType.FLOW, "my-flow", 5);
     }
 
     @Test
     void return_201_when_creating_a_new_standard_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "my-standard")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.STANDARD, "my-standard")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("my-standard"), eq(ResourceType.STANDARD), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("my-standard")
@@ -137,12 +137,12 @@ public class TestMappingControllerResourceShould {
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/standards/my-standard/versions/1.0.0"));
 
-        verify(mockMappingStore).updateMappingNumericId("finos", "my-standard", 3);
+        verify(mockMappingStore).updateMappingNumericId("finos", ResourceType.STANDARD, "my-standard", 3);
     }
 
     @Test
     void return_201_when_creating_a_new_interface_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "my-interface")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.INTERFACE, "my-interface")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("my-interface"), eq(ResourceType.INTERFACE), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("my-interface")
@@ -156,7 +156,7 @@ public class TestMappingControllerResourceShould {
                 .then().statusCode(201)
                 .header("Location", containsString("/calm/namespaces/finos/interfaces/my-interface/versions/1.0.0"));
 
-        verify(mockMappingStore).updateMappingNumericId("finos", "my-interface", 4);
+        verify(mockMappingStore).updateMappingNumericId("finos", ResourceType.INTERFACE, "my-interface", 4);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_namespace_not_found_on_create() throws Exception {
-        when(mockMappingStore.getMapping("invalid", "test-resource")).thenThrow(new NamespaceNotFoundException());
+        when(mockMappingStore.getMapping("invalid", ResourceType.PATTERN, "test-resource")).thenThrow(new NamespaceNotFoundException());
 
         given().header("Content-Type", "application/json").body(versionedDoc("invalid", "patterns", "test-resource", "1.0.0")).when()
                 .post("/calm")
@@ -192,7 +192,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_409_when_duplicate_name_on_create() throws Exception {
-        when(mockMappingStore.getMapping("finos", "dup-id")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "dup-id")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("dup-id"), eq(ResourceType.PATTERN), eq(0)))
                 .thenThrow(new DuplicateMappingException());
 
@@ -203,7 +203,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void rollback_mapping_when_store_creation_fails() throws Exception {
-        when(mockMappingStore.getMapping("finos", "fail-create")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "fail-create")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("fail-create"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("fail-create")
@@ -215,25 +215,25 @@ public class TestMappingControllerResourceShould {
                 .post("/calm")
                 .then().statusCode(400);
 
-        verify(mockMappingStore).deleteMapping("finos", "fail-create");
+        verify(mockMappingStore).deleteMapping("finos", ResourceType.PATTERN, "fail-create");
     }
 
     @Test
     void rollback_mapping_even_when_rollback_itself_fails() throws Exception {
-        when(mockMappingStore.getMapping("finos", "rollback-me")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "rollback-me")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("rollback-me"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("rollback-me")
                         .setResourceType(ResourceType.PATTERN).setNumericId(0).build());
         when(mockPatternStore.createPatternForNamespace(any(CreatePatternRequest.class), eq("finos")))
                 .thenThrow(new RuntimeException("store failure"));
-        doThrow(new RuntimeException("rollback failed")).when(mockMappingStore).deleteMapping("finos", "rollback-me");
+        doThrow(new RuntimeException("rollback failed")).when(mockMappingStore).deleteMapping("finos", ResourceType.PATTERN, "rollback-me");
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "rollback-me", "1.0.0")).when()
                 .post("/calm")
                 .then().statusCode(400);
 
-        verify(mockMappingStore).deleteMapping("finos", "rollback-me");
+        verify(mockMappingStore).deleteMapping("finos", ResourceType.PATTERN, "rollback-me");
     }
 
     // --- POST /calm adding explicit version to existing resource ---
@@ -243,7 +243,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "api-gateway", "2.0.0")).when()
@@ -257,7 +257,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-arch")
                 .setResourceType(ResourceType.ARCHITECTURE).setNumericId(2).build();
-        when(mockMappingStore.getMapping("finos", "my-arch")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.ARCHITECTURE, "my-arch")).thenReturn(existing);
         when(mockArchitectureStore.getArchitectureVersions(any(Architecture.class))).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "architectures", "my-arch", "2.0.0")).when()
@@ -273,7 +273,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-flow")
                 .setResourceType(ResourceType.FLOW).setNumericId(5).build();
-        when(mockMappingStore.getMapping("finos", "my-flow")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.FLOW, "my-flow")).thenReturn(existing);
         when(mockFlowStore.getFlowVersions(any(Flow.class))).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "flows", "my-flow", "2.0.0")).when()
@@ -289,7 +289,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-standard")
                 .setResourceType(ResourceType.STANDARD).setNumericId(3).build();
-        when(mockMappingStore.getMapping("finos", "my-standard")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.STANDARD, "my-standard")).thenReturn(existing);
         when(mockStandardStore.getStandardVersions("finos", 3)).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "standards", "my-standard", "2.0.0")).when()
@@ -305,7 +305,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-interface")
                 .setResourceType(ResourceType.INTERFACE).setNumericId(4).build();
-        when(mockMappingStore.getMapping("finos", "my-interface")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.INTERFACE, "my-interface")).thenReturn(existing);
         when(mockInterfaceStore.getInterfaceVersions("finos", 4)).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "interfaces", "my-interface", "2.0.0")).when()
@@ -321,7 +321,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("orphan")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "orphan")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "orphan")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of());
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "orphan", "2.0.0")).when()
@@ -334,7 +334,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("null-msg")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "null-msg")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "null-msg")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
         when(mockPatternStore.createPatternForVersion(any(Pattern.class))).thenThrow(new RuntimeException((String) null));
 
@@ -348,7 +348,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("badns").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("badns", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("badns", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenThrow(new NamespaceNotFoundException());
 
         given().header("Content-Type", "application/json").body(versionedDoc("badns", "patterns", "api-gateway", "2.0.0")).when()
@@ -375,7 +375,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_400_when_first_create_requests_non_1_0_0_via_versioned_id() throws Exception {
-        when(mockMappingStore.getMapping("finos", "seed-me")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "seed-me")).thenThrow(new MappingNotFoundException());
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "seed-me", "2.0.0")).when()
                 .post("/calm")
@@ -384,7 +384,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_201_when_first_create_uses_versioned_id_of_1_0_0() throws Exception {
-        when(mockMappingStore.getMapping("finos", "seed-one")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "seed-one")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("seed-one"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("seed-one")
@@ -420,7 +420,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_201_when_creating_specific_version_on_new_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "v-new")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "v-new")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("v-new"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("v-new")
@@ -437,7 +437,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_400_when_creating_non_1_0_0_specific_version_on_new_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "v-seed")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "v-seed")).thenThrow(new MappingNotFoundException());
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "v-seed", "2.0.0")).when()
                 .post("/calm/namespaces/finos/patterns/v-seed/versions/2.0.0")
@@ -449,7 +449,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("v-exist")
                 .setResourceType(ResourceType.PATTERN).setNumericId(9).build();
-        when(mockMappingStore.getMapping("finos", "v-exist")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "v-exist")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "v-exist", "2.0.0")).when()
@@ -465,7 +465,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("v-dup")
                 .setResourceType(ResourceType.PATTERN).setNumericId(10).build();
-        when(mockMappingStore.getMapping("finos", "v-dup")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "v-dup")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0", "2.0.0"));
 
         given().header("Content-Type", "application/json").body(versionedDoc("finos", "patterns", "v-dup", "2.0.0")).when()
@@ -491,7 +491,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_400_when_title_is_missing_on_new_resource_create() throws Exception {
-        when(mockMappingStore.getMapping("finos", "no-title")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "no-title")).thenThrow(new MappingNotFoundException());
         // Body has $id and version 1.0.0 but NO title field
         String body = "{\"$id\":\"http://localhost:8080/calm/namespaces/finos/patterns/no-title/versions/1.0.0\"}";
 
@@ -507,7 +507,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0", "1.1.0"));
 
         given().when().get("/calm/namespaces/finos/patterns/api-gateway/versions")
@@ -522,7 +522,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("sorted-test")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "sorted-test")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "sorted-test")).thenReturn(mapping);
         when(mockPatternStore.getPatternVersions(any(Pattern.class)))
                 .thenReturn(List.of("2.0.0", "1.0.0", "1.1.0", "1.0.1"));
 
@@ -537,7 +537,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_mapping_not_found_on_list_versions() throws Exception {
-        when(mockMappingStore.getMapping("finos", "nonexistent")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "nonexistent")).thenThrow(new MappingNotFoundException());
 
         given().when().get("/calm/namespaces/finos/patterns/nonexistent/versions")
                 .then().statusCode(404);
@@ -548,7 +548,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("missing-versions")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "missing-versions")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "missing-versions")).thenReturn(mapping);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenThrow(new PatternNotFoundException());
 
         given().when().get("/calm/namespaces/finos/patterns/missing-versions/versions")
@@ -560,7 +560,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("err-list-versions")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "err-list-versions")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "err-list-versions")).thenReturn(mapping);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenThrow(new RuntimeException("boom"));
 
         given().when().get("/calm/namespaces/finos/patterns/err-list-versions/versions")
@@ -572,7 +572,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
 
         given().when().get("/calm/namespaces/finos/patterns/api-gateway/versions").then().statusCode(200);
@@ -586,7 +586,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenReturn("{\"version\": \"1.0.0\"}");
 
         given().when().get("/calm/namespaces/finos/patterns/api-gateway/versions/1.0.0")
@@ -598,7 +598,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-arch")
                 .setResourceType(ResourceType.ARCHITECTURE).setNumericId(2).build();
-        when(mockMappingStore.getMapping("finos", "my-arch")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.ARCHITECTURE, "my-arch")).thenReturn(mapping);
         when(mockArchitectureStore.getArchitectureForVersion(any(Architecture.class))).thenReturn("{\"v\": \"1.0.0\"}");
 
         given().when().get("/calm/namespaces/finos/architectures/my-arch/versions/1.0.0")
@@ -610,7 +610,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-flow")
                 .setResourceType(ResourceType.FLOW).setNumericId(5).build();
-        when(mockMappingStore.getMapping("finos", "my-flow")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.FLOW, "my-flow")).thenReturn(mapping);
         when(mockFlowStore.getFlowForVersion(any(Flow.class))).thenReturn("{\"v\": \"1.0.0\"}");
 
         given().when().get("/calm/namespaces/finos/flows/my-flow/versions/1.0.0")
@@ -622,7 +622,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-standard")
                 .setResourceType(ResourceType.STANDARD).setNumericId(3).build();
-        when(mockMappingStore.getMapping("finos", "my-standard")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.STANDARD, "my-standard")).thenReturn(mapping);
         when(mockStandardStore.getStandardForVersion("finos", 3, "1.0.0")).thenReturn("{\"v\": \"1.0.0\"}");
 
         given().when().get("/calm/namespaces/finos/standards/my-standard/versions/1.0.0")
@@ -634,7 +634,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("my-interface")
                 .setResourceType(ResourceType.INTERFACE).setNumericId(4).build();
-        when(mockMappingStore.getMapping("finos", "my-interface")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.INTERFACE, "my-interface")).thenReturn(mapping);
         when(mockInterfaceStore.getInterfaceForVersion("finos", 4, "1.0.0")).thenReturn("{\"v\": \"1.0.0\"}");
 
         given().when().get("/calm/namespaces/finos/interfaces/my-interface/versions/1.0.0")
@@ -643,7 +643,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_mapping_not_found_on_get_version() throws Exception {
-        when(mockMappingStore.getMapping("finos", "nonexistent")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "nonexistent")).thenThrow(new MappingNotFoundException());
 
         given().when().get("/calm/namespaces/finos/patterns/nonexistent/versions/1.0.0")
                 .then().statusCode(404);
@@ -654,7 +654,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenThrow(new PatternVersionNotFoundException());
 
         given().when().get("/calm/namespaces/finos/patterns/api-gateway/versions/9.9.9")
@@ -666,7 +666,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("missing-pattern")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "missing-pattern")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "missing-pattern")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenThrow(new PatternNotFoundException());
 
         given().when().get("/calm/namespaces/finos/patterns/missing-pattern/versions/1.0.0")
@@ -678,7 +678,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("badns").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("badns", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("badns", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenThrow(new NamespaceNotFoundException());
 
         given().when().get("/calm/namespaces/badns/patterns/api-gateway/versions/1.0.0")
@@ -690,7 +690,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("err-version")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "err-version")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "err-version")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenThrow(new RuntimeException("boom"));
 
         given().when().get("/calm/namespaces/finos/patterns/err-version/versions/1.0.0")
@@ -702,7 +702,7 @@ public class TestMappingControllerResourceShould {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class))).thenReturn("{}");
 
         given().when().get("/calm/namespaces/finos/patterns/api-gateway/versions/1.0.0").then().statusCode(200);
@@ -1085,7 +1085,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_400_when_versioned_post_body_is_blank() throws Exception {
-        when(mockMappingStore.getMapping("finos", "my-res")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "my-res")).thenThrow(new MappingNotFoundException());
         given().header("Content-Type", "application/json")
                 .body("   ")
                 .when().post("/calm/namespaces/finos/patterns/my-res/versions/1.0.0")
@@ -1094,7 +1094,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_namespace_not_found_on_versioned_post_via_namespace_exception() throws Exception {
-        when(mockMappingStore.getMapping("badns", "v-test")).thenThrow(new NamespaceNotFoundException());
+        when(mockMappingStore.getMapping("badns", ResourceType.PATTERN, "v-test")).thenThrow(new NamespaceNotFoundException());
         given().header("Content-Type", "application/json")
                 .body(versionedDoc("badns", "patterns", "v-test", "1.0.0"))
                 .when().post("/calm/namespaces/badns/patterns/v-test/versions/1.0.0")
@@ -1113,7 +1113,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_namespace_exception_on_list_versions() throws Exception {
-        when(mockMappingStore.getMapping("badns", "api-gateway")).thenThrow(new NamespaceNotFoundException());
+        when(mockMappingStore.getMapping("badns", ResourceType.PATTERN, "api-gateway")).thenThrow(new NamespaceNotFoundException());
         given().when().get("/calm/namespaces/badns/patterns/api-gateway/versions")
                 .then().statusCode(404);
     }
@@ -1134,7 +1134,7 @@ public class TestMappingControllerResourceShould {
 
     @Test
     void return_404_when_namespace_not_found_in_mapping_store_on_create() throws Exception {
-        when(mockMappingStore.getMapping("badns", "new-res")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("badns", ResourceType.PATTERN, "new-res")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("badns"), eq("new-res"), eq(ResourceType.PATTERN), eq(0)))
                 .thenThrow(new NamespaceNotFoundException());
         given().header("Content-Type", "application/json")

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceWithBaseUrlShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingControllerResourceWithBaseUrlShould.java
@@ -74,7 +74,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
     void rewrite_id_with_versioned_url_on_get_version() throws Exception {
         ResourceMapping mapping = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway").setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(mapping);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(mapping);
         when(mockPatternStore.getPatternForVersion(any(Pattern.class)))
                 .thenReturn("{ \"$id\": \"old-id\", \"name\": \"original\" }");
 
@@ -89,7 +89,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
     /** POST to /calm with a versioned $id of 1.0.0 matching the canonical URL creates the resource. */
     @Test
     void return_201_when_post_to_calm_with_versioned_id_matching_canonical_url() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("api-gateway"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("api-gateway")
@@ -145,7 +145,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
      */
     @Test
     void return_400_when_post_with_versioned_id_above_1_0_0_on_new_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
 
         String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\" }";
 
@@ -164,7 +164,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
      */
     @Test
     void return_201_when_post_with_versioned_id_of_1_0_0_on_new_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("api-gateway"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("api-gateway")
@@ -191,7 +191,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
     /** Specific-version endpoint creates 1.0.0 on a brand-new resource. */
     @Test
     void return_201_when_specific_version_endpoint_creates_1_0_0_on_new_resource() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("api-gateway"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("api-gateway")
@@ -216,7 +216,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
     /** Specific-version endpoint rejects a first version other than 1.0.0. */
     @Test
     void return_400_when_specific_version_endpoint_seeds_above_1_0_0() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
 
         String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\" }";
 
@@ -236,7 +236,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0"));
 
         String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\", \"title\": \"API gateway pattern\" }";
@@ -259,7 +259,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
         ResourceMapping existing = new ResourceMapping.ResourceMappingBuilder()
                 .setNamespace("finos").setCustomId("api-gateway")
                 .setResourceType(ResourceType.PATTERN).setNumericId(1).build();
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenReturn(existing);
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenReturn(existing);
         when(mockPatternStore.getPatternVersions(any(Pattern.class))).thenReturn(List.of("1.0.0", "2.0.0"));
 
         String body = "{ \"$id\": \"https://hub.example.com/calm/namespaces/finos/patterns/api-gateway/versions/2.0.0\" }";
@@ -308,7 +308,7 @@ public class TestMappingControllerResourceWithBaseUrlShould {
      */
     @Test
     void post_strips_id_but_preserves_document_content() throws Exception {
-        when(mockMappingStore.getMapping("finos", "api-gateway")).thenThrow(new MappingNotFoundException());
+        when(mockMappingStore.getMapping("finos", ResourceType.PATTERN, "api-gateway")).thenThrow(new MappingNotFoundException());
         when(mockMappingStore.createMapping(eq("finos"), eq("api-gateway"), eq(ResourceType.PATTERN), eq(0)))
                 .thenReturn(new ResourceMapping.ResourceMappingBuilder()
                         .setNamespace("finos").setCustomId("api-gateway")

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoResourceMappingStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoResourceMappingStoreShould.java
@@ -18,8 +18,10 @@ import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.DuplicateMappingException;
 import org.finos.calm.domain.exception.MappingNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -67,6 +69,28 @@ public class TestMongoResourceMappingStoreShould {
     }
 
     @Test
+    void create_mapping_with_same_custom_id_as_a_different_resource_type() throws DuplicateMappingException, NamespaceNotFoundException {
+        // The store itself performs no in-memory duplicate check on create — uniqueness is
+        // enforced by MongoDB's (namespace, resourceType, customId) unique index (see
+        // MongoIndexInitializationStep / MongoResourceMappingIndexStep). This asserts the
+        // document written for each type carries the correct resourceType, so the same
+        // customId ("repo") can be stored once per type without this store layer blocking it.
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        store.createMapping("finos", "repo", ResourceType.PATTERN, 1);
+        store.createMapping("finos", "repo", ResourceType.ARCHITECTURE, 1);
+
+        ArgumentCaptor<Document> insertCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(mappingCollection, times(2)).insertOne(insertCaptor.capture());
+
+        List<Document> inserted = insertCaptor.getAllValues();
+        assertThat(inserted.get(0).getString("customId"), is("repo"));
+        assertThat(inserted.get(0).getString("resourceType"), is("PATTERN"));
+        assertThat(inserted.get(1).getString("customId"), is("repo"));
+        assertThat(inserted.get(1).getString("resourceType"), is("ARCHITECTURE"));
+    }
+
+    @Test
     void throw_namespace_not_found_on_create_when_namespace_does_not_exist() {
         when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
 
@@ -100,7 +124,7 @@ public class TestMongoResourceMappingStoreShould {
         when(mappingCollection.find(any(org.bson.conversions.Bson.class))).thenReturn(findIterable);
         when(findIterable.first()).thenReturn(doc);
 
-        ResourceMapping result = store.getMapping("finos", "api-gateway");
+        ResourceMapping result = store.getMapping("finos", ResourceType.PATTERN, "api-gateway");
 
         assertThat(result.getNamespace(), is("finos"));
         assertThat(result.getCustomId(), is("api-gateway"));
@@ -117,7 +141,7 @@ public class TestMongoResourceMappingStoreShould {
         when(findIterable.first()).thenReturn(null);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.getMapping("finos", "nonexistent"));
+                () -> store.getMapping("finos", ResourceType.PATTERN, "nonexistent"));
     }
 
     @Test
@@ -125,7 +149,30 @@ public class TestMongoResourceMappingStoreShould {
         when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.getMapping("invalid", "test"));
+                () -> store.getMapping("invalid", ResourceType.PATTERN, "test"));
+    }
+
+    @Test
+    void scope_get_mapping_query_by_resource_type() throws MappingNotFoundException, NamespaceNotFoundException {
+        // Regression guard for #2970: a customId lookup must be scoped by resourceType, or a
+        // pattern and an architecture sharing a customId (e.g. "repo") collide.
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        Document doc = new Document("namespace", "finos")
+                .append("customId", "repo")
+                .append("resourceType", "ARCHITECTURE")
+                .append("numericId", 1);
+
+        DocumentFindIterable findIterable = Mockito.mock(DocumentFindIterable.class);
+        ArgumentCaptor<Bson> filterCaptor = ArgumentCaptor.forClass(Bson.class);
+        when(mappingCollection.find(filterCaptor.capture())).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(doc);
+
+        store.getMapping("finos", ResourceType.ARCHITECTURE, "repo");
+
+        String filterJson = filterCaptor.getValue().toBsonDocument().toJson();
+        assertThat(filterJson, containsString("\"resourceType\": \"ARCHITECTURE\""));
+        assertThat(filterJson, containsString("\"customId\": \"repo\""));
     }
 
     // --- listMappings ---
@@ -258,7 +305,7 @@ public class TestMongoResourceMappingStoreShould {
         when(updateResult.getMatchedCount()).thenReturn(1L);
         when(mappingCollection.updateOne(any(org.bson.conversions.Bson.class), any(Document.class))).thenReturn(updateResult);
 
-        store.updateMappingNumericId("finos", "api-gateway", 42);
+        store.updateMappingNumericId("finos", ResourceType.PATTERN, "api-gateway", 42);
 
         verify(mappingCollection).updateOne(any(org.bson.conversions.Bson.class), any(Document.class));
     }
@@ -272,7 +319,7 @@ public class TestMongoResourceMappingStoreShould {
         when(mappingCollection.updateOne(any(org.bson.conversions.Bson.class), any(Document.class))).thenReturn(updateResult);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.updateMappingNumericId("finos", "nonexistent", 42));
+                () -> store.updateMappingNumericId("finos", ResourceType.PATTERN, "nonexistent", 42));
     }
 
     @Test
@@ -280,7 +327,7 @@ public class TestMongoResourceMappingStoreShould {
         when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.updateMappingNumericId("invalid", "test", 42));
+                () -> store.updateMappingNumericId("invalid", ResourceType.PATTERN, "test", 42));
     }
 
     // --- deleteMapping ---
@@ -293,7 +340,7 @@ public class TestMongoResourceMappingStoreShould {
         when(deleteResult.getDeletedCount()).thenReturn(1L);
         when(mappingCollection.deleteOne(any(org.bson.conversions.Bson.class))).thenReturn(deleteResult);
 
-        store.deleteMapping("finos", "api-gateway");
+        store.deleteMapping("finos", ResourceType.PATTERN, "api-gateway");
 
         verify(mappingCollection).deleteOne(any(org.bson.conversions.Bson.class));
     }
@@ -307,7 +354,7 @@ public class TestMongoResourceMappingStoreShould {
         when(mappingCollection.deleteOne(any(org.bson.conversions.Bson.class))).thenReturn(deleteResult);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.deleteMapping("finos", "nonexistent"));
+                () -> store.deleteMapping("finos", ResourceType.PATTERN, "nonexistent"));
     }
 
     @Test
@@ -315,7 +362,7 @@ public class TestMongoResourceMappingStoreShould {
         when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.deleteMapping("invalid", "test"));
+                () -> store.deleteMapping("invalid", ResourceType.PATTERN, "test"));
     }
 
     // --- Helper interfaces for Mockito generics ---

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteResourceMappingStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteResourceMappingStoreShould.java
@@ -13,6 +13,7 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,6 +22,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -91,6 +93,37 @@ public class TestNitriteResourceMappingStoreShould {
                 () -> store.createMapping(NAMESPACE, "api-gateway", ResourceType.PATTERN, 1));
     }
 
+    @Test
+    void allow_creating_mapping_with_same_custom_id_as_a_different_resource_type() throws DuplicateMappingException, NamespaceNotFoundException {
+        // Regression guard for #2970: the duplicate check must be scoped by resourceType, so a
+        // pattern and an architecture can both be named "repo" in the same namespace.
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        ResourceMapping pattern = store.createMapping(NAMESPACE, "repo", ResourceType.PATTERN, 1);
+        ResourceMapping architecture = store.createMapping(NAMESPACE, "repo", ResourceType.ARCHITECTURE, 1);
+
+        assertThat(pattern.getResourceType(), is(ResourceType.PATTERN));
+        assertThat(architecture.getResourceType(), is(ResourceType.ARCHITECTURE));
+        verify(mockCollection, times(2)).insert(any(Document.class));
+    }
+
+    @Test
+    void scope_duplicate_check_filter_by_resource_type_on_create() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+        when(mockCollection.find(filterCaptor.capture())).thenReturn(cursor);
+
+        assertDoesNotThrow(() -> store.createMapping(NAMESPACE, "repo", ResourceType.ARCHITECTURE, 1));
+
+        assertThat(filterCaptor.getValue().toString(), containsString("resourceType"));
+        assertThat(filterCaptor.getValue().toString(), containsString("ARCHITECTURE"));
+    }
+
     // --- getMapping ---
 
     @Test
@@ -107,7 +140,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(cursor.firstOrNull()).thenReturn(doc);
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
-        ResourceMapping result = store.getMapping(NAMESPACE, "api-gateway");
+        ResourceMapping result = store.getMapping(NAMESPACE, ResourceType.PATTERN, "api-gateway");
 
         assertThat(result.getNamespace(), is(NAMESPACE));
         assertThat(result.getCustomId(), is("api-gateway"));
@@ -123,7 +156,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.getMapping(NAMESPACE, "nonexistent"));
+                () -> store.getMapping(NAMESPACE, ResourceType.PATTERN, "nonexistent"));
     }
 
     @Test
@@ -131,7 +164,30 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockNamespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.getMapping("invalid", "test"));
+                () -> store.getMapping("invalid", ResourceType.PATTERN, "test"));
+    }
+
+    @Test
+    void scope_get_mapping_query_by_resource_type() throws MappingNotFoundException, NamespaceNotFoundException {
+        // Regression guard for #2970: a customId lookup must be scoped by resourceType, or a
+        // pattern and an architecture sharing a customId (e.g. "repo") collide.
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document doc = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("customId", "repo")
+                .put("resourceType", "ARCHITECTURE")
+                .put("numericId", 1);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(doc);
+        ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+        when(mockCollection.find(filterCaptor.capture())).thenReturn(cursor);
+
+        store.getMapping(NAMESPACE, ResourceType.ARCHITECTURE, "repo");
+
+        assertThat(filterCaptor.getValue().toString(), containsString("resourceType"));
+        assertThat(filterCaptor.getValue().toString(), containsString("ARCHITECTURE"));
     }
 
     // --- listMappings ---
@@ -289,7 +345,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(cursor.firstOrNull()).thenReturn(existing);
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
-        store.updateMappingNumericId(NAMESPACE, "api-gateway", 99);
+        store.updateMappingNumericId(NAMESPACE, ResourceType.PATTERN, "api-gateway", 99);
 
         verify(mockCollection).update(any(Document.class));
     }
@@ -299,7 +355,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockNamespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.updateMappingNumericId("invalid", "test", 1));
+                () -> store.updateMappingNumericId("invalid", ResourceType.PATTERN, "test", 1));
     }
 
     @Test
@@ -311,7 +367,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.updateMappingNumericId(NAMESPACE, "nonexistent", 1));
+                () -> store.updateMappingNumericId(NAMESPACE, ResourceType.PATTERN, "nonexistent", 1));
     }
 
     // --- deleteMapping ---
@@ -330,7 +386,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(cursor.firstOrNull()).thenReturn(existing);
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
-        store.deleteMapping(NAMESPACE, "api-gateway");
+        store.deleteMapping(NAMESPACE, ResourceType.PATTERN, "api-gateway");
 
         verify(mockCollection).remove(existing);
     }
@@ -340,7 +396,7 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockNamespaceStore.namespaceExists("invalid")).thenReturn(false);
 
         assertThrows(NamespaceNotFoundException.class,
-                () -> store.deleteMapping("invalid", "test"));
+                () -> store.deleteMapping("invalid", ResourceType.PATTERN, "test"));
     }
 
     @Test
@@ -352,6 +408,6 @@ public class TestNitriteResourceMappingStoreShould {
         when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
 
         assertThrows(MappingNotFoundException.class,
-                () -> store.deleteMapping(NAMESPACE, "nonexistent"));
+                () -> store.deleteMapping(NAMESPACE, ResourceType.PATTERN, "nonexistent"));
     }
 }


### PR DESCRIPTION
## Description

Fixes #2970. `calm hub push pattern repo.pattern.json` and `calm hub push architecture repo.architecture.json` collided in CALM Hub — both derive the customId `repo` from their `$id`, but `resource_mappings` was keyed by `(namespace, customId)` only, with `resourceType` stored on every document but ignored on every lookup.

- Second push's version-probe resolved the mapping by customId alone, returning the **pattern's** version list
- CLI computed a semver bump off that wrong version and POSTed; server looked up the mapping untyped again and wrote the **architecture document into the `patterns` collection** under the pattern's numeric id
- `hub list patterns` showed `repo`; `hub list architectures` did not, despite the push reporting `201 Created`
- Reads (`GET .../versions/{v}`) had the same untyped-lookup bug independent of any write — a wrong-type document could be served back with a rewritten `$id`

Fix: make `ResourceType` part of the mapping's identity everywhere it's looked up by customId.

- `ResourceMappingStore.getMapping` / `updateMappingNumericId` / `deleteMapping` now require a `ResourceType` parameter — no untyped overload, since a 3-field unique index makes an untyped lookup ambiguous
- Both Mongo and Nitrite stores updated; Nitrite's app-level duplicate check now scopes on `(namespace, resourceType, customId)`
- New `MongoResourceMappingIndexStep` migration (schema v11→12) widens the Mongo unique index from `(namespace, customId)` to `(namespace, resourceType, customId)` for existing deployments — editing `MongoIndexInitializationStep` alone only fixes fresh databases, since it runs once at schema version 0 (see `MongoLayoutIndexStep` for the same precedent)
- Service/resource layers thread the type through; the two `resource_mappings` conflict messages now name the resource type, so a mismatched CLI subcommand/file fails with a legible 409 instead of silently corrupting data
- `mongo/init-mongo.js` dev-seed index and `LATEST_SCHEMA_VERSION` updated to match

**Scope**: server-only (`calm-hub/`), no CLI changes. Traced the CLI's existing 404→`[]` handling (`calm-hub-client.ts:365-368`) against the fixed server — the version-probe now correctly 404s for a genuinely new resource, the CLI forces `1.0.0`, and the push proceeds correctly. The full repro (including the "increments and swaps type" symptom) resolves server-side.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

- 2631 unit tests pass (`../mvnw test`), including new coverage in `TestMongoResourceMappingStoreShould`, `TestNitriteResourceMappingStoreShould`, and a new `TestMongoResourceMappingIndexStepShould`
- 526 integration tests pass (`../mvnw -P integration verify`, TestContainers Mongo), including new cross-type regression tests in `MongoMappingControllerIntegration` and `NitriteMappingControllerIntegration` that push the same customId as a pattern and an architecture, then assert each type's read returns the correct document and each type's list contains exactly one entry
- JaCoCo coverage gate met
- Ran `/code-review` locally (twice, fixing two findings in between: a missed `LATEST_SCHEMA_VERSION` bump per `calm-hub/AGENTS.md`, and two integration assertions that used `hasItem` instead of an exact-count check)

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards

Known limitation, not blocking: if a deployment already hit the write-corruption failure mode described above, the stray wrong-type document isn't cleaned up by this migration — it becomes unreachable once the correct-type mapping becomes creatable. No backfill needed since `resourceType` is present on every existing `resource_mappings` document.