### PR TITLE
fix(calm-hub): apply GLOBAL_ACCESS guard to getUserAccessForNamespaceAndId

### DIFF
--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoUserAccessStore.java
@@ -134,7 +134,9 @@ public class MongoUserAccessStore implements UserAccessStore {
     public UserAccess getUserAccessForNamespaceAndId(String namespace, Integer userAccessId)
             throws NamespaceNotFoundException, UserAccessNotFoundException {
 
-        namespaceStore.requireNamespace(namespace);
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
+        }
 
         Document document = userAccessCollection.find(Filters.and(
                         Filters.eq("namespace", namespace),

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteUserAccessStore.java
@@ -138,7 +138,9 @@ public class NitriteUserAccessStore implements UserAccessStore {
     public UserAccess getUserAccessForNamespaceAndId(String namespace, Integer userAccessId) 
             throws NamespaceNotFoundException, UserAccessNotFoundException {
         
-        namespaceStore.requireNamespace(namespace);
+        if (!GLOBAL_ACCESS.equals(namespace)) {
+            namespaceStore.requireNamespace(namespace);
+        }
 
         Filter filter = where(NAMESPACE_FIELD).eq(namespace).and(where(USER_ACCESS_ID_FIELD).eq(userAccessId));
         Document document = userAccessCollection.find(filter).firstOrNull();

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoUserAccessStoreShould.java
@@ -537,6 +537,28 @@ public class TestMongoUserAccessStoreShould {
     }
 
     @Test
+    void get_user_access_for_global_namespace_and_id_without_namespace_existence_check() throws Exception {
+        Integer userAccessId = 202;
+
+        Document document = new Document("username", "alice")
+                .append("namespace", "GLOBAL")
+                .append("permission", Permission.admin.name())
+                .append("userAccessId", userAccessId);
+
+        DocumentFindIterable mockFindIterable = mock(DocumentFindIterable.class);
+        when(userAccessCollection.find(Filters.and(
+                Filters.eq("namespace", "GLOBAL"),
+                Filters.eq("userAccessId", userAccessId)
+        ))).thenReturn(mockFindIterable);
+        when(mockFindIterable.first()).thenReturn(document);
+
+        UserAccess actual = mongoUserAccessStore.getUserAccessForNamespaceAndId("GLOBAL", userAccessId);
+
+        assertThat(actual.getNamespace(), is("GLOBAL"));
+        verify(namespaceStore, never()).namespaceExists("GLOBAL");
+    }
+
+    @Test
     void delete_user_access_for_global_namespace_without_namespace_existence_check() throws NamespaceNotFoundException, UserAccessNotFoundException {
         com.mongodb.client.result.DeleteResult deleteResult = mock(com.mongodb.client.result.DeleteResult.class);
         when(deleteResult.getDeletedCount()).thenReturn(1L);

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteUserAccessStoreShould.java
@@ -388,6 +388,24 @@ public class TestNitriteUserAccessStoreShould {
     }
 
     @Test
+    public void getUserAccessForNamespaceAndId_succeedsForGlobalWithoutNamespaceExistenceCheck() throws Exception {
+        Document mockDoc = mock(Document.class);
+        when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);
+        when(mockCursor.firstOrNull()).thenReturn(mockDoc);
+
+        when(mockDoc.get("username", String.class)).thenReturn("alice");
+        when(mockDoc.get("namespace", String.class)).thenReturn("GLOBAL");
+        when(mockDoc.get("domain", String.class)).thenReturn(null);
+        when(mockDoc.get("permission", String.class)).thenReturn("admin");
+        when(mockDoc.get("userAccessId", Integer.class)).thenReturn(303);
+
+        UserAccess result = userAccessStore.getUserAccessForNamespaceAndId("GLOBAL", 303);
+
+        assertThat(result.getNamespace(), is("GLOBAL"));
+        verify(mockNamespaceStore, never()).namespaceExists("GLOBAL");
+    }
+
+    @Test
     public void deleteUserAccessForNamespace_succeedsForGlobalWithoutNamespaceExistenceCheck() throws Exception {
         Document mockDoc = mock(Document.class);
         when(mockCollection.find(any(Filter.class))).thenReturn(mockCursor);


### PR DESCRIPTION
## Description
Pre-existing bug identified by @jpgough-ms in a previous PR. Fixing now...

`getUserAccessForNamespaceAndId` in both `MongoUserAccessStore` and `NitriteUserAccessStore` called `namespaceStore.requireNamespace(namespace)` unconditionally, unlike its sibling methods (`createUserAccessForNamespace`, `getUserAccessForNamespace`, `deleteUserAccessForNamespace`), which special-case `GLOBAL_ACCESS` since `GLOBAL` is never a persisted `NamespaceInfo`.

Reproduction before this fix:
- `POST .../namespaces/GLOBAL/user-access` succeeds (create special-cases GLOBAL_ACCESS)
- `GET .../namespaces/GLOBAL/user-access/{id}` on that same record then 404s

This applies the same `!GLOBAL_ACCESS.equals(namespace)` guard used by the sibling methods to `getUserAccessForNamespaceAndId` in both store implementations.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Commit Message Format ✅
- [x] Followed

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Added unit tests in `TestMongoUserAccessStoreShould` and `TestNitriteUserAccessStoreShould` covering `getUserAccessForNamespaceAndId("GLOBAL", ...)` succeeding without a namespace-existence check. Ran `../mvnw -o test -Dtest=TestMongoUserAccessStoreShould,TestNitriteUserAccessStoreShould` — all pass.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards