### PR TITLE
feat(calm-hub): expose customId on resources and use in UI when present

### DIFF
--- a/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.test.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.test.ts
@@ -65,7 +65,7 @@ describe('useNamespaceItems', () => {
         ]);
     });
 
-    it('labels ADRs with title and status, and keeps numeric interface ids', async () => {
+    it('labels ADRs with title and status, and falls back to numeric interface ids', async () => {
         const { result } = renderHook(() => useNamespaceItems('traderx'));
         await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -77,6 +77,28 @@ describe('useNamespaceItems', () => {
             id: '7',
             name: 'My Interface',
             description: 'A port',
+        });
+        expect(interfaces?.items[0].customId).toBeUndefined();
+    });
+
+    it('prefers the customId over the numeric id for interfaces that have one', async () => {
+        const { InterfaceService } = await import('../../../service/interface-service.js');
+        vi.mocked(InterfaceService).mockImplementationOnce(function (this: unknown) {
+            return {
+                fetchInterfacesForNamespace: vi.fn().mockResolvedValue([
+                    { id: 7, name: 'My Interface', description: 'A port', customId: 'my-interface' },
+                ]),
+            } as unknown as InstanceType<typeof InterfaceService>;
+        });
+
+        const { result } = renderHook(() => useNamespaceItems('traderx'));
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const interfaces = result.current.groups.find((g) => g.type === 'Interfaces');
+        expect(interfaces?.items[0]).toMatchObject({
+            id: 'my-interface',
+            name: 'My Interface',
+            customId: 'my-interface',
         });
     });
 });

--- a/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
+++ b/calm-hub-ui/src/hub/components/namespace-page/useNamespaceItems.ts
@@ -69,9 +69,10 @@ export function useNamespaceItems(namespace: string): { groups: NamespaceItemGro
                 {
                     type: 'Interfaces',
                     items: interfaces.map((i) => ({
-                        id: i.id.toString(),
+                        id: i.customId ?? i.id.toString(),
                         name: i.name,
                         description: i.description,
+                        customId: i.customId,
                     })),
                 },
             ]);

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.test.tsx
@@ -94,6 +94,21 @@ describe('useResourceFromRoute', () => {
         });
     });
 
