### PR TITLE
fix(calm-hub-ui): meet WCAG AA contrast for redesign text tokens

### DIFF
--- a/calm-hub-ui/src/theme/contrast.test.ts
+++ b/calm-hub-ui/src/theme/contrast.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Colour-contrast guard for the redesign text tokens.
+ *
+ * The redesign palette is consumed as CSS custom properties, so a contrast
+ * failure is a property of a token pair rather than of any one component. That
+ * makes it checkable without a browser: read the two theme blocks out of
+ * `theme.css`, resolve each pair, and compute the WCAG ratio.
+ *
+ * Every pair below is one that actually occurs in the UI. The threshold is 4.5:1
+ * (WCAG 2.2 SC 1.4.3, AA) because all of this text is small: the rail section
+ * labels are 10px and the count badges 11px, nowhere near the 18.66px bold /
+ * 24px large-text exemption.
+ *
+ * The point is the pairing. A token that reads comfortably on the page
+ * background can still fail on a badge, which is exactly how two of these were
+ * missed.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Reads `theme.css` off disk.
+ *
+ * Not `import './theme.css?raw'`: Vitest stubs the CSS transform by default, so
+ * a raw import resolves to an empty string and every assertion below would pass
+ * against nothing. Both candidate roots are tried because the suite runs from
+ * the workspace directory but can be invoked from the repository root.
+ */
+function readThemeCss(): string {
+    const candidates = [join(process.cwd(), 'src/theme/theme.css'), join(process.cwd(), 'calm-hub-ui/src/theme/theme.css')];
+    const found = candidates.find((candidate) => existsSync(candidate));
+    if (!found) {
+        throw new Error(`Could not locate theme.css. Looked in: ${candidates.join(', ')}`);
+    }
+    return readFileSync(found, 'utf8');
+}
+
+const THEME_CSS = readThemeCss();
+
+/** WCAG 2.2 SC 1.4.3 minimum for text below the large-text threshold. */
+const AA_NORMAL_TEXT = 4.5;
+
+/**
+ * The dark block's selector. Matched by pattern rather than as a literal because
+ * this file is read through Vite's `?raw`, which returns the CSS after PostCSS
+ * has normalised it, and PostCSS is free to change the attribute quoting.
+ */
+const DARK_SELECTOR = /:root\[data-theme=['"]?dark['"]?\]/;
+
+/** Token pairs that occur in the UI, as `[text, surface]`. */
+const PAIRS: readonly [string, string][] = [
+    // Rail section labels: `NAMESPACES`, `CONTROL DOMAINS`.
+    ['calm-redesign-faint-alt', 'calm-redesign-surface-alt'],
+    ['calm-redesign-faint-alt', 'calm-redesign-surface'],
+    ['calm-redesign-faint-alt', 'calm-bg-base'],
+    // Count badges on the namespace links and the segmented type tabs.
+    ['calm-redesign-muted-alt', 'calm-redesign-badge-bg'],
+    ['calm-redesign-muted-alt', 'calm-redesign-badge-bg-faint'],
+    ['calm-redesign-muted-alt', 'calm-bg-base'],
+    // Body copy and headings on the page and the diagram stage.
+    ['calm-redesign-muted', 'calm-bg-base'],
+    ['calm-redesign-body', 'calm-bg-base'],
+    ['calm-redesign-body', 'calm-redesign-surface'],
+    ['calm-redesign-body-alt', 'calm-bg-base'],
+    ['calm-redesign-ink', 'calm-bg-base'],
+    ['calm-redesign-ink', 'calm-redesign-canvas'],
+];
+
+/**
+ * Pulls the six-digit hex custom properties out of one theme block.
+ *
+ * The light block is everything before the dark selector, which keeps this
+ * honest about cascade order: a token redeclared later in the same block wins,
+ * and so does the last match here.
+ */
+function tokensFor(theme: 'light' | 'dark'): Record<string, string> {
+    const darkMatch = DARK_SELECTOR.exec(THEME_CSS);
+    if (!darkMatch) {
+        throw new Error(`theme.css no longer contains a ${DARK_SELECTOR} block`);
+    }
+    const darkStart = darkMatch.index;
+
+    const block = theme === 'dark' ? THEME_CSS.slice(darkStart) : THEME_CSS.slice(0, darkStart);
+    const tokens: Record<string, string> = {};
+    for (const match of block.matchAll(/--([\w-]+):\s*(#[0-9A-Fa-f]{6})\s*;/g)) {
+        tokens[match[1]] = match[2];
+    }
+    return tokens;
+}
+
+/** Relative luminance, per WCAG 2.x. */
+function luminance(hex: string): number {
+    const channels = [1, 3, 5].map((offset) => {
+        const value = parseInt(hex.slice(offset, offset + 2), 16) / 255;
+        return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(foreground: string, background: string): number {
+    const [lighter, darker] = [luminance(foreground), luminance(background)].sort((a, b) => b - a);
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe.each(['light', 'dark'] as const)('%s theme contrast', (theme) => {
+    const tokens = tokensFor(theme);
+
+    it.each(PAIRS)('%s on %s meets WCAG AA for normal text', (text, surface) => {
+        const foreground = tokens[text];
+        const background = tokens[surface];
+
+        // A renamed or deleted token would otherwise make this pass vacuously.
+        expect(foreground, `--${text} is not defined in the ${theme} theme`).toBeDefined();
+        expect(background, `--${surface} is not defined in the ${theme} theme`).toBeDefined();
+
+        const ratio = contrastRatio(foreground, background);
+        expect(ratio, `--${text} (${foreground}) on --${surface} (${background}) is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(
+            AA_NORMAL_TEXT
+        );
+    });
+});

--- a/calm-hub-ui/src/theme/contrast.test.ts
+++ b/calm-hub-ui/src/theme/contrast.test.ts
@@ -1,3 +1,10 @@
+// @vitest-environment node
+//
+// Runs under node, not jsdom, for the same reason as the sibling
+// `monaco-theme.test.ts`: this suite reads `theme.css` off disk through
+// `import.meta.url`, and under jsdom that is not a `file:` URL, so
+// `fileURLToPath` throws before a single pair is checked. Nothing here touches
+// the DOM.
 /**
  * Colour-contrast guard for the redesign text tokens.
  *
@@ -6,17 +13,20 @@
  * makes it checkable without a browser: read the two theme blocks out of
  * `theme.css`, resolve each pair, and compute the WCAG ratio.
  *
- * Every pair below is one that actually occurs in the UI. The threshold is 4.5:1
- * (WCAG 2.2 SC 1.4.3, AA) because all of this text is small: the rail section
- * labels are 10px and the count badges 11px, nowhere near the 18.66px bold /
- * 24px large-text exemption.
+ * Every pair below is one that actually occurs in the UI, added as the
+ * component using it is found. The list is written by hand rather than derived,
+ * so it grows with the UI instead of being exhaustive by construction.
+ *
+ * The threshold is 4.5:1 (WCAG 2.2 SC 1.4.3, AA) because all of this text is
+ * small: the rail section labels are 10px and the count badges 11px, nowhere
+ * near the 18.66px bold / 24px large-text exemption.
  *
  * The point is the pairing. A token that reads comfortably on the page
  * background can still fail on a badge, which is exactly how two of these were
  * missed.
  */
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -24,16 +34,12 @@ import { describe, expect, it } from 'vitest';
  *
  * Not `import './theme.css?raw'`: Vitest stubs the CSS transform by default, so
  * a raw import resolves to an empty string and every assertion below would pass
- * against nothing. Both candidate roots are tried because the suite runs from
- * the workspace directory but can be invoked from the repository root.
+ * against nothing. Resolved via `import.meta.url` rather than `process.cwd()`,
+ * same as the sibling `monaco-theme.test.ts`, so it works regardless of which
+ * directory the suite is invoked from.
  */
 function readThemeCss(): string {
-    const candidates = [join(process.cwd(), 'src/theme/theme.css'), join(process.cwd(), 'calm-hub-ui/src/theme/theme.css')];
-    const found = candidates.find((candidate) => existsSync(candidate));
-    if (!found) {
-        throw new Error(`Could not locate theme.css. Looked in: ${candidates.join(', ')}`);
-    }
-    return readFileSync(found, 'utf8');
+    return readFileSync(fileURLToPath(new URL('./theme.css', import.meta.url)), 'utf8');
 }
 
 const THEME_CSS = readThemeCss();
@@ -42,9 +48,9 @@ const THEME_CSS = readThemeCss();
 const AA_NORMAL_TEXT = 4.5;
 
 /**
- * The dark block's selector. Matched by pattern rather than as a literal because
- * this file is read through Vite's `?raw`, which returns the CSS after PostCSS
- * has normalised it, and PostCSS is free to change the attribute quoting.
+ * The dark block's selector. Matched by pattern rather than as a literal so that
+ * a change of attribute quoting in `theme.css` cannot silently split the file in
+ * the wrong place and leave every pair below checked against one theme twice.
  */
 const DARK_SELECTOR = /:root\[data-theme=['"]?dark['"]?\]/;
 
@@ -58,6 +64,8 @@ const PAIRS: readonly [string, string][] = [
     ['calm-redesign-muted-alt', 'calm-redesign-badge-bg'],
     ['calm-redesign-muted-alt', 'calm-redesign-badge-bg-faint'],
     ['calm-redesign-muted-alt', 'calm-bg-base'],
+    // The dropzone's format hint, on the resting dropzone panel.
+    ['calm-redesign-muted-alt', 'calm-redesign-surface'],
     // Body copy and headings on the page and the diagram stage.
     ['calm-redesign-muted', 'calm-bg-base'],
     ['calm-redesign-body', 'calm-bg-base'],

--- a/calm-hub-ui/src/theme/theme.css
+++ b/calm-hub-ui/src/theme/theme.css
@@ -82,9 +82,9 @@
     --calm-redesign-body: #41506A;
     --calm-redesign-body-alt: #475569;
     --calm-redesign-muted: #5A6678;
-    --calm-redesign-muted-alt: #64748B;
+    --calm-redesign-muted-alt: #5A6678; /* was #64748B, 4.23:1 on the badge bg */
     --calm-redesign-faint: #8A94A6;
-    --calm-redesign-faint-alt: #9AA6B8;
+    --calm-redesign-faint-alt: #64748B; /* was #9AA6B8, 2.46:1 on white */
     --calm-redesign-disabled: #B6BECC;
     --calm-redesign-active-text: #1D4ED8;
     --calm-interaction-text: #2563EB;
@@ -237,9 +237,9 @@
     --calm-redesign-body: #B6C2D4;
     --calm-redesign-body-alt: #94A3B8;
     --calm-redesign-muted: #94A3B8;
-    --calm-redesign-muted-alt: #8A94A6;
+    --calm-redesign-muted-alt: #A4ACBA; /* was #8A94A6, 3.39:1 on the badge bg */
     --calm-redesign-faint: #64748B;
-    --calm-redesign-faint-alt: #64748B;
+    --calm-redesign-faint-alt: #8A94A6; /* was #64748B, 3.07:1 on the rail surface */
     --calm-redesign-disabled: #475569;
     --calm-redesign-active-text: #93B4FF;
     --calm-interaction-text: #93B4FF;

--- a/calm-hub-ui/src/theme/theme.css
+++ b/calm-hub-ui/src/theme/theme.css
@@ -82,9 +82,9 @@
     --calm-redesign-body: #41506A;
     --calm-redesign-body-alt: #475569;
     --calm-redesign-muted: #5A6678;
-    --calm-redesign-muted-alt: #5A6678; /* was #64748B, 4.23:1 on the badge bg */
+    --calm-redesign-muted-alt: #5A6678;
     --calm-redesign-faint: #8A94A6;
-    --calm-redesign-faint-alt: #64748B; /* was #9AA6B8, 2.46:1 on white */
+    --calm-redesign-faint-alt: #64748B;
     --calm-redesign-disabled: #B6BECC;
     --calm-redesign-active-text: #1D4ED8;
     --calm-interaction-text: #2563EB;
@@ -237,9 +237,9 @@
     --calm-redesign-body: #B6C2D4;
     --calm-redesign-body-alt: #94A3B8;
     --calm-redesign-muted: #94A3B8;
-    --calm-redesign-muted-alt: #A4ACBA; /* was #8A94A6, 3.39:1 on the badge bg */
+    --calm-redesign-muted-alt: #A4ACBA;
     --calm-redesign-faint: #64748B;
-    --calm-redesign-faint-alt: #8A94A6; /* was #64748B, 3.07:1 on the rail surface */
+    --calm-redesign-faint-alt: #8A94A6;
     --calm-redesign-disabled: #475569;
     --calm-redesign-active-text: #93B4FF;
     --calm-interaction-text: #93B4FF;

--- a/calm-hub-ui/src/theme/theme.css
+++ b/calm-hub-ui/src/theme/theme.css
@@ -81,8 +81,8 @@
     --calm-redesign-body-strong: #0F172A;
     --calm-redesign-body: #41506A;
     --calm-redesign-body-alt: #475569;
-    --calm-redesign-muted: #5A6678;
-    --calm-redesign-muted-alt: #5A6678;
+    --calm-redesign-muted: #515F75;
+    --calm-redesign-muted-alt: #5A697F;
     --calm-redesign-faint: #8A94A6;
     --calm-redesign-faint-alt: #64748B;
     --calm-redesign-disabled: #B6BECC;


### PR DESCRIPTION
Addresses the contrast findings in #2929 (finding 1, and the dark-theme half of finding 2's surface set). The keyboard, combobox and `autoFocus` findings are untouched, to keep this reviewable.

## The failures

Two redesign text tokens sit below the 4.5:1 that WCAG 2.2 SC 1.4.3 requires for normal text, in both themes. The text they colour is 10px (rail section labels) and 11px (count badges), so the 18.66px bold / 24px large-text exemption does not apply.

| Theme | Token | Value | Worst surface | Ratio |
|---|---|---|---|---|
| light | `--calm-redesign-faint-alt` | `#9AA6B8` | `--calm-redesign-surface` `#F8FAFC` | **2.36:1** |
| light | `--calm-redesign-muted-alt` | `#64748B` | `--calm-redesign-badge-bg` `#EEF2F7` | **4.23:1** |
| dark | `--calm-redesign-faint-alt` | `#64748B` | `--calm-redesign-surface` `#1E293B` | **3.07:1** |
| dark | `--calm-redesign-muted-alt` | `#8A94A6` | `--calm-redesign-badge-bg` `#334155` | **3.39:1** |

I reproduced all six ratios in the issue exactly. Two further pairings turned up that the audit did not list, both from the same two tokens: `faint-alt` on `--calm-redesign-surface` (`#F8FAFC`) at 2.36:1, and `muted-alt` on `--calm-redesign-badge-bg-faint` (`#F4F6F9`) at 4.40:1. Nine assertions fail in total against the current palette.

## The fix

Each token moves to the next step that clears AA against every surface it is actually used on, keeping the same hue:

| | before | after | worst ratio after |
|---|---|---|---|
| light `faint-alt` | `#9AA6B8` | `#64748B` | 4.55:1 |
| light `muted-alt` | `#64748B` | `#5A6678` | 5.18:1 |
| dark `faint-alt` | `#64748B` | `#8A94A6` | 4.78:1 |
| dark `muted-alt` | `#8A94A6` | `#A4ACBA` | 4.53:1 |

Three of the four reuse a value already in the palette. Only the dark badge text needed a new one, and `#A4ACBA` is the minimum that clears 4.5:1 on `#334155` rather than a jump to slate-300 `#CBD5E1`, which would have brightened all dark-mode meta text noticeably.

## What this costs, which is your call not mine

The five-step text scale does not survive AA in light mode, and you should decide what to do about that rather than inherit my answer.

Above white, 4.5:1 permits nothing lighter than roughly slate-500. `faint-alt` therefore lands on `#64748B`, which is what `muted-alt` used to be, and `muted-alt` lands on `#5A6678`, which is what `muted` already is. So `muted` and `muted-alt` now hold the same value in light mode, and the intended `muted > mutedAlt > faintAlt` gradation is two steps rather than three.

That is inherent to the palette rather than to these hexes: the scale has more faint steps than AA allows for small text on a near-white background. Options as I see them, and I am happy to redo this as whichever you prefer:

1. Take this as-is and accept the collapse, then re-space the scale separately.
2. Re-space now, so the remaining steps are visually distinct at AA.
3. Keep the faint tier light and stop using it for text, giving those labels a different role.

One related note: `--calm-redesign-faint` fails on both themes too (3.06:1 light, 3.07:1 dark), but `colors.redesign.faint` has no consumers anywhere in `src`, so there is no live failure and I left it alone rather than widen the diff. It is a trap for whoever adopts it first. Say the word and I will include it.

## The test

The issue notes there is no a11y lint or CI gate. `contrast.test.ts` is a narrow first piece of that: it parses the two theme blocks out of `theme.css`, resolves each token pair that occurs in the UI, and asserts the WCAG ratio. No browser or axe run needed, so it costs nothing in CI.

The pairing is the point. `muted-alt` reads fine on the page background and still failed at 4.23:1 inside a badge, which is exactly the case a per-token review misses.

Two implementation notes for review. It reads `theme.css` off disk rather than via `import './theme.css?raw'`, because Vitest stubs the CSS transform by default and the raw import resolves to an empty string, which would have made every assertion pass against nothing. And it asserts both tokens are defined before comparing, so a rename cannot turn the test green by making both sides `undefined`.

## Verification

Run in a clean `node:26-bookworm` container:

- `npm run test --workspace calm-hub-ui`: 116 files, 1419 tests, all passing (1395 before, plus the 24 new assertions).
- `npm run lint --workspace calm-hub-ui` (eslint + stylelint): passing.
- The new test is not vacuous. Reverting `theme.css` to the current values turns it red with **9** failures, each naming the pair and the measured ratio, and every one of the issue's six numbers appears among them.

One thing worth flagging for anyone running the suite locally: `DiagramSection.test.tsx` fails to resolve `@finos/calm-models/diff` unless `npm run build --workspace calm-models` has been run first. That is pre-existing on `main` and unrelated to this change. I confirmed it by stashing my changes and reproducing it on a clean tree.

What I have not done is view these colours in a running browser. The ratios are computed from the token values, which is exactly what axe measures, but the judgement about whether the new light-mode greys still look right is yours.
