### PR TITLE
feat(calm-hub): add GLOBAL_ADMIN-gated delete endpoints for all resource types

### DIFF
--- a/calm-hub/PERMISSIONS.md
+++ b/calm-hub/PERMISSIONS.md
@@ -90,7 +90,12 @@ canWrite(username, namespace):
 | `write` | Domain `D` | Read + write content in `D` | Flat — no hierarchy |
 | `admin` | Namespace `N` | Read + write content in `N` and descendants; list/grant/revoke entitlements in `N` and descendants; create child namespaces of `N` | **OR any ancestor** |
 | `admin` | Domain `D` | Read + write content in `D`; list/grant/revoke entitlements for `D` | Flat — no hierarchy |
-| `admin` | `GLOBAL` | Create/delete any namespace or domain; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` — only `admin` is valid; `read`/`write` grants on `GLOBAL` are rejected with 400 |
+| `admin` | `GLOBAL` | Create/delete any namespace or domain; delete any architecture, pattern, flow, standard, interface, timeline, ADR, decorator, control requirement, or control configuration; read + write all content; manage all entitlements (including further `GLOBAL admin` grants) | Bypasses all checks via `hasGlobalAdmin()` — only `admin` is valid; `read`/`write` grants on `GLOBAL` are rejected with 400 |
+
+Content-resource deletion is deliberately `GLOBAL admin`-only — a namespace- or
+domain-scoped `admin` grant does not permit it, even for content the grant
+otherwise gives full read/write access to. A control requirement refuses to
+delete (`409`) while it still has configurations; delete those first.
 
 ---
 

--- a/calm-hub/decisions/0001-versioned-artefact-storage.md
+++ b/calm-hub/decisions/0001-versioned-artefact-storage.md
@@ -14,6 +14,13 @@ the old shape too. Both are excluded by
 revisiting with the implementation experience it was waiting for. Tracked in
 [#2884](https://github.com/finos/architecture-as-code/issues/2884).
 
+The "nothing is ever deleted" premise below described the old shape and no
+longer holds: every type this ADR covers, plus Control and Decorator, now
+has a `GLOBAL admin`-gated `DELETE` endpoint that removes a resource and all
+of its versions outright. See `PERMISSIONS.md` and
+`store/util/MongoVersionDocumentStore#deleteResource` /
+`NitriteVersionDocumentStore#deleteResource`.
+
 ## Context
 
 Every Mongo store in `calm-hub` (`store/mongo/`) uses a **one document per

--- a/calm-hub/decisions/0003-shared-version-store-helper.md
+++ b/calm-hub/decisions/0003-shared-version-store-helper.md
@@ -106,8 +106,10 @@ the primitive operations every store needs against its
   that fails, removing the header again. The split shape makes that
   compensation necessary — the old shape wrote the resource and its first
   version in one document write, so a failure left nothing behind — and
-  there is no delete endpoint for any of these types, so a header stranded
-  with `versionCount: 0` stays visible in listings and search permanently.
+  without it a header stranded with `versionCount: 0` stays visible in
+  listings and search until an admin notices and deletes it by hand via the
+  `deleteResource` endpoint added later; `deleteHeader` exists so that never
+  has to happen in the ordinary case.
 
   That is why it belongs here rather than in each store. A per-store copy
   is a correctness routine duplicated once per type per backend, fourteen

--- a/calm-hub/src/integration-test/java/integration/MongoArchitectureIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoArchitectureIntegration.java
@@ -180,4 +180,35 @@ public class MongoArchitectureIntegration {
                 .statusCode(200)
                 .body("values", hasSize(2));
     }
