### PR TITLE
fix(calm-hub): migrate UserAccessStore namespace checks to requireNamespace

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -44,8 +44,8 @@ public class MongoUserAccessStore implements UserAccessStore {
             throws NamespaceNotFoundException {
 
         log.info("User-access details: {}", userAccess);
-        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace()) && !namespaceStore.namespaceExists(userAccess.getNamespace())) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace())) {
+            namespaceStore.requireNamespace(userAccess.getNamespace());
         }
 
         return createUserAccess(userAccess, "namespace", userAccess.getNamespace());
@@ -120,8 +120,8 @@ public class MongoUserAccessStore implements UserAccessStore {
 
     @Override
     public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
         }
         List<UserAccess> userAccessList = new ArrayList<>();
         for (Document doc : userAccessCollection.find(Filters.eq("namespace", namespace))) {
@@ -134,9 +134,7 @@ public class MongoUserAccessStore implements UserAccessStore {
     public UserAccess getUserAccessForNamespaceAndId(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        namespaceStore.requireNamespace(namespace);
 
         Document document = userAccessCollection.find(Filters.and(
                         Filters.eq("namespace", namespace),
@@ -187,8 +185,8 @@ public class MongoUserAccessStore implements UserAccessStore {
     public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
         }
 
         DeleteResult result = userAccessCollection.deleteOne(Filters.and(

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -63,8 +63,8 @@ public class NitriteUserAccessStore implements UserAccessStore {
     public UserAccess createUserAccessForNamespace(UserAccess userAccess) throws NamespaceNotFoundException {
         LOG.info("User-access details: {}", userAccess);
 
-        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace()) && !namespaceStore.namespaceExists(userAccess.getNamespace())) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(userAccess.getNamespace())) {
+            namespaceStore.requireNamespace(userAccess.getNamespace());
         }
 
         lock.lock();
@@ -123,8 +123,8 @@ public class NitriteUserAccessStore implements UserAccessStore {
 
     @Override
     public List<UserAccess> getUserAccessForNamespace(String namespace) throws NamespaceNotFoundException {
-        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
         }
         Filter filter = where(NAMESPACE_FIELD).eq(namespace);
         List<UserAccess> userAccessList = new ArrayList<>();
@@ -138,9 +138,7 @@ public class NitriteUserAccessStore implements UserAccessStore {
     public UserAccess getUserAccessForNamespaceAndId(String namespace, Integer userAccessId) 
             throws NamespaceNotFoundException, UserAccessNotFoundException {
         
-        if (!namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
-        }
+        namespaceStore.requireNamespace(namespace);
 
         Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(USER_ACCESS_ID_FIELD).eq(userAccessId));
         Document document = userAccessCollection.find(filter).firstOrNull();
@@ -225,8 +223,8 @@ public class NitriteUserAccessStore implements UserAccessStore {
     public void deleteUserAccessForNamespace(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        if (!GLOBAL_ACCESS.equals(namespace) && !namespaceStore.namespaceExists(namespace)) {
-            throw new NamespaceNotFoundException();
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
         }
 
         lock.lock();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -46,10 +46,11 @@ public class TestMongoUserAccessStoreShould {
     private MongoUserAccessStore mongoUserAccessStore;
 
     @BeforeEach
-    void setup() {
+    void setup() throws NamespaceNotFoundException {
         userAccessCollection = Mockito.mock(DocumentMongoCollection.class);
 
         when(mongoDatabase.getCollection("userAccess")).thenReturn(userAccessCollection);
+        doCallRealMethod().when(namespaceStore).requireNamespace(anyString());
         mongoUserAccessStore = new MongoUserAccessStore(mongoDatabase, namespaceStore, counterStore);
     }
 

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
@@ -45,8 +45,9 @@ public class TestNitriteUserAccessStoreShould {
     private NitriteUserAccessStore userAccessStore;
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws NamespaceNotFoundException {
         when(mockDb.getCollection("userAccess")).thenReturn(mockCollection);
+        lenient().doCallRealMethod().when(mockNamespaceStore).requireNamespace(any());
         userAccessStore = new NitriteUserAccessStore(mockDb, mockNamespaceStore, mockCounterStore);
     }
 


### PR DESCRIPTION
## Description
`MongoUserAccessStore` and `NitriteUserAccessStore` still contained the `if (!namespaceStore.namespaceExists(x)) throw NamespaceNotFoundException` shape that PR #2959 eliminated everywhere else, replacing it with `NamespaceStore#requireNamespace`. This was flagged in a review comment on #2959 as missed. This PR applies the same drop-in replacement to the remaining 4 call sites in each store, guarded by the existing `GLOBAL_ACCESS` special case where it was already present.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Ran `../mvnw clean verify -Ddependency-check.skip=true` — 2620 tests, 0 failures, 0 errors, JaCoCo coverage passed.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards