### PR TITLE
fix(shared): stop CalmHubDocumentLoader claiming http(s) URLs that are not scoped to the configured instance

### DIFF
--- a/cli/smoke/generate-validate.smoke.spec.ts
+++ b/cli/smoke/generate-validate.smoke.spec.ts
@@ -96,37 +96,27 @@ describe('Flow 2: generate/validate (local + CalmHub refs)', () => {
         expect(nodes.length).toBeGreaterThan(0);
     });
 
-    // Known limitation tracked by #2827: when validating with `-c`, CalmHubDocumentLoader claims
-    // external http(s) control-schema references (here https://calm.finos.org/...) and fetches them
-    // path-only against the `-c` hub, which fails. We deliberately assert this unsupported behaviour
-    // so that adopting a loader routing rule (host-scoped fall-through) trips this test and forces an
-    // update, rather than the limitation regressing silently.
-    test('validate with -c against a pattern referencing cross-host CalmHub control schemas is not supported yet (see #2827)', async () => {
+    // #2827 fixed: an http(s) control-schema ref on a different host to `-c` now falls through to
+    // DirectUrlDocumentLoader (calm.finos.org is allowlisted by default) instead of being wrongly
+    // claimed and fetched path-only against the wrong hub.
+    test('validate with -c against a pattern referencing cross-host CalmHub control schemas resolves them via DirectUrlDocumentLoader (#2827)', async () => {
         const arch = path.join(cli.tempDir, 'hub-arch.json');
         expect(fs.existsSync(arch)).toBe(true);
 
-        const result = await cli
-            .run(['validate', '-p', PATTERN_URL, '-a', arch, '-f', 'json', '-c', SMOKE_HUB_URL])
-            .catch(e => e);
+        const { stdout } = await cli.run(['validate', '-p', PATTERN_URL, '-a', arch, '-f', 'json', '-c', SMOKE_HUB_URL]);
 
-        expect(result.exitCode).toBe(1);
-
-        const parsed = JSON.parse(result.stdout) as ValidationResult;
-        expect(parsed.hasErrors).toBe(true);
+        const parsed = JSON.parse(stdout) as ValidationResult;
+        expect(parsed.hasErrors).toBe(false);
 
         const controlErrors = parsed.jsonSchemaValidationOutputs.filter(
             o => o.code === 'control-requirement-validation'
         );
-        expect(controlErrors.length).toBeGreaterThan(0);
-        expect(
-            controlErrors.every(o => (o.message ?? '').includes('Failed to load document from CALMHub'))
-        ).toBe(true);
+        expect(controlErrors).toEqual([]);
     });
 
-    // Online counterpart to the #2827 limitation above: when the control requirement and config are
-    // hosted on the SAME host as -c, CalmHubDocumentLoader resolves them correctly and the control is
-    // validated end to end. The good architecture also carries a node-details detailed-architecture
-    // (itself hub-hosted), exercising the recursive descent into detailed architectures.
+    // Same-host counterpart to #2827 above: requirement/config hosted on the same host as -c, so
+    // CalmHubDocumentLoader resolves them directly. Also exercises recursive descent into a
+    // hub-hosted node-details detailed-architecture.
     test('a compliant control validated against its CalmHub-hosted requirement passes', async () => {
         const { stdout } = await cli.run(['validate', '-a', GOOD_CONTROL_ARCH, '-c', SMOKE_HUB_URL, '-f', 'json']);
         const result = JSON.parse(stdout) as ValidationResult;

--- a/shared/src/document-loader/calmhub-direct-url-fallthrough.spec.ts
+++ b/shared/src/document-loader/calmhub-direct-url-fallthrough.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { Axios } from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import { CalmHubDocumentLoader } from './calmhub-document-loader';
 import { DirectUrlDocumentLoader } from './direct-url-document-loader';
@@ -12,18 +12,26 @@ describe('CalmHubDocumentLoader + DirectUrlDocumentLoader fall-through', () => {
     const calmHubBaseUrl = 'http://local-calmhub';
     const allowedHost = 'schemas.example.com';
 
-    it('falls through to DirectUrlDocumentLoader for an allowlisted host not hosted on CalmHub', async () => {
-        const hubAx = axios.create({ baseURL: calmHubBaseUrl });
+    let hubAx: Axios;
+    let directAx: Axios;
+    let directMock: AxiosMockAdapter;
+    let multi: MultiStrategyDocumentLoader;
+
+    beforeEach(() => {
+        hubAx = axios.create({ baseURL: calmHubBaseUrl });
         new AxiosMockAdapter(hubAx); // no handlers registered: any request 404s
 
-        const directAx = axios.create({});
-        const directMock = new AxiosMockAdapter(directAx);
-        const externalUrl = `https://${allowedHost}/core.json`;
-        directMock.onGet('/core.json').reply(200, { '$id': externalUrl, 'title': 'schema' });
+        directAx = axios.create({});
+        directMock = new AxiosMockAdapter(directAx);
 
         const calmHubLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, undefined, hubAx);
         const directLoader = new DirectUrlDocumentLoader(false, directAx, [allowedHost]);
-        const multi = new MultiStrategyDocumentLoader([calmHubLoader, directLoader]);
+        multi = new MultiStrategyDocumentLoader([calmHubLoader, directLoader]);
+    });
+
+    it('falls through to DirectUrlDocumentLoader for an allowlisted host not hosted on CalmHub', async () => {
+        const externalUrl = `https://${allowedHost}/core.json`;
+        directMock.onGet('/core.json').reply(200, { '$id': externalUrl, 'title': 'schema' });
 
         const document = await multi.loadMissingDocument(externalUrl, 'schema');
 
@@ -31,16 +39,6 @@ describe('CalmHubDocumentLoader + DirectUrlDocumentLoader fall-through', () => {
     });
 
     it('still surfaces a fatal error when the URL host is not allowlisted anywhere', async () => {
-        const hubAx = axios.create({ baseURL: calmHubBaseUrl });
-        new AxiosMockAdapter(hubAx);
-
-        const directAx = axios.create({});
-        new AxiosMockAdapter(directAx);
-
-        const calmHubLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, undefined, hubAx);
-        const directLoader = new DirectUrlDocumentLoader(false, directAx, [allowedHost]);
-        const multi = new MultiStrategyDocumentLoader([calmHubLoader, directLoader]);
-
         await expect(multi.loadMissingDocument('https://not-allowed.example.com/core.json', 'schema'))
             .rejects.toThrow('is not allowlisted');
     });

--- a/shared/src/document-loader/calmhub-direct-url-fallthrough.spec.ts
+++ b/shared/src/document-loader/calmhub-direct-url-fallthrough.spec.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import AxiosMockAdapter from 'axios-mock-adapter';
+import { CalmHubDocumentLoader } from './calmhub-document-loader';
+import { DirectUrlDocumentLoader } from './direct-url-document-loader';
+import { MultiStrategyDocumentLoader } from './multi-strategy-document-loader';
+
+// Regression test for a bug where CalmHubDocumentLoader claimed ownership of *any* http(s)
+// reference (not just ones actually hosted on CalmHub), tried to load it from CalmHub, failed
+// fatally, and short-circuited MultiStrategyDocumentLoader before DirectUrlDocumentLoader ever got
+// a turn — even when the URL's host was allowlisted for direct loading.
+describe('CalmHubDocumentLoader + DirectUrlDocumentLoader fall-through', () => {
+    const calmHubBaseUrl = 'http://local-calmhub';
+    const allowedHost = 'schemas.example.com';
+
+    it('falls through to DirectUrlDocumentLoader for an allowlisted host not hosted on CalmHub', async () => {
+        const hubAx = axios.create({ baseURL: calmHubBaseUrl });
+        new AxiosMockAdapter(hubAx); // no handlers registered: any request 404s
+
+        const directAx = axios.create({});
+        const directMock = new AxiosMockAdapter(directAx);
+        const externalUrl = `https://${allowedHost}/core.json`;
+        directMock.onGet('/core.json').reply(200, { '$id': externalUrl, 'title': 'schema' });
+
+        const calmHubLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, undefined, hubAx);
+        const directLoader = new DirectUrlDocumentLoader(false, directAx, [allowedHost]);
+        const multi = new MultiStrategyDocumentLoader([calmHubLoader, directLoader]);
+
+        const document = await multi.loadMissingDocument(externalUrl, 'schema');
+
+        expect(document).toEqual({ '$id': externalUrl, 'title': 'schema' });
+    });
+
+    it('still surfaces a fatal error when the URL host is not allowlisted anywhere', async () => {
+        const hubAx = axios.create({ baseURL: calmHubBaseUrl });
+        new AxiosMockAdapter(hubAx);
+
+        const directAx = axios.create({});
+        new AxiosMockAdapter(directAx);
+
+        const calmHubLoader = new CalmHubDocumentLoader(calmHubBaseUrl, false, undefined, hubAx);
+        const directLoader = new DirectUrlDocumentLoader(false, directAx, [allowedHost]);
+        const multi = new MultiStrategyDocumentLoader([calmHubLoader, directLoader]);
+
+        await expect(multi.loadMissingDocument('https://not-allowed.example.com/core.json', 'schema'))
+            .rejects.toThrow('is not allowlisted');
+    });
+});

--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -57,10 +57,28 @@ describe('calmhub-document-loader', () => {
         await expect(calmHubDocumentLoader.loadMissingDocument(calmHubUrl, 'schema')).rejects.toThrow();
     });
 
-    it('throws an error when the protocol is not calm:', async () => {
-        const calmHubUrl = 'https://not.calmhub.com/schemas/2025-03/meta/nonexistent.json';
+    it('throws an error when the protocol is not http/https/calm', async () => {
+        const calmHubUrl = 'ftp://not.calmhub.com/schemas/2025-03/meta/nonexistent.json';
 
         await expect(calmHubDocumentLoader.loadMissingDocument(calmHubUrl, 'schema')).rejects.toThrow();
+    });
+
+    it('does not claim an http(s) URL whose origin is not this CalmHub instance, so other loaders can try it', async () => {
+        const externalUrl = 'https://not.calmhub.com/schemas/2025-03/meta/nonexistent.json';
+
+        const promise = calmHubDocumentLoader.loadMissingDocument(externalUrl, 'schema');
+        await expect(promise).rejects.toThrow('only loads http(s) documents from the configured CALMHub origin');
+        // Recoverable: a plain Error, not a fatal DocumentLoadError, so MultiStrategyDocumentLoader falls through.
+        await expect(promise).rejects.not.toBeInstanceOf(DocumentLoadError);
+    });
+
+    it('loads an http(s) URL whose origin matches this CalmHub instance', async () => {
+        const hubUrl = `${calmHubBaseUrl}/schemas/2025-03/meta/core.json`;
+        const document = await calmHubDocumentLoader.loadMissingDocument(hubUrl, 'schema');
+        expect(document).toEqual({
+            '$id': 'https://calm.finos.org/calm/schemas/2025-03/meta/core.json',
+            'value': 'test'
+        });
     });
 
     it('rejects paths containing directory traversal segments', async () => {

--- a/shared/src/document-loader/calmhub-document-loader.spec.ts
+++ b/shared/src/document-loader/calmhub-document-loader.spec.ts
@@ -68,8 +68,14 @@ describe('calmhub-document-loader', () => {
 
         const promise = calmHubDocumentLoader.loadMissingDocument(externalUrl, 'schema');
         await expect(promise).rejects.toThrow('only loads http(s) documents from the configured CALMHub origin');
-        // Recoverable: a plain Error, not a fatal DocumentLoadError, so MultiStrategyDocumentLoader falls through.
-        await expect(promise).rejects.not.toBeInstanceOf(DocumentLoadError);
+        // Recoverable: a DocumentLoadError with recoverable: true, so MultiStrategyDocumentLoader falls through.
+        await expect(promise).rejects.toBeInstanceOf(DocumentLoadError);
+        await expect(promise).rejects.toMatchObject({ recoverable: true });
+    });
+
+    it('rejects a calmHubUrl that is not a parseable absolute URL', () => {
+        expect(() => new CalmHubDocumentLoader('not-a-url', false, undefined, ax))
+            .toThrow('Invalid CalmHub URL');
     });
 
     it('loads an http(s) URL whose origin matches this CalmHub instance', async () => {

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -11,9 +11,8 @@ export class CalmHubDocumentLoader implements DocumentLoader {
     private readonly logger: Logger;
     private readonly authPlugin?: AuthPlugin;
     // The origin (protocol + host + port) that an http(s) reference must match to be considered
-    // "ours". undefined (calmHubUrl isn't a parseable absolute URL) means no http(s) reference
-    // will ever match, so such references fall through to other loaders instead of crashing here.
-    private readonly calmHubOrigin: string | undefined;
+    // "ours". calmHubUrl must be a parseable absolute URL — see the constructor validation below.
+    private readonly calmHubOrigin: string;
 
     constructor(private calmHubUrl: string, debug: boolean, authPlugin?: AuthPlugin, axiosInstance?: Axios) {
         if (axiosInstance) {
@@ -30,8 +29,14 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         this.authPlugin = authPlugin;
         try {
             this.calmHubOrigin = new URL(calmHubUrl).origin;
-        } catch {
-            this.calmHubOrigin = undefined;
+        } catch (err) {
+            // Fail fast: a calmHubUrl that isn't a parseable absolute URL means the origin check
+            // below would silently reject every http(s) reference forever, masking a config typo
+            // behind a confusing "not from this CALMHub origin" error at load time instead.
+            const reason = err instanceof Error ? `: ${err.message}` : '';
+            throw new Error(
+                `Invalid CalmHub URL '${calmHubUrl}': must be an absolute URL, e.g. 'https://calmhub.example.com'${reason}.`
+            );
         }
 
         if (this.authPlugin) {
@@ -73,14 +78,22 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         const protocol = url.protocol;
         if (!CALM_HUB_PROTOS.some(p => p === protocol)) {
             // Not a protocol we recognise — recoverable, let other loaders try.
-            throw new Error(`CalmHubDocumentLoader can only load documents with protocol '${CALM_HUB_PROTOS.join(', ')}'. (Requested: ${protocol})`);
+            throw new DocumentLoadError({
+                name: 'UNKNOWN',
+                message: `CalmHubDocumentLoader can only load documents with protocol '${CALM_HUB_PROTOS.join(', ')}'. (Requested: ${protocol})`,
+                recoverable: true
+            });
         }
 
         // An http(s) reference is only ours if it actually points at this CalmHub instance.
         // Anything else (e.g. an allowlisted external host meant for DirectUrlDocumentLoader) is
         // recoverable — let other loaders try. calm: references are host-agnostic and always ours.
         if ((protocol === 'http:' || protocol === 'https:') && url.origin !== this.calmHubOrigin) {
-            throw new Error(`CalmHubDocumentLoader only loads http(s) documents from the configured CALMHub origin '${this.calmHubOrigin}'. (Requested: ${url.origin})`);
+            throw new DocumentLoadError({
+                name: 'UNKNOWN',
+                message: `CalmHubDocumentLoader only loads http(s) documents from the configured CALMHub origin '${this.calmHubOrigin}'. (Requested: ${url.origin})`,
+                recoverable: true
+            });
         }
 
         // From here the reference is ours: any failure is fatal and must not fall through to

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -10,6 +10,10 @@ export class CalmHubDocumentLoader implements DocumentLoader {
     private readonly ax: Axios;
     private readonly logger: Logger;
     private readonly authPlugin?: AuthPlugin;
+    // The origin (protocol + host + port) that an http(s) reference must match to be considered
+    // "ours". undefined (calmHubUrl isn't a parseable absolute URL) means no http(s) reference
+    // will ever match, so such references fall through to other loaders instead of crashing here.
+    private readonly calmHubOrigin: string | undefined;
 
     constructor(private calmHubUrl: string, debug: boolean, authPlugin?: AuthPlugin, axiosInstance?: Axios) {
         if (axiosInstance) {
@@ -24,7 +28,12 @@ export class CalmHubDocumentLoader implements DocumentLoader {
             });
         }
         this.authPlugin = authPlugin;
-        
+        try {
+            this.calmHubOrigin = new URL(calmHubUrl).origin;
+        } catch {
+            this.calmHubOrigin = undefined;
+        }
+
         if (this.authPlugin) {
             this.ax.interceptors.request.use(async (config) => {
                 const fullUrl = (config.baseURL || '') + (config.url || '');
@@ -63,8 +72,15 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         const url = new URL(documentId);
         const protocol = url.protocol;
         if (!CALM_HUB_PROTOS.some(p => p === protocol)) {
-            // Not a calm: reference — recoverable, let other loaders try.
+            // Not a protocol we recognise — recoverable, let other loaders try.
             throw new Error(`CalmHubDocumentLoader can only load documents with protocol '${CALM_HUB_PROTOS.join(', ')}'. (Requested: ${protocol})`);
+        }
+
+        // An http(s) reference is only ours if it actually points at this CalmHub instance.
+        // Anything else (e.g. an allowlisted external host meant for DirectUrlDocumentLoader) is
+        // recoverable — let other loaders try. calm: references are host-agnostic and always ours.
+        if ((protocol === 'http:' || protocol === 'https:') && url.origin !== this.calmHubOrigin) {
+            throw new Error(`CalmHubDocumentLoader only loads http(s) documents from the configured CALMHub origin '${this.calmHubOrigin}'. (Requested: ${url.origin})`);
         }
 
         // From here the reference is ours: any failure is fatal and must not fall through to

--- a/shared/src/document-loader/calmhub-document-loader.ts
+++ b/shared/src/document-loader/calmhub-document-loader.ts
@@ -30,9 +30,7 @@ export class CalmHubDocumentLoader implements DocumentLoader {
         try {
             this.calmHubOrigin = new URL(calmHubUrl).origin;
         } catch (err) {
-            // Fail fast: a calmHubUrl that isn't a parseable absolute URL means the origin check
-            // below would silently reject every http(s) reference forever, masking a config typo
-            // behind a confusing "not from this CALMHub origin" error at load time instead.
+            // Fail fast on a bad calmHubUrl, rather than silently rejecting every http(s) ref later.
             const reason = err instanceof Error ? `: ${err.message}` : '';
             throw new Error(
                 `Invalid CalmHub URL '${calmHubUrl}': must be an absolute URL, e.g. 'https://calmhub.example.com'${reason}.`


### PR DESCRIPTION
CalmHubDocumentLoader treated any http:/https: reference as its own (widened from calm:-only in #2612), regardless of the URL's host. With calmHubUrl configured, a document reference to an unrelated allowlisted host would be grabbed by CalmHubDocumentLoader, fail against CalmHub, and throw a fatal error — so MultiStrategyDocumentLoader never gave DirectUrlDocumentLoader a chance to try it, even though the host was allowlisted for direct loading.

CalmHubDocumentLoader now only claims an http(s) reference when its origin matches the configured calmHubUrl's origin. calm: references are unaffected. Non-matching http(s) URLs now throw a recoverable error so later loaders in the chain (DirectUrlDocumentLoader) get a chance.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
