### PR TITLE
fix(cli): allow workspaces in non-git projects and store relative paths in add

### DIFF
--- a/cli/src/command-helpers/workspace/bundle.spec.ts
+++ b/cli/src/command-helpers/workspace/bundle.spec.ts
@@ -4,6 +4,7 @@ import {
     saveManifest,
     determineDocumentId,
     addFileToBundle,
+    resolveFilePath,
     buildDependencyGraph,
     printBundleTree,
     extractReferenceValue,
@@ -189,10 +190,10 @@ describe('bundle', () => {
 
             expect(result.id).toBe('source-doc');
             expect(result.destPath).toBe(srcFile);
-            expect(result.rel).toBe(srcFile);
+            expect(result.rel).toBe('../source.json');
 
             const manifest = await loadManifest(bundlePath);
-            expect(manifest['source-doc'].path).toBe(srcFile);
+            expect(manifest['source-doc'].path).toBe('../source.json');
             expect(manifest['source-doc'].type).toBe('unknown');
         });
 
@@ -236,6 +237,31 @@ describe('bundle', () => {
             expect(existsSync(filesPath)).toBe(false);
             await addFileToBundle(bundlePath, srcFile, { copy: true });
             expect(existsSync(filesPath)).toBe(true);
+        });
+
+        it('should store a path relative to the bundle for a file nested under it', async () => {
+            const nestedDir = path.join(testDir, 'nested');
+            await mkdir(nestedDir, { recursive: true });
+            const nestedFile = path.join(nestedDir, 'nested.json');
+            await writeFile(nestedFile, JSON.stringify({ '$id': 'nested-doc' }));
+
+            const result = await addFileToBundle(bundlePath, nestedFile);
+
+            expect(result.rel).toBe('../nested/nested.json');
+            const manifest = await loadManifest(bundlePath);
+            expect(manifest['nested-doc'].path).toBe('../nested/nested.json');
+        });
+    });
+
+    describe('resolveFilePath', () => {
+        it('should resolve a relative entry against the bundle path, including parent traversal', () => {
+            expect(resolveFilePath(bundlePath, '../source.json')).toBe(path.join(bundlePath, '../source.json'));
+            expect(resolveFilePath(bundlePath, 'files/source.json')).toBe(path.join(bundlePath, 'files/source.json'));
+        });
+
+        it('should pass an absolute entry through unchanged for backwards compatibility', () => {
+            const absolute = path.join(testDir, 'legacy-absolute.json');
+            expect(resolveFilePath(bundlePath, absolute)).toBe(absolute);
         });
     });
 