+
+    @Test
+    @Order(9)
+    void end_to_end_delete_an_architecture() {
+        given()
+                .when().delete("/api/calm/namespaces/finos/architectures/1")
+                .then()
+                .statusCode(204);
+
+        // Deleting removes the whole resource, all versions included — not just the latest.
+        given()
+                .when().get("/api/calm/namespaces/finos/architectures/1/versions/1.0.0")
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/api/calm/namespaces/finos/architectures")
+                .then()
+                .statusCode(200)
+                .body("values", hasSize(1))
+                .body("values[0].id", equalTo(2));
+    }
+
+    @Test
+    @Order(10)
+    void end_to_end_delete_a_missing_architecture_returns_404() {
+        given()
+                .when().delete("/api/calm/namespaces/finos/architectures/999")
+                .then()
+                .statusCode(404);
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/MongoControlIntegration.java
@@ -213,11 +213,15 @@ public class MongoControlIntegration {
 
     @Test
     @Order(15)
-    void end_to_end_get_configuration_returns_404_for_nonexistent_config() {
+    void end_to_end_get_configuration_by_id_alone_returns_405() {
+        // There is no GET at this exact path — only .../configurations/{id}/versions[...] —
+        // so it always fell through to a 404 "no matching route". Since the DELETE endpoint
+        // now claims this exact path, JAX-RS correctly reports 405 (path matched, method
+        // didn't) instead of 404 (nothing matched).
         given()
                 .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/1/configurations/999")
                 .then()
-                .statusCode(404);
+                .statusCode(405);
     }
 
     @Test
@@ -551,5 +555,99 @@ public class MongoControlIntegration {
                 .statusCode(200)
                 .body("values.find { it.id == 1 }.name", equalTo("Final Access Control"))
                 .body("values.find { it.id == 1 }.description", equalTo("Final"));
+    }
+
+    // --- Delete: requirement + configuration ---
+    //
+    // Uses a freshly created control (rather than control 1, already exercised above) so this
+    // scenario is self-contained and doesn't depend on the ordering or accumulated state of the
+    // tests above.
+
+    @Test
+    @Order(50)
+    void end_to_end_delete_control_refuses_while_configurations_exist_then_succeeds() throws JsonProcessingException {
+        CreateControlRequirement requirementRequest = new CreateControlRequirement(
+                "Delete Test Control", "Control created to exercise delete", "{\"type\": \"requirement\"}");
+
+        String location = given()
+                .body(objectMapper.writeValueAsString(requirementRequest))
+                .header("Content-Type", "application/json")
+                .when().post("/api/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(201)
+                .extract().header("Location");
+        int controlId = Integer.parseInt(location.substring(location.lastIndexOf('/') + 1));
+
+        CreateControlConfiguration configRequest = new CreateControlConfiguration("{\"setting\": \"enabled\"}");
+        String configLocation = given()
+                .body(objectMapper.writeValueAsString(configRequest))
+                .header("Content-Type", "application/json")
+                .when().post("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations")
+                .then()
+                .statusCode(201)
+                .extract().header("Location");
+        int configId = Integer.parseInt(configLocation.substring(configLocation.lastIndexOf('/') + 1));
+
+        // Refuses while the configuration still exists — does not cascade.
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId)
+                .then()
+                .statusCode(409)
+                .body(containsString("configuration"));
+
+        // Requirement is untouched by the refused delete.
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/requirement/versions/1.0.0")
+                .then()
+                .statusCode(200);
+
+        // Delete the configuration first...
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations/" + configId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations/" + configId + "/versions")
+                .then()
+                .statusCode(404);
+
+        // ...then the requirement can be deleted.
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/requirement/versions/1.0.0")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(51)
+    void end_to_end_delete_control_returns_404_for_missing_control() {
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/99999")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(52)
+    void end_to_end_delete_control_returns_404_for_invalid_domain() {
+        given()
+                .when().delete("/api/calm/domains/" + INVALID_DOMAIN + "/controls/1")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(53)
+    void end_to_end_delete_configuration_returns_404_for_missing_configuration() {
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/1/configurations/99999")
+                .then()
+                .statusCode(404);
     }
 }

--- a/calm-hub/src/integration-test/java/integration/NitriteArchitectureIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteArchitectureIntegration.java
@@ -109,4 +109,34 @@ public class NitriteArchitectureIntegration {
                 .statusCode(400)
                 .body(containsString("could not be parsed"));
     }
+
+    @Test
+    @Order(7)
+    void end_to_end_delete_an_architecture() {
+        given()
+                .when().delete("/api/calm/namespaces/finos/architectures/1")
+                .then()
+                .statusCode(204);
+
+        // Deleting removes the whole resource, all versions included — not just the latest.
+        given()
+                .when().get("/api/calm/namespaces/finos/architectures/1/versions/1.0.0")
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/api/calm/namespaces/finos/architectures")
+                .then()
+                .statusCode(200)
+                .body("values", empty());
+    }
+
+    @Test
+    @Order(8)
+    void end_to_end_delete_a_missing_architecture_returns_404() {
+        given()
+                .when().delete("/api/calm/namespaces/finos/architectures/999")
+                .then()
+                .statusCode(404);
+    }
 }

--- a/calm-hub/src/integration-test/java/integration/NitriteControlIntegration.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteControlIntegration.java
@@ -189,11 +189,15 @@ public class NitriteControlIntegration {
 
     @Test
     @Order(15)
-    void end_to_end_get_configuration_returns_404_for_nonexistent_config() {
+    void end_to_end_get_configuration_by_id_alone_returns_405() {
+        // There is no GET at this exact path — only .../configurations/{id}/versions[...] —
+        // so it always fell through to a 404 "no matching route". Since the DELETE endpoint
+        // now claims this exact path, JAX-RS correctly reports 405 (path matched, method
+        // didn't) instead of 404 (nothing matched).
         given()
                 .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/1/configurations/999")
                 .then()
-                .statusCode(404);
+                .statusCode(405);
     }
 
     @Test
@@ -513,5 +517,99 @@ public class NitriteControlIntegration {
                 .statusCode(200)
                 .body("values.find { it.id == 1 }.name", equalTo("Final Access Control"))
                 .body("values.find { it.id == 1 }.description", equalTo("Final"));
+    }
+
+    // --- Delete: requirement + configuration ---
+    //
+    // Uses a freshly created control (rather than control 1, already exercised above) so this
+    // scenario is self-contained and doesn't depend on the ordering or accumulated state of the
+    // tests above.
+
+    @Test
+    @Order(50)
+    void end_to_end_delete_control_refuses_while_configurations_exist_then_succeeds() throws JsonProcessingException {
+        CreateControlRequirement requirementRequest = new CreateControlRequirement(
+                "Delete Test Control", "Control created to exercise delete", "{\"type\": \"requirement\"}");
+
+        String location = given()
+                .body(objectMapper.writeValueAsString(requirementRequest))
+                .header("Content-Type", "application/json")
+                .when().post("/api/calm/domains/" + VALID_DOMAIN + "/controls")
+                .then()
+                .statusCode(201)
+                .extract().header("Location");
+        int controlId = Integer.parseInt(location.substring(location.lastIndexOf('/') + 1));
+
+        CreateControlConfiguration configRequest = new CreateControlConfiguration("{\"setting\": \"enabled\"}");
+        String configLocation = given()
+                .body(objectMapper.writeValueAsString(configRequest))
+                .header("Content-Type", "application/json")
+                .when().post("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations")
+                .then()
+                .statusCode(201)
+                .extract().header("Location");
+        int configId = Integer.parseInt(configLocation.substring(configLocation.lastIndexOf('/') + 1));
+
+        // Refuses while the configuration still exists — does not cascade.
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId)
+                .then()
+                .statusCode(409)
+                .body(containsString("configuration"));
+
+        // Requirement is untouched by the refused delete.
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/requirement/versions/1.0.0")
+                .then()
+                .statusCode(200);
+
+        // Delete the configuration first...
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations/" + configId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/configurations/" + configId + "/versions")
+                .then()
+                .statusCode(404);
+
+        // ...then the requirement can be deleted.
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/api/calm/domains/" + VALID_DOMAIN + "/controls/" + controlId + "/requirement/versions/1.0.0")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(51)
+    void end_to_end_delete_control_returns_404_for_missing_control() {
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/99999")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(52)
+    void end_to_end_delete_control_returns_404_for_invalid_domain() {
+        given()
+                .when().delete("/api/calm/domains/" + INVALID_DOMAIN + "/controls/1")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(53)
+    void end_to_end_delete_configuration_returns_404_for_missing_configuration() {
+        given()
+                .when().delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/1/configurations/99999")
+                .then()
+                .statusCode(404);
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/domain/exception/ControlHasConfigurationsException.java
+++ b/calm-hub/src/main/java/org/finos/calm/domain/exception/ControlHasConfigurationsException.java
@@ -1,0 +1,31 @@
+package org.finos.calm.domain.exception;
+
+/**
+ * Thrown when a control requirement cannot be deleted because it still has
+ * configurations associated with it. Carries the raw control id and configuration
+ * count as fields rather than a formatted message — the resource layer (see
+ * {@code ControlResource#controlHasConfigurationsResponse}) is solely responsible
+ * for composing the user-facing message, so it isn't duplicated here.
+ */
+public class ControlHasConfigurationsException extends Exception {
+    private final int controlId;
+    private final int configurationCount;
+
+    /**
+     * @param controlId          the control that could not be deleted because it still has configurations
+     * @param configurationCount how many configurations exist under the control
+     */
+    public ControlHasConfigurationsException(int controlId, int configurationCount) {
+        super("Control not empty: " + controlId);
+        this.controlId = controlId;
+        this.configurationCount = configurationCount;
+    }
+
+    public int getControlId() {
+        return controlId;
+    }
+
+    public int getConfigurationCount() {
+        return configurationCount;
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/AdrResource.java
@@ -293,6 +293,33 @@ public class AdrResource {
         }
     }
 
+    /**
+     * Delete an ADR and all of its revisions
+     *
+     * @param namespace the namespace the ADR is in
+     * @param adrId     the ID of the ADR
+     * @return no content on success
+     */
+    @DELETE
+    @Path("{namespace}/adrs/{adrId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete an ADR",
+            description = "Deletes an ADR and all of its revisions from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteAdrForNamespace(
+            @PathParam("namespace") @Pattern(regexp= NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("adrId") int adrId
+    ) {
+        try {
+            store.deleteAdr(namespace, adrId);
+        } catch (Exception e) {
+            return handleException(e, namespace, adrId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response adrWithLocationResponse(AdrMeta adrMeta) throws URISyntaxException {
         return Response.created(new URI("/api/calm/namespaces/" + adrMeta.getNamespace() + "/adrs/" + adrMeta.getId() + "/revisions/" + adrMeta.getRevision())).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -299,6 +300,30 @@ public class ArchitectureResource {
             logger.error("Failed to serialise timeline for architecture [{}] in namespace [{}]", architectureId, namespace, e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Failed to build timeline for architecture: " + architectureId).build();
         }
+    }
+
+    @DELETE
+    @Path("{namespace}/architectures/{architectureId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete an architecture",
+            description = "Deletes an architecture and all of its versions from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteArchitecture(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("architectureId") int architectureId
+    ) {
+        try {
+            store.deleteArchitecture(namespace, architectureId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting architecture", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (ArchitectureNotFoundException e) {
+            logger.error("Invalid architecture [{}] when deleting architecture", architectureId, e);
+            return invalidArchitectureResponse(architectureId);
+        }
+        return Response.noContent().build();
     }
 
     private Response architectureWithLocationResponse(Architecture architecture) throws URISyntaxException {

--- a/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ArchitectureResource.java
@@ -33,6 +33,7 @@ import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.ArchitectureTimelineService;
 import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.ArchitectureStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,7 @@ public class ArchitectureResource {
     private final ArchitectureStore store;
     private final ArchitectureTimelineService timelineService;
     private final CustomIdEnrichmentService customIds;
+    private final ResourceMappingStore mappingStore;
 
     private final Logger logger = LoggerFactory.getLogger(ArchitectureResource.class);
 
@@ -65,10 +67,11 @@ public class ArchitectureResource {
 
     @Inject
     public ArchitectureResource(ArchitectureStore store, ArchitectureTimelineService timelineService,
-                                CustomIdEnrichmentService customIds) {
+                                CustomIdEnrichmentService customIds, ResourceMappingStore mappingStore) {
         this.store = store;
         this.timelineService = timelineService;
         this.customIds = customIds;
+        this.mappingStore = mappingStore;
     }
 
     /**
@@ -323,6 +326,7 @@ public class ArchitectureResource {
             logger.error("Invalid architecture [{}] when deleting architecture", architectureId, e);
             return invalidArchitectureResponse(architectureId);
         }
+        MappingCleanup.deleteMapping(mappingStore, logger, namespace, ResourceType.ARCHITECTURE, architectureId);
         return Response.noContent().build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/ControlResource.java
@@ -327,6 +327,63 @@ public class ControlResource {
         }
     }
 
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{domain}/controls/{controlId}")
+    @Operation(
+            summary = "Delete a control requirement",
+            description = "Deletes a control requirement and all of its versions. Refuses if the control still has configurations. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteControlRequirement(
+            @PathParam("domain")
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
+            String domain,
+            @PathParam("controlId") int controlId) {
+        try {
+            store.deleteControlRequirement(domain, controlId);
+        } catch (DomainNotFoundException e) {
+            logger.error("Invalid domain [{}] when deleting control", domain, e);
+            return invalidDomainResponse(domain);
+        } catch (ControlNotFoundException e) {
+            logger.error("Control [{}] not found in domain [{}]", controlId, domain, e);
+            return invalidControlResponse(controlId);
+        } catch (ControlHasConfigurationsException e) {
+            logger.error("Control [{}] has {} configuration(s) and cannot be deleted", controlId, e.getConfigurationCount(), e);
+            return controlHasConfigurationsResponse(e.getControlId(), e.getConfigurationCount());
+        }
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{domain}/controls/{controlId}/configurations/{configId}")
+    @Operation(
+            summary = "Delete a control configuration",
+            description = "Deletes a control configuration and all of its versions. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteControlConfiguration(
+            @PathParam("domain")
+            @Pattern(regexp = DOMAIN_REGEX, message = DOMAIN_MESSAGE)
+            String domain,
+            @PathParam("controlId") int controlId,
+            @PathParam("configId") int configId) {
+        try {
+            store.deleteControlConfiguration(domain, controlId, configId);
+        } catch (DomainNotFoundException e) {
+            logger.error("Invalid domain [{}] when deleting configuration", domain, e);
+            return invalidDomainResponse(domain);
+        } catch (ControlNotFoundException e) {
+            logger.error("Control [{}] not found in domain [{}]", controlId, domain, e);
+            return invalidControlResponse(controlId);
+        } catch (ControlConfigurationNotFoundException e) {
+            logger.error("Configuration [{}] not found for control [{}]", configId, controlId, e);
+            return invalidConfigurationResponse(configId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response invalidDomainResponse(String domain) {
         return Response.status(Response.Status.NOT_FOUND)
                 .entity("Invalid domain provided: " + STRICT_SANITIZATION_POLICY.sanitize(domain))
@@ -342,6 +399,12 @@ public class ControlResource {
     private Response invalidConfigurationResponse(int configId) {
         return Response.status(Response.Status.NOT_FOUND)
                 .entity("Configuration not found: " + configId)
+                .build();
+    }
+
+    private Response controlHasConfigurationsResponse(int controlId, int configurationCount) {
+        return Response.status(Response.Status.CONFLICT)
+                .entity("Control " + controlId + " has " + configurationCount + " configuration(s) and cannot be deleted")
                 .build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/DecoratorResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/DecoratorResource.java
@@ -196,4 +196,35 @@ public class DecoratorResource {
             return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
         }
     }
+
+    /**
+     * Delete an existing decorator by ID in a given namespace.
+     *
+     * @param namespace the namespace containing the decorator
+     * @param id        the id of the decorator to delete
+     * @return 204 No Content, or an appropriate error response
+     */
+    @DELETE
+    @Path("{namespace}/decorators/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete a decorator by ID in a given namespace",
+            description = "Deletes a decorator from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteDecoratorForNamespace(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("id") @Min(value = 1, message = "ID must be a positive integer") int id
+    ) {
+        try {
+            decoratorStore.deleteDecorator(namespace, id);
+        } catch (DecoratorNotFoundException e) {
+            logger.error("Decorator [{}] not found in namespace [{}] when deleting", id, namespace, e);
+            return CalmResourceErrorResponses.decoratorNotFoundResponse(namespace, id);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting decorator [{}]", namespace, id, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        }
+        return Response.noContent().build();
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
@@ -274,6 +274,30 @@ public class FlowResource {
         }
     }
 
+    @DELETE
+    @Path("{namespace}/flows/{flowId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete a flow",
+            description = "Deletes a flow and all of its versions from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteFlow(
+            @PathParam("namespace") @Pattern(regexp= NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("flowId") int flowId
+    ) {
+        try {
+            store.deleteFlow(namespace, flowId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting flow", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (FlowNotFoundException e) {
+            logger.error("Invalid flow [{}] when deleting flow", flowId, e);
+            return invalidFlowResponse(flowId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response flowWithLocationResponse(Flow flow) throws URISyntaxException {
         return Response.created(new URI("/api/calm/namespaces/" + flow.getNamespace() + "/flows/" + flow.getId() + "/versions/" + flow.getDotVersion())).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/FlowResource.java
@@ -23,6 +23,7 @@ import org.finos.calm.domain.flow.CreateFlowRequest;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.FlowStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,7 @@ public class FlowResource {
 
     private final FlowStore store;
     private final CustomIdEnrichmentService customIds;
+    private final ResourceMappingStore mappingStore;
 
     private final Logger logger = LoggerFactory.getLogger(FlowResource.class);
 
@@ -49,9 +51,10 @@ public class FlowResource {
     Boolean allowPutOperations;
 
     @Inject
-    public FlowResource(FlowStore store, CustomIdEnrichmentService customIds) {
+    public FlowResource(FlowStore store, CustomIdEnrichmentService customIds, ResourceMappingStore mappingStore) {
         this.store = store;
         this.customIds = customIds;
+        this.mappingStore = mappingStore;
     }
 
     @GET
@@ -295,6 +298,7 @@ public class FlowResource {
             logger.error("Invalid flow [{}] when deleting flow", flowId, e);
             return invalidFlowResponse(flowId);
         }
+        MappingCleanup.deleteMapping(mappingStore, logger, namespace, ResourceType.FLOW, flowId);
         return Response.noContent().build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
@@ -152,6 +152,26 @@ public class InterfaceResource {
         }
     }
 
+    @DELETE
+    @Path("{namespace}/interfaces/{interfaceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteInterface(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("interfaceId") Integer interfaceId
+    ) {
+        try {
+            interfaceStore.deleteInterface(namespace, interfaceId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting interface", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (InterfaceNotFoundException e) {
+            logger.error("Invalid interface [{}] when deleting interface", interfaceId, e);
+            return invalidInterfaceResponse(interfaceId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response invalidInterfaceResponse(int interfaceId) {
         return Response.status(Response.Status.NOT_FOUND).entity("Invalid interface provided: " + interfaceId).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/InterfaceResource.java
@@ -21,6 +21,7 @@ import org.finos.calm.domain.interfaces.CreateInterfaceRequest;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.InterfaceStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +36,15 @@ public class InterfaceResource {
 
     private final InterfaceStore interfaceStore;
     private final CustomIdEnrichmentService customIds;
+    private final ResourceMappingStore mappingStore;
 
     private final Logger logger = LoggerFactory.getLogger(InterfaceResource.class);
 
     @Inject
-    public InterfaceResource(InterfaceStore interfaceStore, CustomIdEnrichmentService customIds) {
+    public InterfaceResource(InterfaceStore interfaceStore, CustomIdEnrichmentService customIds, ResourceMappingStore mappingStore) {
         this.interfaceStore = interfaceStore;
         this.customIds = customIds;
+        this.mappingStore = mappingStore;
     }
 
     @GET
@@ -169,6 +172,7 @@ public class InterfaceResource {
             logger.error("Invalid interface [{}] when deleting interface", interfaceId, e);
             return invalidInterfaceResponse(interfaceId);
         }
+        MappingCleanup.deleteMapping(mappingStore, logger, namespace, ResourceType.INTERFACE, interfaceId);
         return Response.noContent().build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/MappingCleanup.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/MappingCleanup.java
@@ -1,0 +1,38 @@
+package org.finos.calm.resources;
+
+import org.finos.calm.domain.ResourceType;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.ResourceMappingStore;
+import org.slf4j.Logger;
+
+/**
+ * Best-effort cleanup of a resource's custom-id mapping after its underlying resource has
+ * already been deleted, shared by the five resource types the name-based ({@code /calm}) API
+ * can map: Architecture, Flow, Interface, Pattern, Standard.
+ *
+ * <p>Without this, deleting a resource that was created (or is also reachable) through the
+ * name-based API leaves its {@code resource_mappings} entry behind: recreating it under the
+ * same custom ID then fails with {@code DuplicateMappingException}, and the custom-id route
+ * keeps resolving to a numeric ID that no longer exists.</p>
+ *
+ * <p>Most resources have no mapping at all — a custom ID only exists for resources written
+ * through the name-based API — so {@link ResourceMappingStore#deleteMappingByNumericId} is a
+ * no-op in the common case. The underlying resource is already gone by the time this runs, so
+ * a failure here is logged and swallowed rather than failing the delete response over cleanup
+ * that can't be rolled back into an undelete anyway.</p>
+ */
+final class MappingCleanup {
+
+    private MappingCleanup() {
+    }
+
+    static void deleteMapping(ResourceMappingStore mappingStore, Logger logger,
+                               String namespace, ResourceType type, int numericId) {
+        try {
+            mappingStore.deleteMappingByNumericId(namespace, type, numericId);
+        } catch (NamespaceNotFoundException e) {
+            logger.warn("Could not clean up the mapping for {} [{}] in namespace [{}] after delete "
+                    + "— the namespace no longer exists", type, numericId, namespace, e);
+        }
+    }
+}

--- a/calm-hub/src/main/java/org/finos/calm/resources/MappingCleanup.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/MappingCleanup.java
@@ -33,6 +33,11 @@ final class MappingCleanup {
         } catch (NamespaceNotFoundException e) {
             logger.warn("Could not clean up the mapping for {} [{}] in namespace [{}] after delete "
                     + "— the namespace no longer exists", type, numericId, namespace, e);
+        } catch (RuntimeException e) {
+            // A driver/DB failure (MongoException, a Nitrite lock/store error, ...) must not
+            // surface as an unhandled 500 for a delete that has already succeeded.
+            logger.warn("Could not clean up the mapping for {} [{}] in namespace [{}] after delete",
+                    type, numericId, namespace, e);
         }
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -248,6 +248,30 @@ public class PatternResource {
 
     }
 
+    @DELETE
+    @Path("{namespace}/patterns/{patternId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete a pattern",
+            description = "Deletes a pattern and all of its versions from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deletePattern(
+            @PathParam("namespace") @jakarta.validation.constraints.Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("patternId") int patternId
+    ) {
+        try {
+            store.deletePattern(namespace, patternId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting pattern", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (PatternNotFoundException e) {
+            logger.error("Invalid pattern [{}] when deleting pattern", patternId, e);
+            return invalidPatternResponse(patternId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response patternWithLocationResponse(Pattern pattern) throws URISyntaxException {
         return Response.created(new URI("/api/calm/namespaces/" + pattern.getNamespace() + "/patterns/" + pattern.getId() + "/versions/" + pattern.getDotVersion())).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/PatternResource.java
@@ -22,6 +22,7 @@ import org.finos.calm.domain.pattern.CreatePatternRequest;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.CustomIdEnrichmentService;
 import org.finos.calm.store.PatternStore;
+import org.finos.calm.store.ResourceMappingStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,7 @@ public class PatternResource {
 
     private final PatternStore store;
     private final CustomIdEnrichmentService customIds;
+    private final ResourceMappingStore mappingStore;
 
     private final Logger logger = LoggerFactory.getLogger(PatternResource.class);
 
@@ -47,9 +49,10 @@ public class PatternResource {
     Boolean allowPutOperations;
 
     @Inject
-    public PatternResource(PatternStore store, CustomIdEnrichmentService customIds) {
+    public PatternResource(PatternStore store, CustomIdEnrichmentService customIds, ResourceMappingStore mappingStore) {
         this.store = store;
         this.customIds = customIds;
+        this.mappingStore = mappingStore;
     }
 
     @GET
@@ -269,6 +272,7 @@ public class PatternResource {
             logger.error("Invalid pattern [{}] when deleting pattern", patternId, e);
             return invalidPatternResponse(patternId);
         }
+        MappingCleanup.deleteMapping(mappingStore, logger, namespace, ResourceType.PATTERN, patternId);
         return Response.noContent().build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
@@ -142,6 +142,26 @@ public class StandardResource {
         }
     }
 
+    @DELETE
+    @Path("{namespace}/standards/{standardId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteStandard(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("standardId") Integer standardId
+    ) {
+        try {
+            standardStore.deleteStandard(namespace, standardId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting standard", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (StandardNotFoundException e) {
+            logger.error("Invalid standard [{}] when deleting standard", standardId, e);
+            return invalidStandardResponse(standardId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response invalidStandardResponse(int standardId) {
         return Response.status(Response.Status.NOT_FOUND).entity("Invalid standard provided: " + standardId).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/StandardResource.java
@@ -16,6 +16,7 @@ import org.finos.calm.domain.exception.StandardVersionNotFoundException;
 import org.finos.calm.domain.standards.CreateStandardRequest;
 import org.finos.calm.security.CalmHubScopes;
 import org.finos.calm.services.CustomIdEnrichmentService;
+import org.finos.calm.store.ResourceMappingStore;
 import org.finos.calm.store.StandardStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,12 +32,14 @@ public class StandardResource {
 
     private final StandardStore standardStore;
     private final CustomIdEnrichmentService customIds;
+    private final ResourceMappingStore mappingStore;
 
     private final Logger logger = LoggerFactory.getLogger(StandardResource.class);
 
-    public StandardResource(StandardStore standardStore, CustomIdEnrichmentService customIds) {
+    public StandardResource(StandardStore standardStore, CustomIdEnrichmentService customIds, ResourceMappingStore mappingStore) {
         this.standardStore = standardStore;
         this.customIds = customIds;
+        this.mappingStore = mappingStore;
     }
 
     @GET
@@ -159,6 +162,7 @@ public class StandardResource {
             logger.error("Invalid standard [{}] when deleting standard", standardId, e);
             return invalidStandardResponse(standardId);
         }
+        MappingCleanup.deleteMapping(mappingStore, logger, namespace, ResourceType.STANDARD, standardId);
         return Response.noContent().build();
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/resources/TimelineResource.java
+++ b/calm-hub/src/main/java/org/finos/calm/resources/TimelineResource.java
@@ -238,6 +238,30 @@ public class TimelineResource {
         }
     }
 
+    @DELETE
+    @Path("{namespace}/timelines/{timelineId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Delete a timeline",
+            description = "Deletes a timeline and all of its versions from the given namespace. Requires global admin privilege."
+    )
+    @PermissionsAllowed(CalmHubScopes.GLOBAL_ADMIN)
+    public Response deleteTimeline(
+            @PathParam("namespace") @Pattern(regexp = NAMESPACE_REGEX, message = NAMESPACE_MESSAGE) String namespace,
+            @PathParam("timelineId") int timelineId
+    ) {
+        try {
+            store.deleteTimeline(namespace, timelineId);
+        } catch (NamespaceNotFoundException e) {
+            logger.error("Invalid namespace [{}] when deleting timeline", namespace, e);
+            return CalmResourceErrorResponses.invalidNamespaceResponse(namespace);
+        } catch (TimelineNotFoundException e) {
+            logger.error("Invalid timeline [{}] when deleting timeline", timelineId, e);
+            return invalidTimelineResponse(timelineId);
+        }
+        return Response.noContent().build();
+    }
+
     private Response timelineWithLocationResponse(Timeline timeline) throws URISyntaxException {
         return Response.created(new URI("/api/calm/namespaces/" + timeline.getNamespace() + "/timelines/" + timeline.getId() + "/versions/" + timeline.getDotVersion())).build();
     }

--- a/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
+++ b/calm-hub/src/main/java/org/finos/calm/security/AuditRequestFilter.java
@@ -353,6 +353,10 @@ public class AuditRequestFilter implements ContainerResponseFilter {
                     AuditEntityType.CONTROL_CONFIGURATION, domain, outcome, responseContext);
             case "createConfigurationForVersion" -> new AuditContext(AuditEntityType.CONTROL_CONFIGURATION,
                     AuditAction.UPDATE, null, domain, uriInfo.getPathParameters().getFirst("configId"), version);
+            case "deleteControlRequirement" -> new AuditContext(AuditEntityType.CONTROL_REQUIREMENT,
+                    AuditAction.DELETE, null, domain, uriInfo.getPathParameters().getFirst("controlId"), null);
+            case "deleteControlConfiguration" -> new AuditContext(AuditEntityType.CONTROL_CONFIGURATION,
+                    AuditAction.DELETE, null, domain, uriInfo.getPathParameters().getFirst("configId"), null);
             default -> null;
         };
     }

--- a/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/AdrStore.java
@@ -32,4 +32,9 @@ public interface AdrStore {
     AdrMeta getAdrRevision(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrParseException;
     AdrMeta updateAdrForNamespace(AdrMeta adrMeta) throws NamespaceNotFoundException, AdrNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException;
     AdrMeta updateAdrStatus(AdrMeta adrMeta, Status status) throws AdrNotFoundException, NamespaceNotFoundException, AdrRevisionNotFoundException, AdrPersistenceException, AdrParseException, AdrRevisionExistsException;
+
+    /**
+     * Deletes an ADR and all of its revisions.
+     */
+    void deleteAdr(String namespace, int adrId) throws NamespaceNotFoundException, AdrNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ArchitectureStore.java
@@ -35,4 +35,9 @@ public interface ArchitectureStore {
     String getArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionNotFoundException;
     Architecture createArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException, ArchitectureVersionExistsException;
     Architecture updateArchitectureForVersion(Architecture architecture) throws NamespaceNotFoundException, ArchitectureNotFoundException;
+
+    /**
+     * Deletes an architecture and all of its versions.
+     */
+    void deleteArchitecture(String namespace, int architectureId) throws NamespaceNotFoundException, ArchitectureNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/ControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ControlStore.java
@@ -7,6 +7,7 @@ import org.finos.calm.domain.controls.CreateControlRequirement;
 import org.finos.calm.domain.exception.ControlConfigurationNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionExistsException;
+import org.finos.calm.domain.exception.ControlHasConfigurationsException;
 import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
@@ -29,4 +30,15 @@ public interface ControlStore {
     List<String> getConfigurationVersions(String domain, int controlId, int configurationId) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException;
     String getConfigurationForVersion(String domain, int controlId, int configurationId, String version) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException, ControlConfigurationVersionNotFoundException;
     void createConfigurationForVersion(String domain, int controlId, int configurationId, String version, CreateControlConfiguration request) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException, ControlConfigurationVersionExistsException;
+
+    /**
+     * Deletes a control requirement and all of its versions. Refuses if the control still
+     * has configurations, rather than cascading — see {@link ControlHasConfigurationsException}.
+     */
+    void deleteControlRequirement(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException, ControlHasConfigurationsException;
+
+    /**
+     * Deletes a control configuration and all of its versions.
+     */
+    void deleteControlConfiguration(String domain, int controlId, int configurationId) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/DecoratorStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/DecoratorStore.java
@@ -64,4 +64,14 @@ public interface DecoratorStore {
      * @throws DecoratorNotFoundException  if no decorator with the given ID exists
      */
     void updateDecorator(String namespace, int id, String decoratorJson) throws NamespaceNotFoundException, DecoratorNotFoundException;
+
+    /**
+     * Delete an existing decorator in the given namespace.
+     *
+     * @param namespace the namespace containing the decorator
+     * @param id        the ID of the decorator to delete
+     * @throws NamespaceNotFoundException if the namespace does not exist
+     * @throws DecoratorNotFoundException if no decorator with the given ID exists
+     */
+    void deleteDecorator(String namespace, int id) throws NamespaceNotFoundException, DecoratorNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/FlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/FlowStore.java
@@ -17,4 +17,9 @@ public interface FlowStore {
     String getFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionNotFoundException;
     Flow createFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException, FlowVersionExistsException;
     Flow updateFlowForVersion(Flow flow) throws NamespaceNotFoundException, FlowNotFoundException;
+
+    /**
+     * Deletes a flow and all of its versions.
+     */
+    void deleteFlow(String namespace, int flowId) throws NamespaceNotFoundException, FlowNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/InterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/InterfaceStore.java
@@ -16,4 +16,9 @@ public interface InterfaceStore {
     List<String> getInterfaceVersions(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException;
     String getInterfaceForVersion(String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionNotFoundException;
     CalmInterface createInterfaceForVersion(CreateInterfaceRequest interfaceRequest, String namespace, Integer interfaceId, String version) throws NamespaceNotFoundException, InterfaceNotFoundException, InterfaceVersionExistsException;
+
+    /**
+     * Deletes an interface and all of its versions.
+     */
+    void deleteInterface(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/PatternStore.java
@@ -37,4 +37,9 @@ public interface PatternStore {
     String getPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionNotFoundException;
     Pattern createPatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException, PatternVersionExistsException;
     Pattern updatePatternForVersion(Pattern pattern) throws NamespaceNotFoundException, PatternNotFoundException;
+
+    /**
+     * Deletes a pattern and all of its versions.
+     */
+    void deletePattern(String namespace, int patternId) throws NamespaceNotFoundException, PatternNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/ResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/ResourceMappingStore.java
@@ -16,4 +16,14 @@ public interface ResourceMappingStore {
     List<ResourceMapping> listMappingsByNumericIds(String namespace, ResourceType type, List<Integer> ids) throws NamespaceNotFoundException;
     void updateMappingNumericId(String namespace, ResourceType type, String customId, int numericId) throws MappingNotFoundException, NamespaceNotFoundException;
     void deleteMapping(String namespace, ResourceType type, String customId) throws MappingNotFoundException, NamespaceNotFoundException;
+
+    /**
+     * Deletes the mapping for a resource by its numeric ID, if one exists.
+     *
+     * <p>A custom ID exists only for resources written through the name-based ({@code /calm})
+     * API, so most numeric-ID resources have no mapping to clean up at all. This is a no-op
+     * rather than throwing when nothing matches, so a resource delete can call it
+     * unconditionally instead of first checking whether a mapping exists.</p>
+     */
+    void deleteMappingByNumericId(String namespace, ResourceType type, int numericId) throws NamespaceNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/StandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/StandardStore.java
@@ -16,4 +16,9 @@ public interface StandardStore {
     List<String> getStandardVersions(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException;
     String getStandardForVersion(String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionNotFoundException;
     Standard createStandardForVersion(CreateStandardRequest standardRequest, String namespace, Integer standardId, String version) throws NamespaceNotFoundException, StandardNotFoundException, StandardVersionExistsException;
+
+    /**
+     * Deletes a standard and all of its versions.
+     */
+    void deleteStandard(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/TimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/TimelineStore.java
@@ -17,4 +17,9 @@ public interface TimelineStore {
     String getTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionNotFoundException;
     Timeline createTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException, TimelineVersionExistsException;
     Timeline updateTimelineForVersion(Timeline timeline) throws NamespaceNotFoundException, TimelineNotFoundException;
+
+    /**
+     * Deletes a timeline and all of its versions.
+     */
+    void deleteTimeline(String namespace, int timelineId) throws NamespaceNotFoundException, TimelineNotFoundException;
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoAdrStore.java
@@ -301,4 +301,12 @@ public class MongoAdrStore implements AdrStore {
             throw new AdrNotFoundException();
         }
     }
+
+    @Override
+    public void deleteAdr(String namespace, int adrId) throws NamespaceNotFoundException, AdrNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, adrId)) {
+            throw new AdrNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoArchitectureStore.java
@@ -156,4 +156,12 @@ public class MongoArchitectureStore implements ArchitectureStore {
             throw new ArchitectureNotFoundException();
         }
     }
+
+    @Override
+    public void deleteArchitecture(String namespace, int architectureId) throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, architectureId)) {
+            throw new ArchitectureNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -195,6 +195,19 @@ public class MongoControlStore implements ControlStore {
         }
     }
 
+    /**
+     * Refuses to delete a control requirement that still has configurations, rather than
+     * cascading — see {@link ControlHasConfigurationsException}.
+     *
+     * <p><b>Known, accepted race</b>: the configuration count and the delete are two separate
+     * calls, not one atomic operation, so a configuration created via
+     * {@link #createConfigurationForVersion} in the gap between them survives under a
+     * requirement that has just been deleted. Not fixed here, consistent with the rest of this
+     * store layer using no transactions or locks anywhere else: a Nitrite-only lock would not
+     * extend the guarantee to Mongo (this backend), and the failure mode — one configuration
+     * document outliving the requirement it belonged to — is a data-hygiene issue, discoverable
+     * and cleanable, not a correctness or security one.</p>
+     */
     @Override
     public void deleteControlRequirement(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException, ControlHasConfigurationsException {
         requireControl(domain, controlId);

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoControlStore.java
@@ -12,6 +12,7 @@ import org.finos.calm.domain.controls.CreateControlRequirement;
 import org.finos.calm.domain.exception.ControlConfigurationNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionExistsException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionNotFoundException;
+import org.finos.calm.domain.exception.ControlHasConfigurationsException;
 import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
@@ -191,6 +192,29 @@ public class MongoControlStore implements ControlStore {
                 configurationNamespace(domain, controlId), configurationId, version, content);
         if (!created) {
             throw new ControlConfigurationVersionExistsException();
+        }
+    }
+
+    @Override
+    public void deleteControlRequirement(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException, ControlHasConfigurationsException {
+        requireControl(domain, controlId);
+
+        int configurationCount = configurationStore.countHeaders(configurationNamespace(domain, controlId));
+        if (configurationCount > 0) {
+            throw new ControlHasConfigurationsException(controlId, configurationCount);
+        }
+
+        if (!requirementStore.deleteResource(domain, controlId)) {
+            throw new ControlNotFoundException();
+        }
+    }
+
+    @Override
+    public void deleteControlConfiguration(String domain, int controlId, int configurationId) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException {
+        requireConfiguration(domain, controlId, configurationId);
+
+        if (!configurationStore.deleteResource(configurationNamespace(domain, controlId), configurationId)) {
+            throw new ControlConfigurationNotFoundException();
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDecoratorStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoDecoratorStore.java
@@ -145,6 +145,22 @@ public class MongoDecoratorStore implements DecoratorStore {
         LOG.debug("Updated decorator with ID {} in namespace '{}'", id, namespace);
     }
 
+    @Override
+    public void deleteDecorator(String namespace, int id) throws NamespaceNotFoundException, DecoratorNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+
+        long modified = decoratorCollection.updateOne(
+                Filters.eq("namespace", namespace),
+                Updates.pull("decorators", Filters.eq(DECORATOR_ID_FIELD, id))
+        ).getModifiedCount();
+
+        if (modified == 0) {
+            throw new DecoratorNotFoundException();
+        }
+
+        LOG.debug("Deleted decorator with ID {} in namespace '{}'", id, namespace);
+    }
+
     /**
      * Fetches the namespace document from MongoDB
      */

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoFlowStore.java
@@ -143,4 +143,12 @@ public class MongoFlowStore implements FlowStore {
             throw new FlowNotFoundException();
         }
     }
+
+    @Override
+    public void deleteFlow(String namespace, int flowId) throws NamespaceNotFoundException, FlowNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, flowId)) {
+            throw new FlowNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoInterfaceStore.java
@@ -131,4 +131,12 @@ public class MongoInterfaceStore implements InterfaceStore {
             throw new InterfaceNotFoundException();
         }
     }
+
+    @Override
+    public void deleteInterface(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, interfaceId)) {
+            throw new InterfaceNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoPatternStore.java
@@ -152,4 +152,12 @@ public class MongoPatternStore implements PatternStore {
             throw new PatternNotFoundException();
         }
     }
+
+    @Override
+    public void deletePattern(String namespace, int patternId) throws NamespaceNotFoundException, PatternNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, patternId)) {
+            throw new PatternNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoResourceMappingStore.java
@@ -198,4 +198,17 @@ public class MongoResourceMappingStore implements ResourceMappingStore {
             throw new MappingNotFoundException();
         }
     }
+
+    @Override
+    public void deleteMappingByNumericId(String namespace, ResourceType type, int numericId) throws NamespaceNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+
+        Bson filter = Filters.and(
+                Filters.eq("namespace", namespace),
+                Filters.eq("resourceType", type.name()),
+                Filters.eq("numericId", numericId)
+        );
+
+        mappingCollection.deleteOne(filter);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoStandardStore.java
@@ -127,4 +127,12 @@ public class MongoStandardStore implements StandardStore {
             throw new StandardNotFoundException();
         }
     }
+
+    @Override
+    public void deleteStandard(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, standardId)) {
+            throw new StandardNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/mongo/MongoTimelineStore.java
@@ -151,4 +151,12 @@ public class MongoTimelineStore implements TimelineStore {
             throw new TimelineNotFoundException();
         }
     }
+
+    @Override
+    public void deleteTimeline(String namespace, int timelineId) throws NamespaceNotFoundException, TimelineNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, timelineId)) {
+            throw new TimelineNotFoundException();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteAdrStore.java
@@ -285,4 +285,13 @@ public class NitriteAdrStore implements AdrStore {
             throw new AdrNotFoundException();
         }
     }
+
+    @Override
+    public void deleteAdr(String namespace, int adrId) throws NamespaceNotFoundException, AdrNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, adrId)) {
+            throw new AdrNotFoundException();
+        }
+        LOG.info("Deleted ADR with ID {} from namespace '{}'", adrId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteArchitectureStore.java
@@ -196,4 +196,13 @@ public class NitriteArchitectureStore implements ArchitectureStore {
         namespaceStore.requireNamespace(architecture.getNamespace());
         requireArchitectureExists(architecture);
     }
+
+    @Override
+    public void deleteArchitecture(String namespace, int architectureId) throws NamespaceNotFoundException, ArchitectureNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, architectureId)) {
+            throw new ArchitectureNotFoundException();
+        }
+        LOG.info("Deleted architecture with ID {} from namespace '{}'", architectureId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -192,6 +192,16 @@ public class NitriteControlStore implements ControlStore {
         }
     }
 
+    /**
+     * Refuses to delete a control requirement that still has configurations, rather than
+     * cascading — see {@link ControlHasConfigurationsException}.
+     *
+     * <p><b>Known, accepted race</b>: same non-atomic count-then-delete as
+     * {@code MongoControlStore#deleteControlRequirement} — see that method's javadoc.
+     * {@code configurationStore} and {@code requirementStore} are two separate
+     * {@link NitriteVersionDocumentStore} instances, each with its own internal lock, so
+     * neither one's locking closes the gap between the count and the delete below.</p>
+     */
     @Override
     public void deleteControlRequirement(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException, ControlHasConfigurationsException {
         requireControl(domain, controlId);

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteControlStore.java
@@ -12,6 +12,7 @@ import org.finos.calm.domain.controls.CreateControlRequirement;
 import org.finos.calm.domain.exception.ControlConfigurationNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionExistsException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionNotFoundException;
+import org.finos.calm.domain.exception.ControlHasConfigurationsException;
 import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
@@ -189,6 +190,31 @@ public class NitriteControlStore implements ControlStore {
         if (!created) {
             throw new ControlConfigurationVersionExistsException();
         }
+    }
+
+    @Override
+    public void deleteControlRequirement(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException, ControlHasConfigurationsException {
+        requireControl(domain, controlId);
+
+        int configurationCount = configurationStore.countHeaders(configurationNamespace(domain, controlId));
+        if (configurationCount > 0) {
+            throw new ControlHasConfigurationsException(controlId, configurationCount);
+        }
+
+        if (!requirementStore.deleteResource(domain, controlId)) {
+            throw new ControlNotFoundException();
+        }
+        LOG.info("Deleted control requirement {} from domain '{}'", controlId, domain);
+    }
+
+    @Override
+    public void deleteControlConfiguration(String domain, int controlId, int configurationId) throws DomainNotFoundException, ControlNotFoundException, ControlConfigurationNotFoundException {
+        requireConfiguration(domain, controlId, configurationId);
+
+        if (!configurationStore.deleteResource(configurationNamespace(domain, controlId), configurationId)) {
+            throw new ControlConfigurationNotFoundException();
+        }
+        LOG.info("Deleted configuration {} from control {} in domain '{}'", configurationId, controlId, domain);
     }
 
     private void requireControl(String domain, int controlId) throws DomainNotFoundException, ControlNotFoundException {

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDecoratorStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteDecoratorStore.java
@@ -182,6 +182,38 @@ public class NitriteDecoratorStore implements DecoratorStore {
         LOG.debug("Updated decorator with ID {} in namespace '{}'", id, namespace);
     }
 
+    @Override
+    public void deleteDecorator(String namespace, int id) throws NamespaceNotFoundException, DecoratorNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+
+        lock.lock();
+        try {
+            Document namespaceDoc = fetchNamespaceDocument(namespace);
+            if (namespaceDoc == null) {
+                throw new DecoratorNotFoundException();
+            }
+
+            TypeSafeNitriteDocument<Document> typeSafeDoc = new TypeSafeNitriteDocument<>(namespaceDoc, Document.class);
+            List<Document> decorators = typeSafeDoc.getList(DECORATORS_FIELD);
+            if (decorators == null) {
+                throw new DecoratorNotFoundException();
+            }
+
+            List<Document> mutableDecorators = new ArrayList<>(decorators);
+            boolean removed = mutableDecorators.removeIf(
+                    decoratorEntry -> Integer.valueOf(id).equals(decoratorEntry.get(DECORATOR_ID_FIELD, Integer.class)));
+            if (!removed) {
+                throw new DecoratorNotFoundException();
+            }
+
+            namespaceDoc.put(DECORATORS_FIELD, mutableDecorators);
+            decoratorCollection.update(namespaceDoc);
+            LOG.debug("Deleted decorator with ID {} in namespace '{}'", id, namespace);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     /**
      * Fetches the namespace document from NitriteDB
      */

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteFlowStore.java
@@ -168,4 +168,13 @@ public class NitriteFlowStore implements FlowStore {
         namespaceStore.requireNamespace(flow.getNamespace());
         requireFlowExists(flow);
     }
+
+    @Override
+    public void deleteFlow(String namespace, int flowId) throws NamespaceNotFoundException, FlowNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, flowId)) {
+            throw new FlowNotFoundException();
+        }
+        LOG.info("Deleted flow with ID {} from namespace '{}'", flowId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteInterfaceStore.java
@@ -157,4 +157,13 @@ public class NitriteInterfaceStore implements InterfaceStore {
         namespaceStore.requireNamespace(namespace);
         requireInterfaceExists(namespace, interfaceId);
     }
+
+    @Override
+    public void deleteInterface(String namespace, Integer interfaceId) throws NamespaceNotFoundException, InterfaceNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, interfaceId)) {
+            throw new InterfaceNotFoundException();
+        }
+        LOG.info("Deleted interface with ID {} from namespace '{}'", interfaceId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitritePatternStore.java
@@ -186,4 +186,13 @@ public class NitritePatternStore implements PatternStore {
         namespaceStore.requireNamespace(pattern.getNamespace());
         requirePatternExists(pattern);
     }
+
+    @Override
+    public void deletePattern(String namespace, int patternId) throws NamespaceNotFoundException, PatternNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, patternId)) {
+            throw new PatternNotFoundException();
+        }
+        LOG.info("Deleted pattern with ID {} from namespace '{}'", patternId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteResourceMappingStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteResourceMappingStore.java
@@ -215,4 +215,22 @@ public class NitriteResourceMappingStore implements ResourceMappingStore {
             lock.unlock();
         }
     }
+
+    @Override
+    public void deleteMappingByNumericId(String namespace, ResourceType type, int numericId) throws NamespaceNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+
+        lock.lock();
+        try {
+            Filter filter = Filter.and(where(NAMESPACE_FIELD).eq(namespace),
+                    where(RESOURCE_TYPE_FIELD).eq(type.name()),
+                    where(NUMERIC_ID_FIELD).eq(numericId));
+            Document existing = mappingCollection.find(filter).firstOrNull();
+            if (existing != null) {
+                mappingCollection.remove(existing);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteStandardStore.java
@@ -153,4 +153,13 @@ public class NitriteStandardStore implements StandardStore {
         namespaceStore.requireNamespace(namespace);
         requireStandardExists(namespace, standardId);
     }
+
+    @Override
+    public void deleteStandard(String namespace, Integer standardId) throws NamespaceNotFoundException, StandardNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, standardId)) {
+            throw new StandardNotFoundException();
+        }
+        LOG.info("Deleted standard with ID {} from namespace '{}'", standardId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/nitrite/NitriteTimelineStore.java
@@ -181,4 +181,13 @@ public class NitriteTimelineStore implements TimelineStore {
         namespaceStore.requireNamespace(timeline.getNamespace());
         requireTimelineExists(timeline);
     }
+
+    @Override
+    public void deleteTimeline(String namespace, int timelineId) throws NamespaceNotFoundException, TimelineNotFoundException {
+        namespaceStore.requireNamespace(namespace);
+        if (!documentStore.deleteResource(namespace, timelineId)) {
+            throw new TimelineNotFoundException();
+        }
+        LOG.info("Deleted timeline with ID {} from namespace '{}'", timelineId, namespace);
+    }
 }

--- a/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/MongoVersionDocumentStore.java
@@ -10,6 +10,7 @@ import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -156,8 +157,9 @@ public class MongoVersionDocumentStore {
      *
      * <p>The old shape pushed the resource and its first version in one document write, so
      * a failure left nothing behind. Splitting them means a failed version write can strand
-     * a header that no API can remove — there is no delete endpoint for these types — and it
-     * would show up in listings and search with {@code versionCount: 0} forever.</p>
+     * a header that no API can remove — this is a narrower operation than
+     * {@link #deleteResource}, the general-purpose delete — and it would show up in listings
+     * and search with {@code versionCount: 0} forever.</p>
      *
      * <p>Not a general-purpose delete: nothing else calls this, and it deliberately does not
      * touch the version collection, because the only caller has just failed to write the
@@ -172,6 +174,31 @@ public class MongoVersionDocumentStore {
             LOG.warn("Failed to remove the header after a failed first version write "
                     + "[namespace={}, {}={}] — it may be left with no versions",
                     namespace, idField, resourceId, e);
+        }
+    }
+
+    /**
+     * Deletes a resource entirely: its header and every version document. This is the
+     * general-purpose delete backing a DELETE endpoint — unlike {@link #deleteHeader}, a
+     * failure here is translated and thrown rather than swallowed, and the version
+     * collection is cleared too.
+     *
+     * <p>Versions are removed before the header, not after: if the version delete fails,
+     * the header is still there as evidence the resource exists, rather than leaving
+     * unreachable version documents behind under a header that's already gone.</p>
+     *
+     * @return {@code true} if a header was actually deleted, {@code false} if none existed
+     * at this (namespace, resourceId) — lets the caller distinguish "already gone" from
+     * "removed".
+     */
+    public boolean deleteResource(String namespace, int resourceId) {
+        try {
+            versionCollection.deleteMany(headerFilter(namespace, resourceId));
+            DeleteResult result = headerCollection.deleteOne(headerFilter(namespace, resourceId));
+            return result.getDeletedCount() > 0;
+        } catch (MongoException e) {
+            LOG.error("Failed to delete resource [namespace={}, {}={}]", namespace, idField, resourceId, e);
+            throw StorageWriteException.writeFailed(e);
         }
     }
 

--- a/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
+++ b/calm-hub/src/main/java/org/finos/calm/store/util/NitriteVersionDocumentStore.java
@@ -157,6 +157,38 @@ public class NitriteVersionDocumentStore {
     }
 
     /**
+     * Deletes a resource entirely: its header and every version document, under a single
+     * write lock so no concurrent read observes a header with no versions or vice versa.
+     * See {@link MongoVersionDocumentStore#deleteResource} — this is the general-purpose
+     * delete backing a DELETE endpoint, unlike {@link #deleteHeader}.
+     *
+     * @return {@code true} if a header was actually removed, {@code false} if none existed.
+     */
+    public boolean deleteResource(String namespace, int resourceId) {
+        lock.writeLock().lock();
+        try {
+            Filter filter = headerFilter(namespace, resourceId);
+            Document header = headerCollection.find(filter).firstOrNull();
+            if (header == null) {
+                return false;
+            }
+            // Materialize matches before removing — mutating the collection while its
+            // cursor is still being iterated is unsafe.
+            List<Document> versions = new ArrayList<>();
+            for (Document versionDocument : versionCollection.find(filter)) {
+                versions.add(versionDocument);
+            }
+            for (Document versionDocument : versions) {
+                versionCollection.remove(versionDocument);
+            }
+            headerCollection.remove(header);
+            return true;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
      * Writes the first version of a newly created resource, removing the header again if
      * that fails. See {@link MongoVersionDocumentStore#createFirstVersion} — the reasoning
      * for owning this here, and for treating {@code !created} as a real failure, is the

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestAdrResourceShould.java
@@ -393,4 +393,27 @@ public class TestAdrResourceShould {
         verify(mockAdrStore, times(1)).getAdr(expectedAdrToRetrieveMeta);
     }
 
+    static Stream<Arguments> provideParametersForDeleteAdrTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new AdrNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteAdrTests")
+    void respond_correctly_to_delete_adr(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws NamespaceNotFoundException, AdrNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockAdrStore).deleteAdr(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/adrs/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockAdrStore, times(1)).deleteAdr(namespace, 12);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
@@ -486,6 +486,40 @@ public class TestArchitectureResourceShould {
     }
 
     @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_architecture() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/architectures/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteArchitectureTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new ArchitectureNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteArchitectureTests")
+    void respond_correctly_to_delete_architecture(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws ArchitectureNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockArchitectureStore).deleteArchitecture(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/architectures/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockArchitectureStore, times(1)).deleteArchitecture(namespace, 12);
+    }
+
+    @Test
     void return_an_implied_timeline_projection_when_architecture_has_versions() throws NamespaceNotFoundException, ArchitectureNotFoundException {
         when(mockTimelineStore.getTimelinesForNamespace(any())).thenReturn(List.of());
         when(mockArchitectureStore.getArchitectureVersions(any()))

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestArchitectureResourceShould.java
@@ -7,6 +7,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Architecture;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.architecture.ArchitectureRequest;
 import org.finos.calm.domain.namespaces.NamespaceResourceSummary;
 import org.finos.calm.domain.exception.ArchitectureNotFoundException;
@@ -517,6 +518,30 @@ public class TestArchitectureResourceShould {
                 .statusCode(expectedStatusCode);
 
         verify(mockArchitectureStore, times(1)).deleteArchitecture(namespace, 12);
+    }
+
+    @Test
+    void delete_architecture_also_cleans_up_its_resource_mapping() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/architectures/12")
+                .then()
+                .statusCode(204);
+
+        verify(mockResourceMappingStore, times(1)).deleteMappingByNumericId("valid", ResourceType.ARCHITECTURE, 12);
+    }
+
+    @Test
+    void not_clean_up_the_resource_mapping_when_deleting_a_missing_architecture() throws Exception {
+        doThrow(new ArchitectureNotFoundException()).when(mockArchitectureStore).deleteArchitecture("valid", 12);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/architectures/12")
+                .then()
+                .statusCode(404);
+
+        verifyNoInteractions(mockResourceMappingStore);
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestControlResourceShould.java
@@ -620,4 +620,74 @@ public class TestControlResourceShould {
                     .statusCode(expectedStatusCode);
         }
     }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_domain_is_provided_on_delete_control_requirement() {
+        given()
+                .when()
+                .delete("/api/calm/domains/invalid_domain/controls/1")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteControlRequirementTests() {
+        return Stream.of(
+                Arguments.of(new DomainNotFoundException(INVALID_DOMAIN), 404),
+                Arguments.of(new ControlNotFoundException(), 404),
+                Arguments.of(new ControlHasConfigurationsException(1, 2), 409),
+                Arguments.of(null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteControlRequirementTests")
+    void respond_correctly_to_delete_control_requirement(Throwable exceptionToThrow, int expectedStatusCode) throws Exception {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockControlStore).deleteControlRequirement(VALID_DOMAIN, 1);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/1")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockControlStore, times(1)).deleteControlRequirement(VALID_DOMAIN, 1);
+    }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_domain_is_provided_on_delete_control_configuration() {
+        given()
+                .when()
+                .delete("/api/calm/domains/invalid_domain/controls/1/configurations/10")
+                .then()
+                .statusCode(400)
+                .body(containsString(DOMAIN_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteControlConfigurationTests() {
+        return Stream.of(
+                Arguments.of(new DomainNotFoundException(INVALID_DOMAIN), 404),
+                Arguments.of(new ControlNotFoundException(), 404),
+                Arguments.of(new ControlConfigurationNotFoundException(), 404),
+                Arguments.of(null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteControlConfigurationTests")
+    void respond_correctly_to_delete_control_configuration(Throwable exceptionToThrow, int expectedStatusCode) throws Exception {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockControlStore).deleteControlConfiguration(VALID_DOMAIN, 1, 10);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/domains/" + VALID_DOMAIN + "/controls/1/configurations/10")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockControlStore, times(1)).deleteControlConfiguration(VALID_DOMAIN, 1, 10);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestDecoratorResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestDecoratorResourceShould.java
@@ -676,4 +676,62 @@ public class TestDecoratorResourceShould {
                 .statusCode(400)
                 .body(containsString("ID must be a positive integer"));
     }
+
+    // ---- DELETE /api/calm/namespaces/{namespace}/decorators/{id} ----
+
+    @Test
+    void return_204_when_decorator_deleted_successfully() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos/decorators/1")
+                .then()
+                .statusCode(204);
+
+        verify(decoratorStore, times(1)).deleteDecorator("finos", 1);
+    }
+
+    @Test
+    void return_404_when_decorator_not_found_for_delete() throws Exception {
+        doThrow(new DecoratorNotFoundException())
+                .when(decoratorStore).deleteDecorator(anyString(), anyInt());
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/finos/decorators/999")
+                .then()
+                .statusCode(404)
+                .body(containsString("Decorator with ID 999 does not exist in namespace: finos"));
+    }
+
+    @Test
+    void return_404_when_namespace_does_not_exist_for_delete_decorator() throws Exception {
+        doThrow(new NamespaceNotFoundException())
+                .when(decoratorStore).deleteDecorator(anyString(), anyInt());
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/invalid-namespace/decorators/1")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void return_400_when_namespace_has_invalid_characters_for_delete_decorator() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/invalid@namespace/decorators/1")
+                .then()
+                .statusCode(400)
+                .body(containsString("namespace must match pattern"));
+    }
+
+    @Test
+    void return_400_when_delete_id_is_zero() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/test-namespace/decorators/0")
+                .then()
+                .statusCode(400)
+                .body(containsString("ID must be a positive integer"));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import org.bson.json.JsonParseException;
 import org.finos.calm.domain.Flow;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.exception.FlowNotFoundException;
 import org.finos.calm.domain.exception.FlowVersionExistsException;
 import org.finos.calm.domain.exception.FlowVersionNotFoundException;
@@ -405,5 +406,29 @@ public class TestFlowResourceShould {
                 .statusCode(expectedStatusCode);
 
         verify(mockFlowStore, times(1)).deleteFlow(namespace, 12);
+    }
+
+    @Test
+    void delete_flow_also_cleans_up_its_resource_mapping() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/flows/12")
+                .then()
+                .statusCode(204);
+
+        verify(mockResourceMappingStore, times(1)).deleteMappingByNumericId("valid", ResourceType.FLOW, 12);
+    }
+
+    @Test
+    void not_clean_up_the_resource_mapping_when_deleting_a_missing_flow() throws Exception {
+        doThrow(new FlowNotFoundException()).when(mockFlowStore).deleteFlow("valid", 12);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/flows/12")
+                .then()
+                .statusCode(404);
+
+        verifyNoInteractions(mockResourceMappingStore);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestFlowResourceShould.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
+import static org.finos.calm.resources.ResourceValidationConstants.NAMESPACE_MESSAGE;
 import static org.finos.calm.resources.ResourceValidationConstants.VERSION_MESSAGE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -370,5 +371,39 @@ public class TestFlowResourceShould {
                 .put("/api/calm/namespaces/test/flows/20/versions/1.0.1")
                 .then()
                 .statusCode(403);
+    }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_flow() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/flows/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteFlowTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new FlowNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteFlowTests")
+    void respond_correctly_to_delete_flow(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws FlowNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockFlowStore).deleteFlow(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/flows/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockFlowStore, times(1)).deleteFlow(namespace, 12);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
@@ -393,4 +393,38 @@ public class TestInterfaceResourceShould {
 
         verify(mockInterfaceStore, times(1)).createInterfaceForVersion(createInterfaceRequest, namespace, 5, "1.0.1");
     }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_interface() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/interfaces/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteInterfaceTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new InterfaceNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteInterfaceTests")
+    void respond_correctly_to_delete_interface(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws InterfaceNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockInterfaceStore).deleteInterface(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/interfaces/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockInterfaceStore, times(1)).deleteInterface(namespace, 12);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestInterfaceResourceShould.java
@@ -427,4 +427,28 @@ public class TestInterfaceResourceShould {
 
         verify(mockInterfaceStore, times(1)).deleteInterface(namespace, 12);
     }
+
+    @Test
+    void delete_interface_also_cleans_up_its_resource_mapping() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/interfaces/12")
+                .then()
+                .statusCode(204);
+
+        verify(mockResourceMappingStore, times(1)).deleteMappingByNumericId("valid", ResourceType.INTERFACE, 12);
+    }
+
+    @Test
+    void not_clean_up_the_resource_mapping_when_deleting_a_missing_interface() throws Exception {
+        doThrow(new InterfaceNotFoundException()).when(mockInterfaceStore).deleteInterface("valid", 12);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/interfaces/12")
+                .then()
+                .statusCode(404);
+
+        verifyNoInteractions(mockResourceMappingStore);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingCleanupShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingCleanupShould.java
@@ -41,4 +41,17 @@ class TestMappingCleanupShould {
 
         verify(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
     }
+
+    @Test
+    void log_rather_than_throw_when_the_mapping_store_fails_at_runtime() throws NamespaceNotFoundException {
+        // A driver/DB failure (MongoException, a Nitrite lock/store error, ...) must not
+        // surface as an unhandled 500 for a delete that has already succeeded.
+        doThrow(new RuntimeException("connection reset"))
+                .when(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
+
+        assertDoesNotThrow(() ->
+                MappingCleanup.deleteMapping(mappingStore, logger, "finos", ResourceType.ARCHITECTURE, 42));
+
+        verify(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestMappingCleanupShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestMappingCleanupShould.java
@@ -1,0 +1,44 @@
+package org.finos.calm.resources;
+
+import org.finos.calm.domain.ResourceType;
+import org.finos.calm.domain.exception.NamespaceNotFoundException;
+import org.finos.calm.store.ResourceMappingStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TestMappingCleanupShould {
+
+    @Mock
+    private ResourceMappingStore mappingStore;
+
+    @Mock
+    private Logger logger;
+
+    @Test
+    void delete_the_mapping_by_numeric_id() throws NamespaceNotFoundException {
+        MappingCleanup.deleteMapping(mappingStore, logger, "finos", ResourceType.ARCHITECTURE, 42);
+
+        verify(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
+    }
+
+    @Test
+    void log_rather_than_throw_when_the_namespace_has_vanished_mid_request() throws NamespaceNotFoundException {
+        // The resource is already deleted by the time this runs, so a failure to clean up its
+        // mapping must not fail the delete response over cleanup that can't be undone anyway.
+        doThrow(new NamespaceNotFoundException())
+                .when(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
+
+        assertDoesNotThrow(() ->
+                MappingCleanup.deleteMapping(mappingStore, logger, "finos", ResourceType.ARCHITECTURE, 42));
+
+        verify(mappingStore).deleteMappingByNumericId("finos", ResourceType.ARCHITECTURE, 42);
+    }
+}

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
@@ -474,4 +474,38 @@ public class TestPatternResourceShould {
                 .then()
                 .statusCode(403);
     }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_pattern() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/patterns/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeletePatternTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new PatternNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeletePatternTests")
+    void respond_correctly_to_delete_pattern(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws PatternNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockPatternStore).deletePattern(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/patterns/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockPatternStore, times(1)).deletePattern(namespace, 12);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestPatternResourceShould.java
@@ -508,4 +508,28 @@ public class TestPatternResourceShould {
 
         verify(mockPatternStore, times(1)).deletePattern(namespace, 12);
     }
+
+    @Test
+    void delete_pattern_also_cleans_up_its_resource_mapping() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/patterns/12")
+                .then()
+                .statusCode(204);
+
+        verify(mockResourceMappingStore, times(1)).deleteMappingByNumericId("valid", ResourceType.PATTERN, 12);
+    }
+
+    @Test
+    void not_clean_up_the_resource_mapping_when_deleting_a_missing_pattern() throws Exception {
+        doThrow(new PatternNotFoundException()).when(mockPatternStore).deletePattern("valid", 12);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/patterns/12")
+                .then()
+                .statusCode(404);
+
+        verifyNoInteractions(mockResourceMappingStore);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
@@ -349,4 +349,38 @@ public class TestStandardResourceShould {
 
         verify(mockStandardStore, times(1)).createStandardForVersion(createStandardRequest, namespace, 5, "1.0.1");
     }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_standard() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/standards/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteStandardTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new StandardNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteStandardTests")
+    void respond_correctly_to_delete_standard(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws StandardNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockStandardStore).deleteStandard(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/standards/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockStandardStore, times(1)).deleteStandard(namespace, 12);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestStandardResourceShould.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import org.finos.calm.domain.ResourceType;
 import org.finos.calm.domain.Standard;
 import org.finos.calm.domain.exception.NamespaceNotFoundException;
 import org.finos.calm.domain.exception.StandardNotFoundException;
@@ -382,5 +383,29 @@ public class TestStandardResourceShould {
                 .statusCode(expectedStatusCode);
 
         verify(mockStandardStore, times(1)).deleteStandard(namespace, 12);
+    }
+
+    @Test
+    void delete_standard_also_cleans_up_its_resource_mapping() throws Exception {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/standards/12")
+                .then()
+                .statusCode(204);
+
+        verify(mockResourceMappingStore, times(1)).deleteMappingByNumericId("valid", ResourceType.STANDARD, 12);
+    }
+
+    @Test
+    void not_clean_up_the_resource_mapping_when_deleting_a_missing_standard() throws Exception {
+        doThrow(new StandardNotFoundException()).when(mockStandardStore).deleteStandard("valid", 12);
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/valid/standards/12")
+                .then()
+                .statusCode(404);
+
+        verifyNoInteractions(mockResourceMappingStore);
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/resources/TestTimelineResourceShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/resources/TestTimelineResourceShould.java
@@ -326,4 +326,38 @@ public class TestTimelineResourceShould {
                 .then()
                 .statusCode(403);
     }
+
+    @Test
+    void return_a_400_when_an_invalid_format_of_namespace_is_provided_on_delete_timeline() {
+        given()
+                .when()
+                .delete("/api/calm/namespaces/fin_os/timelines/12")
+                .then()
+                .statusCode(400)
+                .body(containsString(NAMESPACE_MESSAGE));
+    }
+
+    static Stream<Arguments> provideParametersForDeleteTimelineTests() {
+        return Stream.of(
+                Arguments.of("invalid", new NamespaceNotFoundException(), 404),
+                Arguments.of("valid", new TimelineNotFoundException(), 404),
+                Arguments.of("valid", null, 204)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForDeleteTimelineTests")
+    void respond_correctly_to_delete_timeline(String namespace, Throwable exceptionToThrow, int expectedStatusCode) throws TimelineNotFoundException, NamespaceNotFoundException {
+        if (exceptionToThrow != null) {
+            doThrow(exceptionToThrow).when(mockTimelineStore).deleteTimeline(namespace, 12);
+        }
+
+        given()
+                .when()
+                .delete("/api/calm/namespaces/" + namespace + "/timelines/12")
+                .then()
+                .statusCode(expectedStatusCode);
+
+        verify(mockTimelineStore, times(1)).deleteTimeline(namespace, 12);
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/security/TestAuditRequestFilterShould.java
@@ -429,6 +429,45 @@ public class TestAuditRequestFilterShould {
         assertThat(entry.getAction(), is(AuditAction.UPDATE));
     }
 
+    @Test
+    void resolve_control_requirement_deletion_directly_from_path_params() {
+        when(resourceInfo.getResourceClass()).thenReturn((Class) ControlResource.class);
+        when(resourceInfo.getResourceMethod()).thenReturn(mockMethod(ControlResource.class, "deleteControlRequirement"));
+        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+        pathParams.putSingle("domain", "payments");
+        pathParams.putSingle("controlId", "11");
+        ContainerRequestContext requestContext = mockRequest("DELETE", pathParams);
+        ContainerResponseContext responseContext = mockResponse(204, null);
+
+        filter.filter(requestContext, responseContext);
+
+        AuditLogEntry entry = captureRecordedEntry();
+        assertThat(entry.getEntityType(), is(AuditEntityType.CONTROL_REQUIREMENT));
+        assertThat(entry.getDomain(), is("payments"));
+        assertThat(entry.getEntityId(), is("11"));
+        assertThat(entry.getAction(), is(AuditAction.DELETE));
+    }
+
+    @Test
+    void resolve_control_configuration_deletion_directly_from_path_params() {
+        when(resourceInfo.getResourceClass()).thenReturn((Class) ControlResource.class);
+        when(resourceInfo.getResourceMethod()).thenReturn(mockMethod(ControlResource.class, "deleteControlConfiguration"));
+        MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+        pathParams.putSingle("domain", "payments");
+        pathParams.putSingle("controlId", "11");
+        pathParams.putSingle("configId", "3");
+        ContainerRequestContext requestContext = mockRequest("DELETE", pathParams);
+        ContainerResponseContext responseContext = mockResponse(204, null);
+
+        filter.filter(requestContext, responseContext);
+
+        AuditLogEntry entry = captureRecordedEntry();
+        assertThat(entry.getEntityType(), is(AuditEntityType.CONTROL_CONFIGURATION));
+        assertThat(entry.getDomain(), is("payments"));
+        assertThat(entry.getEntityId(), is("3"));
+        assertThat(entry.getAction(), is(AuditAction.DELETE));
+    }
+
     // --- MappingControllerResource dispatch --------------------------------------
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoAdrStoreShould.java
@@ -8,6 +8,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -454,5 +455,31 @@ public class TestMongoAdrStoreShould {
         // number. The loser must be told, not silently overwrite the winner.
         assertThrows(AdrRevisionExistsException.class,
                 () -> store.updateAdrStatus(adrMeta(1, null), Status.accepted));
+    }
+
+    // --- deleteAdr ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_an_adr_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteAdr(NAMESPACE, ADR_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_revisions_when_the_adr_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteAdr(NAMESPACE, ADR_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_an_adr_exception_when_deleting_a_missing_adr() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(AdrNotFoundException.class, () -> store.deleteAdr(NAMESPACE, ADR_ID));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoArchitectureStoreShould.java
@@ -7,6 +7,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -429,6 +430,32 @@ public class TestMongoArchitectureStoreShould {
         StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> store.updateArchitectureForVersion(architecture("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
+    }
+
+    // --- deleteArchitecture ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_an_architecture_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_architecture_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_an_architecture_exception_when_deleting_a_missing_architecture() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(ArchitectureNotFoundException.class, () -> store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoControlStoreShould.java
@@ -6,6 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -19,6 +20,7 @@ import org.finos.calm.domain.controls.CreateControlRequirement;
 import org.finos.calm.domain.exception.ControlConfigurationNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionExistsException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionNotFoundException;
+import org.finos.calm.domain.exception.ControlHasConfigurationsException;
 import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -580,5 +583,79 @@ public class TestMongoControlStoreShould {
                 new CreateControlConfiguration("{}"));
 
         verify(configHeaders, Mockito.times(1)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- deleteControlRequirement ---
+
+    @Test
+    void throw_a_domain_exception_when_deleting_a_control_requirement_in_a_missing_domain() {
+        assertThrows(DomainNotFoundException.class, () -> store.deleteControlRequirement("invalid", CONTROL_ID));
+    }
+
+    @Test
+    void throw_a_control_exception_when_deleting_a_missing_control_requirement() {
+        controlDoesNotExist();
+
+        assertThrows(ControlNotFoundException.class, () -> store.deleteControlRequirement(DOMAIN, CONTROL_ID));
+    }
+
+    @Test
+    void refuse_to_delete_a_control_requirement_that_still_has_configurations() {
+        controlExists();
+        when(configHeaders.countDocuments(any(Bson.class))).thenReturn(2L);
+
+        ControlHasConfigurationsException exception = assertThrows(ControlHasConfigurationsException.class,
+                () -> store.deleteControlRequirement(DOMAIN, CONTROL_ID));
+        assertThat(exception.getControlId(), is(CONTROL_ID));
+        assertThat(exception.getConfigurationCount(), is(2));
+        verify(controlHeaders, never()).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void delete_the_requirement_header_and_all_versions_when_it_has_no_configurations() throws Exception {
+        controlExists();
+        when(configHeaders.countDocuments(any(Bson.class))).thenReturn(0L);
+        when(controlHeaders.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteControlRequirement(DOMAIN, CONTROL_ID);
+
+        verify(controlVersions).deleteMany(any(Bson.class));
+        verify(controlHeaders).deleteOne(any(Bson.class));
+    }
+
+    // --- deleteControlConfiguration ---
+
+    @Test
+    void throw_a_domain_exception_when_deleting_a_configuration_in_a_missing_domain() {
+        assertThrows(DomainNotFoundException.class,
+                () -> store.deleteControlConfiguration("invalid", CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void throw_a_control_exception_when_deleting_a_configuration_for_a_missing_control() {
+        controlDoesNotExist();
+
+        assertThrows(ControlNotFoundException.class,
+                () -> store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void throw_a_configuration_exception_when_deleting_a_missing_configuration() {
+        controlExists();
+        stubFind(configHeaders, List.of());
+
+        assertThrows(ControlConfigurationNotFoundException.class,
+                () -> store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void delete_the_configuration_header_and_all_versions_when_it_exists() throws Exception {
+        configurationExists();
+        when(configHeaders.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID);
+
+        verify(configVersions).deleteMany(any(Bson.class));
+        verify(configHeaders).deleteOne(any(Bson.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDecoratorStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoDecoratorStoreShould.java
@@ -728,4 +728,58 @@ class TestMongoDecoratorStoreShould {
         verify(namespaceStore).namespaceExists(namespace);
         verify(decoratorCollection, never()).updateOne(any(Bson.class), any(Bson.class));
     }
+
+    @Test
+    void should_delete_decorator_successfully() throws Exception {
+        // Given
+        String namespace = "finos";
+        int decoratorId = 1;
+
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        UpdateResult updateResult = mock(UpdateResult.class);
+        when(updateResult.getModifiedCount()).thenReturn(1L);
+        when(decoratorCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(updateResult);
+
+        // When
+        decoratorStore.deleteDecorator(namespace, decoratorId);
+
+        // Then
+        verify(namespaceStore).namespaceExists(namespace);
+        verify(decoratorCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void should_throw_decorator_not_found_when_delete_matches_nothing() {
+        // Given
+        String namespace = "finos";
+        int decoratorId = 99;
+
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        UpdateResult updateResult = mock(UpdateResult.class);
+        when(updateResult.getModifiedCount()).thenReturn(0L);
+        when(decoratorCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(updateResult);
+
+        // When & Then
+        assertThrows(DecoratorNotFoundException.class,
+                () -> decoratorStore.deleteDecorator(namespace, decoratorId));
+
+        verify(namespaceStore).namespaceExists(namespace);
+        verify(decoratorCollection).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    @Test
+    void should_throw_namespace_not_found_when_deleting_decorator_in_unknown_namespace() {
+        // Given
+        String namespace = "unknown-namespace";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        // When & Then
+        assertThrows(NamespaceNotFoundException.class,
+                () -> decoratorStore.deleteDecorator(namespace, 1));
+
+        verify(namespaceStore).namespaceExists(namespace);
+        verify(decoratorCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoFlowStoreShould.java
@@ -7,6 +7,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -411,5 +412,31 @@ public class TestMongoFlowStoreShould {
         StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> store.updateFlowForVersion(flow("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
+    }
+
+    // --- deleteFlow ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_a_flow_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteFlow(NAMESPACE, FLOW_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_flow_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteFlow(NAMESPACE, FLOW_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_a_flow_exception_when_deleting_a_missing_flow() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(FlowNotFoundException.class, () -> store.deleteFlow(NAMESPACE, FLOW_ID));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoInterfaceStoreShould.java
@@ -6,6 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -293,5 +294,31 @@ public class TestMongoInterfaceStoreShould {
         // Interface's old shape $set both fields unconditionally, unlike Pattern and Flow
         // which guarded them. Preserved rather than harmonised — see the store's javadoc.
         verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- deleteInterface ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_an_interface_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteInterface(NAMESPACE, INTERFACE_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_interface_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteInterface(NAMESPACE, INTERFACE_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_an_interface_exception_when_deleting_a_missing_interface() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(InterfaceNotFoundException.class, () -> store.deleteInterface(NAMESPACE, INTERFACE_ID));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoPatternStoreShould.java
@@ -7,6 +7,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -176,6 +177,32 @@ public class TestMongoPatternStoreShould {
 
         assertThat(store.getPatternsForNamespace(NAMESPACE), contains(
                 new NamespaceResourceSummary("Pattern 7", "", 7, 0)));
+    }
+
+    // --- deletePattern ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_a_pattern_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deletePattern(NAMESPACE, PATTERN_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_pattern_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deletePattern(NAMESPACE, PATTERN_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_a_pattern_exception_when_deleting_a_missing_pattern() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(PatternNotFoundException.class, () -> store.deletePattern(NAMESPACE, PATTERN_ID));
     }
 
     @Test

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoResourceMappingStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoResourceMappingStoreShould.java
@@ -365,6 +365,44 @@ public class TestMongoResourceMappingStoreShould {
                 () -> store.deleteMapping("invalid", ResourceType.PATTERN, "test"));
     }
 
+    // --- deleteMappingByNumericId ---
+
+    @Test
+    void delete_mapping_by_numeric_id_successfully() throws NamespaceNotFoundException {
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        var deleteResult = Mockito.mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(mappingCollection.deleteOne(any(org.bson.conversions.Bson.class))).thenReturn(deleteResult);
+
+        store.deleteMappingByNumericId("finos", ResourceType.PATTERN, 42);
+
+        verify(mappingCollection).deleteOne(any(org.bson.conversions.Bson.class));
+    }
+
+    @Test
+    void not_throw_when_deleting_a_mapping_by_numeric_id_that_does_not_exist() throws NamespaceNotFoundException {
+        // Most resources have no custom-id mapping at all — this must be a silent no-op, not
+        // an error, so a resource delete can call it unconditionally.
+        when(namespaceStore.namespaceExists("finos")).thenReturn(true);
+
+        var deleteResult = Mockito.mock(com.mongodb.client.result.DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(0L);
+        when(mappingCollection.deleteOne(any(org.bson.conversions.Bson.class))).thenReturn(deleteResult);
+
+        store.deleteMappingByNumericId("finos", ResourceType.PATTERN, 999);
+
+        verify(mappingCollection).deleteOne(any(org.bson.conversions.Bson.class));
+    }
+
+    @Test
+    void throw_namespace_not_found_when_deleting_a_mapping_by_numeric_id_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists("invalid")).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.deleteMappingByNumericId("invalid", ResourceType.PATTERN, 42));
+    }
+
     // --- Helper interfaces for Mockito generics ---
 
     private interface DocumentMongoCollection extends MongoCollection<Document> {

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoStandardStoreShould.java
@@ -6,6 +6,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -293,5 +294,31 @@ public class TestMongoStandardStoreShould {
         // Standard's old shape $set both fields unconditionally, unlike Pattern and Flow
         // which guarded them. Preserved rather than harmonised — see the store's javadoc.
         verify(headerCollection, Mockito.times(2)).updateOne(any(Bson.class), any(Bson.class));
+    }
+
+    // --- deleteStandard ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_a_standard_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteStandard(NAMESPACE, STANDARD_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_standard_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteStandard(NAMESPACE, STANDARD_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_a_standard_exception_when_deleting_a_missing_standard() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(StandardNotFoundException.class, () -> store.deleteStandard(NAMESPACE, STANDARD_ID));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/mongo/TestMongoTimelineStoreShould.java
@@ -7,6 +7,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -411,5 +412,31 @@ public class TestMongoTimelineStoreShould {
         StorageWriteException exception = assertThrows(StorageWriteException.class,
                 () -> store.updateTimelineForVersion(timeline("1.0.1")));
         assertThat(exception.isCapacityExceeded(), is(false));
+    }
+
+    // --- deleteTimeline ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_a_timeline_in_a_missing_namespace() {
+        when(namespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteTimeline(NAMESPACE, TIMELINE_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_versions_when_the_timeline_exists() throws Exception {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        store.deleteTimeline(NAMESPACE, TIMELINE_ID);
+
+        verify(versionCollection).deleteMany(any(Bson.class));
+        verify(headerCollection).deleteOne(any(Bson.class));
+    }
+
+    @Test
+    void throw_a_timeline_exception_when_deleting_a_missing_timeline() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThrows(TimelineNotFoundException.class, () -> store.deleteTimeline(NAMESPACE, TIMELINE_ID));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteAdrStoreShould.java
@@ -382,4 +382,33 @@ public class TestNitriteAdrStoreShould {
         assertThrows(AdrRevisionExistsException.class,
                 () -> store.updateAdrStatus(adrMeta(1, null), Status.accepted));
     }
+
+    // --- deleteAdr ---
+
+    @Test
+    void throw_a_namespace_exception_when_deleting_an_adr_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteAdr(NAMESPACE, ADR_ID));
+    }
+
+    @Test
+    void delete_the_header_and_all_revisions_when_the_adr_exists() throws Exception {
+        adrExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1"),
+                Document.createDocument().put("version", "2")));
+
+        store.deleteAdr(NAMESPACE, ADR_ID);
+
+        verify(versionCollection, org.mockito.Mockito.times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    void throw_an_adr_exception_when_deleting_a_missing_adr() {
+        adrDoesNotExist();
+
+        assertThrows(AdrNotFoundException.class, () -> store.deleteAdr(NAMESPACE, ADR_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteArchitectureStoreShould.java
@@ -428,4 +428,33 @@ public class TestNitriteArchitectureStoreShould {
 
         verify(versionCollection).insert(any(Document.class));
     }
+
+    // --- deleteArchitecture ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_an_architecture_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_architecture_exists() throws Exception {
+        architectureExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID);
+
+        verify(versionCollection, org.mockito.Mockito.times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_an_architecture_exception_when_deleting_a_missing_architecture() {
+        architectureDoesNotExist();
+
+        assertThrows(ArchitectureNotFoundException.class, () -> store.deleteArchitecture(NAMESPACE, ARCHITECTURE_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteControlStoreShould.java
@@ -12,6 +12,7 @@ import org.finos.calm.domain.controls.CreateControlRequirement;
 import org.finos.calm.domain.exception.ControlConfigurationNotFoundException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionExistsException;
 import org.finos.calm.domain.exception.ControlConfigurationVersionNotFoundException;
+import org.finos.calm.domain.exception.ControlHasConfigurationsException;
 import org.finos.calm.domain.exception.ControlNotFoundException;
 import org.finos.calm.domain.exception.ControlRequirementVersionExistsException;
 import org.finos.calm.domain.exception.ControlRequirementVersionNotFoundException;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -111,6 +113,13 @@ public class TestNitriteControlStoreShould {
     private void configurationDoesNotExist() {
         controlExists();
         stubFind(configHeaders, List.of());
+    }
+
+    /** Stubs the count query {@code countHeaders} runs against the configuration namespace. */
+    private void configurationCountIs(long count) {
+        DocumentCursor countCursor = mock(DocumentCursor.class);
+        when(configHeaders.find(any(Filter.class))).thenReturn(countCursor);
+        when(countCursor.size()).thenReturn(count);
     }
 
     // --- getControlsForDomain ---
@@ -501,5 +510,74 @@ public class TestNitriteControlStoreShould {
                 new CreateControlConfiguration("{}"));
 
         verify(configHeaders, times(1)).update(any(Filter.class), any(Document.class));
+    }
+
+    // --- deleteControlRequirement ---
+
+    @Test
+    void throw_a_domain_exception_when_deleting_a_control_requirement_in_a_missing_domain() {
+        assertThrows(DomainNotFoundException.class, () -> store.deleteControlRequirement("invalid", CONTROL_ID));
+    }
+
+    @Test
+    void throw_a_control_exception_when_deleting_a_missing_control_requirement() {
+        controlDoesNotExist();
+
+        assertThrows(ControlNotFoundException.class, () -> store.deleteControlRequirement(DOMAIN, CONTROL_ID));
+    }
+
+    @Test
+    void refuse_to_delete_a_control_requirement_that_still_has_configurations() {
+        controlExists();
+        configurationCountIs(2);
+
+        ControlHasConfigurationsException exception = assertThrows(ControlHasConfigurationsException.class,
+                () -> store.deleteControlRequirement(DOMAIN, CONTROL_ID));
+        assertThat(exception.getControlId(), is(CONTROL_ID));
+        assertThat(exception.getConfigurationCount(), is(2));
+        verify(controlHeaders, never()).remove(any(Document.class));
+    }
+
+    @Test
+    void delete_the_requirement_header_and_all_versions_when_it_has_no_configurations() throws Exception {
+        controlExists();
+        configurationCountIs(0);
+
+        store.deleteControlRequirement(DOMAIN, CONTROL_ID);
+
+        verify(controlHeaders).remove(any(Document.class));
+    }
+
+    // --- deleteControlConfiguration ---
+
+    @Test
+    void throw_a_domain_exception_when_deleting_a_configuration_in_a_missing_domain() {
+        assertThrows(DomainNotFoundException.class,
+                () -> store.deleteControlConfiguration("invalid", CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void throw_a_control_exception_when_deleting_a_configuration_for_a_missing_control() {
+        controlDoesNotExist();
+
+        assertThrows(ControlNotFoundException.class,
+                () -> store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void throw_a_configuration_exception_when_deleting_a_missing_configuration() {
+        configurationDoesNotExist();
+
+        assertThrows(ControlConfigurationNotFoundException.class,
+                () -> store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID));
+    }
+
+    @Test
+    void delete_the_configuration_header_and_all_versions_when_it_exists() throws Exception {
+        configurationExists();
+
+        store.deleteControlConfiguration(DOMAIN, CONTROL_ID, CONFIGURATION_ID);
+
+        verify(configHeaders).remove(any(Document.class));
     }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteDecoratorStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteDecoratorStoreShould.java
@@ -678,4 +678,74 @@ class TestNitriteDecoratorStoreShould {
         assertEquals(1, decoratorIds.get(2));
         verify(namespaceStore).namespaceExists(namespace);
     }
+
+    @Test
+    void should_delete_decorator_successfully() throws NamespaceNotFoundException, DecoratorNotFoundException {
+        // Given
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document decorator1 = Document.createDocument("decoratorId", 1)
+                .put("decorator", Document.createDocument("unique-id", "decorator-1"));
+        Document decorator2 = Document.createDocument("decoratorId", 2)
+                .put("decorator", Document.createDocument("unique-id", "decorator-2"));
+        Document namespaceDocument = Document.createDocument("namespace", namespace)
+                .put("decorators", List.of(decorator1, decorator2));
+
+        when(decoratorCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(namespaceDocument);
+
+        // When
+        decoratorStore.deleteDecorator(namespace, 1);
+
+        // Then
+        verify(namespaceStore).namespaceExists(namespace);
+        verify(decoratorCollection).update(any(Document.class));
+    }
+
+    @Test
+    void should_throw_decorator_not_found_when_deleting_an_id_not_present() {
+        // Given
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+
+        Document decorator1 = Document.createDocument("decoratorId", 1)
+                .put("decorator", Document.createDocument("unique-id", "decorator-1"));
+        Document namespaceDocument = Document.createDocument("namespace", namespace)
+                .put("decorators", List.of(decorator1));
+
+        when(decoratorCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(namespaceDocument);
+
+        // When & Then
+        assertThrows(DecoratorNotFoundException.class, () -> decoratorStore.deleteDecorator(namespace, 99));
+
+        verify(decoratorCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void should_throw_decorator_not_found_when_deleting_from_a_namespace_with_no_document() {
+        // Given
+        String namespace = "finos";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(true);
+        when(decoratorCollection.find(any(Filter.class))).thenReturn(cursor);
+        when(cursor.firstOrNull()).thenReturn(null);
+
+        // When & Then
+        assertThrows(DecoratorNotFoundException.class, () -> decoratorStore.deleteDecorator(namespace, 1));
+
+        verify(decoratorCollection, never()).update(any(Document.class));
+    }
+
+    @Test
+    void should_throw_namespace_not_found_when_deleting_decorator_in_unknown_namespace() {
+        // Given
+        String namespace = "unknown-namespace";
+        when(namespaceStore.namespaceExists(namespace)).thenReturn(false);
+
+        // When & Then
+        assertThrows(NamespaceNotFoundException.class, () -> decoratorStore.deleteDecorator(namespace, 1));
+
+        verify(decoratorCollection, never()).find(any(Filter.class));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteFlowStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteFlowStoreShould.java
@@ -389,4 +389,33 @@ public class TestNitriteFlowStoreShould {
 
         verify(versionCollection).insert(any(Document.class));
     }
+
+    // --- deleteFlow ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_a_flow_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteFlow(NAMESPACE, FLOW_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_flow_exists() throws Exception {
+        flowExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deleteFlow(NAMESPACE, FLOW_ID);
+
+        verify(versionCollection, org.mockito.Mockito.times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_a_flow_exception_when_deleting_a_missing_flow() {
+        flowDoesNotExist();
+
+        assertThrows(FlowNotFoundException.class, () -> store.deleteFlow(NAMESPACE, FLOW_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteInterfaceStoreShould.java
@@ -263,4 +263,33 @@ public class TestNitriteInterfaceStoreShould {
         // Unconditional, unlike Pattern and Flow — Interface's old shape did not guard these.
         verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
+
+    // --- deleteInterface ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_an_interface_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteInterface(NAMESPACE, INTERFACE_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_interface_exists() throws Exception {
+        interfaceExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deleteInterface(NAMESPACE, INTERFACE_ID);
+
+        verify(versionCollection, times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_an_interface_exception_when_deleting_a_missing_interface() {
+        interfaceDoesNotExist();
+
+        assertThrows(InterfaceNotFoundException.class, () -> store.deleteInterface(NAMESPACE, INTERFACE_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitritePatternStoreShould.java
@@ -431,4 +431,33 @@ public class TestNitritePatternStoreShould {
 
         verify(versionCollection).insert(any(Document.class));
     }
+
+    // --- deletePattern ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_a_pattern_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deletePattern(NAMESPACE, PATTERN_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_pattern_exists() throws Exception {
+        patternExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deletePattern(NAMESPACE, PATTERN_ID);
+
+        verify(versionCollection, org.mockito.Mockito.times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_a_pattern_exception_when_deleting_a_missing_pattern() {
+        patternDoesNotExist();
+
+        assertThrows(PatternNotFoundException.class, () -> store.deletePattern(NAMESPACE, PATTERN_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteResourceMappingStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteResourceMappingStoreShould.java
@@ -410,4 +410,48 @@ public class TestNitriteResourceMappingStoreShould {
         assertThrows(MappingNotFoundException.class,
                 () -> store.deleteMapping(NAMESPACE, ResourceType.PATTERN, "nonexistent"));
     }
+
+    // --- deleteMappingByNumericId ---
+
+    @Test
+    void delete_mapping_by_numeric_id_successfully() throws NamespaceNotFoundException {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        Document existing = Document.createDocument()
+                .put("namespace", NAMESPACE)
+                .put("customId", "api-gateway")
+                .put("resourceType", "PATTERN")
+                .put("numericId", 42);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(existing);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        store.deleteMappingByNumericId(NAMESPACE, ResourceType.PATTERN, 42);
+
+        verify(mockCollection).remove(existing);
+    }
+
+    @Test
+    void not_throw_when_deleting_a_mapping_by_numeric_id_that_does_not_exist() throws NamespaceNotFoundException {
+        // Most resources have no custom-id mapping at all — this must be a silent no-op, not
+        // an error, so a resource delete can call it unconditionally.
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(true);
+
+        DocumentCursor cursor = mock(DocumentCursor.class);
+        when(cursor.firstOrNull()).thenReturn(null);
+        when(mockCollection.find(any(Filter.class))).thenReturn(cursor);
+
+        store.deleteMappingByNumericId(NAMESPACE, ResourceType.PATTERN, 999);
+
+        verify(mockCollection, never()).remove(any(Document.class));
+    }
+
+    @Test
+    void throw_namespace_not_found_when_deleting_a_mapping_by_numeric_id_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists("invalid")).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class,
+                () -> store.deleteMappingByNumericId("invalid", ResourceType.PATTERN, 42));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteStandardStoreShould.java
@@ -263,4 +263,33 @@ public class TestNitriteStandardStoreShould {
         // Unconditional, unlike Pattern and Flow — Standard's old shape did not guard these.
         verify(headerCollection, times(2)).update(any(Filter.class), any(Document.class));
     }
+
+    // --- deleteStandard ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_a_standard_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteStandard(NAMESPACE, STANDARD_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_standard_exists() throws Exception {
+        standardExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deleteStandard(NAMESPACE, STANDARD_ID);
+
+        verify(versionCollection, times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_a_standard_exception_when_deleting_a_missing_standard() {
+        standardDoesNotExist();
+
+        assertThrows(StandardNotFoundException.class, () -> store.deleteStandard(NAMESPACE, STANDARD_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/nitrite/TestNitriteTimelineStoreShould.java
@@ -389,4 +389,33 @@ public class TestNitriteTimelineStoreShould {
 
         verify(versionCollection).insert(any(Document.class));
     }
+
+    // --- deleteTimeline ---
+
+    @Test
+    public void throw_a_namespace_exception_when_deleting_a_timeline_in_a_missing_namespace() {
+        when(mockNamespaceStore.namespaceExists(NAMESPACE)).thenReturn(false);
+
+        assertThrows(NamespaceNotFoundException.class, () -> store.deleteTimeline(NAMESPACE, TIMELINE_ID));
+    }
+
+    @Test
+    public void delete_the_header_and_all_versions_when_the_timeline_exists() throws Exception {
+        timelineExists();
+        stubFind(versionCollection, List.of(
+                Document.createDocument().put("version", "1.0.0"),
+                Document.createDocument().put("version", "1.0.1")));
+
+        store.deleteTimeline(NAMESPACE, TIMELINE_ID);
+
+        verify(versionCollection, org.mockito.Mockito.times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(any(Document.class));
+    }
+
+    @Test
+    public void throw_a_timeline_exception_when_deleting_a_missing_timeline() {
+        timelineDoesNotExist();
+
+        assertThrows(TimelineNotFoundException.class, () -> store.deleteTimeline(NAMESPACE, TIMELINE_ID));
+    }
 }

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestMongoVersionDocumentStoreShould.java
@@ -7,6 +7,7 @@ import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.BsonDocument;
 import org.bson.BsonObjectId;
@@ -177,6 +178,39 @@ class TestMongoVersionDocumentStoreShould {
         // The only caller is already failing a create. Propagating this would replace the
         // real write failure with a misleading one about the cleanup.
         assertDoesNotThrow(() -> store.deleteHeader(NAMESPACE, RESOURCE_ID));
+    }
+
+    // --- deleteResource ---
+
+    @Test
+    void delete_the_header_and_all_versions_of_a_resource() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(1));
+
+        boolean deleted = store.deleteResource(NAMESPACE, RESOURCE_ID);
+
+        assertThat(deleted, is(true));
+        ArgumentCaptor<Bson> versionFilterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(versionCollection).deleteMany(versionFilterCaptor.capture());
+        assertThat(asJson(versionFilterCaptor.getValue()), containsString(NAMESPACE));
+        ArgumentCaptor<Bson> headerFilterCaptor = ArgumentCaptor.forClass(Bson.class);
+        verify(headerCollection).deleteOne(headerFilterCaptor.capture());
+        assertThat(asJson(headerFilterCaptor.getValue()), containsString(NAMESPACE));
+    }
+
+    @Test
+    void report_false_when_deleting_a_resource_that_does_not_exist() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        assertThat(store.deleteResource(NAMESPACE, RESOURCE_ID), is(false));
+    }
+
+    @Test
+    void translate_a_write_failure_when_deleting_a_resource() {
+        when(headerCollection.deleteOne(any(Bson.class))).thenThrow(new MongoTimeoutException("no server"));
+
+        // Unlike deleteHeader, this backs a real DELETE endpoint — a failure here must be
+        // reported, not swallowed as best-effort cleanup.
+        assertThrows(StorageWriteException.class, () -> store.deleteResource(NAMESPACE, RESOURCE_ID));
     }
 
     // --- createVersion ---

--- a/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
+++ b/calm-hub/src/test/java/org/finos/calm/store/util/TestNitriteVersionDocumentStoreShould.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -123,6 +124,30 @@ class TestNitriteVersionDocumentStoreShould {
 
         // Matches the Mongo helper: the caller is already failing a create.
         assertDoesNotThrow(() -> store.deleteHeader(NAMESPACE, RESOURCE_ID));
+    }
+
+    // --- deleteResource ---
+
+    @Test
+    void delete_the_header_and_all_versions_of_a_resource() {
+        Document header = header(RESOURCE_ID, "name", "description", 2);
+        stubFind(headerCollection, List.of(header));
+        stubFind(versionCollection, List.of(versionDocument("1.0.0"), versionDocument("2.0.0")));
+
+        boolean deleted = store.deleteResource(NAMESPACE, RESOURCE_ID);
+
+        assertThat(deleted, is(true));
+        verify(versionCollection, times(2)).remove(any(Document.class));
+        verify(headerCollection).remove(header);
+    }
+
+    @Test
+    void report_false_when_deleting_a_resource_that_does_not_exist() {
+        stubFind(headerCollection, List.of());
+
+        assertThat(store.deleteResource(NAMESPACE, RESOURCE_ID), is(false));
+        verify(headerCollection, never()).remove(any(Document.class));
+        verifyNoInteractions(versionCollection);
     }
 
     // --- createVersion ---


### PR DESCRIPTION
## Description

Adds a `DELETE` endpoint for every CALM Hub resource type that didn't already have one (Architecture, Pattern, Flow, Standard, Interface, Timeline, Adr, Decorator, Control Requirement, Control Configuration), gated behind `GLOBAL_ADMIN`.

**Delete semantics**: delete removes the *whole* resource — its header **and every version** — not just the latest version or the header alone. The shared `MongoVersionDocumentStore`/`NitriteVersionDocumentStore` helpers gain a new `deleteResource(namespace, id)` for this; it's distinct from the existing `deleteHeader`, which is internal-only compensation logic used when a first version write fails and deliberately never touches the version collection.

**Control requirements caveat**: a control requirement that still has configurations underneath it refuses to delete (`409 Conflict`) rather than cascading. Delete the configurations first, then the requirement. Configurations themselves delete normally.

Decorator isn't part of the versioned-document family (one doc per namespace, embedded array), so its delete is a bespoke pull/list-removal rather than a `deleteResource` call.

Audit logging picks up all the new endpoints automatically via the existing generic path-param resolution, except Control's two new methods, which needed one manual addition to `AuditRequestFilter`'s per-method dispatch (Control is the one resource that doesn't use the generic resolution path).

Also updates `PERMISSIONS.md` (content-resource deletion is deliberately `GLOBAL admin`-only, distinct from namespace/domain admin) and two ADRs whose "nothing is ever deleted" premise this change reverses, and adds Mongo + Nitrite integration test coverage for Architecture (representative simple case) and Control (the cascade-refuse case).

## Review notes

This PR is best reviewed commit by commit:
1. Store interface method signatures
2. Mongo implementations + tests
3. Nitrite implementations + tests
4. New `ControlHasConfigurationsException` + audit filter wiring + audit test
5. REST resource endpoints + tests
6. Docs (PERMISSIONS.md + ADRs 0001/0003)
7. Integration tests (Architecture + Control, Mongo + Nitrite)

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Affected Components
- [x] CALM Hub (`calm-hub/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

Full suite passes: `../mvnw clean verify -Ddependency-check.skip=true` — 2835 tests, 0 failures, JaCoCo coverage gate satisfied. `../mvnw -P integration verify` also passes in full (Docker/TestContainers). Also manually verified end-to-end against a running standalone instance: header+versions are genuinely gone from storage (not just the header), repeat delete returns 404, invalid namespace returns 400, audit log entries are recorded, and the control-requirement-with-configurations 409-refuse-then-succeed sequence behaves as intended.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
