### PR TITLE
Slice 2/5: build(calm-hub): add observability and GitHub-backend dependencies

### DIFF
--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -97,6 +97,36 @@
             <artifactId>owasp-java-html-sanitizer</artifactId>
             <version>20240325.1</version>
         </dependency>
+
+        <!-- Caffeine in-memory cache -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <!-- JGit for GitHub clone/pull operations -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>7.2.0.202503040940-r</version>
+        </dependency>
+
+        <!-- Quarkus Scheduler for periodic sync -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry + Micrometer observability -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>

--- a/calm-hub/pom.xml
+++ b/calm-hub/pom.xml
@@ -98,10 +98,14 @@
             <version>20240325.1</version>
         </dependency>
 
-        <!-- Caffeine in-memory cache -->
+        <!-- Caffeine in-memory cache. Use the Quarkus extension, not the bare
+             ben-manes jar: Caffeine builds its cache implementation reflectively,
+             and quarkus-caffeine supplies the native-image reflection config for
+             that (the bare jar would only fail this at native build time). It
+             pulls the ben-manes artifact transitively. -->
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine</artifactId>
         </dependency>
 
         <!-- JGit for GitHub clone/pull operations -->

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -167,6 +167,19 @@ quarkus.micrometer.enabled=true
 quarkus.micrometer.binder.http-server.enabled=${CALM_OTEL_METRICS_ENABLED:false}
 quarkus.micrometer.binder.http-client.enabled=${CALM_OTEL_METRICS_ENABLED:false}
 
-# Test profile: disable OTEL/Micrometer to avoid noise
+# Disable OTEL/Micrometer to avoid noise across every test profile in this module.
+# Both quarkus.otel.enabled and quarkus.micrometer.enabled are build/run-time-fixed
+# per active profile NAME (the same pitfall the jacoco comment above documents) —
+# a %test. prefix only applies when a test's QuarkusTestProfile.getConfigProfile()
+# is literally "test", so each custom profile name used in this module needs its
+# own override or these stay enabled (default true/CALM_OTEL_ENABLED) under it.
 %test.quarkus.otel.enabled=false
 %test.quarkus.micrometer.enabled=false
+%integration-test.quarkus.otel.enabled=false
+%integration-test.quarkus.micrometer.enabled=false
+%nitrite-integration-test.quarkus.otel.enabled=false
+%nitrite-integration-test.quarkus.micrometer.enabled=false
+%secure.quarkus.otel.enabled=false
+%secure.quarkus.micrometer.enabled=false
+%proxy-auth.quarkus.otel.enabled=false
+%proxy-auth.quarkus.micrometer.enabled=false

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -156,3 +156,16 @@ calm.mcp.enabled=false
 %dev.quarkus.mcp.server.traffic-logging=true
 quarkus.log.category."org.finos.calm".level=DEBUG
 quarkus.log.category."org.mongodb.driver".level=OFF
+
+# OpenTelemetry — disabled by default, enable via CALM_OTEL_ENABLED=true in production
+quarkus.otel.service.name=${OTEL_SERVICE_NAME:calm-hub}
+quarkus.otel.enabled=${CALM_OTEL_ENABLED:false}
+quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
+quarkus.otel.traces.sampler=parentbased_traceidratio
+quarkus.otel.traces.sampler.arg=${CALM_OTEL_SAMPLING_RATIO:1.0}
+quarkus.micrometer.enabled=true
+quarkus.micrometer.binder.http-server.enabled=${CALM_OTEL_METRICS_ENABLED:false}
+quarkus.micrometer.binder.http-client.enabled=${CALM_OTEL_METRICS_ENABLED:false}
+
+# Test profile: disable OTEL/Micrometer to avoid noise
+%test.quarkus.otel.enabled=false

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -169,3 +169,4 @@ quarkus.micrometer.binder.http-client.enabled=${CALM_OTEL_METRICS_ENABLED:false}
 
 # Test profile: disable OTEL/Micrometer to avoid noise
 %test.quarkus.otel.enabled=false
+%test.quarkus.micrometer.enabled=false

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -157,29 +157,35 @@ calm.mcp.enabled=false
 quarkus.log.category."org.finos.calm".level=DEBUG
 quarkus.log.category."org.mongodb.driver".level=OFF
 
-# OpenTelemetry — disabled by default, enable via CALM_OTEL_ENABLED=true in production
+# OpenTelemetry — the extension is always compiled in (quarkus.otel.enabled is a
+# build-time flag; a build-once-deploy-many pipeline can't flip it per environment)
+# and disabled at runtime by default via the genuinely runtime-mutable
+# quarkus.otel.sdk.disabled. Set CALM_OTEL_DISABLED=false on the deployed
+# container/process to turn it on — no rebuild required.
 quarkus.otel.service.name=${OTEL_SERVICE_NAME:calm-hub}
