### PR TITLE
ci: sanitize PR head ref usage in calm-models publish workflow

### DIFF
--- a/.github/workflows/release-calm-models-maven-publish.yml
+++ b/.github/workflows/release-calm-models-maven-publish.yml
@@ -17,9 +17,15 @@ jobs:
         steps:
             - name: Extract release version
               id: version
+              env:
+                REF: ${{ github.event.pull_request.head.ref }}
               run: |
-                REF="${{ github.event.pull_request.head.ref }}"
-                echo "release_version=${REF#release-prep/calm-models-v}" >> "$GITHUB_OUTPUT"
+                RELEASE_VERSION="${REF#release-prep/calm-models-v}"
+                if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "::error::Branch name did not yield a valid semver release version: $REF"
+                  exit 1
+                fi
+                echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Checkout main at merge commit
               uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -47,8 +53,9 @@ jobs:
                 git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
             - name: Tag release
+              env:
+                RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
               run: |
-                RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
                 git tag -a "calm-models-v${RELEASE_VERSION}" -m "calm-models v${RELEASE_VERSION}"
                 git push origin "calm-models-v${RELEASE_VERSION}"
 
@@ -66,8 +73,8 @@ jobs:
             - name: Prepare next development iteration PR
               env:
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
               run: |
-                RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
                 IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
                 NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
                 BRANCH="release-prep/calm-models-next-dev-v${NEXT_VERSION}"


### PR DESCRIPTION
## Description
Closes the OSPS-BR-01.01 / OSPS-BR-01.02 findings from the LFX Insights build & release review. `release-calm-models-maven-publish.yml` interpolated `github.event.pull_request.head.ref` directly into a `run:` script to extract the release version, and that derived value then flowed the same way into two further shell steps (tag + next-dev-iteration PR). A branch name containing shell metacharacters could inject commands into a job that has `contents: write` and Maven Central deploy credentials.

Fix: pass the ref and the derived version through `env:` in all three steps instead of template-interpolating them into the script body, and validate the extracted version against a strict `MAJOR.MINOR.PATCH` pattern before it's used anywhere — the job already gates on `startsWith(head.ref, 'release-prep/calm-models-v')`, so this catches any unexpected suffix.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CI/CD

## Commit Message Format ✅
Used `ci:` (unscoped `fix`/`feat`/`perf` trigger releases per `cli/.releaserc.json`'s fallback rule; `ci` is release-neutral).

## Testing
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

This workflow only runs on a merged `release-prep/calm-models-v*` PR against `main`, so it can't be exercised in CI here. Verified: YAML parses correctly, and the shell logic (prefix-strip, semver validation, `env:` substitution) was traced by hand against the existing step outputs and Copilot CLI reviewed the diff with no findings.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