+    it('loads an interface via onInterfaceLoad when the slug matches', async () => {
+        fetchInterfacesForNamespace.mockResolvedValue([
+            { id: 7, name: 'My Interface', description: 'desc', customId: 'my-interface' },
+        ]);
+        renderAt('/traderx/interfaces/my-interface/detail');
+        await waitFor(() => {
+            expect(callbacks.onInterfaceLoad).toHaveBeenCalledWith({
+                namespace: 'traderx',
+                interfaceId: 7,
+                interfaceName: 'My Interface',
+                interfaceDescription: 'desc',
+            });
+        });
+    });
+
     it('loads a control via onControlLoad when the id matches', async () => {
         fetchControlsForDomain.mockResolvedValue([{ id: 5, name: 'Encryption', description: 'desc' }]);
         renderAt('/security/controls/5/detail');

--- a/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
+++ b/calm-hub-ui/src/hub/hooks/useResourceFromRoute.ts
@@ -93,7 +93,11 @@ export function useResourceFromRoute({
                 .fetchInterfacesForNamespace(namespace)
                 .then((interfaces) => {
                     if (cancelled) return;
-                    const match = interfaces.find((i) => i.id === Number(params.id));
+                    // Interfaces are deep-linked both by numeric id and by customId (the namespace
+                    // browse page prefers the customId when one exists), so match either.
+                    const match = interfaces.find(
+                        (i) => i.id === Number(params.id) || i.customId === params.id
+                    );
                     if (match) {
                         onInterfaceLoadRef.current({
                             namespace,

--- a/calm-hub-ui/src/model/interface.ts
+++ b/calm-hub-ui/src/model/interface.ts
@@ -5,6 +5,7 @@ export interface InterfaceDetail {
     id: number;
     name: string;
     description: string;
+    customId?: string;
 }
 
 /**

--- a/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoMappingControllerIntegration.java
@@ -465,4 +465,37 @@ public class MongoMappingControllerIntegration {
                 .statusCode(200)
                 .body(containsString("Repo Pattern"));
     }
+
+    @Test
+    @Order(35)
+    void numeric_pattern_listing_carries_the_custom_id_for_patterns_created_by_name() {
+        // Relies on the ordered tests above having created these through the name-based API.
+        given()
+                .when().get("/api/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.customId", hasItems("test-pattern", "repo"))
+                .body("values.find { it.customId == 'test-pattern' }.id", notNullValue());
+    }
+
+    @Test
+    @Order(36)
+    void numeric_pattern_listing_omits_the_custom_id_for_a_pattern_created_by_the_numeric_api() {
+        // Created through /api/calm, which writes no mapping — so it has no customId to report.
+        String location = given()
+                .body("{\"name\": \"Unmapped Pattern\", \"description\": \"No custom ID\", \"patternJson\": \"{}\"}")
+                .header("Content-Type", "application/json")
+                .when().post("/api/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location");
+        int id = Integer.parseInt(location.replaceAll(".*/patterns/(\\d+)/.*", "$1"));
+
+        given()
+                .when().get("/api/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values.find { it.id == " + id + " }.customId", nullValue());
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/CustomIdentifiable.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/CustomIdentifiable.java
@@ -1,0 +1,16 @@
+package org.finos.calm.domain;
+
+/**
+ * Implemented by namespace listing summaries so {@code CustomIdEnrichmentService} can resolve
+ * the custom ID for any of them through one code path — the listing endpoints return two unrelated
+ * summary types with no common supertype of their own.
+ */
+public interface CustomIdentifiable {
+
+    /** Read-only: the numeric ID is minted by the counter store when the summary is built. */
+    Integer getId();
+
+    String getCustomId();
+
+    void setCustomId(String customId);
+}

--- a/calm-hub/src/main/java/org/finos/calm/domain/interfaces/NamespaceInterfaceSummary.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/interfaces/NamespaceInterfaceSummary.java
@@ -1,14 +1,16 @@
 package org.finos.calm.domain.interfaces;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.finos.calm.domain.CustomIdentifiable;
 
 import java.util.Objects;
 
 @RegisterForReflection
-public class NamespaceInterfaceSummary {
+public class NamespaceInterfaceSummary implements CustomIdentifiable {
     private String name;
     private String description;
     private Integer id;
+    private String customId;
 
     public NamespaceInterfaceSummary(String name, String description, Integer id) {
         this.name = name;
@@ -32,6 +34,7 @@ public class NamespaceInterfaceSummary {
         this.description = description;
     }
 
+    @Override
     public Integer getId() {
         return id;
     }
@@ -41,14 +44,24 @@ public class NamespaceInterfaceSummary {
     }
 
     @Override
+    public String getCustomId() {
+        return customId;
+    }
+
+    @Override
+    public void setCustomId(String customId) {
+        this.customId = customId;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         NamespaceInterfaceSummary that = (NamespaceInterfaceSummary) o;
-        return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(id, that.id);
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(id, that.id) && Objects.equals(customId, that.customId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, id);
+        return Objects.hash(name, description, id, customId);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/namespaces/NamespaceResourceSummary.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/namespaces/NamespaceResourceSummary.java
@@ -1,15 +1,17 @@
 package org.finos.calm.domain.namespaces;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.finos.calm.domain.CustomIdentifiable;
 
 import java.util.Objects;
 
 @RegisterForReflection
-public class NamespaceResourceSummary {
+public class NamespaceResourceSummary implements CustomIdentifiable {
     private String name;
     private String description;
     private Integer id;
     private int versionCount;
+    private String customId;
 
     public NamespaceResourceSummary(String name, String description, Integer id, int versionCount) {
         this.name = name;
@@ -34,6 +36,7 @@ public class NamespaceResourceSummary {
         this.description = description;
     }
 
+    @Override
     public Integer getId() {
         return id;
     }
@@ -47,14 +50,24 @@ public class NamespaceResourceSummary {
     }
 
     @Override
+    public String getCustomId() {
+        return customId;
+    }
+
+    @Override
+    public void setCustomId(String customId) {
+        this.customId = customId;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         NamespaceResourceSummary that = (NamespaceResourceSummary) o;
-        return versionCount == that.versionCount && Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(id, that.id);
+        return versionCount == that.versionCount && Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(id, that.id) && Objects.equals(customId, that.customId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, id, versionCount);
+        return Objects.hash(name, description, id, versionCount, customId);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.Architecture;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.architecture.ArchitectureRequest;
 import org.finos.calm.domain.exception.ArchitectureNotFoundException;
@@ -29,6 +30,7 @@ import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.ArchitectureTimelineService;
+import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.ArchitectureStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,7 @@ public class ArchitectureResource {
 
     private final ArchitectureStore store;
     private final ArchitectureTimelineService timelineService;
+    private final CustomIdEnrichmentService customIds;
 
     private final Logger logger = LoggerFactory.getLogger(ArchitectureResource.class);
 
@@ -60,9 +63,11 @@ public class ArchitectureResource {
     Boolean allowPutOperations;
 
     @Inject
-    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService) {
+    public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService,
+                                CustomIdEnrichmentService customIds) {
         this.store = store;
         this.timelineService = timelineService;
+        this.customIds = customIds;
     }
 
     /**
@@ -86,7 +91,8 @@ public class ArchitectureResource {
             @Valid @BeanParam PaginationQueryParams page
     ) {
         try {
-            return Response.ok(new ValueWrapper<>(store.getArchitecturesForNamespace(namespace, page.toPageRequest()))).build();
+            return Response.ok(new ValueWrapper<>(customIds.enrich(namespace, ResourceType.ARCHITECTURE,
+                    store.getArchitecturesForNamespace(namespace, page.toPageRequest())))).build();
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving architectures", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);

--- a/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.Flow;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
@@ -20,6 +21,7 @@ import org.finos.calm.domain.exception.FlowVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.FlowStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,7 @@ import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX
 public class FlowResource {
 
     private final FlowStore store;
+    private final CustomIdEnrichmentService customIds;
 
     private final Logger logger = LoggerFactory.getLogger(FlowResource.class);
 
@@ -46,8 +49,9 @@ public class FlowResource {
     Boolean allowPutOperations;
 
     @Inject
-    public FlowResource(FlowStore store) {
+    public FlowResource(FlowStore store, CustomIdEnrichmentService customIds) {
         this.store = store;
+        this.customIds = customIds;
     }
 
     @GET
@@ -62,7 +66,8 @@ public class FlowResource {
             @PathParam("namespace") @Pattern(regexp= NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace
     ) {
         try {
-            return Response.ok(new ValueWrapper<>(store.getFlowsForNamespace(namespace))).build();
+            return Response.ok(new ValueWrapper<>(customIds.enrich(namespace, ResourceType.FLOW,
+                    store.getFlowsForNamespace(namespace)))).build();
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving flows", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);

--- a/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.CalmInterface;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
@@ -18,6 +19,7 @@ import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.InterfaceStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,12 +34,14 @@ import static org.finos.calm.resources.ResourceValidationConstants.*;
 public class InterfaceResource {
 
     private final InterfaceStore interfaceStore;
+    private final CustomIdEnrichmentService customIds;
 
     private final Logger logger = LoggerFactory.getLogger(InterfaceResource.class);
 
     @Inject
-    public InterfaceResource(InterfaceStore interfaceStore) {
+    public InterfaceResource(InterfaceStore interfaceStore, CustomIdEnrichmentService customIds) {
         this.interfaceStore = interfaceStore;
+        this.customIds = customIds;
     }
 
     @GET
@@ -48,7 +52,8 @@ public class InterfaceResource {
             @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace
     ) {
         try {
-            return Response.ok(new ValueWrapper<>(interfaceStore.getInterfacesForNamespace(namespace))).build();
+            return Response.ok(new ValueWrapper<>(customIds.enrich(namespace, ResourceType.INTERFACE,
+                    interfaceStore.getInterfacesForNamespace(namespace)))).build();
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving interfaces", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.finos.calm.domain.Pattern;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
@@ -19,6 +20,7 @@ import org.finos.calm.domain.exception.PatternVersionExistsException;
 import org.finos.calm.domain.exception.PatternVersionNotFoundException;
 import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.PatternStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,7 @@ import static org.finos.calm.resources.ResourceValidationConstants.VERSION_REGEX
 public class PatternResource {
 
     private final PatternStore store;
+    private final CustomIdEnrichmentService customIds;
 
     private final Logger logger = LoggerFactory.getLogger(PatternResource.class);
 
@@ -44,8 +47,9 @@ public class PatternResource {
     Boolean allowPutOperations;
 
     @Inject
-    public PatternResource(PatternStore store) {
+    public PatternResource(PatternStore store, CustomIdEnrichmentService customIds) {
         this.store = store;
+        this.customIds = customIds;
     }
 
     @GET
@@ -63,7 +67,8 @@ public class PatternResource {
             @Valid @BeanParam PaginationQueryParams page
     ) {
         try {
-            return Response.ok(new ValueWrapper<>(store.getPatternsForNamespace(namespace, page.toPageRequest()))).build();
+            return Response.ok(new ValueWrapper<>(customIds.enrich(namespace, ResourceType.PATTERN,
+                    store.getPatternsForNamespace(namespace, page.toPageRequest())))).build();
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving patterns", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);

--- a/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.ValueWrapper;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
@@ -14,6 +15,7 @@ import org.finos.calm.domain.exception.StandardVersionExistsException;
 import org.finos.calm.domain.exception.StandardVersionNotFoundException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.security.CalmHubScopes;
+import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.StandardStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,11 +30,13 @@ import static org.finos.calm.resources.ResourceValidationConstants.*;
 public class StandardResource {
 
     private final StandardStore standardStore;
+    private final CustomIdEnrichmentService customIds;
 
     private final Logger logger = LoggerFactory.getLogger(StandardResource.class);
 
-    public StandardResource(StandardStore standardStore) {
+    public StandardResource(StandardStore standardStore, CustomIdEnrichmentService customIds) {
         this.standardStore = standardStore;
+        this.customIds = customIds;
     }
 
     @GET
@@ -43,7 +47,8 @@ public class StandardResource {
             @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace
     ) {
         try {
-            return Response.ok(new ValueWrapper<>(standardStore.getStandardsForNamespace(namespace))).build();
+            return Response.ok(new ValueWrapper<>(customIds.enrich(namespace, ResourceType.STANDARD,
+                    standardStore.getStandardsForNamespace(namespace)))).build();
         } catch (NamespaceNotFoundException e) {
             logger.error("Invalid namespace [{}] when retrieving architectures", namespace, e);
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);

--- a/calm-hub/src/main/java/org/finos/calm/services/CustomIdEnrichmentService.java
+++ b/calm-hub/src/main/java/org/finos/calm/services/CustomIdEnrichmentService.java
@@ -1,0 +1,90 @@
+package org.finos.calm.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.finos.calm.domain.CustomIdentifiable;
+import org.finos.calm.domain.ResourceMapping;
+import org.finos.calm.domain.ResourceType;
+import org.finos.calm.store.ResourceMappingStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.finos.calm.resources.ResourceValidationConstants.STRICT_SANITIZATION_POLICY;
+
+/**
+ * Resolves the human-readable {@code customId} held in {@code resource_mappings} for a page of
+ * namespace listing summaries, so a caller can link a resource by custom ID without a second
+ * round trip per item.
+ *
+ * <p>A custom ID exists only for resources written through the name-based ({@code /calm}) API, so a
+ * listing is normally a mix of mapped and unmapped resources. Enrichment is therefore a display
+ * affordance, not a correctness requirement — see {@link #enrich}.</p>
+ */
+@ApplicationScoped
+public class CustomIdEnrichmentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CustomIdEnrichmentService.class);
+
+    private final ResourceMappingStore mappingStore;
+
+    @Inject
+    public CustomIdEnrichmentService(ResourceMappingStore mappingStore) {
+        this.mappingStore = mappingStore;
+    }
+
+    /**
+     * Writes the resolved custom ID onto each summary that has a mapping, via one batched lookup
+     * against the {@code (namespace, resourceType, numericId)} index rather than a query per
+     * summary. Mutates and returns the list it was given.
+     *
+     * <p>A failure resolving the mappings is logged and swallowed: the numeric IDs are already
+     * complete, so losing a custom ID degrades a link to its numeric form rather than breaking the
+     * listing.</p>
+     */
+    public <T extends CustomIdentifiable> List<T> enrich(String namespace, ResourceType type, List<T> summaries) {
+        if (summaries == null || summaries.isEmpty()) {
+            return summaries;
+        }
+
+        List<Integer> numericIds = summaries.stream()
+                .map(CustomIdentifiable::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (numericIds.isEmpty()) {
+            return summaries;
+        }
+
+        try {
+            // Only (namespace, resourceType, customId) is unique, so two custom IDs may point at the
+            // same numeric ID — collapse on collision rather than letting toMap throw. A mapping
+            // document with no customId at all is dropped for the same reason: toMap rejects a null
+            // value, and one malformed row must not cost the whole page its custom IDs.
+            Map<Integer, String> customIdsByNumericId = mappingStore
+                    .listMappingsByNumericIds(namespace, type, numericIds)
+                    .stream()
+                    .filter(mapping -> mapping.getCustomId() != null)
+                    .collect(Collectors.toMap(
+                            ResourceMapping::getNumericId,
+                            ResourceMapping::getCustomId,
+                            (first, second) -> first));
+
+            for (T summary : summaries) {
+                String customId = customIdsByNumericId.get(summary.getId());
+                if (customId != null) {
+                    summary.setCustomId(customId);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not resolve custom IDs for [{}] in namespace [{}]; returning numeric IDs only",
+                    type, STRICT_SANITIZATION_POLICY.sanitize(namespace), e);
+        }
+
+        return summaries;
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
@@ -14,6 +14,7 @@ import org.finos.calm.domain.exception.ArchitectureVersionExistsException;
 import org.finos.calm.domain.exception.ArchitectureVersionNotFoundException;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.store.ArchitectureStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.TimelineStore;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ public class TestArchitectureResourceShould {
     private static final String TEST_DESCRIPTION = "test description";
     @InjectMock
     ArchitectureStore mockArchitectureStore;
+
+    @InjectMock
+    ResourceMappingStore mockResourceMappingStore;
 
     @InjectMock
     TimelineStore mockTimelineStore;

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
@@ -12,6 +12,7 @@ import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.FlowStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,6 +36,9 @@ public class TestFlowResourceShould {
 
     @InjectMock
     FlowStore mockFlowStore;
+
+    @InjectMock
+    ResourceMappingStore mockResourceMappingStore;
 
     @Test
     void return_a_404_when_an_invalid_namespace_is_provided_on_get_flows() throws NamespaceNotFoundException {

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
@@ -7,6 +7,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.CalmInterface;
+import org.finos.calm.domain.ResourceMapping;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.InterfaceNotFoundException;
 import org.finos.calm.domain.exception.InterfaceVersionExistsException;
 import org.finos.calm.domain.exception.InterfaceVersionNotFoundException;
@@ -15,6 +17,7 @@ import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
 import org.finos.calm.store.InterfaceStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +34,7 @@ import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MES
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -41,6 +45,9 @@ public class TestInterfaceResourceShould {
 
     @InjectMock
     InterfaceStore mockInterfaceStore;
+
+    @InjectMock
+    ResourceMappingStore mockResourceMappingStore;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -93,6 +100,29 @@ public class TestInterfaceResourceShould {
                 .body("values[1].description", equalTo("HTTP URL Interface"));
 
         verify(mockInterfaceStore).getInterfacesForNamespace("valid");
+    }
+
+    @Test
+    void include_the_custom_id_on_interface_summaries_that_have_a_mapping() throws Exception {
+        when(mockInterfaceStore.getInterfacesForNamespace("valid"))
+                .thenReturn(List.of(this.tcpInterfaceSummary, this.httpInterfaceSummary));
+        when(mockResourceMappingStore.listMappingsByNumericIds("valid", ResourceType.INTERFACE, List.of(1, 2)))
+                .thenReturn(List.of(new ResourceMapping.ResourceMappingBuilder()
+                        .setNamespace("valid")
+                        .setCustomId("tcp-port")
+                        .setResourceType(ResourceType.INTERFACE)
+                        .setNumericId(1)
+                        .build()));
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/valid/interfaces")
+                .then()
+                .statusCode(200)
+                .body("values[0].id", equalTo(1))
+                .body("values[0].customId", equalTo("tcp-port"))
+                .body("values[1].id", equalTo(2))
+                .body("values[1].customId", nullValue());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
@@ -5,6 +5,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Pattern;
+import org.finos.calm.domain.ResourceMapping;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.PatternNotFoundException;
 import org.finos.calm.domain.exception.PatternVersionExistsException;
@@ -13,6 +15,7 @@ import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.PageRequest;
 import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +34,9 @@ import static org.finos.calm.resources.ResourceValidationConstants.OFFSET_MESSAG
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -42,6 +47,9 @@ public class TestPatternResourceShould {
 
     @InjectMock
     PatternStore mockPatternStore;
+
+    @InjectMock
+    ResourceMappingStore mockResourceMappingStore;
 
     @Test
     void return_a_404_when_an_invalid_namespace_is_provided_on_get_patterns() throws NamespaceNotFoundException {
@@ -89,6 +97,49 @@ public class TestPatternResourceShould {
                 .body("values[1].versionCount", equalTo(1));
 
         verify(mockPatternStore, times(1)).getPatternsForNamespace("finos", PageRequest.UNPAGED);
+    }
+
+    @Test
+    void include_the_custom_id_on_pattern_summaries_that_have_a_mapping() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("Pattern One", "First", 12345, 3),
+                new NamespaceResourceSummary("Pattern Two", "Second", 54321, 1)
+        );
+        when(mockPatternStore.getPatternsForNamespace(anyString(), any())).thenReturn(summaries);
+        when(mockResourceMappingStore.listMappingsByNumericIds("finos", ResourceType.PATTERN, List.of(12345, 54321)))
+                .thenReturn(List.of(new ResourceMapping.ResourceMappingBuilder()
+                        .setNamespace("finos")
+                        .setCustomId("api-gateway-pattern")
+                        .setResourceType(ResourceType.PATTERN)
+                        .setNumericId(12345)
+                        .build()));
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values[0].id", equalTo(12345))
+                .body("values[0].customId", equalTo("api-gateway-pattern"))
+                .body("values[1].id", equalTo(54321))
+                .body("values[1].customId", nullValue());
+    }
+
+    @Test
+    void still_return_pattern_summaries_when_the_custom_id_lookup_fails() throws Exception {
+        when(mockPatternStore.getPatternsForNamespace(anyString(), any()))
+                .thenReturn(List.of(new NamespaceResourceSummary("Pattern One", "First", 12345, 3)));
+        when(mockResourceMappingStore.listMappingsByNumericIds(anyString(), any(), anyList()))
+                .thenThrow(new IllegalStateException("mapping collection unavailable"));
+
+        given()
+                .when()
+                .get("/api/calm/namespaces/finos/patterns")
+                .then()
+                .statusCode(200)
+                .body("values[0].name", equalTo("Pattern One"))
+                .body("values[0].id", equalTo(12345))
+                .body("values[0].customId", nullValue());
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
@@ -14,6 +14,7 @@ import org.finos.calm.domain.exception.StorageWriteException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.store.StandardStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,9 @@ public class TestStandardResourceShould {
 
     @InjectMock
     StandardStore mockStandardStore;
+
+    @InjectMock
+    ResourceMappingStore mockResourceMappingStore;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/calm-hub/src/test/java/org/finos/calm/services/TestCustomIdEnrichmentServiceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/services/TestCustomIdEnrichmentServiceShould.java
@@ -1,0 +1,215 @@
+package org.finos.calm.services;
+
+import org.finos.calm.domain.ResourceMapping;
+import org.finos.calm.domain.ResourceType;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.domain.interfaces.NamespaceInterfaceSummary;
+import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
+import org.finos.calm.store.ResourceMappingStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestCustomIdEnrichmentServiceShould {
+
+    private static final String NAMESPACE = "finos";
+
+    @Mock
+    ResourceMappingStore mappingStore;
+
+    private CustomIdEnrichmentService service;
+
+    @BeforeEach
+    void setup() {
+        service = new CustomIdEnrichmentService(mappingStore);
+    }
+
+    private static ResourceMapping mapping(String customId, ResourceType type, int numericId) {
+        return new ResourceMapping.ResourceMappingBuilder()
+                .setNamespace(NAMESPACE)
+                .setCustomId(customId)
+                .setResourceType(type)
+                .setNumericId(numericId)
+                .build();
+    }
+
+    @Test
+    void set_the_custom_id_on_every_summary_that_has_a_mapping() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("Sample Architecture", "First", 1, 3),
+                new NamespaceResourceSummary("TraderX", "Second", 3, 1)
+        );
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.ARCHITECTURE, List.of(1, 3)))
+                .thenReturn(List.of(
+                        mapping("sample-architecture", ResourceType.ARCHITECTURE, 1),
+                        mapping("traderx", ResourceType.ARCHITECTURE, 3)));
+
+        List<NamespaceResourceSummary> enriched =
+                service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        assertEquals("sample-architecture", enriched.get(0).getCustomId());
+        assertEquals("traderx", enriched.get(1).getCustomId());
+    }
+
+    @Test
+    void leave_the_custom_id_null_for_a_summary_with_no_mapping() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("Mapped", "Has a custom ID", 1, 1),
+                new NamespaceResourceSummary("Unmapped", "Created via the numeric API", 2, 1)
+        );
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.PATTERN, List.of(1, 2)))
+                .thenReturn(List.of(mapping("api-gateway-pattern", ResourceType.PATTERN, 1)));
+
+        service.enrich(NAMESPACE, ResourceType.PATTERN, summaries);
+
+        assertEquals("api-gateway-pattern", summaries.get(0).getCustomId());
+        assertNull(summaries.get(1).getCustomId());
+    }
+
+    @Test
+    void enrich_interface_summaries_through_the_same_path() throws Exception {
+        List<NamespaceInterfaceSummary> summaries =
+                List.of(new NamespaceInterfaceSummary("Host Port", "A host/port interface", 7));
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.INTERFACE, List.of(7)))
+                .thenReturn(List.of(mapping("host-port", ResourceType.INTERFACE, 7)));
+
+        service.enrich(NAMESPACE, ResourceType.INTERFACE, summaries);
+
+        assertEquals("host-port", summaries.get(0).getCustomId());
+    }
+
+    @Test
+    void keep_the_first_custom_id_when_two_map_to_the_same_numeric_id() throws Exception {
+        List<NamespaceResourceSummary> summaries =
+                List.of(new NamespaceResourceSummary("Sample", "Aliased", 1, 1));
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.ARCHITECTURE, List.of(1)))
+                .thenReturn(List.of(
+                        mapping("first-custom-id", ResourceType.ARCHITECTURE, 1),
+                        mapping("second-custom-id", ResourceType.ARCHITECTURE, 1)));
+
+        service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        assertEquals("first-custom-id", summaries.get(0).getCustomId());
+    }
+
+    @Test
+    void skip_a_mapping_with_no_custom_id_without_losing_the_rest_of_the_page() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("Malformed", "Mapping row with no customId", 1, 1),
+                new NamespaceResourceSummary("Fine", "Ordinary mapping", 2, 1)
+        );
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.ARCHITECTURE, List.of(1, 2)))
+                .thenReturn(List.of(
+                        mapping(null, ResourceType.ARCHITECTURE, 1),
+                        mapping("fine", ResourceType.ARCHITECTURE, 2)));
+
+        service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        assertNull(summaries.get(0).getCustomId());
+        assertEquals("fine", summaries.get(1).getCustomId());
+    }
+
+    @Test
+    void not_query_the_mapping_store_for_an_empty_list() throws Exception {
+        List<NamespaceResourceSummary> summaries = List.of();
+
+        assertSame(summaries, service.enrich(NAMESPACE, ResourceType.FLOW, summaries));
+
+        verifyNoInteractions(mappingStore);
+    }
+
+    @Test
+    void return_null_unchanged_when_given_null() {
+        assertNull(service.enrich(NAMESPACE, ResourceType.FLOW, null));
+
+        verifyNoInteractions(mappingStore);
+    }
+
+    @Test
+    void not_query_the_mapping_store_when_every_summary_has_a_null_id() throws Exception {
+        List<NamespaceResourceSummary> summaries =
+                List.of(new NamespaceResourceSummary("No ID", "Unstored", null, 0));
+
+        service.enrich(NAMESPACE, ResourceType.STANDARD, summaries);
+
+        verify(mappingStore, never()).listMappingsByNumericIds(anyString(), any(), anyList());
+        assertNull(summaries.get(0).getCustomId());
+    }
+
+    @Test
+    void omit_null_ids_from_the_lookup_but_still_enrich_the_rest() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("No ID", "Unstored", null, 0),
+                new NamespaceResourceSummary("Has ID", "Stored", 4, 1)
+        );
+        when(mappingStore.listMappingsByNumericIds(NAMESPACE, ResourceType.STANDARD, List.of(4)))
+                .thenReturn(List.of(mapping("a-standard", ResourceType.STANDARD, 4)));
+
+        service.enrich(NAMESPACE, ResourceType.STANDARD, summaries);
+
+        assertNull(summaries.get(0).getCustomId());
+        assertEquals("a-standard", summaries.get(1).getCustomId());
+    }
+
+    @Test
+    void return_summaries_unenriched_when_the_mapping_store_reports_an_unknown_namespace() throws Exception {
+        List<NamespaceResourceSummary> summaries =
+                new ArrayList<>(List.of(new NamespaceResourceSummary("Sample", "First", 1, 1)));
+        when(mappingStore.listMappingsByNumericIds(anyString(), any(), anyList()))
+                .thenThrow(new NamespaceNotFoundException());
+
+        List<NamespaceResourceSummary> enriched =
+                service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        assertSame(summaries, enriched);
+        assertNull(enriched.get(0).getCustomId());
+    }
+
+    @Test
+    void return_summaries_unenriched_when_the_mapping_store_throws_at_runtime() throws Exception {
+        List<NamespaceResourceSummary> summaries =
+                new ArrayList<>(List.of(new NamespaceResourceSummary("Sample", "First", 1, 1)));
+        when(mappingStore.listMappingsByNumericIds(anyString(), any(), anyList()))
+                .thenThrow(new IllegalStateException("mapping collection unavailable"));
+
+        List<NamespaceResourceSummary> enriched =
+                service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        assertSame(summaries, enriched);
+        assertNull(enriched.get(0).getCustomId());
+    }
+
+    @Test
+    void query_the_mapping_store_once_for_the_whole_page() throws Exception {
+        List<NamespaceResourceSummary> summaries = Arrays.asList(
+                new NamespaceResourceSummary("One", "First", 1, 1),
+                new NamespaceResourceSummary("Two", "Second", 2, 1),
+                new NamespaceResourceSummary("Three", "Third", 3, 1)
+        );
+        when(mappingStore.listMappingsByNumericIds(anyString(), any(), anyList())).thenReturn(List.of());
+
+        service.enrich(NAMESPACE, ResourceType.ARCHITECTURE, summaries);
+
+        verify(mappingStore).listMappingsByNumericIds(
+                eq(NAMESPACE), eq(ResourceType.ARCHITECTURE), eq(List.of(1, 2, 3)));
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,7 +1189,7 @@
         },
         "cli": {
             "name": "@finos/calm-cli",
-            "version": "1.53.0",
+            "version": "1.55.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.0.0",


### PR DESCRIPTION
## Description
added the customId field to the response for our different resources, if it is present. This allows us to use it in the UI for crafting the URL's of the UI itself for navigation, and also to display the canonical URL that they can copy to reference from the backend

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [X] CALM Hub (`calm-hub/`)
- [X] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [X] I have tested my changes locally
- [X] I have added/updated unit tests
- [X] All existing tests pass

## Checklist
- [X] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [X] I have updated documentation if necessary
- [X] I have added tests for my changes (if applicable)
- [X] My changes follow the project's coding standards
