### PR TITLE
fix(shared): emit POSIX-style paths in generated front matter

### DIFF
--- a/cli/src/command-helpers/timeline-paths.spec.ts
+++ b/cli/src/command-helpers/timeline-paths.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+
+// path is mocked to win32 so the Windows behaviour runs on any host. Separate
+// file because the mock is module-wide and timeline.spec.ts uses real paths.
+vi.mock('path', async () => {
+    const actual = await vi.importActual<typeof import('path')>('path');
+    return { ...actual.win32, default: actual.win32, posix: actual.posix, win32: actual.win32 };
+});
+
+const OUTPUT = 'C:\\docs\\timeline\\timeline.json';
+const ARCHITECTURE = 'C:\\work\\architectures\\payments.arch.json';
+const EXPECTED = '/work/architectures/payments.arch.json';
+
+describe('buildImpliedTimeline path portability', () => {
+    it('writes a forward-slash detailed-architecture reference on Windows', async () => {
+        const { buildImpliedTimeline } = await import('./timeline');
+
+        const timeline = buildImpliedTimeline([ARCHITECTURE], OUTPUT);
+        const reference = timeline.moments[0].details['detailed-architecture'];
+
+        // The full resolved path, not a substring: the backslash form also
+        // ends with the filename.
+        expect(path.posix.resolve('/docs/timeline', reference)).toBe(EXPECTED);
+        expect(reference).not.toContain('\\');
+    });
+
+    it('leaves a POSIX relative path unchanged', () => {
+        const relative = '../../work/architectures/payments.arch.json';
+
+        expect(relative.split(path.posix.sep).join('/')).toBe(relative);
+        expect(path.posix.resolve('/docs/timeline', relative)).toBe(EXPECTED);
+    });
+});

--- a/cli/src/command-helpers/timeline.spec.ts
+++ b/cli/src/command-helpers/timeline.spec.ts
@@ -74,8 +74,9 @@ describe('buildImpliedTimeline', () => {
 
         const timeline = buildImpliedTimeline([a], outputPath);
 
+        // Not path.join: that would assert the host separator.
         expect(timeline.moments[0].details['detailed-architecture']).toBe(
-            path.join('..', 'archs', 'v1.json'),
+            '../archs/v1.json',
         );
     });
 

--- a/cli/src/command-helpers/timeline.ts
+++ b/cli/src/command-helpers/timeline.ts
@@ -77,7 +77,11 @@ export function buildImpliedTimeline(architecturePaths: string[], outputPath?: s
         }
         seenIds.add(uniqueId);
 
-        const relativeRef = path.relative(refBaseDir, path.resolve(archPath));
+        // Forward slashes: this reference is read on other machines.
+        const relativeRef = path
+            .relative(refBaseDir, path.resolve(archPath))
+            .split(path.sep)
+            .join('/');
 
         return {
             'unique-id': uniqueId,

--- a/cli/src/command-helpers/workspace/bundle.ts
+++ b/cli/src/command-helpers/workspace/bundle.ts
@@ -181,7 +181,8 @@ export async function addFileToBundle(
         const destName = opts.destName ?? path.basename(srcPath);
         destPath = path.join(filesDir, destName);
         await copyFile(srcPath, destPath);
-        rel = path.relative(bundlePath, destPath);
+        // Forward slashes: the manifest travels with the bundle.
+        rel = path.relative(bundlePath, destPath).split(path.sep).join('/');
     } else {
         // reference the original file using its absolute path so it remains resolvable
         // regardless of where the bundle directory sits

--- a/shared/src/template/front-matter-paths.spec.ts
+++ b/shared/src/template/front-matter-paths.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+
+// path is mocked to win32 so the Windows behaviour runs on any host. A
+// "no backslashes" assertion would pass on a Linux runner either way.
+vi.mock('path', async () => {
+    const actual = await vi.importActual<typeof import('path')>('path');
+    return { ...actual.win32, default: actual.win32, posix: actual.posix, win32: actual.win32 };
+});
+
+const ARCHITECTURE = 'C:\\work\\command\\generate\\service.arch.json';
+const URL_MAPPING = 'C:\\work\\command\\generate\\url-mapping.json';
+const OUTPUT_FILE = 'C:\\docs\\site\\index.md';
+const EXPECTED_ARCHITECTURE = '/work/command/generate/service.arch.json';
+
+describe('injectFrontMatter path portability', () => {
+    it('writes forward-slash paths when generated on Windows', async () => {
+        const { injectFrontMatter } = await import('./front-matter');
+
+        const result = injectFrontMatter('# Docs\n', OUTPUT_FILE, {
+            architecturePath: ARCHITECTURE,
+            urlMappingPath: URL_MAPPING,
+        });
+
+        const architecture = result.match(/^architecture: (.+)$/m)?.[1];
+        const urlMapping = result.match(/^url-to-local-file-mapping: (.+)$/m)?.[1];
+
+        expect(architecture).toBeDefined();
+        expect(urlMapping).toBeDefined();
+
+        // The full resolved path, not a substring: the backslash form also
+        // ends with the filename.
+        expect(path.posix.resolve('/docs/site', architecture!)).toBe(EXPECTED_ARCHITECTURE);
+        expect(path.posix.resolve('/docs/site', urlMapping!)).toBe(
+            '/work/command/generate/url-mapping.json'
+        );
+    });
+
+    it('leaves a POSIX relative path unchanged', () => {
+        const relative = '../../work/command/generate/service.arch.json';
+
+        expect(relative.split(path.posix.sep).join('/')).toBe(relative);
+        expect(path.posix.resolve('/docs/site', relative)).toBe(EXPECTED_ARCHITECTURE);
+    });
+});

--- a/shared/src/template/front-matter.ts
+++ b/shared/src/template/front-matter.ts
@@ -183,7 +183,8 @@ function resolveVariables(variables?: Record<string, string>, itemId?: string): 
 
 function calculateRelativePath(outputDir: string, inputPath: string): string {
     const resolvedPath = path.resolve(inputPath);
-    return path.relative(outputDir, resolvedPath);
+    // Forward slashes: this reference is read on other machines.
+    return path.relative(outputDir, resolvedPath).split(path.sep).join('/');
 }
 
 function extractExistingFrontMatterFields(content: string): Set<string> {


### PR DESCRIPTION
Closes #3008.

`path.relative` returns the host separator, so paths generated on Windows are written into documents that a POSIX reader cannot resolve — the backslash form is read as a single filename rather than a path. Three sites persist a path this way: front matter, the timeline document, and the bundle manifest.

`workspace/tree.ts` is left alone; it renders for terminal display, where the host separator is correct.

Two gotchas worth flagging:

- Two existing `bundle.spec.ts` assertions already expected forward slashes and were failing on Windows. They pass now, untouched.
- `timeline.spec.ts` used `path.join` for an expected value, which pinned the host separator and so stayed green on a Linux-only CI. It now expects the literal POSIX path.

The new tests mock `path` to `win32` so the Windows behaviour is exercised on any host — a "no backslashes" assertion would pass on Linux with or without the fix.
