### PR TITLE
feat(calm-studio): add standalone Dockerfile for dev server

### DIFF
--- a/Dockerfile.calm-studio
+++ b/Dockerfile.calm-studio
@@ -1,0 +1,24 @@
+# Standalone dev image for CALM Studio.
+# Clones the repo at build time and starts the Vite dev server on port 5173.
+#
+# Build:  docker build -f Dockerfile.calm-studio -t calm-studio .
+# Run:    docker run -p 5173:5173 calm-studio
+
+FROM node:26
+
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN git clone https://github.com/finos/architecture-as-code.git .
+
+RUN npm install
+
+RUN npm run build --workspace=@finos/calm-models && \
+    npm run build --workspace=@calmstudio/calm-core && \
+    npm run build --workspace=@calmstudio/extensions
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--workspace=@calmstudio/studio", "--", "--host"]


### PR DESCRIPTION
## Description

Adds `Dockerfile.calm-studio` — a self-contained image that installs all prerequisites, clones the repo, and starts the CALM Studio Vite dev server on port 5173.

This removes the need to install Node 26, clone the repo manually, or manage workspace build order to try CALM Studio locally.

```bash
docker build -f Dockerfile.calm-studio -t calm-studio .
docker run -p 5173:5173 calm-studio
# open http://localhost:5173
```

The image builds the workspace dependencies that Vite requires at runtime (`@finos/calm-models` → `@calmstudio/calm-core` → `@calmstudio/extensions`) before starting the dev server, since their `package.json` exports point to compiled `dist/` output.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅

`feat(calm-studio): add standalone Dockerfile for dev server`

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests
- [x] All existing tests pass

Built and ran the image; Vite started cleanly on port 5173 with no errors, serving the SvelteKit app shell.

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards