### PR TITLE
docs: state FINOS meetings are recorded in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -25,7 +25,7 @@ https://zoom-lfx.platform.linuxfoundation.org/meeting/95612628024?password=bd0f2
 
 - FINOS meetings involve participation by industry competitors, and it is the intention of FINOS and the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Please contact legal@finos.org with any questions.
 
-- FINOS project meetings may be recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
+- FINOS project meetings are recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
 
 ## Agenda
 

--- a/.github/ISSUE_TEMPLATE/Office_Hours.md
+++ b/.github/ISSUE_TEMPLATE/Office_Hours.md
@@ -21,7 +21,7 @@ https://zoom-lfx.platform.linuxfoundation.org/meeting/98579493833?password=2af32
 
 - FINOS meetings involve participation by industry competitors, and it is the intention of FINOS and the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Please contact legal@finos.org with any questions.
 
-- FINOS project meetings may be recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
+- FINOS project meetings are recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
 
 ## Agenda
 


### PR DESCRIPTION
## Description
Updates the Office Hours and Meeting issue templates to state that FINOS project meetings **are** recorded, rather than "may be recorded". Reflects current practice.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] Documentation (`docs/`)

## Testing
- [x] I have tested my changes locally (text-only change to issue templates)

## Checklist
- [x] My commits follow the conventional commit format

cc @rocketstack-matt