-quarkus.otel.enabled=${CALM_OTEL_ENABLED:false}
+quarkus.otel.enabled=true
+quarkus.otel.sdk.disabled=${CALM_OTEL_DISABLED:true}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
 quarkus.otel.traces.sampler=parentbased_traceidratio
 quarkus.otel.traces.sampler.arg=${CALM_OTEL_SAMPLING_RATIO:1.0}
+# Micrometer has no equivalent runtime-mutable switch — quarkus.micrometer.enabled
+# and the binder .enabled properties below are all build-time-fixed (they decide
+# which binder beans get compiled in at all), so CALM_OTEL_METRICS_ENABLED is a
+# build-time knob: it must be set when the artifact is built, not per-deployment.
 quarkus.micrometer.enabled=true
 quarkus.micrometer.binder.http-server.enabled=${CALM_OTEL_METRICS_ENABLED:false}
 quarkus.micrometer.binder.http-client.enabled=${CALM_OTEL_METRICS_ENABLED:false}
 
-# Disable OTEL/Micrometer to avoid noise across every test profile in this module.
-# Both quarkus.otel.enabled and quarkus.micrometer.enabled are build/run-time-fixed
-# per active profile NAME (the same pitfall the jacoco comment above documents) —
-# a %test. prefix only applies when a test's QuarkusTestProfile.getConfigProfile()
-# is literally "test", so each custom profile name used in this module needs its
-# own override or these stay enabled (default true/CALM_OTEL_ENABLED) under it.
-%test.quarkus.otel.enabled=false
+# Disable Micrometer to avoid noise across every test profile in this module —
+# quarkus.micrometer.enabled is build/run-time-fixed per active profile NAME (the
+# same pitfall the jacoco comment above documents), so a %test. prefix only
+# applies when a test's QuarkusTestProfile.getConfigProfile() is literally "test";
+# each custom profile name used in this module needs its own override or
+# Micrometer's core registry (and its auto-enabled binders) stays active under it.
+# quarkus.otel.sdk.disabled needs no such per-profile treatment: it's genuinely
+# RUN_TIME-scoped and already defaults to disabled everywhere, tests included.
 %test.quarkus.micrometer.enabled=false
-%integration-test.quarkus.otel.enabled=false
 %integration-test.quarkus.micrometer.enabled=false
-%nitrite-integration-test.quarkus.otel.enabled=false
 %nitrite-integration-test.quarkus.micrometer.enabled=false
-%secure.quarkus.otel.enabled=false
 %secure.quarkus.micrometer.enabled=false
-%proxy-auth.quarkus.otel.enabled=false
 %proxy-auth.quarkus.micrometer.enabled=false


### PR DESCRIPTION
## Description

- Extracted from #3001 — the second of 5 layered slices, see the tracking comment on #3001 for the full stack
- **Targets `main`** — #3061 (slice 1 of 5) merged, and GitHub retargeted this PR automatically
- Adds caffeine, jgit `7.2.0`, `quarkus-scheduler`, and the OpenTelemetry/Micrometer stack as dependencies
- All additions are inert until a later slice wires a consumer — no runtime behaviour change
- OpenTelemetry is always compiled in (`quarkus.otel.enabled=true`) and disabled at runtime by default via the genuinely runtime-mutable `quarkus.otel.sdk.disabled` — set `CALM_OTEL_DISABLED=false` on the deployed container to turn it on, no rebuild required
- Commit authorship preserved: attributed to @byrash, committed by @jpgough-ms as part of this split

## Review history

Went through 4 rounds of review-and-fix before being marked ready:
1. Comment claimed the test profile disabled both OTEL and Micrometer, but only OTEL was `%test.`-prefixed — Micrometer's core registry stayed active under `mvn test`
2. That same `%test.` prefix only applies when a test's profile name is literally `test` — this module has 4 other custom `QuarkusTestProfile` names, so Micrometer stayed active under `mvn -P integration verify` too
3. **`quarkus.otel.enabled` is build-time-fixed** — verified via `javap` against the Quarkus 3.34.7 jars and empirically (packaged one jar, ran it twice with only the env var changed: no toggle effect either way). The originally-documented `CALM_OTEL_ENABLED=true` production toggle silently never worked in a build-once-deploy-many pipeline. Fixed by switching to `quarkus.otel.sdk.disabled`, which is genuinely `RUN_TIME`-scoped — re-verified empirically that the same built jar now responds live to the env var. Micrometer has no equivalent runtime switch (confirmed via `javap`), so its binder toggles are honestly documented as build-time-only.
4. Clean — no findings

## Type of Change
- [x] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
- [x] CALM Hub (`calm-hub/`)
- [x] Dependencies

## Testing
- [x] I have tested my changes locally
- [x] All existing tests pass — full unit suite (2868 tests) and full Docker-backed integration suite (`mvn -P integration verify`, 540 tests), both 0 failures
- [x] Empirically verified the runtime OTel toggle in both JVM mode (uber-jar) and GraalVM native compilation (Docker image against real MongoDB) — same jar/binary, only the env var changed between runs

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have added tests for my changes (if applicable) — n/a, no new application code
- [x] My changes follow the project's coding standards

---
Split from #3001.

