### PR TITLE
Slice 1/5: feat(calm-hub-ui): loading states and link-based navigation

### DIFF
--- a/calm-hub-ui/src/hub/Hub.test.tsx
+++ b/calm-hub-ui/src/hub/Hub.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import Hub from './Hub.js';
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { authStore } from '../service/utils/auth-store.js';
+import { CountsService } from '../service/counts-service.js';
 import type { Data, Adr } from '../model/calm.js';
 import type { ControlData } from '../model/control.js';
 import type { InterfaceData } from '../model/interface.js';
@@ -473,6 +474,14 @@ describe('Hub', () => {
         it('renders DomainPage with the control count from counts on /domain/:domain', async () => {
             renderAt('/domain/security');
             expect(await screen.findByTestId('domain-page')).toHaveTextContent('Domain: security (3)');
+        });
+
+        it('passes an unknown (undefined) control count, not a misleading 0, when the domain counts fetch fails', async () => {
+            // A failed fetch means the count is unknown, not a confirmed zero —
+            // the same distinction Hub already makes for namespace counts.
+            vi.spyOn(CountsService.prototype, 'fetchDomainCounts').mockRejectedValueOnce(new Error('boom'));
+            renderAt('/domain/security');
+            expect(await screen.findByTestId('domain-page')).toHaveTextContent('Domain: security ()');
         });
 
         it('renders the intro (not a namespace/domain page) on the empty / route', async () => {

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -465,6 +465,7 @@ export default function Hub() {
                             <ExploreRail
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
+                                loading={!namespaceCountsLoaded || !domainCountsLoaded}
                                 onCollapse={() => setIsSidebarOpen(false)}
                             />
                         ) : (
@@ -498,6 +499,7 @@ export default function Hub() {
                             <MobileNavMenu
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
+                                countsLoading={!namespaceCountsLoaded || !domainCountsLoaded}
                                 onClose={() => setIsMobileNavOpen(false)}
                             />
                         </div>

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -69,6 +69,8 @@ export default function Hub() {
     const [namespaceCountsFailed, setNamespaceCountsFailed] = useState(false);
     const [domainCounts, setDomainCounts] = useState<DomainControlCount[]>([]);
     const [domainCountsLoaded, setDomainCountsLoaded] = useState(false);
+    // Mirrors namespaceCountsFailed above — a failed fetch means "unknown", not "zero".
+    const [domainCountsFailed, setDomainCountsFailed] = useState(false);
     const isMobile = useIsMobile();
 
     // Route-first content selection (redesign problem #4): the same <Hub/> element
@@ -112,7 +114,10 @@ export default function Hub() {
         countsService
             .fetchDomainCounts()
             .then(setDomainCounts)
-            .catch(() => setDomainCounts([]))
+            .catch(() => {
+                setDomainCounts([]);
+                setDomainCountsFailed(true);
+            })
             .finally(() => setDomainCountsLoaded(true));
     }, [countsService]);
 
@@ -467,6 +472,8 @@ export default function Hub() {
                                 domainCounts={domainCounts}
                                 namespacesLoading={!namespaceCountsLoaded}
                                 domainsLoading={!domainCountsLoaded}
+                                namespacesFailed={namespaceCountsFailed}
+                                domainsFailed={domainCountsFailed}
                                 onCollapse={() => setIsSidebarOpen(false)}
                             />
                         ) : (
@@ -502,6 +509,8 @@ export default function Hub() {
                                 domainCounts={domainCounts}
                                 namespacesLoading={!namespaceCountsLoaded}
                                 domainsLoading={!domainCountsLoaded}
+                                namespacesFailed={namespaceCountsFailed}
+                                domainsFailed={domainCountsFailed}
                                 onClose={() => setIsMobileNavOpen(false)}
                             />
                         </div>

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -465,7 +465,8 @@ export default function Hub() {
                             <ExploreRail
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
-                                loading={!namespaceCountsLoaded || !domainCountsLoaded}
+                                namespacesLoading={!namespaceCountsLoaded}
+                                domainsLoading={!domainCountsLoaded}
                                 onCollapse={() => setIsSidebarOpen(false)}
                             />
                         ) : (
@@ -499,7 +500,8 @@ export default function Hub() {
                             <MobileNavMenu
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
-                                countsLoading={!namespaceCountsLoaded || !domainCountsLoaded}
+                                namespacesLoading={!namespaceCountsLoaded}
+                                domainsLoading={!domainCountsLoaded}
                                 onClose={() => setIsMobileNavOpen(false)}
                             />
                         </div>

--- a/calm-hub-ui/src/hub/Hub.tsx
+++ b/calm-hub-ui/src/hub/Hub.tsx
@@ -345,20 +345,26 @@ export default function Hub() {
             }
         );
     }, [namespaceCounts, namespaceCountsLoaded, namespaceCountsFailed, activeNamespace]);
-    // Both counts stay `undefined` until the domain-counts fetch settles, so a
-    // deep-link shows "controls" rather than a misleading "0 controls" before it
-    // resolves (mirrors the activeNamespaceCounts gate above).
+    // Both counts stay `undefined` until the domain-counts fetch settles OR if it
+    // failed, so a deep-link shows "controls" rather than a misleading "0 controls"
+    // (mirrors the activeNamespaceCounts gate above).
     const domainControlCount = useMemo(
-        () => (domainCountsLoaded ? (domainCounts.find((c) => c.domain === activeDomain)?.controlCount ?? 0) : undefined),
-        [domainCounts, domainCountsLoaded, activeDomain]
+        () =>
+            !domainCountsLoaded || domainCountsFailed
+                ? undefined
+                : (domainCounts.find((c) => c.domain === activeDomain)?.controlCount ?? 0),
+        [domainCounts, domainCountsLoaded, domainCountsFailed, activeDomain]
     );
     // Count for the grid shown behind a selected control's panel — the control's own
     // domain, which may differ from the route's activeDomain when reached via the
     // detail route (deep-link / mobile drill-down).
     const controlDomain = controlData?.domain;
     const controlDomainCount = useMemo(
-        () => (domainCountsLoaded ? (domainCounts.find((c) => c.domain === controlDomain)?.controlCount ?? 0) : undefined),
-        [domainCounts, domainCountsLoaded, controlDomain]
+        () =>
+            !domainCountsLoaded || domainCountsFailed
+                ? undefined
+                : (domainCounts.find((c) => c.domain === controlDomain)?.controlCount ?? 0),
+        [domainCounts, domainCountsLoaded, domainCountsFailed, controlDomain]
     );
 
     // Chrome-free intro / front door (`/` with nothing else active): early-returns

--- a/calm-hub-ui/src/hub/components/LoadingSpinner.tsx
+++ b/calm-hub-ui/src/hub/components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+/**
+ * Shared spinner markup for the drill-down/browse navigation surfaces
+ * (ExploreRail, MobileNavMenu). Callers own their own wrapper element and
+ * spacing (a rail `<div>` vs a mobile `<li>`), since those differ by context —
+ * only the spinner itself needs to stay identical between them.
+ */
+export function LoadingSpinner({ label }: { label: string }) {
+    return <span role="status" aria-label={label} className="loading loading-spinner loading-md text-base-content/50" />;
+}

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -151,12 +151,13 @@ export function Sparkline({
 
             {/* Track row. A single-version resource has nothing to scrub, so the
                 track is suppressed (the version pill already states what's shown).
-                overflow-hidden clips long labels at the track edge (#2728). */}
+                Individual labels are bounded by maxWidth + ellipsis (#2728); the
+                track itself uses overflow-visible so the last label isn't clipped. */}
             {!singleVersion && (
                 <div
                     data-testid="timeline-sparkline-track"
                     className="relative"
-                    style={{ height: 72, overflow: 'hidden' }}
+                    style={{ height: 72 }}
                 >
                     {/* Inner track wrapper inset 10px each side so dot percentages map directly */}
                     <div className="absolute" style={{ left: 10, right: 10, top: 0, bottom: 0 }}>

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { IoChevronUpOutline } from 'react-icons/io5';
 import { colors } from '../../../../theme/colors.js';
 import { TimelineHeader } from './TimelineHeader.js';
@@ -24,7 +24,7 @@ interface ContextMenuState {
     y: number;
 }
 
-/** Label box width; edge labels are anchored so this can never leave the card (#2728). */
+/** Label box width; labels are clamped to the track so this can never leave the card (#2728). */
 const LABEL_WIDTH = 120;
 
 /**
@@ -65,11 +65,7 @@ export function Sparkline({
     // Progress overlay: left edge to the viewed dot in single mode; between
     // FROM and TO in compare mode.
     const progressLeft = comparing && fromIdx >= 0 && toIdx >= 0 ? pct(Math.min(fromIdx, toIdx)) : 0;
-    const progressRight = comparing && fromIdx >= 0 && toIdx >= 0
-        ? pct(Math.max(fromIdx, toIdx))
-        : viewedIdx >= 0
-            ? pct(viewedIdx)
-            : 0;
+    const progressRight = comparing && fromIdx >= 0 && toIdx >= 0 ? pct(Math.max(fromIdx, toIdx)) : viewedIdx >= 0 ? pct(viewedIdx) : 0;
 
     useEffect(() => {
         if (!menu) return;
@@ -154,21 +150,14 @@ export function Sparkline({
 
             {/* Track row. A single-version resource has nothing to scrub, so the
                 track is suppressed (the version pill already states what's shown).
-                Labels are bounded by LABEL_WIDTH + ellipsis, and the first/last are
-                anchored to their column so they stay inside DiagramSection's
-                overflow-hidden card rather than being sliced (#2728). */}
+                Labels are bounded by LABEL_WIDTH + ellipsis, and clamped to stay
+                inside the track — and so inside DiagramSection's overflow-hidden
+                card — for any dot, not just the true first/last (#2728). */}
             {!singleVersion && (
-                <div
-                    data-testid="timeline-sparkline-track"
-                    className="relative"
-                    style={{ height: 72 }}
-                >
+                <div data-testid="timeline-sparkline-track" className="relative" style={{ height: 72 }}>
                     {/* Inner track wrapper inset 10px each side so dot percentages map directly */}
                     <div className="absolute" style={{ left: 10, right: 10, top: 0, bottom: 0 }}>
-                        <div
-                            className="absolute"
-                            style={{ left: 0, right: 0, top: 15, height: 2, backgroundColor: colors.ink[200] }}
-                        />
+                        <div className="absolute" style={{ left: 0, right: 0, top: 15, height: 2, backgroundColor: colors.ink[200] }} />
                         {progressRight > progressLeft && (
                             <div
                                 data-testid="timeline-progress"
@@ -193,59 +182,66 @@ export function Sparkline({
                             // Active = filled 12px blue dot with a halo; others = 9px white
                             // dots with a slate ring (redesign #4 anatomy).
                             const dotSize = isActive ? 12 : 9;
-                            // The first/last dot sit 30px from the card edge, so a centred
-                            // label would hang outside DiagramSection's rounded,
-                            // overflow-hidden card and be sliced (#2728). Anchor the edge
-                            // labels to their column so the text grows inwards instead.
-                            const labelBox =
-                                i === 0
-                                    ? { left: 0, textAlign: 'left' as const }
-                                    : i === total - 1
-                                      ? { right: 0, textAlign: 'right' as const }
-                                      : { left: '50%', transform: 'translateX(-50%)', textAlign: 'center' as const };
+                            const dotPct = pct(i);
+                            // A centred label can hang past the track edge and be sliced by
+                            // DiagramSection's overflow-hidden card (#2728) — not just for the
+                            // true first/last dot, but for ANY dot close enough to an edge that
+                            // its label's half-width doesn't fit (e.g. the 2nd dot of many in a
+                            // narrow track). clamp() keeps the label's left edge within
+                            // [0, trackWidth - LABEL_WIDTH] for every dot, regardless of dot
+                            // count or track width, rather than special-casing just the ends.
+                            const labelLeft = `clamp(0px, calc(${dotPct}% - ${LABEL_WIDTH / 2}px), calc(100% - ${LABEL_WIDTH}px))`;
+                            // i===0 and i===total-1 always hit the clamp's lower/upper bound
+                            // respectively (0% - half-width is always negative; 100% - half-width
+                            // always exceeds the upper bound) — so anchoring their text in the
+                            // direction the clamp pushes them keeps it hugging the dot instead of
+                            // drifting toward track-center. Interior dots are only clamped in the
+                            // rare narrow-track case, where centered text is an acceptable
+                            // compromise since it's no longer the overflow that mattered (#2728).
+                            const labelTextAlign: 'left' | 'center' | 'right' = i === 0 ? 'left' : i === total - 1 ? 'right' : 'center';
                             return (
-                                <div
-                                    key={moment.key}
-                                    className="absolute top-0"
-                                    style={{ left: `${pct(i)}%`, transform: 'translateX(-50%)', width: 32 }}
-                                >
-                                    <button
-                                        type="button"
-                                        aria-label={`Moment ${moment.label}`}
-                                        aria-current={isCurrent ? 'true' : undefined}
-                                        aria-pressed={isFrom || isTo ? true : undefined}
-                                        onClick={() => handleDotClick(moment)}
-                                        onContextMenu={(e) => handleDotContextMenu(e, moment)}
-                                        className="bg-transparent p-0 border-0 cursor-pointer flex items-center justify-center"
-                                        style={{ width: 32, height: 32 }}
-                                    >
-                                        <div
-                                            data-active={isActive ? 'true' : undefined}
-                                            style={{
-                                                width: dotSize,
-                                                height: dotSize,
-                                                borderRadius: 999,
-                                                backgroundColor: isActive ? colors.redesign.primary : '#ffffff',
-                                                border: isActive
-                                                    ? `2px solid ${colors.redesign.primary}`
-                                                    : `1.5px solid ${colors.ink[400]}`,
-                                                boxShadow: isActive
-                                                    ? `0 0 0 4px ${colors.redesign.primary}33`
-                                                    : 'none',
-                                            }}
-                                        />
-                                    </button>
+                                <Fragment key={moment.key}>
                                     <div
-                                        className="absolute"
-                                        style={{ top: 36, width: LABEL_WIDTH, ...labelBox }}
+                                        className="absolute top-0"
+                                        style={{ left: `${dotPct}%`, transform: 'translateX(-50%)', width: 32 }}
                                     >
+                                        <button
+                                            type="button"
+                                            aria-label={`Moment ${moment.label}`}
+                                            aria-current={isCurrent ? 'true' : undefined}
+                                            aria-pressed={isFrom || isTo ? true : undefined}
+                                            onClick={() => handleDotClick(moment)}
+                                            onContextMenu={(e) => handleDotContextMenu(e, moment)}
+                                            className="bg-transparent p-0 border-0 cursor-pointer flex items-center justify-center"
+                                            style={{ width: 32, height: 32 }}
+                                        >
+                                            <div
+                                                data-active={isActive ? 'true' : undefined}
+                                                style={{
+                                                    width: dotSize,
+                                                    height: dotSize,
+                                                    borderRadius: 999,
+                                                    backgroundColor: isActive ? colors.redesign.primary : '#ffffff',
+                                                    border: isActive
+                                                        ? `2px solid ${colors.redesign.primary}`
+                                                        : `1.5px solid ${colors.ink[400]}`,
+                                                    boxShadow: isActive ? `0 0 0 4px ${colors.redesign.primary}33` : 'none',
+                                                }}
+                                            />
+                                        </button>
+                                    </div>
+                                    {/* Positioned relative to the same inset wrapper as the dots (not
+                                    the 32px dot column) so clamp()'s percentages resolve against
+                                    the full track width — required for the clamp to be able to
+                                    keep the label inside the track for any dot, not just i===0/total-1. */}
+                                    <div className="absolute" style={{ top: 36, left: labelLeft, width: LABEL_WIDTH }}>
                                         <div
                                             className="font-inter"
                                             style={{
                                                 fontSize: 12,
                                                 fontWeight: isActive ? 600 : 500,
                                                 color: isActive ? colors.ink[900] : colors.ink[700],
-                                                textAlign: labelBox.textAlign,
+                                                textAlign: labelTextAlign,
                                                 // Bound + truncate long names so the strip stays
                                                 // readable; the title tooltip shows the full name (#2728).
                                                 maxWidth: LABEL_WIDTH,
@@ -260,13 +256,13 @@ export function Sparkline({
                                         {moment.validFrom && (
                                             <div
                                                 className="font-mono-jb"
-                                                style={{ fontSize: 10, color: colors.ink[400], textAlign: labelBox.textAlign }}
+                                                style={{ fontSize: 10, color: colors.ink[400], textAlign: labelTextAlign }}
                                             >
                                                 {moment.validFrom}
                                             </div>
                                         )}
                                     </div>
-                                </div>
+                                </Fragment>
                             );
                         })}
                     </div>

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -256,7 +256,19 @@ export function Sparkline({
                                         {moment.validFrom && (
                                             <div
                                                 className="font-mono-jb"
-                                                style={{ fontSize: 10, color: colors.ink[400], textAlign: labelTextAlign }}
+                                                style={{
+                                                    fontSize: 10,
+                                                    color: colors.ink[400],
+                                                    textAlign: labelTextAlign,
+                                                    // The track's own overflow was removed in favour of
+                                                    // clamp()-based horizontal containment (#2728) — this
+                                                    // row still needs its own vertical/horizontal bound so
+                                                    // it can't grow past the track height that clip used
+                                                    // to provide.
+                                                    overflow: 'hidden',
+                                                    textOverflow: 'ellipsis',
+                                                    whiteSpace: 'nowrap',
+                                                }}
                                             >
                                                 {moment.validFrom}
                                             </div>

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/Sparkline.tsx
@@ -24,6 +24,9 @@ interface ContextMenuState {
     y: number;
 }
 
+/** Label box width; edge labels are anchored so this can never leave the card (#2728). */
+const LABEL_WIDTH = 120;
+
 /**
  * Collapsed timeline strip — a "Browse versions" header (with the current-version
  * pill) above a sparkline of version dots with title + date below each. Single
@@ -151,8 +154,9 @@ export function Sparkline({
 
             {/* Track row. A single-version resource has nothing to scrub, so the
                 track is suppressed (the version pill already states what's shown).
-                Individual labels are bounded by maxWidth + ellipsis (#2728); the
-                track itself uses overflow-visible so the last label isn't clipped. */}
+                Labels are bounded by LABEL_WIDTH + ellipsis, and the first/last are
+                anchored to their column so they stay inside DiagramSection's
+                overflow-hidden card rather than being sliced (#2728). */}
             {!singleVersion && (
                 <div
                     data-testid="timeline-sparkline-track"
@@ -189,11 +193,21 @@ export function Sparkline({
                             // Active = filled 12px blue dot with a halo; others = 9px white
                             // dots with a slate ring (redesign #4 anatomy).
                             const dotSize = isActive ? 12 : 9;
+                            // The first/last dot sit 30px from the card edge, so a centred
+                            // label would hang outside DiagramSection's rounded,
+                            // overflow-hidden card and be sliced (#2728). Anchor the edge
+                            // labels to their column so the text grows inwards instead.
+                            const labelBox =
+                                i === 0
+                                    ? { left: 0, textAlign: 'left' as const }
+                                    : i === total - 1
+                                      ? { right: 0, textAlign: 'right' as const }
+                                      : { left: '50%', transform: 'translateX(-50%)', textAlign: 'center' as const };
                             return (
                                 <div
                                     key={moment.key}
-                                    className="absolute top-0 flex flex-col items-center"
-                                    style={{ left: `${pct(i)}%`, transform: 'translateX(-50%)' }}
+                                    className="absolute top-0"
+                                    style={{ left: `${pct(i)}%`, transform: 'translateX(-50%)', width: 32 }}
                                 >
                                     <button
                                         type="button"
@@ -222,32 +236,36 @@ export function Sparkline({
                                         />
                                     </button>
                                     <div
-                                        className="font-inter"
-                                        style={{
-                                            marginTop: 4,
-                                            fontSize: 12,
-                                            fontWeight: isActive ? 600 : 500,
-                                            color: isActive ? colors.ink[900] : colors.ink[700],
-                                            textAlign: 'center',
-                                            // Bound + truncate long names so the strip stays
-                                            // readable; the title tooltip shows the full name (#2728).
-                                            maxWidth: 120,
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
-                                            whiteSpace: 'nowrap',
-                                        }}
-                                        title={moment.label}
+                                        className="absolute"
+                                        style={{ top: 36, width: LABEL_WIDTH, ...labelBox }}
                                     >
-                                        {moment.label}
-                                    </div>
-                                    {moment.validFrom && (
                                         <div
-                                            className="font-mono-jb"
-                                            style={{ fontSize: 10, color: colors.ink[400] }}
+                                            className="font-inter"
+                                            style={{
+                                                fontSize: 12,
+                                                fontWeight: isActive ? 600 : 500,
+                                                color: isActive ? colors.ink[900] : colors.ink[700],
+                                                textAlign: labelBox.textAlign,
+                                                // Bound + truncate long names so the strip stays
+                                                // readable; the title tooltip shows the full name (#2728).
+                                                maxWidth: LABEL_WIDTH,
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                            title={moment.label}
                                         >
-                                            {moment.validFrom}
+                                            {moment.label}
                                         </div>
-                                    )}
+                                        {moment.validFrom && (
+                                            <div
+                                                className="font-mono-jb"
+                                                style={{ fontSize: 10, color: colors.ink[400], textAlign: labelBox.textAlign }}
+                                            >
+                                                {moment.validFrom}
+                                            </div>
+                                        )}
+                                    </div>
                                 </div>
                             );
                         })}

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
@@ -257,13 +257,12 @@ describe('TimelineBar', () => {
 
     // #2728 — long moment names must not block the expand control or clip cards.
     describe('long moment names are bounded (#2728)', () => {
-        it('clips the collapsed sparkline track so labels cannot paint over the expand button', () => {
+        it('does not clip the sparkline track so edge labels remain fully visible', () => {
             renderBar();
-            // The centre track is clipped so an overlong label can never overflow
-            // out to cover the statically-positioned expand button.
-            expect(screen.getByTestId('timeline-sparkline-track')).toHaveStyle({
-                overflow: 'hidden',
-            });
+            // Per-label maxWidth + ellipsis bounds individual labels (#2728);
+            // the track itself must NOT clip so the last label is not cut off.
+            const track = screen.getByTestId('timeline-sparkline-track');
+            expect(track).not.toHaveStyle({ overflow: 'hidden' });
         });
 
         it('truncates each collapsed label with an ellipsis while keeping its full-name tooltip', () => {

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
@@ -257,7 +257,7 @@ describe('TimelineBar', () => {
 
     // #2728 — long moment names must not block the expand control or clip cards.
     describe('long moment names are bounded (#2728)', () => {
-        it('anchors the first and last collapsed labels to their column so they cannot leave the card', () => {
+        it('anchors the first and last collapsed labels so they cannot leave the card', () => {
             renderBar();
             // The first/last dots sit close to the card edge, so a centred label
             // would overflow the ancestor card's overflow-hidden boundary and be
@@ -265,6 +265,31 @@ describe('TimelineBar', () => {
             expect(screen.getByText('1.0.0')).toHaveStyle({ textAlign: 'left' });
             expect(screen.getByText('1.5.0')).toHaveStyle({ textAlign: 'center' });
             expect(screen.getByText('2.0.0')).toHaveStyle({ textAlign: 'right' });
+        });
+
+        it('clamps every label to the track, not just the true first/last dot', () => {
+            // With enough versions, a *non-edge* dot (e.g. the 2nd of many) can sit
+            // close enough to the edge that centering its label would still overflow
+            // the card. A fixed set of 3 moments can't exercise this — the fix must
+            // hold for any dot count and track width, which a per-dot clamp() gives us
+            // (rather than only special-casing i===0/total-1).
+            const many: TimelineMoment[] = Array.from({ length: 12 }, (_, i) => ({
+                key: `m${i}`,
+                label: `${i}.0.0`,
+                version: `${i}.0.0`,
+            }));
+            render(
+                <TimelineBar moments={many} currentVersion="0.0.0" compareFrom={null} compareTo={null} onNavigate={vi.fn()} onCompare={vi.fn()} />
+            );
+            // Dot 1 of 12 sits at 1/11 ≈ 9.09% along the track — close enough to the
+            // left edge that a centred 120px-wide label would still overflow. Its
+            // clamp() expression must reflect that dot's own position, not the
+            // static 50%-centered value the old per-index special case fell back to
+            // for every non-edge dot.
+            const secondLabel = screen.getByText('1.0.0');
+            expect(secondLabel.parentElement).toHaveStyle({
+                left: 'clamp(0px, calc(9.090909090909092% - 60px), calc(100% - 120px))',
+            });
         });
 
         it('truncates each collapsed label with an ellipsis while keeping its full-name tooltip', () => {

--- a/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
+++ b/calm-hub-ui/src/hub/components/diagram-section/timeline/TimelineBar.test.tsx
@@ -257,12 +257,14 @@ describe('TimelineBar', () => {
 
     // #2728 — long moment names must not block the expand control or clip cards.
     describe('long moment names are bounded (#2728)', () => {
-        it('does not clip the sparkline track so edge labels remain fully visible', () => {
+        it('anchors the first and last collapsed labels to their column so they cannot leave the card', () => {
             renderBar();
-            // Per-label maxWidth + ellipsis bounds individual labels (#2728);
-            // the track itself must NOT clip so the last label is not cut off.
-            const track = screen.getByTestId('timeline-sparkline-track');
-            expect(track).not.toHaveStyle({ overflow: 'hidden' });
+            // The first/last dots sit close to the card edge, so a centred label
+            // would overflow the ancestor card's overflow-hidden boundary and be
+            // sliced. Edge labels grow inward instead of centering (#2728).
+            expect(screen.getByText('1.0.0')).toHaveStyle({ textAlign: 'left' });
+            expect(screen.getByText('1.5.0')).toHaveStyle({ textAlign: 'center' });
+            expect(screen.getByText('2.0.0')).toHaveStyle({ textAlign: 'right' });
         });
 
         it('truncates each collapsed label with an ellipsis while keeping its full-name tooltip', () => {

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
@@ -14,7 +14,7 @@ const domainCounts: DomainControlCount[] = [
     { domain: 'compliance', controlCount: 0 },
 ];
 
-const renderRail = (path = '/', onCollapse?: () => void) =>
+const renderRail = (path = '/', onCollapse?: () => void, loading?: boolean) =>
     render(
         <MemoryRouter initialEntries={[path]}>
             <Routes>
@@ -26,6 +26,7 @@ const renderRail = (path = '/', onCollapse?: () => void) =>
                             <ExploreRail
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
+                                loading={loading}
                                 onCollapse={onCollapse}
                             />
                         }
@@ -90,5 +91,22 @@ describe('ExploreRail', () => {
         fireEvent.click(screen.getByLabelText('Collapse sidebar'));
         expect(onCollapse).toHaveBeenCalled();
         await screen.findByRole('link', { name: /finos/ });
+    });
+
+    it('shows loading spinners instead of items when loading is true', () => {
+        renderRail('/', undefined, true);
+        const spinners = screen.getAllByClassName
+            ? document.querySelectorAll('.loading-spinner')
+            : screen.getByText('NAMESPACES').parentElement!.querySelectorAll('.loading-spinner');
+        expect(spinners.length).toBeGreaterThanOrEqual(2);
+        expect(screen.queryByRole('link', { name: /finos/ })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /security/ })).not.toBeInTheDocument();
+    });
+
+    it('shows items instead of spinners when loading is false', async () => {
+        renderRail('/', undefined, false);
+        expect(await screen.findByRole('link', { name: /finos/ })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /security/ })).toBeInTheDocument();
+        expect(document.querySelectorAll('.loading-spinner').length).toBe(0);
     });
 });

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
@@ -14,7 +14,13 @@ const domainCounts: DomainControlCount[] = [
     { domain: 'compliance', controlCount: 0 },
 ];
 
-const renderRail = (path = '/', onCollapse?: () => void, loading?: boolean) =>
+interface RenderRailOptions {
+    onCollapse?: () => void;
+    namespacesLoading?: boolean;
+    domainsLoading?: boolean;
+}
+
+const renderRail = (path = '/', opts: RenderRailOptions = {}) =>
     render(
         <MemoryRouter initialEntries={[path]}>
             <Routes>
@@ -26,8 +32,9 @@ const renderRail = (path = '/', onCollapse?: () => void, loading?: boolean) =>
                             <ExploreRail
                                 namespaceCounts={namespaceCounts}
                                 domainCounts={domainCounts}
-                                loading={loading}
-                                onCollapse={onCollapse}
+                                namespacesLoading={opts.namespacesLoading}
+                                domainsLoading={opts.domainsLoading}
+                                onCollapse={opts.onCollapse}
                             />
                         }
                     />
@@ -87,26 +94,37 @@ describe('ExploreRail', () => {
 
     it('invokes onCollapse when the collapse button is clicked', async () => {
         const onCollapse = vi.fn();
-        renderRail('/', onCollapse);
+        renderRail('/', { onCollapse });
         fireEvent.click(screen.getByLabelText('Collapse sidebar'));
         expect(onCollapse).toHaveBeenCalled();
         await screen.findByRole('link', { name: /finos/ });
     });
 
-    it('shows loading spinners instead of items when loading is true', () => {
-        renderRail('/', undefined, true);
-        const spinners = screen.getAllByClassName
-            ? document.querySelectorAll('.loading-spinner')
-            : screen.getByText('NAMESPACES').parentElement!.querySelectorAll('.loading-spinner');
-        expect(spinners.length).toBeGreaterThanOrEqual(2);
+    it('shows a spinner in both sections while both are loading', () => {
+        renderRail('/', { namespacesLoading: true, domainsLoading: true });
+        expect(screen.getAllByRole('status')).toHaveLength(2);
         expect(screen.queryByRole('link', { name: /finos/ })).not.toBeInTheDocument();
         expect(screen.queryByRole('link', { name: /security/ })).not.toBeInTheDocument();
     });
 
-    it('shows items instead of spinners when loading is false', async () => {
-        renderRail('/', undefined, false);
+    it('resolves the namespaces section independently of a still-loading domains section', async () => {
+        renderRail('/', { namespacesLoading: false, domainsLoading: true });
+        expect(await screen.findByRole('link', { name: /finos/ })).toBeInTheDocument();
+        expect(screen.getByRole('status', { name: 'Loading control domains' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /security/ })).not.toBeInTheDocument();
+    });
+
+    it('resolves the domains section independently of a still-loading namespaces section', async () => {
+        renderRail('/', { namespacesLoading: true, domainsLoading: false });
+        expect(await screen.findByRole('link', { name: /security/ })).toBeInTheDocument();
+        expect(screen.getByRole('status', { name: 'Loading namespaces' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /finos/ })).not.toBeInTheDocument();
+    });
+
+    it('shows items instead of spinners once both sections finish loading', async () => {
+        renderRail('/', { namespacesLoading: false, domainsLoading: false });
         expect(await screen.findByRole('link', { name: /finos/ })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /security/ })).toBeInTheDocument();
-        expect(document.querySelectorAll('.loading-spinner').length).toBe(0);
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
@@ -18,6 +18,8 @@ interface RenderRailOptions {
     onCollapse?: () => void;
     namespacesLoading?: boolean;
     domainsLoading?: boolean;
+    namespacesFailed?: boolean;
+    domainsFailed?: boolean;
 }
 
 const renderRail = (path = '/', opts: RenderRailOptions = {}) =>
@@ -34,6 +36,8 @@ const renderRail = (path = '/', opts: RenderRailOptions = {}) =>
                                 domainCounts={domainCounts}
                                 namespacesLoading={opts.namespacesLoading}
                                 domainsLoading={opts.domainsLoading}
+                                namespacesFailed={opts.namespacesFailed}
+                                domainsFailed={opts.domainsFailed}
                                 onCollapse={opts.onCollapse}
                             />
                         }
@@ -126,5 +130,14 @@ describe('ExploreRail', () => {
         expect(await screen.findByRole('link', { name: /finos/ })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /security/ })).toBeInTheDocument();
         expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('shows a distinct message when a counts fetch fails, rather than an ambiguous empty state', async () => {
+        renderRail('/', { namespacesLoading: false, domainsLoading: false, namespacesFailed: true, domainsFailed: true });
+        // A failed fetch is "unknown", not "confirmed zero" — the empty-state text
+        // must say so rather than looking identical to a genuinely empty namespace.
+        expect(await screen.findByText("Couldn't load namespaces")).toBeInTheDocument();
+        expect(screen.getByText("Couldn't load control domains")).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /finos/ })).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.test.tsx
@@ -83,6 +83,14 @@ describe('ExploreRail', () => {
         expect(screen.getByRole('link', { name: /security/ })).toBeInTheDocument();
     });
 
+    it('tells a filter matching nothing apart from a genuinely empty namespace list', async () => {
+        renderRail();
+        await screen.findByRole('link', { name: /finos/ });
+
+        fireEvent.change(screen.getByLabelText('Filter namespaces'), { target: { value: 'no-such-namespace' } });
+        expect(screen.getByText('No namespaces match your filter')).toBeInTheDocument();
+    });
+
     it('marks the namespace row matching the URL as active', async () => {
         renderRail('/namespace/traderx');
         const active = await screen.findByRole('link', { name: /traderx/ });

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
@@ -12,6 +12,8 @@ interface ExploreRailProps {
     namespaceCounts: NamespaceCounts[];
     /** Per-domain control counts, fetched once by {@link Hub} and passed down. */
     domainCounts: DomainControlCount[];
+    /** True while the counts are still being fetched from the backend. */
+    loading?: boolean;
     /** Collapse the rail (keeps the existing sidebar collapse affordance). */
     onCollapse?: () => void;
 }
@@ -28,7 +30,7 @@ type RailRouteParams = { ns?: string; domain?: string; namespace?: string };
  * once there and shared), so this component takes them as props rather than
  * re-fetching them itself.
  */
-export function ExploreRail({ namespaceCounts, domainCounts, onCollapse }: ExploreRailProps) {
+export function ExploreRail({ namespaceCounts, domainCounts, loading, onCollapse }: ExploreRailProps) {
     // `ns` comes from /namespace/:ns; on the detail route /:namespace/:type/:id/:version the
     // param is `namespace`. Fall back to it so the rail keeps its highlight during a detail session.
     const { ns, domain: activeDomain, namespace } = useParams<RailRouteParams>();
@@ -82,28 +84,40 @@ export function ExploreRail({ namespaceCounts, domainCounts, onCollapse }: Explo
             <div className="flex-1 overflow-auto pb-3">
                 <RailSectionLabel>NAMESPACES</RailSectionLabel>
                 <div className="flex flex-col gap-0.5 px-1.5">
-                    {filteredNamespaces.map((nc) => (
-                        <RailItem
-                            key={nc.namespace}
-                            label={nc.namespace}
-                            count={nc.total}
-                            active={nc.namespace === activeNamespace}
-                            to={`/namespace/${nc.namespace}`}
-                        />
-                    ))}
+                    {loading ? (
+                        <div className="flex items-center justify-center py-6">
+                            <span className="loading loading-spinner loading-md text-base-content/50" />
+                        </div>
+                    ) : (
+                        filteredNamespaces.map((nc) => (
+                            <RailItem
+                                key={nc.namespace}
+                                label={nc.namespace}
+                                count={nc.total}
+                                active={nc.namespace === activeNamespace}
+                                to={`/namespace/${nc.namespace}`}
+                            />
+                        ))
+                    )}
                 </div>
 
                 <RailSectionLabel>CONTROL DOMAINS</RailSectionLabel>
                 <div className="flex flex-col gap-0.5 px-1.5">
-                    {domainCounts.map((dc) => (
-                        <RailItem
-                            key={dc.domain}
-                            label={dc.domain}
-                            count={dc.controlCount}
-                            active={dc.domain === activeDomain}
-                            to={`/domain/${dc.domain}`}
-                        />
-                    ))}
+                    {loading ? (
+                        <div className="flex items-center justify-center py-6">
+                            <span className="loading loading-spinner loading-md text-base-content/50" />
+                        </div>
+                    ) : (
+                        domainCounts.map((dc) => (
+                            <RailItem
+                                key={dc.domain}
+                                label={dc.domain}
+                                count={dc.controlCount}
+                                active={dc.domain === activeDomain}
+                                to={`/domain/${dc.domain}`}
+                            />
+                        ))
+                    )}
                 </div>
             </div>
         </div>

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
@@ -6,6 +6,7 @@ import { colors } from '../../../theme/colors.js';
 import { redesignTokens } from '../../../theme/redesign-tokens.js';
 import { RailItem } from './RailItem.js';
 import { RailSectionLabel } from './RailSectionLabel.js';
+import { LoadingSpinner } from '../LoadingSpinner.js';
 
 interface ExploreRailProps {
     /** Per-namespace counts, fetched once by {@link Hub} and passed down. */
@@ -27,7 +28,7 @@ interface ExploreRailProps {
 function RailSpinner({ label }: { label: string }) {
     return (
         <div className="flex items-center justify-center py-6">
-            <span role="status" aria-label={label} className="loading loading-spinner loading-md text-base-content/50" />
+            <LoadingSpinner label={label} />
         </div>
     );
 }

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { IoCompassOutline, IoChevronBackOutline } from 'react-icons/io5';
 import { NamespaceCounts, DomainControlCount } from '../../../model/counts.js';
@@ -12,10 +12,24 @@ interface ExploreRailProps {
     namespaceCounts: NamespaceCounts[];
     /** Per-domain control counts, fetched once by {@link Hub} and passed down. */
     domainCounts: DomainControlCount[];
-    /** True while the counts are still being fetched from the backend. */
-    loading?: boolean;
+    /** True while the namespace counts are still being fetched. */
+    namespacesLoading?: boolean;
+    /** True while the domain control counts are still being fetched. */
+    domainsLoading?: boolean;
     /** Collapse the rail (keeps the existing sidebar collapse affordance). */
     onCollapse?: () => void;
+}
+
+function RailSpinner({ label }: { label: string }) {
+    return (
+        <div className="flex items-center justify-center py-6">
+            <span role="status" aria-label={label} className="loading loading-spinner loading-md text-base-content/50" />
+        </div>
+    );
+}
+
+function RailEmpty({ children }: { children: ReactNode }) {
+    return <div className="px-2 py-6 text-center text-base-content/50 text-sm">{children}</div>;
 }
 
 type RailRouteParams = { ns?: string; domain?: string; namespace?: string };
@@ -30,7 +44,13 @@ type RailRouteParams = { ns?: string; domain?: string; namespace?: string };
  * once there and shared), so this component takes them as props rather than
  * re-fetching them itself.
  */
-export function ExploreRail({ namespaceCounts, domainCounts, loading, onCollapse }: ExploreRailProps) {
+export function ExploreRail({
+    namespaceCounts,
+    domainCounts,
+    namespacesLoading,
+    domainsLoading,
+    onCollapse,
+}: ExploreRailProps) {
     // `ns` comes from /namespace/:ns; on the detail route /:namespace/:type/:id/:version the
     // param is `namespace`. Fall back to it so the rail keeps its highlight during a detail session.
     const { ns, domain: activeDomain, namespace } = useParams<RailRouteParams>();
@@ -84,10 +104,10 @@ export function ExploreRail({ namespaceCounts, domainCounts, loading, onCollapse
             <div className="flex-1 overflow-auto pb-3">
                 <RailSectionLabel>NAMESPACES</RailSectionLabel>
                 <div className="flex flex-col gap-0.5 px-1.5">
-                    {loading ? (
-                        <div className="flex items-center justify-center py-6">
-                            <span className="loading loading-spinner loading-md text-base-content/50" />
-                        </div>
+                    {namespacesLoading ? (
+                        <RailSpinner label="Loading namespaces" />
+                    ) : filteredNamespaces.length === 0 ? (
+                        <RailEmpty>Nothing here</RailEmpty>
                     ) : (
                         filteredNamespaces.map((nc) => (
                             <RailItem
@@ -103,10 +123,10 @@ export function ExploreRail({ namespaceCounts, domainCounts, loading, onCollapse
 
                 <RailSectionLabel>CONTROL DOMAINS</RailSectionLabel>
                 <div className="flex flex-col gap-0.5 px-1.5">
-                    {loading ? (
-                        <div className="flex items-center justify-center py-6">
-                            <span className="loading loading-spinner loading-md text-base-content/50" />
-                        </div>
+                    {domainsLoading ? (
+                        <RailSpinner label="Loading control domains" />
+                    ) : domainCounts.length === 0 ? (
+                        <RailEmpty>Nothing here</RailEmpty>
                     ) : (
                         domainCounts.map((dc) => (
                             <RailItem

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
@@ -116,7 +116,9 @@ export function ExploreRail({
                     ) : namespacesFailed ? (
                         <RailEmpty>Couldn&apos;t load namespaces</RailEmpty>
                     ) : filteredNamespaces.length === 0 ? (
-                        <RailEmpty>Nothing here</RailEmpty>
+                        <RailEmpty>
+                            {namespaceCounts.length === 0 ? 'Nothing here' : 'No namespaces match your filter'}
+                        </RailEmpty>
                     ) : (
                         filteredNamespaces.map((nc) => (
                             <RailItem

--- a/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
+++ b/calm-hub-ui/src/hub/components/explore-rail/ExploreRail.tsx
@@ -16,6 +16,10 @@ interface ExploreRailProps {
     namespacesLoading?: boolean;
     /** True while the domain control counts are still being fetched. */
     domainsLoading?: boolean;
+    /** True if the namespace counts fetch failed — distinct from "loaded and empty". */
+    namespacesFailed?: boolean;
+    /** True if the domain counts fetch failed — distinct from "loaded and empty". */
+    domainsFailed?: boolean;
     /** Collapse the rail (keeps the existing sidebar collapse affordance). */
     onCollapse?: () => void;
 }
@@ -49,6 +53,8 @@ export function ExploreRail({
     domainCounts,
     namespacesLoading,
     domainsLoading,
+    namespacesFailed,
+    domainsFailed,
     onCollapse,
 }: ExploreRailProps) {
     // `ns` comes from /namespace/:ns; on the detail route /:namespace/:type/:id/:version the
@@ -106,6 +112,8 @@ export function ExploreRail({
                 <div className="flex flex-col gap-0.5 px-1.5">
                     {namespacesLoading ? (
                         <RailSpinner label="Loading namespaces" />
+                    ) : namespacesFailed ? (
+                        <RailEmpty>Couldn&apos;t load namespaces</RailEmpty>
                     ) : filteredNamespaces.length === 0 ? (
                         <RailEmpty>Nothing here</RailEmpty>
                     ) : (
@@ -125,6 +133,8 @@ export function ExploreRail({
                 <div className="flex flex-col gap-0.5 px-1.5">
                     {domainsLoading ? (
                         <RailSpinner label="Loading control domains" />
+                    ) : domainsFailed ? (
+                        <RailEmpty>Couldn&apos;t load control domains</RailEmpty>
                     ) : domainCounts.length === 0 ? (
                         <RailEmpty>Nothing here</RailEmpty>
                     ) : (

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
@@ -1,8 +1,14 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SectionHeader } from './SectionHeader.js';
+import { MemoryRouter } from 'react-router-dom';
+import { SectionHeader as SectionHeaderRaw } from './SectionHeader.js';
 import { describe, it, expect, vi } from 'vitest';
 import type { BreadcrumbItem } from '../../../model/calm.js';
+
+function SectionHeader(props: React.ComponentProps<typeof SectionHeaderRaw>) {
+    return <MemoryRouter><SectionHeaderRaw {...props} /></MemoryRouter>;
+}
 
 describe('SectionHeader', () => {
     it('renders icon, namespace, id, and version', () => {

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.test.tsx
@@ -53,6 +53,50 @@ describe('SectionHeader', () => {
         expect(heading).not.toHaveTextContent('42');
     });
 
+    it('links the namespace and type label to the correct namespace/filtered-type routes', () => {
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="my-namespace"
+                id="42"
+                version="1.0.0"
+                typeSegment="architectures"
+                typeLabel="Architecture"
+            />
+        );
+
+        expect(screen.getByRole('link', { name: 'my-namespace' })).toHaveAttribute(
+            'href',
+            '/namespace/my-namespace'
+        );
+        expect(screen.getByRole('link', { name: 'Architecture' })).toHaveAttribute(
+            'href',
+            '/namespace/my-namespace?type=architectures'
+        );
+    });
+
+    it('encodes namespace and type segments containing reserved URL characters', () => {
+        render(
+            <SectionHeader
+                icon={<span>Icon</span>}
+                namespace="my namespace"
+                id="42"
+                version="1.0.0"
+                typeSegment="building blocks"
+                typeLabel="Building Block"
+            />
+        );
+
+        expect(screen.getByRole('link', { name: 'my namespace' })).toHaveAttribute(
+            'href',
+            '/namespace/my%20namespace'
+        );
+        expect(screen.getByRole('link', { name: 'Building Block' })).toHaveAttribute(
+            'href',
+            '/namespace/my%20namespace?type=building%20blocks'
+        );
+    });
+
     it('renders right content when provided', () => {
         const icon = <span>Icon</span>;
         const rightContent = <div data-testid="right-content">Right Content</div>;

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { IoCopyOutline, IoCheckmarkOutline, IoLinkOutline } from 'react-icons/io5';
 import { BreadcrumbItem, isSlug } from '../../../model/calm.js';
 import { BreadcrumbTrail } from './BreadcrumbTrail.js';
@@ -45,11 +46,12 @@ export function SectionHeader({ icon, namespace, id, version, typeSegment, right
                 <h2 className="text-base sm:text-xl font-semibold flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0">
                     {icon}
                     {breadcrumbs && <BreadcrumbTrail breadcrumbs={breadcrumbs} onBreadcrumbClick={onBreadcrumbClick} />}
-                    {namespace}
+                    <Link to={`/namespace/${encodeURIComponent(namespace)}`} className="text-accent hover:underline">{namespace}</Link>
                     {typeLabel && (
                         <>
                             {' '}
-                            <span className="text-base-content/40">/</span> {typeLabel}
+                            <span className="text-base-content/40">/</span>{' '}
+                            <Link to={`/namespace/${encodeURIComponent(namespace)}?type=${typeSegment}`} className="text-accent hover:underline">{typeLabel}</Link>
                         </>
                     )}{' '}
                     <span className="text-base-content/40">/</span>{' '}

--- a/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
+++ b/calm-hub-ui/src/hub/components/section-header/SectionHeader.tsx
@@ -51,7 +51,7 @@ export function SectionHeader({ icon, namespace, id, version, typeSegment, right
                         <>
                             {' '}
                             <span className="text-base-content/40">/</span>{' '}
-                            <Link to={`/namespace/${encodeURIComponent(namespace)}?type=${typeSegment}`} className="text-accent hover:underline">{typeLabel}</Link>
+                            <Link to={`/namespace/${encodeURIComponent(namespace)}?type=${encodeURIComponent(typeSegment)}`} className="text-accent hover:underline">{typeLabel}</Link>
                         </>
                     )}{' '}
                     <span className="text-base-content/40">/</span>{' '}

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -185,4 +185,26 @@ describe('MobileNavMenu', () => {
         expect(await screen.findByText('traderx')).toBeInTheDocument();
         expect(screen.queryByText('Architectures')).not.toBeInTheDocument();
     });
+
+    it('shows a spinner at the root level when countsLoading is true', () => {
+        render(
+            <MemoryRouter>
+                <MobileNavMenu {...props} countsLoading={true} />
+            </MemoryRouter>
+        );
+        const spinner = document.querySelector('.loading-spinner');
+        expect(spinner).toBeInTheDocument();
+        expect(screen.queryByText('Namespaces')).not.toBeInTheDocument();
+    });
+
+    it('shows rows at the root level when countsLoading is false', () => {
+        render(
+            <MemoryRouter>
+                <MobileNavMenu {...props} countsLoading={false} />
+            </MemoryRouter>
+        );
+        expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
+        expect(screen.getByText('Namespaces')).toBeInTheDocument();
+        expect(screen.getByText('Control Domains')).toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -186,25 +186,33 @@ describe('MobileNavMenu', () => {
         expect(screen.queryByText('Architectures')).not.toBeInTheDocument();
     });
 
-    it('shows a spinner at the root level when countsLoading is true', () => {
+    it('shows the static root rows immediately, even while counts are still loading', () => {
         render(
             <MemoryRouter>
-                <MobileNavMenu {...props} countsLoading={true} />
+                <MobileNavMenu {...props} namespacesLoading={true} domainsLoading={true} />
             </MemoryRouter>
         );
-        const spinner = document.querySelector('.loading-spinner');
-        expect(spinner).toBeInTheDocument();
-        expect(screen.queryByText('Namespaces')).not.toBeInTheDocument();
-    });
-
-    it('shows rows at the root level when countsLoading is false', () => {
-        render(
-            <MemoryRouter>
-                <MobileNavMenu {...props} countsLoading={false} />
-            </MemoryRouter>
-        );
-        expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
+        // The root rows are static labels, not derived from counts, so they must
+        // never be hidden behind a counts spinner.
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
         expect(screen.getByText('Namespaces')).toBeInTheDocument();
         expect(screen.getByText('Control Domains')).toBeInTheDocument();
+    });
+
+    it('shows a spinner only for the section whose own counts are still loading', async () => {
+        render(
+            <MemoryRouter>
+                <MobileNavMenu {...props} namespacesLoading={false} domainsLoading={true} />
+            </MemoryRouter>
+        );
+        // A single OR'd flag couldn't tell these two cases apart.
+        fireEvent.click(screen.getByText('Namespaces'));
+        expect(await screen.findByText('traderx')).toBeInTheDocument();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Back'));
+        fireEvent.click(screen.getByText('Control Domains'));
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText('security')).not.toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -215,4 +215,27 @@ describe('MobileNavMenu', () => {
         expect(screen.getByRole('status')).toBeInTheDocument();
         expect(screen.queryByText('security')).not.toBeInTheDocument();
     });
+
+    it('shows a distinct message when a counts fetch fails, rather than an ambiguous empty state', async () => {
+        // Hub clears counts to [] on a failed fetch, so the failure looks
+        // identical to a genuinely empty namespace/domain list unless the
+        // *Failed flag is threaded through to distinguish "unknown" from "zero".
+        render(
+            <MemoryRouter>
+                <MobileNavMenu
+                    {...props}
+                    namespaceCounts={[]}
+                    domainCounts={[]}
+                    namespacesFailed={true}
+                    domainsFailed={true}
+                />
+            </MemoryRouter>
+        );
+        fireEvent.click(screen.getByText('Namespaces'));
+        expect(await screen.findByText("Couldn't load — try again")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Back'));
+        fireEvent.click(screen.getByText('Control Domains'));
+        expect(await screen.findByText("Couldn't load — try again")).toBeInTheDocument();
+    });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -212,7 +212,9 @@ describe('MobileNavMenu', () => {
 
         fireEvent.click(screen.getByLabelText('Back'));
         fireEvent.click(screen.getByText('Control Domains'));
-        expect(screen.getByRole('status')).toBeInTheDocument();
+        // Section-specific, matching ExploreRail's equivalent spinner labels —
+        // not a bare "Loading" that doesn't say which section to a screen reader.
+        expect(screen.getByRole('status', { name: 'Loading control domains' })).toBeInTheDocument();
         expect(screen.queryByText('security')).not.toBeInTheDocument();
     });
 

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.test.tsx
@@ -232,10 +232,11 @@ describe('MobileNavMenu', () => {
             </MemoryRouter>
         );
         fireEvent.click(screen.getByText('Namespaces'));
-        expect(await screen.findByText("Couldn't load — try again")).toBeInTheDocument();
+        // No retry action exists here, so the copy must not promise one.
+        expect(await screen.findByText("Couldn't load namespaces")).toBeInTheDocument();
 
         fireEvent.click(screen.getByLabelText('Back'));
         fireEvent.click(screen.getByText('Control Domains'));
-        expect(await screen.findByText("Couldn't load — try again")).toBeInTheDocument();
+        expect(await screen.findByText("Couldn't load control domains")).toBeInTheDocument();
     });
 });

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -27,6 +27,8 @@ interface MobileNavMenuProps {
     namespaceCounts: NamespaceCounts[];
     /** Per-domain control counts, fetched once by {@link Hub} and passed down. */
     domainCounts: DomainControlCount[];
+    /** True while the counts are still being fetched from the backend. */
+    countsLoading?: boolean;
     /** Dismiss the menu (e.g. after a resource is chosen). */
     onClose: () => void;
 }
@@ -66,7 +68,7 @@ interface LeafItem {
  * {@link Hub} (fetched once and shared) and passed in as props rather than
  * re-fetched here.
  */
-export function MobileNavMenu({ namespaceCounts, domainCounts, onClose }: MobileNavMenuProps) {
+export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, onClose }: MobileNavMenuProps) {
     const navigate = useNavigate();
     const params = useParams<HubParams>();
 
@@ -287,7 +289,8 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, onClose }: Mobile
         }
     })();
 
-    const isEmpty = !loading && rows.length === 0;
+    const showLoading = loading || (countsLoading && (view.level === 'root' || view.level === 'namespaces' || view.level === 'domains'));
+    const isEmpty = !showLoading && rows.length === 0;
 
     return (
         <div className="h-full w-full flex flex-col">
@@ -309,7 +312,7 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, onClose }: Mobile
 
             {!searching && (
                 <ul className="flex-1 overflow-auto divide-y divide-base-200">
-                    {loading && (
+                    {showLoading && (
                         <li className="flex items-center justify-center py-8">
                             <span className="loading loading-spinner loading-md text-base-content/50" />
                         </li>
@@ -317,7 +320,7 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, onClose }: Mobile
                     {isEmpty && (
                         <li className="px-4 py-8 text-center text-base-content/50 text-sm">Nothing here</li>
                     )}
-                    {!loading &&
+                    {!showLoading &&
                         rows.map((row) => (
                             <li key={row.key}>
                                 <button

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -27,8 +27,10 @@ interface MobileNavMenuProps {
     namespaceCounts: NamespaceCounts[];
     /** Per-domain control counts, fetched once by {@link Hub} and passed down. */
     domainCounts: DomainControlCount[];
-    /** True while the counts are still being fetched from the backend. */
-    countsLoading?: boolean;
+    /** True while the namespace counts are still being fetched. */
+    namespacesLoading?: boolean;
+    /** True while the domain control counts are still being fetched. */
+    domainsLoading?: boolean;
     /** Dismiss the menu (e.g. after a resource is chosen). */
     onClose: () => void;
 }
@@ -68,7 +70,13 @@ interface LeafItem {
  * {@link Hub} (fetched once and shared) and passed in as props rather than
  * re-fetched here.
  */
-export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, onClose }: MobileNavMenuProps) {
+export function MobileNavMenu({
+    namespaceCounts,
+    domainCounts,
+    namespacesLoading,
+    domainsLoading,
+    onClose,
+}: MobileNavMenuProps) {
     const navigate = useNavigate();
     const params = useParams<HubParams>();
 
@@ -79,7 +87,7 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, on
 
     const [view, setView] = useState<View>({ level: 'root' });
     const [leafItems, setLeafItems] = useState<LeafItem[]>([]);
-    const [loading, setLoading] = useState(false);
+    const [leafLoading, setLeafLoading] = useState(false);
     const [searching, setSearching] = useState(false);
 
     // Derive the namespace/domain lists from the counts Hub already fetched, rather than
@@ -113,10 +121,10 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, on
         (namespace: string, type: TypeInUI) => {
             setView({ level: 'resources', namespace, type });
             setLeafItems([]);
-            setLoading(true);
+            setLeafLoading(true);
             const finish = (items: LeafItem[]) => {
                 setLeafItems(items);
-                setLoading(false);
+                setLeafLoading(false);
             };
             if (type === 'Interfaces') {
                 interfaceService
@@ -151,14 +159,14 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, on
         (domain: string) => {
             setView({ level: 'controls', domain });
             setLeafItems([]);
-            setLoading(true);
+            setLeafLoading(true);
             controlService
                 .fetchControlsForDomain(domain)
                 .then((controls: ControlDetail[]) =>
                     setLeafItems(controls.map((c) => ({ id: c.id.toString(), name: c.title ?? c.name })))
                 )
                 .catch(() => setLeafItems([]))
-                .finally(() => setLoading(false));
+                .finally(() => setLeafLoading(false));
         },
         [controlService]
     );
@@ -289,7 +297,13 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, on
         }
     })();
 
-    const showLoading = loading || (countsLoading && (view.level === 'root' || view.level === 'namespaces' || view.level === 'domains'));
+    // The root rows ('Namespaces', 'Control Domains') are static labels, not
+    // count-derived, so they render immediately — only the level whose data is
+    // actually in flight shows a spinner.
+    const showLoading =
+        leafLoading ||
+        (view.level === 'namespaces' && namespacesLoading) ||
+        (view.level === 'domains' && domainsLoading);
     const isEmpty = !showLoading && rows.length === 0;
 
     return (
@@ -314,7 +328,7 @@ export function MobileNavMenu({ namespaceCounts, domainCounts, countsLoading, on
                 <ul className="flex-1 overflow-auto divide-y divide-base-200">
                     {showLoading && (
                         <li className="flex items-center justify-center py-8">
-                            <span className="loading loading-spinner loading-md text-base-content/50" />
+                            <span role="status" aria-label="Loading" className="loading loading-spinner loading-md text-base-content/50" />
                         </li>
                     )}
                     {isEmpty && (

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -311,6 +311,10 @@ export function MobileNavMenu({
         leafLoading ||
         (view.level === 'namespaces' && namespacesLoading) ||
         (view.level === 'domains' && domainsLoading);
+    // Matches ExploreRail's section-specific spinner labels, rather than a bare
+    // "Loading" that doesn't tell a screen-reader user which section.
+    const loadingLabel =
+        view.level === 'namespaces' ? 'Loading namespaces' : view.level === 'domains' ? 'Loading control domains' : 'Loading';
     const isEmpty = !showLoading && rows.length === 0;
     // Distinguish "the fetch failed" from "there's genuinely nothing here" — a
     // failed counts fetch is unknown, not zero (mirrors Hub's own namespaceCountsFailed).
@@ -345,7 +349,7 @@ export function MobileNavMenu({
                 <ul className="flex-1 overflow-auto divide-y divide-base-200">
                     {showLoading && (
                         <li className="flex items-center justify-center py-8">
-                            <LoadingSpinner label="Loading" />
+                            <LoadingSpinner label={loadingLabel} />
                         </li>
                     )}
                     {isEmpty && (

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -31,6 +31,10 @@ interface MobileNavMenuProps {
     namespacesLoading?: boolean;
     /** True while the domain control counts are still being fetched. */
     domainsLoading?: boolean;
+    /** True if the namespace counts fetch failed — distinct from "loaded and empty". */
+    namespacesFailed?: boolean;
+    /** True if the domain counts fetch failed — distinct from "loaded and empty". */
+    domainsFailed?: boolean;
     /** Dismiss the menu (e.g. after a resource is chosen). */
     onClose: () => void;
 }
@@ -75,6 +79,8 @@ export function MobileNavMenu({
     domainCounts,
     namespacesLoading,
     domainsLoading,
+    namespacesFailed,
+    domainsFailed,
     onClose,
 }: MobileNavMenuProps) {
     const navigate = useNavigate();
@@ -305,6 +311,11 @@ export function MobileNavMenu({
         (view.level === 'namespaces' && namespacesLoading) ||
         (view.level === 'domains' && domainsLoading);
     const isEmpty = !showLoading && rows.length === 0;
+    // Distinguish "the fetch failed" from "there's genuinely nothing here" — a
+    // failed counts fetch is unknown, not zero (mirrors Hub's own namespaceCountsFailed).
+    const failed =
+        (view.level === 'namespaces' && namespacesFailed) || (view.level === 'domains' && domainsFailed);
+    const emptyMessage = failed ? "Couldn't load — try again" : 'Nothing here';
 
     return (
         <div className="h-full w-full flex flex-col">
@@ -332,7 +343,7 @@ export function MobileNavMenu({
                         </li>
                     )}
                     {isEmpty && (
-                        <li className="px-4 py-8 text-center text-base-content/50 text-sm">Nothing here</li>
+                        <li className="px-4 py-8 text-center text-base-content/50 text-sm">{emptyMessage}</li>
                     )}
                     {!showLoading &&
                         rows.map((row) => (

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -19,6 +19,7 @@ import {
     fetchVersionsForResource,
 } from './navigation-loaders.js';
 import { ExplorerSearch } from '../../../components/navbar/ExplorerSearch.js';
+import { LoadingSpinner } from '../LoadingSpinner.js';
 
 const RESOURCE_TYPES: TypeInUI[] = ['Architectures', 'Patterns', 'Flows', 'Standards', 'ADRs', 'Interfaces'];
 
@@ -339,7 +340,7 @@ export function MobileNavMenu({
                 <ul className="flex-1 overflow-auto divide-y divide-base-200">
                     {showLoading && (
                         <li className="flex items-center justify-center py-8">
-                            <span role="status" aria-label="Loading" className="loading loading-spinner loading-md text-base-content/50" />
+                            <LoadingSpinner label="Loading" />
                         </li>
                     )}
                     {isEmpty && (

--- a/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
+++ b/calm-hub-ui/src/hub/components/tree-navigation/MobileNavMenu.tsx
@@ -314,9 +314,14 @@ export function MobileNavMenu({
     const isEmpty = !showLoading && rows.length === 0;
     // Distinguish "the fetch failed" from "there's genuinely nothing here" — a
     // failed counts fetch is unknown, not zero (mirrors Hub's own namespaceCountsFailed).
-    const failed =
-        (view.level === 'namespaces' && namespacesFailed) || (view.level === 'domains' && domainsFailed);
-    const emptyMessage = failed ? "Couldn't load — try again" : 'Nothing here';
+    // No retry action exists here (Hub fetches counts once on mount), so the copy
+    // must not promise one — matches ExploreRail's equivalent desktop wording.
+    const emptyMessage =
+        view.level === 'namespaces' && namespacesFailed
+            ? "Couldn't load namespaces"
+            : view.level === 'domains' && domainsFailed
+              ? "Couldn't load control domains"
+              : 'Nothing here';
 
     return (
         <div className="h-full w-full flex flex-col">


### PR DESCRIPTION
## Description

- Extracted from #3001 ("OIDC + SCM (Git) backend support") — that PR bundled these UI changes in with the GitHub storage backend work, with no connection to auth or GitHub
- **Layered PR 1 of 5** splitting #3001 into reviewable slices — see the stacking order and full plan in the tracking comment on #3001
- **This PR targets `main` directly** — it has no dependency on the other slices
- Loading states for the explore rail and mobile nav while counts resolve
- Namespace/type in the section header now render as links
- Sparkline overflow fix (#2728)
- Commit authorship preserved: all commits are attributed to @byrash (original PR author), committed by @jpgough-ms as part of this split

## Type of Change
- [x] ♻️ Refactoring (no functional changes)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Code style/formatting changes

## Affected Components
- [x] CALM Hub UI (`calm-hub-ui/`)

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass (lint clean, no test regressions)

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have added tests for my changes (if applicable) — n/a, existing tests carried over unchanged
- [x] My changes follow the project's coding standards

---
Split from #3001.
