### PR TITLE
docs: trim root AGENTS.md, correct structure notes, and add docs writing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,6 @@
 - Do NOT create working files in other directories (they may accidentally be committed)
 - Clean up the sandbox when work is complete if appropriate
 
-```bash
-# Example: Create working files in sandbox
-mkdir -p sandbox
-echo "My notes" > sandbox/my-notes.md
-```
-
 ---
 
 ## Project Overview
@@ -69,78 +63,32 @@ from inside these folders.
 
 ## Technology Stack
 
-**TypeScript/Node.js** (npm workspaces):
-- CLI, models, widgets, shared, VSCode plugin, Hub UI, calm-server, calm-ai, CalmStudio and CALMGuard
-- Build: tsup (esbuild), vitest for testing
-- Package manager: npm workspaces (single root lockfile; see [Lockfile Regeneration](#lockfile-regeneration))
-
-**Java/Maven** (Maven reactor build):
-- Root pom.xml defines multi-module reactor
-- Modules: calm-hub (Java/Quarkus), cli, calm, docs, shared (POM modules)
-- calm-hub backend (Quarkus 3.34+)
-- MongoDB/NitriteDB storage
-- TestContainers for integration tests
-- Maven reactor allows building all modules from root: `./mvnw clean install`
-
-**Documentation**:
-- Docusaurus for main docs (and for CALMGuard's `calmguard-docs`)
+- **TypeScript/Node.js** — everything except calm-hub. Built with tsup (esbuild), tested with
+  vitest, managed as npm workspaces off a single root lockfile
+  (see [Lockfile Regeneration](#lockfile-regeneration)).
+- **Java/Maven** — calm-hub only (Quarkus 3.34+, MongoDB/NitriteDB, TestContainers). The root
+  `pom.xml` is a reactor; `cli`, `calm`, `docs` and `shared` are POM-only placeholders.
+- **Documentation** — Docusaurus, both for the main site and CALMGuard's `calmguard-docs`.
 
 ## Node Version Requirements
 
-**Canonical Node version: 26.** All CI workflows run on Node 26 via `node-version-file: '.nvmrc'`
-(which pins `26.3.1`). The `engines` field (`>=26.0.0`) requires Node 26+, and `engine-strict`
-in `.npmrc` blocks installs on anything older. **Node 26 is the version used to validate builds
-and tests in CI.**
+**Canonical Node version: 26.** `.nvmrc` pins `26.3.1`, CI reads it via
+`node-version-file: '.nvmrc'`, and `engine-strict=true` in `.npmrc` blocks installs on anything
+older. Node 26 is the only version builds and tests are validated against.
 
-**Before running any commands**, verify your Node version:
 ```bash
 node --version   # MUST show v26.x.x
+nvm use          # if not — reads .nvmrc → 26.3.1
 ```
 
-If you are on the wrong version:
-```bash
-# If using nvm:
-nvm use   # reads .nvmrc → 26.3.1
-```
+Running on another major version breaks in ways that are slow to diagnose: native bindings
+(`@swc/core`, `@tailwindcss/oxide`) resolve for the wrong ABI, and Node 26's global Web Storage API
+shadows jsdom's `localStorage` in tests. `@types/node` is pinned to `^26` by a root `package.json`
+override and by a Renovate `allowedVersions` rule, because transitive deps with loose constraints
+will otherwise hoist an older major to the root and mask API differences.
 
-### Node 26 — Web Storage API and localStorage
-
-Node 25+ shipped the [Web Storage API](https://nodejs.org/api/globals.html) as a global, meaning
-`localStorage` and `sessionStorage` are now real globals in the Node runtime. Node 26 made this
-stricter: accessing `localStorage` without `--localstorage-file` **throws a `DOMException`** at
-runtime.
-
-In Vitest's jsdom environment, Node's global **shadows** jsdom's `localStorage`, breaking any test
-that calls methods like `.clear()` or `.getItem()`.
-
-**How calm-hub-ui handles this:**
-
-1. **Storage Dependency Injection** — `node-position-service.tsx`, `TimelineBar.tsx`, and
-   `viewportStore.ts` all accept an optional `Storage` parameter (defaulting to `localStorage` /
-   `sessionStorage`). Tests inject an explicit `createMemoryStorage()` fake from
-   `src/test-support/memory-storage.ts`.
-
-2. **`vi.stubGlobal` safety net** — `calm-hub-ui/vitest.setup.ts` stubs both `localStorage` and
-   `sessionStorage` with `createMemoryStorage()` instances for the entire test run, ensuring even
-   tests that don't inject explicitly see a working Storage, not Node's throwing global.
-
-If you add new tests that use `localStorage`/`sessionStorage`, follow this pattern:
-- In pure services/utilities: inject a `Storage` parameter with `= localStorage` default.
-- In React components: accept `storage?: Storage` as a prop, default to `localStorage`.
-- In tests: pass `createMemoryStorage()` explicitly, or rely on the global stub in `vitest.setup.ts`.
-
-⚠️ **Latent risk in calm-studio:** `calm-studio/apps/studio/src/lib/stores/theme.svelte.ts`
-uses `localStorage` in production code under a jsdom test environment. No test currently exercises
-this path, but the first jsdom test written against it on Node 26 will need the same stub pattern.
-
-### Configuration Details
-
-- **`.nvmrc`** pins `26.3.1` — run `nvm use` to switch automatically
-- **`.npmrc`** has `engine-strict=true` — `npm install` will refuse to run on Node versions outside
-  the `engines` range
-- **`@types/node`** is overridden to `^26` in root `package.json` to prevent transitive dependencies
-  from pulling in a different major version
-- **Renovate** is configured with `allowedVersions: "<27.0.0"` for `@types/node`
+Packages that touch `localStorage` or `sessionStorage` document their own stubbing pattern — see
+[calm-hub-ui/AGENTS.md](calm-hub-ui/AGENTS.md) and [calm-studio/AGENTS.md](calm-studio/AGENTS.md).
 
 ### Lockfile Regeneration
 
@@ -158,23 +106,10 @@ rm -rf node_modules package-lock.json && npm install
 **Never** regenerate the lockfile without deleting `node_modules` first. The `validate-lockfile`
 CI workflow checks that all expected platform variants are present in `package-lock.json`.
 
-### Why this matters
+## Package-Specific Guides
 
-Running `npm install` or tests on a different Node major version causes:
-1. **Test failures from Web Storage conflicts** — Node 26's global `localStorage` shadows jsdom's
-   implementation, causing `DOMException` instead of working Storage methods
-2. **Native binding failures** — platform-specific packages (`@swc/core`, `@tailwindcss/oxide`)
-   resolve for the wrong Node ABI, breaking CI builds
-3. **`@types/node` version drift** — transitive deps with loose constraints (`>=18`, `*`) allow
-   an older `@types/node` to be hoisted to root, masking API differences
-4. **Noisy lockfile diffs** — Renovate's `npmDedupe` recalculates the dependency tree, producing
-   large spurious changes
+Read the guide for a package before working on its code, tests, or build.
 
-## Quick Navigation
-
-### Package-Specific Guides
-
-For detailed guidance on specific packages, see:
 - **[calm/AGENTS.md](calm/AGENTS.md)** - CALM JSON Meta Schema, schema change workflow, draft/release rules
 - **[cli/AGENTS.md](cli/AGENTS.md)** - CLI commands, build pipeline, Commander.js patterns
 - **[calm-hub/AGENTS.md](calm-hub/AGENTS.md)** - Java/Quarkus backend, storage modes, security
@@ -186,106 +121,42 @@ For detailed guidance on specific packages, see:
 - **[calm-studio/AGENTS.md](calm-studio/AGENTS.md)** - CalmStudio visual editor, CALM 1.2 rules, nested workspaces
 - **[calm-guard/AGENTS.md](calm-guard/AGENTS.md)** - CALMGuard compliance platform, agents/skills
 
-### When to Use Package-Specific Guides
-
-Open the package-specific AGENTS.md when:
-- Working on code or tests in that package
-- Debugging package-specific issues
-- Understanding architecture patterns
-- Running package-specific commands
-
 ## Key Commands
 
-**IMPORTANT**: Always run npm commands from the **repository root** using workspaces, not from within individual package directories.
+**IMPORTANT**: Always run npm commands from the **repository root** using workspaces, not from within
+individual package directories. Any script below can be narrowed to one package with
+`--workspace <name>`, e.g. `npm test --workspace cli`.
 
 ```bash
-# Root-level commands (npm workspaces)
+# npm workspaces (from the repository root)
 npm run build              # Build all TypeScript workspaces
 npm test                   # Test all TypeScript workspaces
 npm run lint               # Lint all workspaces
-npm run build:cli          # Build CLI and dependencies
+npm run lint-fix           # Fix auto-fixable lint issues
+npm run build:cli          # Build CLI and its dependencies
 npm run build:shared       # Build shared packages
+npm run link:cli           # Link the CLI globally for manual testing
+npm run watch --workspace <name>   # Watch mode
 
-# Package-specific builds (from root using workspaces)
-npm run build --workspace cli
-npm run build --workspace calm-widgets
-npm run build --workspace shared
-npm run build --workspace calm-plugins/vscode
-
-# Root-level Maven reactor build
+# Maven reactor (from the repository root)
 ./mvnw clean install       # Build all Maven modules (mainly calm-hub)
-./mvnw test                # Test all Maven modules (mainly calm-hub)
-
-# Testing specific packages (from root using workspaces)
-npm test --workspace cli              # Test CLI only
-npm test --workspace shared  # Test shared packages
-npm test --workspace calm-plugins/vscode # Test VSCode extension
-npm test --workspace calm-models      # Test calm-models
-npm test --workspace calm-widgets     # Test calm-widgets
-# Java/Maven (calm-hub specific)
-cd calm-hub
-../mvnw quarkus:dev        # Development mode with hot reload
-../mvnw -P integration verify  # Full test suite with integration tests
-../mvnw test               # Unit tests only
-
-# CLI (from root)
-npm run link:cli           # Link CLI globally for testing
-calm --version             # Test CLI
-
-# Watch modes (from root)
-npm run watch --workspace cli                  # Watch CLI
-npm run watch --workspace calm-plugins/vscode  # Watch VSCode extension
-npm run watch --workspace calm-widgets         # Watch widgets
+./mvnw test                # Test all Maven modules
 ```
+
+Package-specific development loops — CLI, VSCode extension, CALM Hub — live in that package's
+AGENTS.md.
 
 ## Build Order Dependencies
 
 ```
 TypeScript packages (npm workspaces) build in order:
   calm-models → calm-widgets → shared → cli → calm-plugins/vscode
-
-Maven modules (reactor build):
-  Parent POM → calm-hub (only Java module with code)
-  Other modules (cli, calm, docs, shared) are POM-only placeholders
 ```
 
-**Important**: 
-- Always build dependencies before dependent packages for TypeScript
-- Maven reactor handles build order automatically: `./mvnw clean install`
-
-## Common Workflows
-
-### Working on the CLI
-```bash
-# From repository root
-npm run build:cli          # Builds models, widgets, shared, cli
-npm run link:cli           # Link globally
-calm --version             # Verify
-npm test --workspace cli   # Run CLI tests
-```
-
-### Working on VSCode Extension
-```bash
-# From repository root
-npm run build:shared       # Build dependencies
-npm run watch --workspace calm-plugins/vscode  # Watch mode
-# Press F5 in VSCode to debug
-```
-
-### Working on CALM Hub
-```bash
-cd calm-hub/local-dev
-docker-compose up          # Start MongoDB
-cd ..
-../mvnw quarkus:dev        # Start backend
-```
+Always build dependencies before dependent packages. The Maven reactor works this out for itself:
+`./mvnw clean install`.
 
 ## Testing
-
-**CRITICAL**: Before considering any change ready:
-1. **All tests must pass** with coverage enabled
-2. **All new code must have tests** (unit and/or integration)
-3. **Run linting** (see Linting section below)
 
 **IMPORTANT**: All workspaces use `vitest run` for the test script, which runs tests once and exits.
 Do NOT use `vitest` without `run` as it enters watch mode and will hang indefinitely.
@@ -294,126 +165,30 @@ Do NOT use `vitest` without `run` as it enters watch mode and will hang indefini
 If you modify the `shared` package, you **MUST** run tests for **ALL** workspaces (`npm run test`) because `shared` is a dependency for CLI, VSCode extension, and other packages. Changes in `shared` can break downstream consumers.
 
 ```bash
-# Run ALL tests with coverage (required before committing)
-npm test -- --coverage      # TypeScript packages with coverage
-cd calm-hub && ../mvnw verify  # Java tests with coverage (JaCoCo enabled by default)
+npm test -- --coverage         # TypeScript packages, with coverage
+cd calm-hub && ../mvnw verify  # Java tests with coverage (JaCoCo on by default)
 
-# Quick test runs (without coverage reports)
-npm test                    # TypeScript packages (runs vitest run in each workspace)
-cd calm-hub && ../mvnw test # Java unit tests (still collects coverage data)
-
-# Run tests for just one class
-# NB you must be in the right project to run that file, because you need vitest.config.ts for tests to run
-npx vitest run ${TEST FILE}
-
-# Package-specific tests (from repository root using workspaces)
-npm test --workspace cli
-npm test --workspace calm-plugins/vscode
-npm test --workspace shared
-npm test --workspace calm-widgets
-npm test --workspace calm-models
+# One file — you must be at or below that package's directory so vitest.config.ts resolves
+npx vitest run ${TEST_FILE}
 
 # Java integration tests (requires Docker)
 cd calm-hub && ../mvnw -P integration verify
 ```
 
-### Test Coverage Requirements
-- All new functions/methods must have tests
-- Aim for >80% coverage on new code
-- Critical paths must have 100% coverage
-- Tests should cover both success and error cases
-
-## Linting
-
-**CRITICAL**: Always run linting after making code changes. Fix all errors before committing.
-
-```bash
-# Lint all workspaces (required before committing)
-npm run lint               # Check all TypeScript/JavaScript code
-
-# Auto-fix issues
-npm run lint-fix           # Fix auto-fixable linting issues
-
-# Package-specific linting
-npm run lint --workspace cli
-npm run lint --workspace calm-plugins/vscode
-```
-
-Linting checks code style, common errors, and best practices.
+All new code needs tests covering both success and error cases. Aim for >80% coverage on new code,
+100% on critical paths.
 
 ## Commit Messages
 
-This project uses **Conventional Commits** enforced by **commitlint** and **husky**.
+**Conventional Commits**, enforced by commitlint via husky — invalid messages are rejected at commit
+time. Format is `<type>(<scope>): <subject>`, subject with no trailing period.
 
-### Commit Message Format
+- **type** (required, lowercase): `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
+  `perf`, `ci`, `build`, `revert`
+- **scope** (optional but preferred): `cli`, `shared`, `calm-widgets`, `calm-hub`, `calm-hub-ui`,
+  `docs`, `vscode`, `deps`, `ci`, `release`
 
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-**Required**:
-- `type`: One of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`, `build`, `revert`
-- `subject`: Brief description (no period at end)
-
-**Optional**:
-- `scope`: Package affected (`cli`, `shared`, `calm-widgets`, `calm-hub`, `calm-hub-ui`, `docs`, `vscode`, `deps`, `ci`, `release`)
-- `body`: Detailed explanation
-- `footer`: Breaking changes, issue references
-
-### Examples
-
-```bash
-# Good commit messages
-feat(cli): add support for schema validation caching
-fix(calm-hub): resolve MongoDB connection timeout issue
-docs(vscode): update extension installation guide
-test(shared): add unit tests for template processor
-chore(deps): update Quarkus to 3.29.4
-
-# Bad commit messages (will be rejected)
-update stuff                          # Missing type
-Fix: bug in code                      # Type must be lowercase
-feat(cli) added new feature.          # Subject ends with period
-FEAT(cli): new feature                # Type must be lowercase
-```
-
-### Type Guidelines
-
-- **feat**: New feature for users
-- **fix**: Bug fix for users
-- **docs**: Documentation only changes
-- **style**: Code style changes (formatting, no logic change)
-- **refactor**: Code restructuring (no behavior change)
-- **test**: Adding or updating tests
-- **chore**: Maintenance tasks (dependencies, tooling)
-- **perf**: Performance improvements
-- **ci**: CI/CD pipeline changes
-- **build**: Build system changes
-- **revert**: Reverting a previous commit
-
-### Automated Enforcement
-
-**Husky** runs commitlint automatically on every commit. Invalid messages are rejected.
-
-To bypass validation (not recommended):
-```bash
-git commit --no-verify -m "message"
-```
-
-### Using Commitizen (Interactive Helper)
-
-For help crafting valid commits:
-```bash
-npx cz
-# or
-npm run commit  # if configured
-```
-
-This provides an interactive prompt to build a compliant message.
+Run `npx cz` for an interactive prompt. Note that only commits scoped `(cli)` trigger a CLI release.
 
 ## Pre-Commit Checklist
 
@@ -427,58 +202,18 @@ Before considering any code change ready:
 - [ ] **Test coverage meets requirements** (>80% for new code)
 - [ ] **Commit message follows Conventional Commits** (enforced by husky)
 
-## Documentation
-
-- **User Docs**: https://calm.finos.org
-- **API Docs**: Generated from code (Swagger for calm-hub)
-
 ## Contributing
 
 **CRITICAL:** Always create a feature branch for your changes and submit a pull request. Never commit directly to the main branch—direct commits will be rejected.
 
-### Pull Request Template Requirement
-
 **CRITICAL:** Always use the repository PR template in `.github/pull_request_template.md` when creating or updating a pull request. Do not submit ad-hoc PR descriptions when a template exists; populate each section with accurate status.
 
-1. **Fork the repository**
-2. **Create a feature branch** with descriptive name (e.g., `feat/add-caching`, `fix/mongodb-timeout`)
-3. **Make your changes** following package-specific guidelines (see AGENTS.md files)
-4. **Write tests** for all new code
-5. **Run the pre-commit checklist** (see above)
-   - Tests with coverage pass
-   - Linting passes (0 errors)
-   - Builds succeed
-6. **Commit with Conventional Commits format**
-   - Example: `feat(cli): add schema validation caching`
-   - Husky will validate your commit message automatically
-7. **Push to your fork** and create a pull request
-8. **Ensure CI passes** on your pull request
-
-### Quick Contribution Workflow
-
-```bash
-# 1. Create feature branch
-git checkout -b feat/my-feature
-
-# 2. Make changes and write tests
-vim src/my-file.ts
-vim src/my-file.spec.ts
-
-# 3. Run pre-commit checks
-npm test -- --coverage
-npm run lint
-npm run build
-
-# 4. Commit with conventional format (husky validates)
-git add .
-git commit -m "feat(cli): add my feature"
-
-# 5. Push and create PR
-git push origin feat/my-feature
-```
+Branch names are descriptive and conventional-commit-flavoured (`feat/add-caching`,
+`fix/mongodb-timeout`). Work through the pre-commit checklist above before pushing, follow the
+package-specific guide for whatever you touched, and make sure CI is green on the PR.
 
 ## Getting Help
 
+- User docs: https://calm.finos.org (calm-hub also serves generated Swagger)
 - Issues: https://github.com/finos/architecture-as-code/issues
 - Discussions: https://github.com/finos/architecture-as-code/discussions
-- Community: FINOS Architecture as Code meetings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,11 @@
 
 ## Notes for supporting documentation
 
+- All documentation should be as concise as possible and should avoid explaining *everything*. Focus on the most significant details for a human reader.
 - When writing PR descriptions, do not describe every technical detail of the PR and don't include much, if any, code. Just explain any important decisions, technical gotchas that may not be obvious, and the overall intent of the PR. Link issues if possible.
-- When writing issues, follow the same guidelines: do not write lots of code examples and thoroughly lay out the entire proposed implementation plan.
+- When writing issues, follow the same guidelines: do not write lots of code examples and thoroughly lay out the entire proposed implementation plan. Prefer tables over lists of options, but don't put too much in each table cell.
 - When writing inline comments, do not explain exactly what the code does. Be concise, focusing on intent and any non-obvious gotchas.
+- Don't add comments to code that doesn't need them. Code should ideally be self-documenting.
 - Write all the above in Simplified Technical English (ASD-STE100) where possible.
 
 ## Sandbox Folder for Working Files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # FINOS CALM Monorepo - AI Assistant Guide
 
+## Notes for supporting documentation
+
+- When writing PR descriptions, do not describe every technical detail of the PR and don't include much, if any, code. Just explain any important decisions, technical gotchas that may not be obvious, and the overall intent of the PR. Link issues if possible.
+- When writing issues, follow the same guidelines: do not write lots of code examples and thoroughly lay out the entire proposed implementation plan.
+- When writing inline comments, do not explain exactly what the code does. Be concise, focusing on intent and any non-obvious gotchas.
+- Write all the above in Simplified Technical English (ASD-STE100) where possible.
+
 ## Sandbox Folder for Working Files
 
 **IMPORTANT:** Use the `/sandbox/` folder for all temporary working files, test outputs, notes, and drafts.
@@ -36,9 +43,8 @@ architecture-as-code/
 ├── calm-models/               # TypeScript data models
 ├── calm-widgets/              # React visualization components
 ├── calm-ai/                   # AI agent tools & prompts
-├── calm-suite/                # Sub-monorepos (see below)
-│   ├── calm-studio/           #   SvelteKit visual CALM editor — nested npm-workspace monorepo
-│   └── calm-guard/            #   Next.js continuous-compliance platform (CALMGuard)
+├── calm-studio/               # SvelteKit visual CALM editor — nested npm-workspace monorepo
+├── calm-guard/                # Next.js continuous-compliance platform (CALMGuard)
 ├── shared/                    # Shared TypeScript utilities
 ├── docs/                      # Docusaurus documentation site
 ├── examples/                  # Example CALM documents — source of truth for the CALM Hub seed scripts
@@ -49,17 +55,22 @@ architecture-as-code/
 └── scripts/                   # Repo maintenance scripts (e.g. lockfile validation)
 ```
 
-### `calm-suite/` — nested workspaces
+### Nested workspaces
 
-`calm-suite/` holds two products whose packages are wired directly into the **root** npm workspaces (run all npm commands from the repo root, never from inside these folders):
+`calm-studio/` and `calm-guard/` are products with their own internal structure, but their packages
+are wired directly into the **root** npm workspaces. Run all npm commands from the repo root, never
+from inside these folders.
 
-- **`calm-studio/`** (`calmstudio-workspace`) — a SvelteKit (Svelte 5) visual CALM editor, itself an npm-workspace monorepo. Sub-packages and the app are root workspaces via `calm-studio/packages/*` and `calm-studio/apps/*`: `@calmstudio/calm-core`, `@calmstudio/calmscript`, `@calmstudio/extensions`, `@calmstudio/github-action`, `@calmstudio/mcp`, `@calmstudio/diagram` (web-component), `calmstudio` (vscode-extension), and `@calmstudio/studio` (app).
-- **`calm-guard/`** (`calmguard`) — a Next.js (App Router) continuous-compliance platform, plus its Docusaurus docs (`calmguard-docs`). Both are root workspaces.
+- **`calm-studio/`** — a SvelteKit (Svelte 5) visual CALM editor, itself an npm-workspace monorepo.
+  Its packages and app join the root workspaces via `calm-studio/packages/*` and `calm-studio/apps/*`.
+  See [calm-studio/AGENTS.md](calm-studio/AGENTS.md) for the package list.
+- **`calm-guard/`** — a Next.js (App Router) continuous-compliance platform (`calmguard`), plus its
+  Docusaurus docs (`calmguard-docs`). Both are root workspaces.
 
 ## Technology Stack
 
 **TypeScript/Node.js** (npm workspaces):
-- CLI, models, widgets, shared, VSCode plugin, Hub UI, calm-server, calm-ai, and the `calm-suite/` products (CalmStudio's 8 packages/app + CALMGuard)
+- CLI, models, widgets, shared, VSCode plugin, Hub UI, calm-server, calm-ai, CalmStudio and CALMGuard
 - Build: tsup (esbuild), vitest for testing
 - Package manager: npm workspaces (single root lockfile; see [Lockfile Regeneration](#lockfile-regeneration))
 
@@ -118,7 +129,7 @@ If you add new tests that use `localStorage`/`sessionStorage`, follow this patte
 - In React components: accept `storage?: Storage` as a prop, default to `localStorage`.
 - In tests: pass `createMemoryStorage()` explicitly, or rely on the global stub in `vitest.setup.ts`.
 
-⚠️ **Latent risk in calm-studio:** `calm-suite/calm-studio/apps/studio/src/lib/stores/theme.svelte.ts`
+⚠️ **Latent risk in calm-studio:** `calm-studio/apps/studio/src/lib/stores/theme.svelte.ts`
 uses `localStorage` in production code under a jsdom test environment. No test currently exercises
 this path, but the first jsdom test written against it on Node 26 will need the same stub pattern.
 
@@ -471,5 +482,3 @@ git push origin feat/my-feature
 - Issues: https://github.com/finos/architecture-as-code/issues
 - Discussions: https://github.com/finos/architecture-as-code/discussions
 - Community: FINOS Architecture as Code meetings
-
----

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - When writing issues, follow the same guidelines: do not write lots of code examples and thoroughly lay out the entire proposed implementation plan. Prefer tables over lists of options, but don't put too much in each table cell.
 - When writing inline comments, do not explain exactly what the code does. Be concise, focusing on intent and any non-obvious gotchas.
 - Don't add comments to code that doesn't need them. Code should ideally be self-documenting.
+- When replying to review feedback, give the conclusion and the change only — "Confirmed, fixed in abc1234" is a complete reply. Do not repeat evidence the reviewer can read for themselves, do not explain how the mistake happened, and do not volunteer follow-up work nobody asked for. If you disagree, give the reason in a sentence or two and stop.
 - Write all the above in Simplified Technical English (ASD-STE100) where possible.
 
 ## Sandbox Folder for Working Files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,13 @@ from inside these folders.
 
 ## Technology Stack
 
-- **TypeScript/Node.js** — everything except calm-hub. Built with tsup (esbuild), tested with
-  vitest, managed as npm workspaces off a single root lockfile
+- **TypeScript/Node.js** — every package except the Java modules below. Built with tsup (esbuild),
+  tested with vitest, managed as npm workspaces off a single root lockfile
   (see [Lockfile Regeneration](#lockfile-regeneration)).
-- **Java/Maven** — calm-hub only (Quarkus 3.34+, MongoDB/NitriteDB, TestContainers). The root
-  `pom.xml` is a reactor; `cli`, `calm`, `docs` and `shared` are POM-only placeholders.
+- **Java/Maven** — the root `pom.xml` is a reactor over six modules. Two carry Java code: `calm-hub`
+  (Quarkus 3.34+, MongoDB/NitriteDB, TestContainers) and `calm-models` (a plain jar). `cli`, `calm`,
+  `docs` and `shared` are POM-only placeholders. Note that `calm-models` is built by both toolchains
+  — it is an npm workspace *and* a Maven module.
 - **Documentation** — Docusaurus, both for the main site and CALMGuard's `calmguard-docs`.
 
 ## Node Version Requirements
@@ -190,7 +192,12 @@ time. Format is `<type>(<scope>): <subject>`, subject with no trailing period.
 - **scope** (optional but preferred): `cli`, `shared`, `calm-widgets`, `calm-hub`, `calm-hub-ui`,
   `docs`, `vscode`, `deps`, `ci`, `release`
 
-Run `npx cz` for an interactive prompt. Note that only commits scoped `(cli)` trigger a CLI release.
+Run `npx cz` for an interactive prompt.
+
+Type and scope drive the automated release, so neither is cosmetic: `cli/.releaserc.json` releases
+on the `cli`, `shared`, `calm-models`, `calm-ai` and `calm-widgets` scopes, and its fallback rule
+also releases any *unscoped* `feat`, `fix`, `perf` or `revert`. Check that file before assuming a
+commit is release-neutral.
 
 ## Pre-Commit Checklist
 

--- a/calm-hub-ui/AGENTS.md
+++ b/calm-hub-ui/AGENTS.md
@@ -301,6 +301,25 @@ Reference components for the patterns above: `hub/Hub.tsx`, `components/navbar/N
 - Mock services at the module level with `vi.mock` and class constructor patterns
 - E2E tests are in `cypress/`
 
+### Storage must be injected, never taken from the global
+
+Node 25+ ships the Web Storage API as a real global, and Node 26 **throws a
+`DOMException`** when `localStorage` is touched without `--localstorage-file`. Under
+Vitest's jsdom environment Node's global shadows jsdom's working implementation, so any
+test that calls `.clear()` or `.getItem()` on the bare global fails.
+
+Two defences, and new code needs both:
+
+1. **Take `Storage` as a parameter.** `node-position-service.tsx`, `TimelineBar.tsx` and
+   `viewportStore.ts` all accept an optional `Storage`, defaulting to `localStorage` /
+   `sessionStorage`. In services and utilities take it as an argument; in components take
+   it as a `storage?: Storage` prop. Tests pass `createMemoryStorage()` from
+   `src/test-support/memory-storage.ts`.
+2. **The safety net.** `vitest.setup.ts` stubs both globals with `createMemoryStorage()`
+   for the whole run via `vi.stubGlobal`, so a test that forgets to inject still sees a
+   working Storage rather than a throwing one. Do not rely on this in new code — it exists
+   to stop the failure mode being silent.
+
 ### Test both desktop and mobile
 
 Any change that touches layout/rendering **must be verified at both a desktop and a

--- a/calm-studio/AGENTS.md
+++ b/calm-studio/AGENTS.md
@@ -3,14 +3,17 @@
 Visual CALM architecture editor. SvelteKit (Svelte 5), TypeScript strict, npm workspaces monorepo.
 
 ## Structure
-- `packages/calm-core/` — CALM types, validation
-- `packages/extensions/` — Node type packs (core, fluxnova, ai, aws, gcp, azure, k8s, messaging, identity, opengris)
-- `packages/calmscript/` — DSL compiler
-- `packages/mcp-server/` — MCP server (20 tools)
-- `packages/github-action/` — GitHub Action build target
-- `packages/vscode-extension/` — VSCode extension build target
-- `packages/web-component/` — embeddable web component build target
-- `apps/studio/src/lib/` — canvas, editor, io, layout, palette, properties, stores, validation, governance, templates (also c4, desktop, search, toolbar; list illustrative)
+Each entry below is a root npm workspace, matched by `calm-studio/packages/*` and
+`calm-studio/apps/*` in the root `package.json`. Run npm commands from the repo root.
+
+- `packages/calm-core/` (`@calmstudio/calm-core`) — CALM types, validation
+- `packages/extensions/` (`@calmstudio/extensions`) — Node type packs (core, fluxnova, ai, aws, gcp, azure, k8s, messaging, identity, opengris)
+- `packages/mcp-server/` (`@calmstudio/mcp`) — MCP server (20 tools)
+- `packages/github-action/` (`@calmstudio/github-action`) — GitHub Action build target
+- `packages/vscode-extension/` (`calmstudio`) — VSCode extension build target
+- `packages/web-component/` (`@calmstudio/diagram`) — embeddable web component build target
+- `packages/docusaurus-plugin/` (`@finos/calm-docusaurus-plugin`) — Docusaurus plugin
+- `apps/studio/` (`@calmstudio/studio`) — the SvelteKit app; `src/lib/` holds canvas, editor, io, layout, palette, properties, stores, validation, governance, templates (also c4, desktop, search, toolbar; list illustrative)
 
 ## Commands
 `npm run dev --workspace=@calmstudio/studio` | `npm run build --workspace=@calmstudio/studio` | `npm run test --workspace=@calmstudio/studio` | `npm run typecheck --workspace=@calmstudio/studio` (from repo root)
@@ -21,8 +24,8 @@ Visual CALM architecture editor. SvelteKit (Svelte 5), TypeScript strict, npm wo
 On Node 26 the global Web Storage API throws a `DOMException` when accessed without
 `--localstorage-file`, and in jsdom it shadows jsdom's own working implementation. No
 test exercises this path today, so the first jsdom test written against it will fail
-unless it stubs Storage. See `calm-hub-ui/AGENTS.md` for the injection pattern used
-elsewhere in the repo.
+unless it stubs Storage. See [../calm-hub-ui/AGENTS.md](../calm-hub-ui/AGENTS.md) for the injection pattern
+used elsewhere in the repo.
 
 ## CALM 1.2 Rules
 

--- a/calm-studio/AGENTS.md
+++ b/calm-studio/AGENTS.md
@@ -15,6 +15,15 @@ Visual CALM architecture editor. SvelteKit (Svelte 5), TypeScript strict, npm wo
 ## Commands
 `npm run dev --workspace=@calmstudio/studio` | `npm run build --workspace=@calmstudio/studio` | `npm run test --workspace=@calmstudio/studio` | `npm run typecheck --workspace=@calmstudio/studio` (from repo root)
 
+## Testing gotcha — `localStorage` under Node 26
+
+`apps/studio/src/lib/stores/theme.svelte.ts` reads `localStorage` in production code.
+On Node 26 the global Web Storage API throws a `DOMException` when accessed without
+`--localstorage-file`, and in jsdom it shadows jsdom's own working implementation. No
+test exercises this path today, so the first jsdom test written against it will fail
+unless it stubs Storage. See `calm-hub-ui/AGENTS.md` for the injection pattern used
+elsewhere in the repo.
+
 ## CALM 1.2 Rules
 
 All output must conform to CALM 1.2. These are non-negotiable:


### PR DESCRIPTION
## Description

The root `AGENTS.md` had grown to almost 500 lines. 
This file is read in EVERY AI request and will greatly increase context/token use.

This PR cuts it to 219 without dropping a anything; everything is either relocated to the package guide that owns it, or stated once instead of multiple times.

Also adds a note on writing style as discussed in #3006 

Several concerns:

- The monorepo tree described a `calm-suite/` folder containing `calm-studio` and `calm-guard`. That was deleted and the inner projects pulled to top level, so updating to reflect that.
- The Node 26 Web Storage guidance only applies to the calmhub UI, so it moves to `calm-hub-ui/AGENTS.md`
- the calm-studio theme-store warning moves to `calm-studio/AGENTS.md`. 
- The "Common Workflows" recipes are dropped as the components each have their own, more detailed versions. 
- Commit-message and contributing guidance is condensed, on the basis that commitlint rejects a bad message more precisely than prose can. The "tests + lint + build before you commit" rule appeared five times; it now appears once, in the checklist.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] Documentation (`docs/`)
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally

Docs-only. Verified every relative link resolves, the one in-page anchor (`#lockfile-regeneration`) still has its heading, and every file path in the relocated guidance exists.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