--- a/cli/src/command-helpers/workspace/bundle.ts
+++ b/cli/src/command-helpers/workspace/bundle.ts
@@ -13,8 +13,9 @@ export const REFERENCE_PROPERTIES = ['$ref', '$schema', 'requirement-url', 'conf
 
 /**
  * Resolve a manifest entry's stored path to an absolute filesystem path.
- * Entries added by reference store their path as absolute; entries added with --copy
- * store a relative path within the bundle directory.
+ * Entries are stored relative to the bundle directory (which may include '../' segments
+ * for files referenced from outside the workspace). Older manifests may still hold an
+ * absolute path, which is returned unchanged for backwards compatibility.
  */
 export function resolveFilePath(bundlePath: string, entryPath: string): string {
     return path.isAbsolute(entryPath) ? entryPath : path.join(bundlePath, entryPath);
@@ -184,10 +185,10 @@ export async function addFileToBundle(
         // Forward slashes: the manifest travels with the bundle.
         rel = path.relative(bundlePath, destPath).split(path.sep).join('/');
     } else {
-        // reference the original file using its absolute path so it remains resolvable
-        // regardless of where the bundle directory sits
-        destPath = srcPath;
-        rel = srcPath;
+        // reference the original file in place, storing its path relative to the bundle
+        // directory so the manifest is portable across machines/checkouts.
+        destPath = path.resolve(srcPath);
+        rel = path.relative(bundlePath, destPath).split(path.sep).join('/');
     }
 
     const manifest = await loadManifest(bundlePath);

--- a/cli/src/command-helpers/workspace/commands.spec.ts
+++ b/cli/src/command-helpers/workspace/commands.spec.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
         runPostBumpValidation: vi.fn(async () => []),
         loadWorkspaceConfig: vi.fn(async () => ({ push: { failIfModified: false }, bump: { defaultIncrement: 'MINOR' } })),
         findWorkspaceManifestPath: vi.fn<() => string | null>(() => '/fake/bundle'),
-        findGitRoot: vi.fn<() => string | null>(() => '/fake/repo'),
+        findProjectRoot: vi.fn<() => string>(() => '/fake/repo'),
         loadManifest: vi.fn(async () => ({})),
         removeDocumentFromManifest: vi.fn(async () => true),
         loadCliConfig: vi.fn(async () => ({ calmHubUrl: 'https://calmhub.example.com' })),
@@ -85,7 +85,7 @@ vi.mock('./config', () => ({
 
 vi.mock('../../workspace-resolver', () => ({
     findWorkspaceManifestPath: mocks.findWorkspaceManifestPath,
-    findGitRoot: mocks.findGitRoot,
+    findProjectRoot: mocks.findProjectRoot,
 }));
 
 vi.mock('../../cli-config', () => ({
@@ -268,10 +268,10 @@ describe('setupWorkspaceCommands', () => {
             expect(mocks.getActiveWorkspace).toHaveBeenCalledWith('/fake/repo');
         });
 
-        it('should exit when no git root found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
-            await expect(program.parseAsync(['node', 'test', 'workspace', 'list'])).rejects.toThrow();
-            expect(exitSpy).toHaveBeenCalledWith(1);
+        it('should fall back to the resolved project root when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
+            await program.parseAsync(['node', 'test', 'workspace', 'list']);
+            expect(mocks.listWorkspaces).toHaveBeenCalledWith('/fake/cwd-no-git');
         });
 
         it('should handle empty workspace list', async () => {
@@ -315,10 +315,10 @@ describe('setupWorkspaceCommands', () => {
             expect(mocks.loadManifest).toHaveBeenCalled();
         });
 
-        it('should exit when no git root found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
-            await expect(program.parseAsync(['node', 'test', 'workspace', 'show'])).rejects.toThrow();
-            expect(exitSpy).toHaveBeenCalledWith(1);
+        it('should fall back to the resolved project root when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
+            await program.parseAsync(['node', 'test', 'workspace', 'show']);
+            expect(mocks.getActiveWorkspace).toHaveBeenCalledWith('/fake/cwd-no-git');
         });
 
         it('should exit on error', async () => {
@@ -374,10 +374,10 @@ describe('setupWorkspaceCommands', () => {
             expect(exitSpy).toHaveBeenCalledWith(1);
         });
 
-        it('should exit when no git root found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
-            await expect(program.parseAsync(['node', 'test', 'workspace', 'switch', 'other'])).rejects.toThrow();
-            expect(exitSpy).toHaveBeenCalledWith(1);
+        it('should fall back to the resolved project root when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
+            await program.parseAsync(['node', 'test', 'workspace', 'switch', 'other']);
+            expect(mocks.setActiveWorkspace).toHaveBeenCalledWith('/fake/cwd-no-git', 'other');
         });
 
         it('should exit on error', async () => {
@@ -398,10 +398,10 @@ describe('setupWorkspaceCommands', () => {
             expect(mocks.cleanAllWorkspaces).toHaveBeenCalledWith('/fake/repo');
         });
 
-        it('should exit when no git root found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
-            await expect(program.parseAsync(['node', 'test', 'workspace', 'clean'])).rejects.toThrow();
-            expect(exitSpy).toHaveBeenCalledWith(1);
+        it('should fall back to the resolved project root when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
+            await program.parseAsync(['node', 'test', 'workspace', 'clean']);
+            expect(mocks.cleanWorkspaceBundle).toHaveBeenCalledWith('/fake/cwd-no-git', 'default');
         });
 
         it('should exit when no active workspace and no --all flag', async () => {
@@ -485,9 +485,10 @@ describe('setupWorkspaceCommands', () => {
             );
         });
 
-        it('passes failIfModified: false when no git root / config is found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
+        it('still loads workspace config, falling back to the resolved project root, when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
             await program.parseAsync(['node', 'test', 'workspace', 'push']);
+            expect(mocks.loadWorkspaceConfig).toHaveBeenCalledWith('/fake/cwd-no-git');
             expect(mocks.pushWorkspaceToHub).toHaveBeenCalledWith(
                 '/fake/bundle',
                 expect.objectContaining({ isMockClient: true }),
@@ -652,11 +653,24 @@ describe('setupWorkspaceCommands', () => {
             );
         });
 
-        it('defaults to MINOR when no git root / config is found', async () => {
-            mocks.findGitRoot.mockReturnValueOnce(null);
+        it('--minor skips prompts and applies MINOR to all docs', async () => {
+            mocks.loadWorkspaceConfig.mockResolvedValueOnce({ push: { failIfModified: false }, bump: { defaultIncrement: 'MAJOR' } } as never);
+            mocks.detectChangedResources.mockResolvedValueOnce(fakeChanged as never);
+            await program.parseAsync(['node', 'test', 'workspace', 'bump', '--minor']);
+            expect(mocks.select).not.toHaveBeenCalled();
+            expect(mocks.bumpWorkspace).toHaveBeenCalledWith(
+                '/fake/bundle',
+                expect.objectContaining({ isMockClient: true }),
+                expect.objectContaining({ increment: 'MINOR' })
+            );
+        });
+
+        it('still loads workspace config, falling back to the resolved project root, when there is no git repo', async () => {
+            mocks.findProjectRoot.mockReturnValueOnce('/fake/cwd-no-git');
             mocks.detectChangedResources.mockResolvedValueOnce(fakeChanged as never);
             mocks.select.mockResolvedValueOnce('MINOR');
             await program.parseAsync(['node', 'test', 'workspace', 'bump']);
+            expect(mocks.loadWorkspaceConfig).toHaveBeenCalledWith('/fake/cwd-no-git');
             expect(mocks.bumpWorkspace).toHaveBeenCalledWith(
                 '/fake/bundle',
                 expect.objectContaining({ isMockClient: true }),

--- a/cli/src/command-helpers/workspace/commands.ts
+++ b/cli/src/command-helpers/workspace/commands.ts
@@ -10,7 +10,7 @@ import { pushWorkspaceToHub } from './push';
 import { detectChangedResources, bumpWorkspace } from './bump';
 import { runPostBumpValidation } from './post-bump-validate';
 import { loadWorkspaceConfig } from './config';
-import { findWorkspaceManifestPath, findGitRoot } from '../../workspace-resolver';
+import { findWorkspaceManifestPath, findProjectRoot } from '../../workspace-resolver';
 import { initLogger, Logger, CalmHubClient, ResourceChangeType, isConformantDocumentId, namespaceFromDocumentId } from '@finos/calm-shared';
 import { select, input } from '@inquirer/prompts';
 import { CALM_DOCUMENT_TYPES_LIST, isValidCalmDocumentType } from '@finos/calm-models/types';
@@ -33,7 +33,7 @@ export function setupWorkspaceCommands(program: Command) {
         .option('--dir <path>', 'Directory in which to create the workspace (defaults to git root)')
         .action(async (name: string, options: { dir?: string }) => {
             const workspaceName: string = name as string;
-            const targetDir = options.dir ? path.resolve(options.dir) : (findGitRoot(process.cwd()) ?? process.cwd());
+            const targetDir = options.dir ? path.resolve(options.dir) : findProjectRoot(process.cwd());
 
             try {
                 const created = await ensureWorkspaceBundle(targetDir, workspaceName);
@@ -151,13 +151,9 @@ export function setupWorkspaceCommands(program: Command) {
         .description('List all available workspaces')
         .action(async () => {
             try {
-                const gitRoot = findGitRoot(process.cwd());
-                if (!gitRoot) {
-                    logger.error('No git repository found. Please run this command from within a git repository.');
-                    process.exit(1);
-                }
-                const workspaces = await listWorkspaces(gitRoot);
-                const activeWorkspace = await getActiveWorkspace(gitRoot);
+                const projectRoot = findProjectRoot(process.cwd());
+                const workspaces = await listWorkspaces(projectRoot);
+                const activeWorkspace = await getActiveWorkspace(projectRoot);
                 if (workspaces.length === 0) {
                     logger.warn('No workspaces found.');
                     return;
@@ -181,12 +177,8 @@ export function setupWorkspaceCommands(program: Command) {
         .description('Show the active workspace')
         .action(async () => {
             try {
-                const gitRoot = findGitRoot(process.cwd());
-                if (!gitRoot) {
-                    logger.error('No git repository found. Please run this command from within a git repository.');
-                    process.exit(1);
-                }
-                const activeWorkspace = await getActiveWorkspace(gitRoot);
+                const projectRoot = findProjectRoot(process.cwd());
+                const activeWorkspace = await getActiveWorkspace(projectRoot);
                 if (!activeWorkspace) {
                     logger.info('No active workspace.');
                     return;
@@ -243,17 +235,13 @@ export function setupWorkspaceCommands(program: Command) {
         .argument('<name>', 'The name of the workspace to switch to')
         .action(async (name: string) => {
             try {
-                const gitRoot = findGitRoot(process.cwd());
-                if (!gitRoot) {
-                    logger.error('No git repository found. Please run this command from within a git repository.');
-                    process.exit(1);
-                }
-                const workspaces = await listWorkspaces(gitRoot);
+                const projectRoot = findProjectRoot(process.cwd());
+                const workspaces = await listWorkspaces(projectRoot);
                 if (!workspaces.includes(name)) {
                     logger.error(`Workspace '${name}' not found.`);
                     process.exit(1);
                 }
-                await setActiveWorkspace(gitRoot, name);
+                await setActiveWorkspace(projectRoot, name);
                 logger.info(`Switched to workspace '${name}'.`);
             } catch (err) {
                 logger.error('Failed to switch workspace: ' + (err instanceof Error ? err.message : String(err)));
@@ -267,22 +255,18 @@ export function setupWorkspaceCommands(program: Command) {
         .option('--all', 'Clean all workspaces and reset workspace.json')
         .action(async (options: { all?: boolean }) => {
             try {
-                const gitRoot = findGitRoot(process.cwd());
-                if (!gitRoot) {
-                    logger.error('No git repository found. Please run this command from within a git repository.');
-                    process.exit(1);
-                }
+                const projectRoot = findProjectRoot(process.cwd());
 
                 if (options.all) {
-                    await cleanAllWorkspaces(gitRoot);
+                    await cleanAllWorkspaces(projectRoot);
                     logger.info('All workspaces cleaned.');
                 } else {
-                    const activeWorkspace = await getActiveWorkspace(gitRoot);
+                    const activeWorkspace = await getActiveWorkspace(projectRoot);
                     if (!activeWorkspace) {
                         logger.error('No active workspace. Use --all to clean all workspaces.');
                         process.exit(1);
                     }
-                    await cleanWorkspaceBundle(gitRoot, activeWorkspace);
+                    await cleanWorkspaceBundle(projectRoot, activeWorkspace);
                     logger.info(`Workspace '${activeWorkspace}' cleaned.`);
                 }
             } catch (err) {
@@ -348,9 +332,8 @@ export function setupWorkspaceCommands(program: Command) {
 
                 const calmHubOptions = await resolveCalmHubOptions({ calmHubUrl: options.calmHubUrl });
 
-                const gitRoot = findGitRoot(process.cwd());
-                const workspaceConfig = gitRoot ? await loadWorkspaceConfig(gitRoot) : undefined;
-                const failIfModified = options.failIfModified ?? workspaceConfig?.push.failIfModified ?? false;
+                const workspaceConfig = await loadWorkspaceConfig(findProjectRoot(process.cwd()));
+                const failIfModified = options.failIfModified ?? workspaceConfig.push.failIfModified;
 
                 const client = new CalmHubClient(calmHubOptions);
                 await pushWorkspaceToHub(bundlePath, client, { failIfModified });
@@ -437,10 +420,9 @@ export function setupWorkspaceCommands(program: Command) {
 
                 const calmHubOptions = await resolveCalmHubOptions({ calmHubUrl: options.calmHubUrl });
 
-                const gitRoot = findGitRoot(process.cwd());
-                const workspaceConfig = gitRoot ? await loadWorkspaceConfig(gitRoot) : undefined;
+                const workspaceConfig = await loadWorkspaceConfig(findProjectRoot(process.cwd()));
                 const defaultIncrement: ResourceChangeType =
-                    options.major ? 'MAJOR' : options.minor ? 'MINOR' : options.patch ? 'PATCH' : workspaceConfig?.bump.defaultIncrement ?? 'MINOR';
+                    options.major ? 'MAJOR' : options.minor ? 'MINOR' : options.patch ? 'PATCH' : workspaceConfig.bump.defaultIncrement;
 
                 const client = new CalmHubClient(calmHubOptions);
 

--- a/cli/src/workspace-resolver.spec.ts
+++ b/cli/src/workspace-resolver.spec.ts
@@ -1,17 +1,25 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { resolveWorkspaceBundlePathFromEnv, findGitRoot, findWorkspaceManifestPath } from './workspace-resolver';
+import { resolveWorkspaceBundlePathFromEnv, findGitRoot, findProjectRoot, findWorkspaceManifestPath } from './workspace-resolver';
 import { mkdir, writeFile, rm } from 'fs/promises';
 import path from 'path';
+import os from 'os';
 
 describe('workspace-resolver', () => {
     const testDir = path.join(__dirname, 'test-workspace-resolver');
+    // testDir lives inside this repo's own git checkout, so anything nested under it
+    // resolves a real .git when walking upward. Tests that specifically need "no git
+    // repository above this path" semantics use a separate tree outside the repo.
+    const noGitTestDir = path.join(os.tmpdir(), 'calm-workspace-resolver-no-git-test');
 
     beforeAll(async () => {
         await mkdir(testDir, { recursive: true });
+        await rm(noGitTestDir, { recursive: true, force: true });
+        await mkdir(noGitTestDir, { recursive: true });
     });
 
     afterAll(async () => {
         await rm(testDir, { recursive: true, force: true });
+        await rm(noGitTestDir, { recursive: true, force: true });
     });
 
     describe('resolveWorkspaceBundlePathFromEnv', () => {
@@ -77,6 +85,26 @@ describe('workspace-resolver', () => {
         });
     });
 
+    describe('findProjectRoot', () => {
+        it('should return the git root when one exists', async () => {
+            const repo = path.join(testDir, 'repo-project-root');
+            await mkdir(path.join(repo, '.git'), { recursive: true });
+            const nested = path.join(repo, 'a', 'b');
+            await mkdir(nested, { recursive: true });
+
+            expect(findProjectRoot(nested)).toBe(repo);
+        });
+
+        it('should fall back to the given path when no .git directory exists above it', () => {
+            const nonGitDir = path.join(noGitTestDir, 'no-git-here');
+            expect(findProjectRoot(nonGitDir)).toBe(nonGitDir);
+        });
+
+        it('should default to process.cwd() when no start path is given', () => {
+            expect(findProjectRoot()).toBe(findGitRoot(process.cwd()) ?? process.cwd());
+        });
+    });
+
     describe('findWorkspaceBundlePath', () => {
         const originalEnv = process.env.CALM_WORKSPACE_BUNDLE;
 
@@ -103,9 +131,19 @@ describe('workspace-resolver', () => {
             expect(findWorkspaceManifestPath(repo)).toBe(envDir);
         });
 
-        it('should return null when no git root and no env var', () => {
+        it('should return null when no git root, no env var, and no .calm-workspace at the given path', () => {
             delete process.env.CALM_WORKSPACE_BUNDLE;
-            expect(findWorkspaceManifestPath('/tmp')).toBeNull();
+            const nonGitDir = path.join(noGitTestDir, 'no-git-no-workspace');
+            expect(findWorkspaceManifestPath(nonGitDir)).toBeNull();
+        });
+
+        it('should resolve a workspace at the given path even without a .git directory', async () => {
+            delete process.env.CALM_WORKSPACE_BUNDLE;
+            const nonGitDir = path.join(noGitTestDir, 'no-git-with-workspace');
+            const bundleDir = path.join(nonGitDir, '.calm-workspace', 'bundles', 'default');
+            await mkdir(bundleDir, { recursive: true });
+
+            expect(findWorkspaceManifestPath(nonGitDir)).toBe(bundleDir);
         });
 
         it('should return null when git root has no .calm-workspace', async () => {

--- a/cli/src/workspace-resolver.spec.ts
+++ b/cli/src/workspace-resolver.spec.ts
@@ -103,6 +103,32 @@ describe('workspace-resolver', () => {
         it('should default to process.cwd() when no start path is given', () => {
             expect(findProjectRoot()).toBe(findGitRoot(process.cwd()) ?? process.cwd());
         });
+
+        it('should prefer an existing .calm-workspace over a .git directory that appears above it', async () => {
+            // Repro from PR review: a workspace initialised before any git repo existed must
+            // stay reachable even if a .git later shows up further up the tree — otherwise it
+            // would silently resolve to the new, higher git root instead.
+            const projectRoot = path.join(noGitTestDir, 'workspace-then-git', 'a', 'b');
+            await mkdir(path.join(projectRoot, '.calm-workspace'), { recursive: true });
+
+            expect(findProjectRoot(projectRoot)).toBe(projectRoot);
+
+            const gitParent = path.join(noGitTestDir, 'workspace-then-git', 'a');
+            await mkdir(path.join(gitParent, '.git'), { recursive: true });
+
+            expect(findProjectRoot(projectRoot)).toBe(projectRoot);
+        });
+
+        it('should find the nearest .calm-workspace from a nested subdirectory, ahead of a higher .git', async () => {
+            const workspaceRoot = path.join(noGitTestDir, 'nested-workspace-then-git', 'a', 'b');
+            await mkdir(path.join(workspaceRoot, '.calm-workspace'), { recursive: true });
+            await mkdir(path.join(noGitTestDir, 'nested-workspace-then-git', 'a', '.git'), { recursive: true });
+
+            const nested = path.join(workspaceRoot, 'c', 'd');
+            await mkdir(nested, { recursive: true });
+
+            expect(findProjectRoot(nested)).toBe(workspaceRoot);
+        });
     });
 
     describe('findWorkspaceBundlePath', () => {

--- a/cli/src/workspace-resolver.ts
+++ b/cli/src/workspace-resolver.ts
@@ -28,14 +28,47 @@ export function findGitRoot(startPath?: string): string | null {
 }
 
 /**
- * Resolve the root directory workspace state should live under: the git root if one
- * exists, otherwise startPath (or the cwd) itself. This lets workspaces be used from
- * folders that aren't git repositories, without walking further up the filesystem
- * when there's no git boundary to stop at.
+ * Walk upward from startPath looking for an existing `.calm-workspace` directory,
+ * stopping at the nearest one found. The search never goes past gitBoundary (inclusive)
+ * — without that limit, a workspace could be "found" in a wholly unrelated ancestor
+ * project once the walk crosses out of the current git repo. When gitBoundary is null
+ * (no git repo above startPath at all), the walk goes all the way to the filesystem root,
+ * same as findGitRoot.
+ */
+function findExistingWorkspaceRoot(startPath: string, gitBoundary: string | null): string | null {
+    let currentPath = startPath;
+    while (true) {
+        const workspacePath = join(currentPath, '.calm-workspace');
+        if (existsSync(workspacePath) && statSync(workspacePath).isDirectory()) {
+            return currentPath;
+        }
+        if (gitBoundary !== null && currentPath === gitBoundary) {
+            break;
+        }
+        const parentPath = dirname(currentPath);
+        if (parentPath === currentPath) {
+            break;
+        }
+        currentPath = parentPath;
+    }
+    return null;
+}
+
+/**
+ * Resolve the root directory workspace state should live under.
+ *
+ * Prefers the nearest ancestor — no further than the current git root, if there is one —
+ * that already has a `.calm-workspace` directory, so a workspace created outside any git
+ * repo stays reachable even if a `.git` later shows up further up the tree (otherwise
+ * findGitRoot would start resolving to that new, higher root and the original workspace
+ * would look like it had disappeared). Falls back to the git root, and finally to
+ * startPath (or the cwd) itself — which lets workspaces be used from folders that aren't
+ * git repositories at all.
  */
 export function findProjectRoot(startPath?: string): string {
     const resolvedStart = startPath || process.cwd();
-    return findGitRoot(resolvedStart) ?? resolvedStart;
+    const gitRoot = findGitRoot(resolvedStart);
+    return findExistingWorkspaceRoot(resolvedStart, gitRoot) ?? gitRoot ?? resolvedStart;
 }
 
 function findWorkspaceRoot(startPath?: string): string | null {

--- a/cli/src/workspace-resolver.ts
+++ b/cli/src/workspace-resolver.ts
@@ -27,10 +27,20 @@ export function findGitRoot(startPath?: string): string | null {
     return null;
 }
 
+/**
+ * Resolve the root directory workspace state should live under: the git root if one
+ * exists, otherwise startPath (or the cwd) itself. This lets workspaces be used from
+ * folders that aren't git repositories, without walking further up the filesystem
+ * when there's no git boundary to stop at.
+ */
+export function findProjectRoot(startPath?: string): string {
+    const resolvedStart = startPath || process.cwd();
+    return findGitRoot(resolvedStart) ?? resolvedStart;
+}
+
 function findWorkspaceRoot(startPath?: string): string | null {
-    const gitRoot = findGitRoot(startPath);
-    if (!gitRoot) return null;
-    const workspacePath = join(gitRoot, '.calm-workspace');
+    const projectRoot = findProjectRoot(startPath);
+    const workspacePath = join(projectRoot, '.calm-workspace');
     if (existsSync(workspacePath) && statSync(workspacePath).isDirectory()) {
         return workspacePath;
     }


### PR DESCRIPTION
## Description

Fixes two of the five issues from #3031 ("Workspace command suite issues"):

- `calm workspace` commands (`init`, `list`, `show`, `switch`, `clean`, `push`, `bump`) required a `.git` directory and hard-failed otherwise. A new `findProjectRoot()` resolver falls back to the given directory (or cwd) when there's no git repo, instead of requiring a fake `.git`.
- `workspace add` stored the full absolute path to a referenced file in the manifest. It now stores a path relative to the bundle directory, matching the convention already used for `--copy`'d files.

The remaining three items in #3031 (standards support in `add`/`new`, stale `new` templates, and fully interactive `rm`) are not part of this PR — tracked separately.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CLI (`cli/`)

## Testing
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
